### PR TITLE
chore: 次のリリースを v3.0.0 に固定しタグ規約を vX.Y.Z へ戻す

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: eqmonitor
 description: An earthquake monitoring Application
 publish_to: "none"
 
-version: 3.0.0
+version: 3.0.0 # x-release-please-version
 
 environment:
   sdk: ^3.14.0-29.0.dev

--- a/docs/knowledge/20260814_release_please_versioning.md
+++ b/docs/knowledge/20260814_release_please_versioning.md
@@ -1,0 +1,64 @@
+# Release Please のバージョン・タグ運用
+
+日付: 2026-08-14
+
+## タグ規約
+
+- リリースタグは `vX.Y.Z` 固定（例: `v3.0.0`）。コンポーネント名を付けない
+  - `release-please-config.json` の `include-component-in-tag: false` で担保する
+  - `deploy-app.yaml` は `v*-beta.*`、`create-beta-release.yaml` は `v${VERSION}-beta.N` を前提にしている
+  - `eqmonitor_workspace-v3.0.0` のような名前になると既存タグ・CHANGELOG の compare リンクと不整合になる
+- Release PR のブランチ名 (`release-please--branches--develop--components--eqmonitor_workspace`) は
+  `include-component-in-tag` の影響を受けない（release-please の `getBranchComponent` はコンポーネント名を常に使う）
+
+## バージョンを任意の値に固定する
+
+conventional commits から計算される値と異なるバージョンを出したい場合は、
+develop に入るコミットの footer に `Release-As` を書く。
+
+```text
+chore: 次のリリースを3.0.0に固定する
+
+Release-As: 3.0.0
+```
+
+- 1回だけ効き、リリース後は自動的に無効になる（後片付け不要）
+- `release-please-config.json` の `release-as` は残り続けるため、**使ったらリリース後に必ず削除する**必要がある。
+  忘れると次回以降も同じバージョンを提案し続けるので、原則 footer 方式を使う
+- squash merge するとメッセージから footer が落ちる可能性がある。merge commit で develop に入れる
+
+## Release PR ブランチを手で編集しないこと
+
+`release-please` は develop への push ごとに実行され、Release PR のブランチを force push で作り直す。
+Release PR 側に手でコミットしても次の push で消えるため、設定変更・バージョン指定は必ず develop 側へ入れる。
+
+## app/pubspec.yaml のコメントを壊さない
+
+`extra-files` に文字列で `app/pubspec.yaml` を指定すると YAML updater が全体を再シリアライズし、
+コメントが全部消える。`app/pubspec.yaml` には次の運用上必須の記述がコメントで書かれているため致命的。
+
+- `flutter.config.enable-native-assets: true`: `package:sqlite3` v3 が build hook で `libsqlite3` を同梱する。
+  無効だと `.so` が同梱されず drift が起動時にクラッシュする
+- `flutter.config.enable-dart-data-assets: true`: `eqmonitor_map` の `hook/build.dart` が生成する `.fmat` を
+  同梱するために必要。`flutter config --enable-dart-data-assets` はマシンごとの global 設定で CI に効かない
+
+そのため `extra-files` は generic updater を使い、バージョン行に注釈を付ける。
+
+```json
+"extra-files": [{ "type": "generic", "path": "app/pubspec.yaml" }]
+```
+
+```yaml
+version: 3.0.0 # x-release-please-version
+```
+
+generic updater は注釈のある行だけを書き換えるのでコメントは保持される。
+`# x-release-please-version` を消すと `app/pubspec.yaml` のバージョンが更新されなくなるので消さない
+（`deploy-app.yaml` は `yq .version app/pubspec.yaml` で参照しており、コメント付きでも読める）。
+
+## 確認コマンド
+
+```bash
+python3 -c "import json; json.load(open('release-please-config.json'))"
+mise exec -- yq .version app/pubspec.yaml -r
+```

--- a/docs/knowledge/20260814_release_please_versioning.md
+++ b/docs/knowledge/20260814_release_please_versioning.md
@@ -27,6 +27,22 @@ Release-As: 3.0.0
   忘れると次回以降も同じバージョンを提案し続けるので、原則 footer 方式を使う
 - squash merge するとメッセージから footer が落ちる可能性がある。merge commit で develop に入れる
 
