### PR TITLE
Chore: mise.lock に Linux(ubuntu24.04) 用 swift エントリを追加

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -866,6 +866,13 @@ checksum = "blake3:59936ad2e0cf9b5b0127c605d24182b2209d4e13ae2c652bfbab25a8c0a5b
 [tools.swift."platforms.macos-arm64"]
 checksum = "blake3:2a9e6afeb9f796a60fb8183f4063960c2ff683476f5cf94464332586a9e86cd3"
 
+[[tools.swift]]
+version = "6.3.3"
+backend = "core:swift"
+
+[tools.swift.options]
+swift_platform = "ubuntu24.04"
+
 [[tools.swiftformat]]
 version = "0.62.1"
 backend = "github:nicklockwood/SwiftFormat"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Linux(ubuntu24.04)環境で `mise install` を実行すると、`core:swift` バックエンドが `swift_platform = "ubuntu24.04"` オプション付きの別バリアントを解決し、`mise.lock` に追記されます。この差分を取り込み、Linux 環境でのツール解決を安定させます。

## 変更内容

`mise.lock` の `swift 6.3.3` に、`swift_platform = "ubuntu24.04"` オプションのエントリを追加しました。既存の macOS(arm64) / linux-x64 のエントリはそのまま維持しています。

```toml
[[tools.swift]]
version = "6.3.3"
backend = "core:swift"

[tools.swift.options]
swift_platform = "ubuntu24.04"
```

## 背景

揺れ検知の無効化対応（別 PR）の作業を Linux VM 上で進める際、環境構築で `mise install` を実行したところ生成された副作用の差分です。機能変更とは独立しているため、本 PR として分離しました。

## 影響範囲

`mise.lock` のみの変更で、アプリのコードやビルドには影響しません。macOS でのビルド・署名フローは既存エントリを使うため変化しません。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-143c8695-ee6b-4384-8c5a-3074e41829f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-143c8695-ee6b-4384-8c5a-3074e41829f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

