### PR TITLE
fix: 推計震度レイヤーの色をテーマ色でマッピングする

### DIFF
--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_details_estimated_intensity_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_details_estimated_intensity_layer.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
 
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
+import 'package:eqmonitor/core/theme/model/estimated_intensity_colors.dart';
+import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
+import 'package:eqmonitor/core/util/converter/color_converter.dart';
 import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
 import 'package:eqmonitor/core/util/map/replace_map_style_layers.dart';
 import 'package:eqmonitor/feature/map/data/provider/map_style_util.dart';
@@ -23,6 +26,9 @@ class EarthquakeHistoryDetailsEstimatedIntensityLayer
   Widget build(BuildContext context, WidgetRef ref) {
     final styleController = MapController.maybeOf(context)?.style;
     final enqueue = useMapOperationQueue();
+    final colors = ref.watch(
+      activeColorSetProvider.select((colorSet) => colorSet.estimatedIntensity),
+    );
     const style = EarthquakeHistoryEstimatedIntensityStyle();
 
     useEffect(() {
@@ -37,6 +43,7 @@ class EarthquakeHistoryDetailsEstimatedIntensityLayer
           () => style.replace(
             styleController: styleController,
             tileUrl: tileUrl,
+            colors: colors,
             isDisposed: () => disposed,
           ),
         ),
@@ -48,7 +55,7 @@ class EarthquakeHistoryDetailsEstimatedIntensityLayer
           enqueue(() => style.remove(styleController: styleController)),
         );
       };
-    }, [styleController, tileUrl]);
+    }, [styleController, tileUrl, colors]);
 
     return const SizedBox.shrink();
   }
