### PR TITLE
build.yamlにduplicate_ignoreの除外を追加

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5,6 +5,7 @@ targets:
         options:
           ignore_for_file:
             - type=lint
+            - duplicate_ignore
       json_serializable:
         options:
           checked: true


### PR DESCRIPTION
## Overview (Required)

- duplicate_ignoreを追加
  - riverpod_generator生成クラスが`// ignore_for_file: type=lint`を作成する関係で 重複したignoreが生成されてしまいます
  - freezedとの兼ね合いもあり`type=lint`は無効にしたくない