+### 落とし穴: footer は 500 コミットで期限切れになる
+
+release-please の `commit-search-depth` の既定値は **500**（`release-search-depth` は 400）。
+tip から 500 コミットより深い位置にある `Release-As` は読まれない。
+
+実例: 2026-07-25 の `185511d4`（`chore: release 3.0.0` / `Release-As: 3.0.0`）は
+develop の tip から 822 コミット深くなっていたため無視され、Release PR は `2.7.0` を提案していた。
+
+リリースまでに 500 コミット以上積まれてしまった場合は、footer 付きコミットを積み直す。
+
+```bash
+git commit --allow-empty -m "chore: 次のリリースを3.0.0に固定する" -m "Release-As: 3.0.0"
+```
+
+深さを増やす（`commit-search-depth`）ことも可能だが、CHANGELOG に取り込む範囲も広がるため安易に変えない。
+
 ## Release PR ブランチを手で編集しないこと
 
 `release-please` は develop への push ごとに実行され、Release PR のブランチを force push で作り直す。

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,10 +4,12 @@
     ".": {
       "release-type": "dart",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
+      "include-component-in-tag": false,
       "extra-files": [
-        "app/pubspec.yaml"
+        {
+          "type": "generic",
+          "path": "app/pubspec.yaml"
+        }
       ]
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 目的

Release Please が提案しているリリースは `2.7.0`（[#1540](https://github.com/YumNumm/EQMonitor/pull/1540)）だが、
`app/pubspec.yaml` は既に `3.0.0`、既存タグも `v3.0.0-beta.1` / `v3.0.0-beta.2` であり、
このリリースは **v3.0.0** であるべき。その修正を develop 側へ入れる。

Release PR のブランチは develop への push ごとに release-please が force push で作り直すため、
[#1540](https://github.com/YumNumm/EQMonitor/pull/1540) を直接編集しても消える。設定・バージョン指定は develop に入れる必要がある。

## なぜ 2.7.0 になっていたのか（原因）

`Release-As: 3.0.0` フッター付きコミット `185511d4`（2026-07-25）は既に develop に入っていたが、
develop の tip から **822 コミット**深くなっていた。
release-please の `commit-search-depth` の既定値は **500** なので、このコミットは走査範囲外で読まれず、
直近 500 コミットの conventional commits から `2.6.0 → 2.7.0` が計算されていた。

そのため本 PR で `Release-As: 3.0.0` を積み直す（tip 直下なので確実に読まれる）。

## 変更内容

- `Release-As: 3.0.0` footer 付きコミットで次のリリースを `3.0.0` に固定
  - `release-please-config.json` の `release-as` は使わない（リリース後に削除が必要で、忘れると次回以降も 3.0.0 を提案し続ける）
- `include-component-in-tag: false`
  - タグ・compare リンクを既存規約の `v3.0.0` / `v2.6.0...v3.0.0` に戻す
  - `deploy-app.yaml`（`v*-beta.*`）・`create-beta-release.yaml`（`v${VERSION}-beta.N`）が `v` 付きタグ前提
  - Release PR のブランチ名は `include-component-in-tag` の影響を受けないため、[#1540](https://github.com/YumNumm/EQMonitor/pull/1540) がそのまま更新される（新規 PR は作られない）
- `extra-files` を generic updater に変更 + `app/pubspec.yaml` に `# x-release-please-version` 注釈
  - 文字列指定では YAML updater が `app/pubspec.yaml` を再シリアライズしてコメントを全消去していた
    （`enable-native-assets` / `enable-dart-data-assets` の必須理由コメントが失われる）
  - generic updater は注釈行のみ書き換えるためコメントを保持する
- 1.0.0 未満でしか効かない `bump-minor-pre-major` / `bump-patch-for-minor-pre-major` を削除
- 上記運用を `docs/knowledge/20260814_release_please_versioning.md` に記録

## マージ方法の注意

**merge commit でマージしてください。** squash merge すると `Release-As: 3.0.0` footer がコミットメッセージ末尾から
外れて解釈されない可能性があり、その場合 release-please は再び `2.7.0` を提案する。

## マージ後の想定

release-please が [#1540](https://github.com/YumNumm/EQMonitor/pull/1540) を次の内容で作り直す。

- タイトル: `chore(develop): release 3.0.0`
- `.release-please-manifest.json`: `3.0.0`
- `app/pubspec.yaml`: `version: 3.0.0 # x-release-please-version`（コメント保持）
- CHANGELOG 見出し: `## [3.0.0](.../compare/v2.6.0...v3.0.0)`
- [#1540](https://github.com/YumNumm/EQMonitor/pull/1540) マージ時に作られるタグ: `v3.0.0`

## 動作確認

```bash
python3 -c "import json; json.load(open('release-please-config.json'))"  # config ok
mise exec -- yq .version app/pubspec.yaml -r                             # 3.0.0（deploy-app.yaml と同じ読み方）
```

`Release-As` footer・`commit-search-depth` の既定値・generic updater の挙動は release-please 本体のソースで確認した
（`src/strategies/base.ts` の RELEASE AS note、`src/manifest.ts` の `DEFAULT_COMMIT_SEARCH_DEPTH = 500`、
`src/updaters/generic.ts` の `x-release-please-version`）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-830e8d68-eb14-4b7a-afa1-dbafd280a998?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-830e8d68-eb14-4b7a-afa1-dbafd280a998&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