@@ -61,9 +68,33 @@ class EarthquakeHistoryEstimatedIntensityStyle {
   static const fillLayerId = 'earthquake-history-estimated-intensity-fill';
   static const lineLayerId = 'earthquake-history-estimated-intensity-line';
 
+  /// タイル側の `name` 属性（`intensity:4` 〜 `intensity:7`）を
+  /// テーマの推計震度色にマッピングする match 式。
+  ///
+  /// タイルの `fill` 属性は生成時の JMA 標準色が焼き込まれているため
+  /// 使用せず、未知の階級のみタイル側の色にフォールバックする。
+  List<Object> colorExpression({required EstimatedIntensityColors colors}) => [
+    'match',
+    ['get', 'name'],
+    'intensity:4',
+    colors.four.background.toHexStringRGB(),
+    'intensity:5-',
+    colors.fiveLower.background.toHexStringRGB(),
+    'intensity:5+',
+    colors.fiveUpper.background.toHexStringRGB(),
+    'intensity:6-',
+    colors.sixLower.background.toHexStringRGB(),
+    'intensity:6+',
+    colors.sixUpper.background.toHexStringRGB(),
+    'intensity:7',
+    colors.seven.background.toHexStringRGB(),
+    ['get', 'fill'],
+  ];
+
   Future<void> replace({
     required StyleController styleController,
     required String tileUrl,
+    required EstimatedIntensityColors colors,
     required bool Function() isDisposed,
   }) async {
     await remove(styleController: styleController);
@@ -76,34 +107,28 @@ class EarthquakeHistoryEstimatedIntensityStyle {
     if (isDisposed()) {
       return;
     }
+    final color = colorExpression(colors: colors);
     await replaceMapStyleLayers(
       styleController: styleController,
       layerIds: const [lineLayerId, fillLayerId],
       layers: [
         (
-          layer: const FillStyleLayer(
+          layer: FillStyleLayer(
             id: fillLayerId,
             sourceId: sourceId,
             sourceLayerId: 'seismic_intensity',
-            paint: {
-              'fill-opacity': 1,
-              'fill-color': ['get', 'fill'],
-            },
+            paint: {'fill-opacity': 1, 'fill-color': color},
           ),
           belowLayerId: BaseLayer.areaForecastLocalELine.name,
           aboveLayerId: null,
           atIndex: null,
         ),
         (
-          layer: const LineStyleLayer(
+          layer: LineStyleLayer(
             id: lineLayerId,
             sourceId: sourceId,
             sourceLayerId: 'seismic_intensity',
-            paint: {
-              'line-opacity': 1,
-              'line-color': ['get', 'fill'],
-              'line-width': 0.5,
-            },
+            paint: {'line-opacity': 1, 'line-color': color, 'line-width': 0.5},
           ),
           belowLayerId: BaseLayer.areaForecastLocalELine.name,
           aboveLayerId: null,

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_estimated_intensity_layer_lifecycle_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_estimated_intensity_layer_lifecycle_test.dart
@@ -1,8 +1,39 @@
+import 'package:eqmonitor/core/theme/model/estimated_intensity_colors.dart';
+import 'package:eqmonitor/core/theme/model/intensity_color_entry.dart';
+import 'package:eqmonitor/core/theme/model/intensity_text_color.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_details_estimated_intensity_layer.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:maplibre/maplibre.dart';
 
 import '../../../../core/util/map/fake_style_controller.dart';
+
+const _colors = EstimatedIntensityColors(
+  four: IntensityColorEntry(
+    background: Color(0xFF111111),
+    foreground: IntensityTextColor.auto(),
+  ),
+  fiveLower: IntensityColorEntry(
+    background: Color(0xFF222222),
+    foreground: IntensityTextColor.auto(),
+  ),
+  fiveUpper: IntensityColorEntry(
+    background: Color(0xFF333333),
+    foreground: IntensityTextColor.auto(),
+  ),
+  sixLower: IntensityColorEntry(
+    background: Color(0xFF444444),
+    foreground: IntensityTextColor.auto(),
+  ),
+  sixUpper: IntensityColorEntry(
+    background: Color(0xFF555555),
+    foreground: IntensityTextColor.auto(),
+  ),
+  seven: IntensityColorEntry(
+    background: Color(0xFF666666),
+    foreground: IntensityTextColor.auto(),
+  ),
+);
 
 void main() {
   const style = EarthquakeHistoryEstimatedIntensityStyle();
@@ -13,11 +44,47 @@ void main() {
     await style.replace(
       styleController: controller,
       tileUrl: 'https://example.com/estimated.pmtiles',
+      colors: _colors,
       isDisposed: () => false,
     );
 
     final source = controller.addedSources.single as VectorSource;
     expect(source.url, 'pmtiles://https://example.com/estimated.pmtiles');
+  });
+
+  test('name 属性をテーマの推計震度色にマッピングする', () async {
+    final controller = EstimatedIntensityStyleController();
+
+    await style.replace(
+      styleController: controller,
+      tileUrl: 'https://example.com/estimated.pmtiles',
+      colors: _colors,
+      isDisposed: () => false,
+    );
+
+    const expectedExpression = [
+      'match',
+      ['get', 'name'],
+      'intensity:4',
+      '#111111',
+      'intensity:5-',
+      '#222222',
+      'intensity:5+',
+      '#333333',
+      'intensity:6-',
+      '#444444',
+      'intensity:6+',
+      '#555555',
+      'intensity:7',
+      '#666666',
+      ['get', 'fill'],
+    ];
+    final fillLayer =
+        controller.addedLayers.whereType<FillStyleLayer>().single;
+    final lineLayer =
+        controller.addedLayers.whereType<LineStyleLayer>().single;
+    expect(fillLayer.paint['fill-color'], expectedExpression);
+    expect(lineLayer.paint['line-color'], expectedExpression);
   });
 
   test('固定 ID の推計震度リソースを再適用前に除去する', () async {
@@ -26,11 +93,13 @@ void main() {
     await style.replace(
       styleController: controller,
       tileUrl: 'https://example.com/first.pmtiles',
+      colors: _colors,
       isDisposed: () => false,
     );
     await style.replace(
       styleController: controller,
       tileUrl: 'https://example.com/second.pmtiles',
+      colors: _colors,
       isDisposed: () => false,
     );
 
@@ -48,6 +117,7 @@ void main() {
     await style.replace(
       styleController: controller,
       tileUrl: 'https://example.com/estimated.pmtiles',
+      colors: _colors,
       isDisposed: () => false,
     );
     controller.operations.clear();

--- a/docs/knowledge/20260814_pmtiles_minzoom_underzoom.md
+++ b/docs/knowledge/20260814_pmtiles_minzoom_underzoom.md
@@ -1,0 +1,37 @@
+# PMTiles / ベクタソースの minzoom は underzoom されない
+
+## 要点
+
+- MapLibre はソース（TileJSON / PMTiles ヘッダ）の **maxzoom を超えた場合のみ overzoom**
+  （親タイルを拡大して描画）する。**minzoom 未満では何も描画されない**（underzoom は存在しない）。
+- したがって tippecanoe の `-Z`（最小ズーム）より低いズームでは、レイヤー側の設定に関係なく
+  そのソースのフィーチャは一切表示されない。
+- 「低ズームでレイヤーが消える」場合は、まずアーカイブのヘッダを確認すること。
+
+## PMTiles ヘッダ・メタデータの確認方法
+
+```bash
+curl -s -o data.pmtiles "https://tiles.eqmonitor.app/ixac41/<eventId>.pmtiles"
+python3 - <<'EOF'
+import struct, gzip, json
+data = open('data.pmtiles','rb').read()
+u64 = lambda off: struct.unpack_from('<Q', data, off)[0]
+print('min_zoom', data[100], 'max_zoom', data[101])
+meta = data[u64(24):u64(24)+u64(32)]
+if data[97] == 2:  # gzip
+    meta = gzip.decompress(meta)
+print(json.dumps(json.loads(meta), indent=1, ensure_ascii=False))
+EOF
+```
+
+メタデータの `generator_options` に tippecanoe の実行引数（`-Z` / `-z`）がそのまま残るため、
+生成側の設定ミスを特定できる。`tilestats.layers[].attributes` で各フィーチャの属性と値の
+一覧（例: 推計震度タイルの `name` = `intensity:4`〜`intensity:7`）も確認できる。
+
+## 関連
+
+- 推計震度 PMTiles（ixac41）は backend の `ixac41-pmtiles-generator` が `-Z 5 -z 14` で生成して
+  おり、zoom 5 未満で表示されない問題がある → `docs/todo/750_estimated_intensity_pmtiles_minzoom.md`
+- 推計震度タイルの `fill` 属性には JMA 標準色が焼き込まれているため、アプリのテーマ色で描画する
+  場合は `name` 属性（震度階級）を match 式でテーマ色にマッピングする
+  （`earthquake_history_details_estimated_intensity_layer.dart`）。

--- a/docs/map_spec_v3.md
+++ b/docs/map_spec_v3.md
@@ -246,10 +246,12 @@ region / city と同構成。レイヤー ID プレフィックスは `eq-histor
 | 表示条件 | `estimatedIntensityTileUrl != null` |
 | ソース | VectorSource (PMTiles URL) |
 | ソースレイヤー | `seismic_intensity` |
-| レイヤータイプ | FillStyleLayer |
-| Fill opacity | 0.65 |
-| Fill color | GeoJSON properties の `fill` |
+| レイヤータイプ | FillStyleLayer + LineStyleLayer |
+| Fill opacity | 1.0 |
+| Fill color | properties の `name`（`intensity:4`〜`intensity:7`）をテーマの推計震度色に match 式でマッピング。未知の階級のみ properties の `fill` にフォールバック |
 | 配置 | `areaForecastLocalELine` より下 |
+
+注意: PMTiles は backend (`ixac41-pmtiles-generator`) で tippecanoe `-Z 5 -z 14` で生成されるため、zoom 5 未満ではタイルが存在せず描画されない（MapLibre は minzoom 側の underzoom を行わない）。
 
 ### 2-9. カメラ
 

--- a/docs/todo/700_flutter_test_ci_10min_timeout.md
+++ b/docs/todo/700_flutter_test_ci_10min_timeout.md
@@ -1,0 +1,36 @@
+# CI の `flutter-test` が 10 分の timeout で打ち切られる
+
+## 現象
+
+`PR Flutter Check` の `flutter-test / Flutter Test` が、テスト失敗 0 件のまま
+`##[error]The operation was canceled.` で failure になる。ジョブ実行時間は
+`10m17s` で、`wc-check-dart-test.yaml` の `timeout-minutes: 10` に張り付いている。
+
+実測例（2026-08-14 / run 31790096949 job 94734931270）:
+
+- ログ全体に `❌` は 1 件も無く、個別テストの失敗は発生していない
+- `09:56` 開始 → `10:06:07` にキャンセル。`eqmonitor` package のテスト実行途中で打ち切り
+- monorepo 全体（24 packages）を `melos exec --concurrency=4` で回しており、
+  総実行時間が 10 分に収まらなくなっている
+
+## 影響
+
+- テストが健全でも `flutter-test` が blocking failure になり、PR のマージ判定に使えない
+- 「テストが落ちた」のか「時間切れ」なのか、チェック名からは区別できない
+
+## 対応方針
+
+`timeout-minutes` を単純に引き上げるだけでは実行時間の増加を追い続けることになるため、
+以下を検討する。
+
+1. 遅い package / テストを計測して特定する（`--file-reporter` の JSON から所要時間を集計）。
+2. package ごとに job を分割し matrix 並列化する。`melos exec --concurrency=4` の
+   単一 job 構成が直列ボトルネックになっている。
+3. その上で残る実行時間に見合った `timeout-minutes` を設定する。
+
+「落ちているテストを通す」目的で `timeout-minutes` だけを緩める変更は行わない。
+
+## 関連
+
+- `docs/todo/770_existing_eqmonitor_flutter_test_failures.md`（既存のテスト失敗 18 件）
+- `docs/todo/760_existing_eqmonitor_custom_lint_debt.md`（`flutter-analyze` の既存負債）

--- a/docs/todo/750_estimated_intensity_pmtiles_minzoom.md
+++ b/docs/todo/750_estimated_intensity_pmtiles_minzoom.md
@@ -1,0 +1,35 @@
+# 推計震度 PMTiles が zoom 5 未満で表示されない
+
+## 現象
+
+地震履歴詳細・ライブモニタの推計震度レイヤー（PMTiles）は、マップの zoom が 5 未満のとき何も描画されない。
+
+## 原因
+
+- backend の `service/ixac41-pmtiles-generator/src/pmtiles-generator.ts` が tippecanoe を
+  `-Z 5 -z 14 --minimum-zoom=5 --maximum-zoom=14` で実行しており、zoom 5 未満のタイルが
+  アーカイブに存在しない。
+- MapLibre（gl-js / native とも）はソースの maxzoom を超えた場合は overzoom（親タイルの拡大表示）を
+  行うが、minzoom 未満の underzoom は行わないため、zoom < 5 ではレイヤーが一切描画されない。
+- アプリ側のレイヤー定義（`EarthquakeHistoryEstimatedIntensityStyle`）には minzoom 指定はなく、
+  アプリ側で回避する手段はない（タイルデータ自体が存在しないため）。
+
+確認例（`https://tiles.eqmonitor.app/ixac41/20260728162718.pmtiles` のヘッダ）:
+
+```text
+min_zoom 5 / max_zoom 14
+generator_options: tippecanoe ... -Z 5 -z 14 --minimum-zoom=5 --maximum-zoom=14 ...
+```
+
+## 対応（backend リポジトリ側）
+
+1. `runTippecanoe` の `-Z 5` / `--minimum-zoom=5` を引き下げる（例: `-Z 2`）。
+   1 イベントあたりのフィーチャ数は震度階級ごとの数個の Polygon のみなので、低ズームタイルの
+   追加コストはごく小さい。
+2. 既に生成・配信済みの `ixac41/*.pmtiles` は minzoom 5 のままなので、過去イベント分も低ズームで
+   表示したい場合は再生成が必要。
+
+## 備考
+
+- アプリ側の詳細マップのデフォルト zoom は 5.0 / 震央 zoom 6.5（`docs/map_spec_v3.md` 2-9）で、
+  ピンチアウトすると zoom 5 を下回るため、ユーザー操作で普通に到達する範囲。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

推計震度レイヤー（PMTiles）を表示している時に、色がテーマの色になっていない問題を調査・修正しました。あわせて、低ズームで表示されない問題の原因を特定しました。

## 調査結果

対象 PMTiles: `https://tiles.eqmonitor.app/ixac41/20260728162718.pmtiles`

ヘッダ／メタデータを解析したところ、以下が判明しました。

```
min_zoom 5 / max_zoom 14
generator_options: tippecanoe ... -Z 5 -z 14 --minimum-zoom=5 --maximum-zoom=14 ...
vector_layers[0].id = "seismic_intensity"
  fields: fill(String), name(String, "intensity:4"〜"intensity:7"), ...
  fill の値 = JMA 標準色 (#FAE696, #FFE600, #FF9900, #FF2800, #A50021, #B40068)
```

### 1. 色がテーマ色にならない

`EarthquakeHistoryDetailsEstimatedIntensityLayer` は fill/line color に PMTiles の `fill` プロパティ（`['get', 'fill']`）をそのまま使っていました。この `fill` はタイル生成時に **JMA 標準色が焼き込まれている** ため、アプリのテーマ（`EstimatedIntensityColors`）が反映されません。

EEW 推計震度レイヤー（`eew_estimated_intensity_layer.dart`）や地域震度レイヤーは `activeColorSetProvider` のテーマ色を使っており、挙動が不一致でした。

**修正**: タイルの `name` 属性（震度階級 `intensity:4`〜`intensity:7`）を MapLibre の `match` 式でテーマ色（`activeColorSetProvider` → `estimatedIntensity`）にマッピングするよう変更。未知の階級のみタイル側の `fill` にフォールバックします。テーマ変更に追従するよう `useEffect` の依存に色を追加しました。

### 2. 低ズームで表示されない（原因特定のみ）

タイルは backend の `ixac41-pmtiles-generator` が tippecanoe `-Z 5`（minzoom=5）で生成しており、**zoom 5 未満のタイルがアーカイブに存在しません**。MapLibre は maxzoom 超過時の overzoom は行いますが、minzoom 未満の underzoom は行わないため、zoom < 5 でレイヤーが一切描画されません。

詳細マップのデフォルト zoom は 5.0（`docs/map_spec_v3.md` 2-9）で、ピンチアウトすると容易に 5 を下回るため通常操作で到達します。

これは **backend（別リポジトリ `eqmonitor-backend`）側でタイル生成の `-Z` を引き下げる必要がある** ため、本 PR ではアプリ側修正の対象外とし、`docs/todo/750_estimated_intensity_pmtiles_minzoom.md` に対応方針を記録しました。

## 変更内容

- `earthquake_history_details_estimated_intensity_layer.dart`: `fill`/`line` の色をテーマの推計震度色に `match` 式でマッピング。`activeColorSetProvider` を watch し、テーマ変更に追従。
- ライフサイクルテストを更新し、`name` → テーマ色マッピングの検証を追加。
- `docs/map_spec_v3.md`: 推計震度レイヤーの仕様を実態に合わせて更新。
- `docs/todo/750_...md`: 低ズーム未表示問題の backend 対応方針を記録。
- `docs/todo/700_...md`: CI の `flutter-test` が 10 分 timeout で打ち切られる問題を記録。
- `docs/knowledge/20260814_...md`: PMTiles の minzoom は underzoom されない知見を記録。

## テスト

追加・変更したテストは CI 上でも 4 件すべて通っています。

```
✅ 推計震度のフル URL に pmtiles scheme を一度だけ付与する
✅ name 属性をテーマの推計震度色にマッピングする
✅ 固定 ID の推計震度リソースを再適用前に除去する
✅ 推計震度リソースを layer から source の順で除去する
```

## CI 状態（既知の既存問題）

本 PR の変更起因ではない failure が 2 件あります。

- `flutter-analyze`: `app` 配下の既存 lint 負債 1,381 件によるもので、analyze が実際に実行された直近の run（`feat/eqmonitor-map-tile-pipeline`）も同様に failure。`docs/todo/760_existing_eqmonitor_custom_lint_debt.md` に記録済み。変更した lib ファイル単体の analyze は clean です。
- `flutter-test`: ログに失敗テストは 0 件で、`timeout-minutes: 10` に張り付いた `10m17s` で `The operation was canceled.` により打ち切られています。monorepo 全体の実行時間が 10 分に収まらなくなったことが原因で、`docs/todo/700_flutter_test_ci_10min_timeout.md` に記録しました。

いずれも「failure を通すための CI 設定変更」は行っていません。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6d8f5e8-9b80-47af-a2b6-cde426d0d646?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6d8f5e8-9b80-47af-a2b6-cde426d0d646&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

