### PR TITLE
fix(earthquake-history): 検索条件設定の不具合を修正

### DIFF
--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_search_parameter_modal.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_search_parameter_modal.dart
@@ -236,7 +236,69 @@ class EarthquakeHistorySearchParameterModal extends HookConsumerWidget {
               IconButton.filledTonal(
                 onPressed: () {
                   unawaited(HapticFeedback.lightImpact());
-                  Navigator.of(context).pop();
+                  final parameter = EarthquakeHistoryParameter(
+                    intensityGte: isIntensityEnabled.value &&
+                            intensityMin.value !=
+                                _IntensityRangeSelector.initialMin
+                        ? intensityMin.value
+                        : null,
+                    intensityLte: isIntensityEnabled.value &&
+                            intensityMax.value !=
+                                _IntensityRangeSelector.initialMax
+                        ? intensityMax.value
+                        : null,
+                    depthGte: isDepthEnabled.value &&
+                            depthMin.value != _DepthRangeSelector.initialMin
+                        ? depthMin.value
+                        : null,
+                    depthLte: isDepthEnabled.value &&
+                            depthMax.value != _DepthRangeSelector.initialMax
+                        ? depthMax.value
+                        : null,
+                    magnitudeGte: isMagnitudeEnabled.value &&
+                            magnitudeMin.value !=
+                                _MagnitudeRangeSelector.initialMin
+                        ? magnitudeMin.value
+                        : null,
+                    magnitudeLte: isMagnitudeEnabled.value &&
+                            magnitudeMax.value !=
+                                _MagnitudeRangeSelector.initialMax
+                        ? magnitudeMax.value
+                        : null,
+                    epicenterCode: isEpicenterEnabled.value &&
+                            selectedEpicenterCode.value != null
+                        ? int.tryParse(selectedEpicenterCode.value!)
+                        : null,
+                    epicenterName: isEpicenterEnabled.value &&
+                            selectedEpicenterCode.value != null
+                        ? selectedEpicenterName.value
+                        : null,
+                    regionSearchType: isRegionIntensityEnabled.value &&
+                            selectedRegionCode.value != null
+                        ? (selectedRegionType.value == 'prefecture'
+                            ? RegionSearchType.prefecture
+                            : RegionSearchType.city)
+                        : null,
+                    regionCode: isRegionIntensityEnabled.value
+                        ? selectedRegionCode.value
+                        : null,
+                    regionName: isRegionIntensityEnabled.value
+                        ? selectedRegionName.value
+                        : null,
+                    regionIntensityGte: isRegionIntensityEnabled.value &&
+                            selectedRegionCode.value != null &&
+                            regionIntensityMin.value !=
+                                _IntensityRangeSelector.initialMin
+                        ? regionIntensityMin.value
+                        : null,
+                    regionIntensityLte: isRegionIntensityEnabled.value &&
+                            selectedRegionCode.value != null &&
+                            regionIntensityMax.value !=
+                                _IntensityRangeSelector.initialMax
+                        ? regionIntensityMax.value
+                        : null,
+                  );
+                  Navigator.of(context).pop(parameter);
                 },
                 icon: const Icon(Icons.check),
               ),

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_parti
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_not_found.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_parameter_persistent_delegate.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_search_parameter_modal.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -91,6 +92,13 @@ class _PagingBody extends StatelessWidget {
                 },
               ),
             ],
+          ),
+          SliverPersistentHeader(
+            pinned: true,
+            delegate: EarthquakeHistoryParameterPersistentDelegate(
+              parameter: parameter.value,
+              onChanged: onParameterChanged,
+            ),
           ),
           SliverGroupedPagingList<String?, String, EarthquakePartial>(
             dataSource: dataSource,


### PR DESCRIPTION
## Summary

- モーダルの AppBar にある `✓` ボタンが `Navigator.pop()` を返り値なしで呼んでいたため、検索条件の変更が破棄されていた（「キャンセル」と同一の挙動になっていた）
- `EarthquakeHistoryParameterPersistentDelegate`（震度・マグニチュード・深さ・ステータスのクイックフィルターチップバー）がファイルとして存在していたが、ページの sliver リストに追加されておらず一切表示されていなかった

## Changes

- `earthquake_history_search_parameter_modal.dart`: `✓` ボタンの `onPressed` を「適用」ボタンと同じパラメータ構築ロジックに統一し、`pop(parameter)` で返すよう修正
- `earthquake_history_page.dart`: `SliverAppBar` と一覧の間に `SliverPersistentHeader` を追加してフィルターチップバーを復元

## Test plan

- [ ] 検索条件モーダルで条件を変更し、`✓` ボタンで閉じた際に条件が反映されることを確認
- [ ] 「キャンセル」ボタンで閉じた際は条件が変わらないことを確認
- [ ] 地震履歴一覧ページにフィルターチップバー（震度・マグニチュード・深さ・ステータス）が表示されることを確認
- [ ] チップから直接フィルターを変更できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)