### PR TITLE
Fix: Analyzer 診断 1,512 件を 0 件にする

### DIFF
--- a/.github/workflows/wc-check-dart-analyze.yaml
+++ b/.github/workflows/wc-check-dart-analyze.yaml
@@ -51,3 +51,11 @@ jobs:
         run: |
           mise exec -- dart pub get
           mise exec -- dart test
+
+      # tools/ は melos workspace 外のため `melos run test` の対象にならない。
+      # ルール実装の回帰防止としてここで実行する。
+      - name: Test eqmonitor_lints_plugin
+        working-directory: tools/eqmonitor_lints_plugin
+        run: |
+          mise exec -- dart pub get
+          mise exec -- dart test

--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -1,4 +1,9 @@
-include: package:eqmonitor_lints/analysis_options.yaml
+# plugins は pub workspace のルートでしか宣言できない（宣言すると
+# plugins_in_inner_options 警告になる）。ルートの analysis_options.yaml を
+# include することで、そこで宣言された自作 analyzer plugin を引き継ぐ。
+# exclude は宣言元ファイルからの相対パスで解決されるため、app 配下の
+# ネイティブディレクトリを除くには以下の宣言を残す必要がある。
+include: ../analysis_options.yaml
 analyzer:
   errors:
     avoid_implementing_value_types: ignore
@@ -18,18 +23,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-
-plugins:
-  eqmonitor_lints_plugin:
-    path: ../tools/eqmonitor_lints_plugin
-    diagnostics:
-      avoid_stateful_widget: true
-      avoid_null_assertion_operator: true
-      avoid_top_level_functions: true
-      avoid_print: true
-      avoid_eqmonitor_api_in_ui: true
-      avoid_mixed_declaration_categories: true
-  eqmonitor_custom_lints:
-    path: ../tools/eqmonitor_custom_lints
-    diagnostics:
-      avoid_direct_color_scheme: true

--- a/docs/superpowers/plans/2026-08-14-analyzer-diagnostics-cleanup.md
+++ b/docs/superpowers/plans/2026-08-14-analyzer-diagnostics-cleanup.md
@@ -1,0 +1,1887 @@
+# Analyzer 診断ゼロ化 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `melos run analyze`（`dart analyze . --fatal-infos`）の診断 1,512 件を 0 件にする。
+
+**Architecture:** 前半で自作 analyzer plugin の誤検出を正し（`main()` / `@pragma('vm:entry-point')` / テストコード除外）、後半で残る実コードの違反を feature 単位で修正する。plugin 側の変更にはテストを追加し、CI で回帰を防ぐ。
+
+**Tech Stack:** Dart 3.14.0 / Flutter 3.48.0-0.1.pre / analyzer 13 / analysis_server_plugin 0.3.x / melos 7
+
+設計書: `docs/superpowers/specs/2026-08-14-analyzer-diagnostics-cleanup-design.md`
+
+## Global Constraints
+
+- Dart / Flutter コマンドは必ず `mise exec -- ` 経由で実行する。
+- 依存追加は `dart pub add` / `flutter pub add` を使う。`pubspec.yaml` の依存部分を直接編集しない。
+- `*.g.dart` / `*.freezed.dart` などの生成ファイルを手で編集しない。必要なら `dart run build_runner build --delete-conflicting-outputs` で再生成する。
+- 生命に関わる情報（震度・マグニチュード・深さ・座標・警報種別・時刻）に、その場しのぎの固定値フォールバックを入れてはならない。
+- `!`（null アサーション演算子）を新規に導入しない。
+- トップレベル関数（プライベート含む）を新規に定義しない。`main()` と `@pragma('vm:entry-point')` 付きのみ例外。
+- `StatefulWidget` / `ConsumerStatefulWidget` を新規に導入しない。`HookWidget` / `HookConsumerWidget` を使う。
+- Widget にメソッドやゲッターを定義しない。再利用しない Widget は private class として切り出す。
+- 変数宣言と代入を分離しない。`final` による即時代入と switch 式を使う。
+- 2 つ以上の引数を持つ関数・クラスは名前付き引数にする。
+- ログは talker または `dart:developer` の `log()` を使う。`print()` は禁止。
+- コミットメッセージは英語 1 単語の prefix + 日本語 1 行。1 コミット 30〜100 行程度の粒度。
+- `dart format` に準拠する（CI 強制）。
+- `git --no-pager` を使って差分を確認する。
+
+### 検証コマンド
+
+全体検証（最終確認用、約 2〜3 分）:
+
+```bash
+cd /workspace && mise exec -- dart run melos exec -c 1 -- dart analyze . --fatal-infos
+```
+
+パッケージ単位の検証（タスク中に使う）:
+
+```bash
+cd /workspace/app && mise exec -- dart analyze lib/feature/<name> --fatal-infos
+```
+
+テスト実行:
+
+```bash
+cd /workspace/app && mise exec -- flutter test test/feature/<name>
+```
+
+---
+
+## File Structure
+
+### 新規作成
+
+- `tools/eqmonitor_lints_plugin/lib/src/lint_target_scope.dart` — 解析対象パス判定（テストコード除外）
+- `tools/eqmonitor_lints_plugin/lib/src/top_level_function_exemption.dart` — トップレベル関数の許可判定
+- `tools/eqmonitor_lints_plugin/test/lint_target_scope_test.dart`
+- `tools/eqmonitor_lints_plugin/test/top_level_function_exemption_test.dart`
+- `tools/eqmonitor_custom_lints/lib/src/lint_target_scope.dart` — 同上（別パッケージのため複製）
+- `tools/eqmonitor_custom_lints/test/lint_target_scope_test.dart`
+- `app/lib/core/util/nullable_value_requirement.dart` — `orFailBecause` extension
+- `app/test/core/util/nullable_value_requirement_test.dart`
+
+### 変更
+
+- `tools/eqmonitor_lints_plugin/lib/rules/*.dart` — 6 ルール全てにスコープ判定を適用
+- `tools/eqmonitor_custom_lints/lib/rules/avoid_direct_color_scheme.dart` — 同上
+- `tools/eqmonitor_lints_plugin/pubspec.yaml` — `test` を dev_dependencies に追加
+- `app/analysis_options.yaml` — 無効な `plugins:` ブロックを削除
+- `.github/workflows/wc-check-dart-analyze.yaml` — plugin のテストジョブを追加
+- `app/lib/**` — feature 単位の違反修正（Task 8 以降）
+- `packages/seismicity_pmtiles/**` — 標準 lint の修正（Task 6, 7）
+
+---
+
+## Task 1: plugin のテスト基盤とスコープ判定を作る
+
+**Files:**
+- Create: `tools/eqmonitor_lints_plugin/lib/src/lint_target_scope.dart`
+- Create: `tools/eqmonitor_lints_plugin/test/lint_target_scope_test.dart`
+- Modify: `tools/eqmonitor_lints_plugin/pubspec.yaml`
+
+**Interfaces:**
+- Produces: `LintTargetScope.isExcluded({required String path}) -> bool`
+  テストコードのパスなら `true` を返す。`tools/eqmonitor_custom_lints` からも同名で複製利用する。
+
+- [ ] **Step 1: `test` パッケージを dev_dependency に追加**
+
+```bash
+cd /workspace/tools/eqmonitor_lints_plugin
+mise exec -- dart pub add dev:test
+```
+
+Expected: `pubspec.yaml` に `dev_dependencies: test:` が入り、`pub get` が成功する。
+
+- [ ] **Step 2: 失敗するテストを書く**
+
+`tools/eqmonitor_lints_plugin/test/lint_target_scope_test.dart`:
+
+```dart
+import 'package:eqmonitor_lints_plugin/src/lint_target_scope.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LintTargetScope.isExcluded', () {
+    test('test ディレクトリ配下は除外する', () {
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/test/feature/eew/a_test.dart'),
+        isTrue,
+      );
+    });
+
+    test('integration_test 配下は除外する', () {
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/integration_test/app_test.dart'),
+        isTrue,
+      );
+    });
+
+    test('test_driver 配下は除外する', () {
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/test_driver/driver.dart'),
+        isTrue,
+      );
+    });
+
+    test('lib 配下は除外しない', () {
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/lib/feature/eew/eew_page.dart'),
+        isFalse,
+      );
+    });
+
+    test('ファイル名やディレクトリ名の部分一致では除外しない', () {
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/lib/core/util/latest_test_helper.dart'),
+        isFalse,
+      );
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/lib/feature/contest/page.dart'),
+        isFalse,
+      );
+    });
+
+    test('Windows 形式の区切り文字でも除外する', () {
+      expect(
+        LintTargetScope.isExcluded(path: r'C:\repo\app\test\feature\a_test.dart'),
+        isTrue,
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 3: テストが失敗することを確認**
+
+```bash
+cd /workspace/tools/eqmonitor_lints_plugin
+mise exec -- dart test
+```
+
+Expected: FAIL。`lint_target_scope.dart` が存在しないため import エラー。
+
+- [ ] **Step 4: 実装を書く**
+
+`tools/eqmonitor_lints_plugin/lib/src/lint_target_scope.dart`:
+
+```dart
+/// 自作 lint ルールの適用対象を判定する。
+///
+/// テストコードは本番コードと設計上の要求が異なるため、
+/// 自作ルールの適用対象外とする（標準 lint は従来どおり適用される）。
+class LintTargetScope {
+  const LintTargetScope._();
+
+  static const _excludedDirectories = {
+    'test',
+    'integration_test',
+    'test_driver',
+  };
+
+  static bool isExcluded({required String path}) {
+    final segments = path.replaceAll(r'\', '/').split('/');
+    return segments.any(_excludedDirectories.contains);
+  }
+}
+```
+
+- [ ] **Step 5: テストが通ることを確認**
+
+```bash
+cd /workspace/tools/eqmonitor_lints_plugin
+mise exec -- dart test
+```
+
+Expected: PASS（6 テスト全て）。出力に警告が出ないこと。
+
+- [ ] **Step 6: 自パッケージの解析を確認**
+
+```bash
+cd /workspace/tools/eqmonitor_lints_plugin
+mise exec -- dart analyze . --fatal-infos
+```
+
+Expected: `No issues found!`
+
+- [ ] **Step 7: コミット**
+
+```bash
+cd /workspace
+git add tools/eqmonitor_lints_plugin
+git commit -m "Feat: lint 適用対象からテストコードを除く判定を追加"
+```
+
+---
+
+## Task 2: 全ルールにスコープ判定を適用する
+
+**Files:**
+- Modify: `tools/eqmonitor_lints_plugin/lib/rules/avoid_top_level_functions.dart`
+- Modify: `tools/eqmonitor_lints_plugin/lib/rules/avoid_null_assertion_operator.dart`
+- Modify: `tools/eqmonitor_lints_plugin/lib/rules/avoid_stateful_widget.dart`
+- Modify: `tools/eqmonitor_lints_plugin/lib/rules/avoid_print_call.dart`
+- Modify: `tools/eqmonitor_lints_plugin/lib/rules/avoid_eqmonitor_api_in_ui.dart`
+- Modify: `tools/eqmonitor_lints_plugin/lib/rules/avoid_mixed_declaration_categories.dart`
+
+**Interfaces:**
+- Consumes: Task 1 の `LintTargetScope.isExcluded({required String path})`
+
+各ルールの `registerNodeProcessors` は現在このような形をしている。
+
+```dart
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) => registry.addFunctionDeclaration(this, _Visitor(this));
+```
+
+`avoid_eqmonitor_api_in_ui.dart` だけは既にパス判定を持っており、こちらが取得方法の参考になる。
+
+```dart
+    final path = context.definingUnit.unit.declaredFragment?.source.fullName;
+```
+
+- [ ] **Step 1: `avoid_top_level_functions.dart` にスコープ判定を入れる**
+
+```dart
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    final path = context.definingUnit.unit.declaredFragment?.source.fullName;
+    if (path != null && LintTargetScope.isExcluded(path: path)) {
+      return;
+    }
+    registry.addFunctionDeclaration(this, _Visitor(this));
+  }
+```
+
+`import 'package:eqmonitor_lints_plugin/src/lint_target_scope.dart';` を追加する。
+既存の import は相対パス（`import 'rules/...'`）ではなく、ルールファイル間では
+`package:` import を使う。`main.dart` の既存 import 形式に合わせること。
+
+- [ ] **Step 2: 残り 5 ルールに同じ判定を入れる**
+
+`avoid_null_assertion_operator.dart` / `avoid_stateful_widget.dart` /
+`avoid_print_call.dart` / `avoid_mixed_declaration_categories.dart` に、
+Step 1 と同じ早期 return を追加する。登録するビジターの種類だけが異なる。
+
+`avoid_eqmonitor_api_in_ui.dart` は既存のパス判定に条件を足す。
+
+```dart
+    final path = context.definingUnit.unit.declaredFragment?.source.fullName;
+    if (path == null ||
+        LintTargetScope.isExcluded(path: path) ||
+        !_isInUiLayer(path)) {
+      return;
+    }
+    registry.addImportDirective(this, _Visitor(this));
+```
+
+- [ ] **Step 3: 解析とテストを実行**
+
+```bash
+cd /workspace/tools/eqmonitor_lints_plugin
+mise exec -- dart analyze . --fatal-infos && mise exec -- dart test
+```
+
+Expected: `No issues found!` かつ全テスト PASS。
+
+- [ ] **Step 4: app のテストコードで診断が消えたことを確認**
+
+```bash
+cd /workspace/app
+mise exec -- dart analyze test --fatal-infos 2>&1 | tail -5
+```
+
+Expected: `avoid_top_level_functions` / `avoid_null_assertion_operator` /
+`avoid_eqmonitor_api_in_ui` が 1 件も出ない。
+
+**注意:** この時点で `app/analysis_options.yaml` の `plugins:` は
+`plugins_in_inner_options` 警告により無視されており、実際に効いているのは
+リポジトリルートの `analysis_options.yaml` である。効果が出ない場合は
+リポジトリルートから `mise exec -- dart analyze app/test --fatal-infos` を試すこと。
+
+- [ ] **Step 5: コミット**
+
+```bash
+cd /workspace
+git add tools/eqmonitor_lints_plugin
+git commit -m "Fix: 自作 lint ルールをテストコードに適用しないよう修正"
+```
+
+---
+
+## Task 3: `main()` と `@pragma('vm:entry-point')` を許可する
+
+**Files:**
+- Create: `tools/eqmonitor_lints_plugin/lib/src/top_level_function_exemption.dart`
+- Create: `tools/eqmonitor_lints_plugin/test/top_level_function_exemption_test.dart`
+- Modify: `tools/eqmonitor_lints_plugin/lib/rules/avoid_top_level_functions.dart`
+
+**Interfaces:**
+- Consumes: Task 2 完了後の `avoid_top_level_functions.dart`
+- Produces: `TopLevelFunctionExemption.isExempt({required FunctionDeclaration node}) -> bool`
+
+現在 `avoid_top_level_functions.dart` の `_Visitor` は `@riverpod` / `@Riverpod` のみ
+除外している。この判定を専用クラスへ移し、許可条件を 3 つに増やす。
+
+1. 関数名が `main`
+2. `@riverpod` / `@Riverpod` アノテーションが付いている
+3. `@pragma('vm:entry-point')` が付いている（第 1 引数が文字列リテラル `'vm:entry-point'`）
+
+`@pragma` 全般を許可してはいけない。`vm:prefer-inline` など無関係な pragma で
+ルールを回避できてしまうため、第 1 引数の文字列リテラル値まで検査する。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tools/eqmonitor_lints_plugin/test/top_level_function_exemption_test.dart`:
+
+```dart
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:eqmonitor_lints_plugin/src/top_level_function_exemption.dart';
+import 'package:test/test.dart';
+
+List<FunctionDeclaration> _declarationsOf(String source) {
+  final unit = parseString(content: source, throwIfDiagnostics: false).unit;
+  return unit.declarations.whereType<FunctionDeclaration>().toList();
+}
+
+void main() {
+  group('TopLevelFunctionExemption.isExempt', () {
+    test('main は許可する', () {
+      final declarations = _declarationsOf('void main() {}');
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isTrue,
+      );
+    });
+
+    test('@riverpod は許可する', () {
+      final declarations = _declarationsOf('@riverpod\nint foo(Ref ref) => 0;');
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isTrue,
+      );
+    });
+
+    test('@Riverpod(keepAlive: true) は許可する', () {
+      final declarations = _declarationsOf(
+        '@Riverpod(keepAlive: true)\nint foo(Ref ref) => 0;',
+      );
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isTrue,
+      );
+    });
+
+    test("@pragma('vm:entry-point') は許可する", () {
+      final declarations = _declarationsOf(
+        "@pragma('vm:entry-point')\nvoid worker(SendPort port) {}",
+      );
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isTrue,
+      );
+    });
+
+    test("@pragma('vm:prefer-inline') は許可しない", () {
+      final declarations = _declarationsOf(
+        "@pragma('vm:prefer-inline')\nvoid helper() {}",
+      );
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isFalse,
+      );
+    });
+
+    test('引数のない @pragma は許可しない', () {
+      final declarations = _declarationsOf('@pragma\nvoid helper() {}');
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isFalse,
+      );
+    });
+
+    test('素のトップレベル関数は許可しない', () {
+      final declarations = _declarationsOf('void helper() {}');
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isFalse,
+      );
+    });
+
+    test('main という名前でもクラスのメソッドは対象外（トップレベルのみ判定）', () {
+      final declarations = _declarationsOf('void mainHandler() {}');
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isFalse,
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+cd /workspace/tools/eqmonitor_lints_plugin
+mise exec -- dart test test/top_level_function_exemption_test.dart
+```
+
+Expected: FAIL。`top_level_function_exemption.dart` が存在しない。
+
+- [ ] **Step 3: 実装を書く**
+
+`tools/eqmonitor_lints_plugin/lib/src/top_level_function_exemption.dart`:
+
+```dart
+import 'package:analyzer/dart/ast/ast.dart';
+
+/// トップレベル関数のうち、言語仕様・フレームワーク上その形でしか
+/// 書けないものを [AvoidTopLevelFunctions] の対象外と判定する。
+class TopLevelFunctionExemption {
+  const TopLevelFunctionExemption._();
+
+  static const _entryPointFunctionName = 'main';
+  static const _riverpodAnnotationNames = {'riverpod', 'Riverpod'};
+  static const _pragmaAnnotationName = 'pragma';
+  static const _vmEntryPointPragma = 'vm:entry-point';
+
+  static bool isExempt({required FunctionDeclaration node}) {
+    if (node.name.lexeme == _entryPointFunctionName) {
+      return true;
+    }
+    return node.metadata.any(_isExemptAnnotation);
+  }
+
+  static bool _isExemptAnnotation(Annotation annotation) {
+    final name = annotation.name.name;
+    if (_riverpodAnnotationNames.contains(name)) {
+      return true;
+    }
+    if (name != _pragmaAnnotationName) {
+      return false;
+    }
+    final firstArgument = annotation.arguments?.arguments.firstOrNull;
+    return firstArgument is SimpleStringLiteral &&
+        firstArgument.value == _vmEntryPointPragma;
+  }
+}
+```
+
+`firstOrNull` は `dart:collection` ではなく `package:collection` 由来ではないかを確認すること。
+Dart 3 の `Iterable.firstOrNull` は `package:collection` の拡張である。
+依存を増やしたくない場合は `annotation.arguments?.arguments` が空かどうかを
+明示的に判定してから `first` を取る形にしてよい。
+
+- [ ] **Step 4: ルール本体を書き換える**
+
+`avoid_top_level_functions.dart` の `_Visitor` から `_hasRiverpodAnnotation` と
+`_riverpodNames` を削除し、`TopLevelFunctionExemption` を使う。
+
+```dart
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    if (node.parent is! CompilationUnit) {
+      return;
+    }
+    if (TopLevelFunctionExemption.isExempt(node: node)) {
+      return;
+    }
+    rule.reportAtToken(node.name);
+  }
+```
+
+- [ ] **Step 5: テストと解析を実行**
+
+```bash
+cd /workspace/tools/eqmonitor_lints_plugin
+mise exec -- dart test && mise exec -- dart analyze . --fatal-infos
+```
+
+Expected: 全テスト PASS、`No issues found!`
+
+- [ ] **Step 6: app 側で `main()` の診断が消えたことを確認**
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib/main.dart --fatal-infos
+```
+
+Expected: `main` に対する `avoid_top_level_functions` が消え、
+`_main` と `_registerNotificationChannelIfNeeded` の 2 件だけが残る。
+
+```bash
+mise exec -- dart analyze app/lib/feature/location/data/jma_map_isolate.dart --fatal-infos
+```
+
+Expected: `jmaMapWorkerEntryPoint` の診断が消える。
+
+- [ ] **Step 7: コミット**
+
+```bash
+cd /workspace
+git add tools/eqmonitor_lints_plugin
+git commit -m "Fix: main と vm:entry-point をトップレベル関数禁止の対象外にする"
+```
+
+---
+
+## Task 4: eqmonitor_custom_lints にもスコープ判定を適用する
+
+**Files:**
+- Create: `tools/eqmonitor_custom_lints/lib/src/lint_target_scope.dart`
+- Create: `tools/eqmonitor_custom_lints/test/lint_target_scope_test.dart`
+- Modify: `tools/eqmonitor_custom_lints/lib/rules/avoid_direct_color_scheme.dart`
+
+**Interfaces:**
+- Consumes: Task 1 で作った `LintTargetScope` と同一の仕様（別パッケージのため実装を複製する）
+
+`tools/eqmonitor_custom_lints` は `tools/eqmonitor_lints_plugin` とは独立した
+pub パッケージであり、相互に依存していない。共有パッケージを新設するのは
+2 パッケージ・1 クラスに対して過剰なので、実装を複製する。
+
+`avoid_direct_color_scheme.dart` は既に `_isAllowed(path)` によるパス判定を持つ。
+そこに `LintTargetScope.isExcluded` を足す。
+
+- [ ] **Step 1: テストを書く**
+
+`tools/eqmonitor_custom_lints/test/lint_target_scope_test.dart` に、
+Task 1 Step 2 と同じ 6 ケースを `package:eqmonitor_custom_lints/src/lint_target_scope.dart`
+に対して書く。テスト本文は Task 1 Step 2 のコードをそのまま使い、import 先だけ変える。
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+cd /workspace/tools/eqmonitor_custom_lints
+mise exec -- dart pub get && mise exec -- dart test test/lint_target_scope_test.dart
+```
+
+Expected: FAIL（import 解決不可）。
+
+- [ ] **Step 3: 実装をコピーする**
+
+`tools/eqmonitor_custom_lints/lib/src/lint_target_scope.dart` に
+Task 1 Step 4 と同一の `LintTargetScope` を作る。
+
+- [ ] **Step 4: ルールに適用する**
+
+`avoid_direct_color_scheme.dart` の `registerNodeProcessors` を次のようにする。
+
+```dart
+    final path = context.definingUnit.unit.declaredFragment?.source.fullName;
+    if (path != null &&
+        (LintTargetScope.isExcluded(path: path) || _isAllowed(path))) {
+      return;
+    }
+```
+
+既存の `_isAllowed` の意味と条件の順序を変えないこと。
+
+- [ ] **Step 5: テストと解析を実行**
+
+```bash
+cd /workspace/tools/eqmonitor_custom_lints
+mise exec -- dart test && mise exec -- dart analyze . --fatal-infos
+```
+
+Expected: 既存の `avoid_direct_color_scheme_test.dart` も含め全 PASS、`No issues found!`
+
+- [ ] **Step 6: コミット**
+
+```bash
+cd /workspace
+git add tools/eqmonitor_custom_lints
+git commit -m "Fix: avoid_direct_color_scheme をテストコードに適用しないよう修正"
+```
+
+---
+
+## Task 5: Analyzer 設定の重複を解消し CI にテストを追加する
+
+**Files:**
+- Modify: `app/analysis_options.yaml`
+- Modify: `.github/workflows/wc-check-dart-analyze.yaml`
+
+**Interfaces:**
+- Consumes: Task 2〜4 で変更した plugin
+
+`app/analysis_options.yaml` の `plugins:` ブロックは
+`WARNING|STATIC_WARNING|PLUGINS_IN_INNER_OPTIONS|/workspace/app/analysis_options.yaml|23|3|428`
+を出している。pub workspace のメンバーパッケージでは `plugins:` を宣言できず、
+この 14 行は無視されている。実際に効いているのはリポジトリルートの
+`analysis_options.yaml` の同名ブロックである。
+
+- [ ] **Step 1: 削除前に plugin ルールが効いていることを記録する**
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib/core/component/chip --fatal-infos 2>&1 | tail -20
+```
+
+Expected: `avoid_null_assertion_operator` が複数件出る。この件数を控える。
+
+- [ ] **Step 2: `app/analysis_options.yaml` から `plugins:` ブロックを削除**
+
+22 行目の空行以降、`plugins:` からファイル末尾までを削除する。
+`analyzer:` セクション（`errors:` と `exclude:`）は残す。
+
+削除後の `app/analysis_options.yaml` は次のようになる。
+
+```yaml
+include: package:eqmonitor_lints/analysis_options.yaml
+analyzer:
+  errors:
+    avoid_implementing_value_types: ignore
+    avoid_print: ignore
+    document_ignores: ignore
+    invalid_annotation_target: ignore
+    lines_longer_than_80_chars: ignore
+    unnecessary_async: ignore
+    unnecessary_cast: ignore
+  exclude:
+    - "**/DerivedData/**"
+    - "**/build/**"
+    - "build/**"
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+```
+
+- [ ] **Step 3: plugin ルールが引き続き効くことを確認**
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib/core/component/chip --fatal-infos 2>&1 | tail -20
+```
+
+Expected: Step 1 と同じ `avoid_null_assertion_operator` の件数が出る。
+`plugins_in_inner_options` の警告は消えている。
+
+**もし plugin ルールが効かなくなった場合**は削除を取り消し、
+代わりにルート `analysis_options.yaml` 側の重複を検討する。
+この場合は BLOCKED として報告すること。どちらの設定が正なのかは
+実測で決める必要があり、勝手にどちらかを消してはいけない。
+
+- [ ] **Step 4: CI に plugin のテストジョブを追加**
+
+`.github/workflows/wc-check-dart-analyze.yaml` の
+`Test eqmonitor_custom_lints` ステップの直後に、同形のステップを追加する。
+
+```yaml
+      # tools/ は melos workspace 外のため `melos run test` の対象にならない。
+      # ルール実装の回帰防止としてここで実行する。
+      - name: Test eqmonitor_lints_plugin
+        working-directory: tools/eqmonitor_lints_plugin
+        run: |
+          mise exec -- dart pub get
+          mise exec -- dart test
+```
+
+- [ ] **Step 5: workflow の構文を検証**
+
+```bash
+cd /workspace
+mise exec -- actionlint .github/workflows/wc-check-dart-analyze.yaml
+```
+
+Expected: 出力なし（エラーなし）。
+
+- [ ] **Step 6: 全体の診断件数を計測して記録する**
+
+```bash
+cd /workspace
+mise exec -- dart run melos exec -c 1 -- dart analyze . --format machine --fatal-infos > /tmp/analyze-after-phase-a.txt 2>&1
+grep -c '^\(ERROR\|WARNING\|INFO\)|' /tmp/analyze-after-phase-a.txt
+```
+
+Expected: 716 件。1,512 件から 796 件（誤検出 4 + テスト 792）減り、
+さらに設定重複 1 件が消えた計算になる。
+件数が 716 から大きくずれる場合は、ずれた理由を報告に書くこと。
+
+- [ ] **Step 7: コミット**
+
+```bash
+cd /workspace
+git add app/analysis_options.yaml .github/workflows/wc-check-dart-analyze.yaml
+git commit -m "Fix: app の無効な plugins 設定を削除し plugin テストを CI に追加"
+```
+
+---
+
+## Task 6: seismicity_pmtiles の lib 配下の lint を解消する
+
+**Files:**
+- Modify: `packages/seismicity_pmtiles/lib/src/decoder/seismicity_chunk_builder.dart`（`prefer_initializing_formals` 2 件）
+- Modify: `packages/seismicity_pmtiles/lib/src/decoder/seismicity_dataset_accumulator.dart`（`prefer_initializing_formals` 2 件）
+- Modify: `packages/seismicity_pmtiles/lib/src/decoder/seismicity_decoder_worker_entry.dart`（`type_annotate_public_apis` 2 件）
+- Modify: `packages/seismicity_pmtiles/lib/src/decoder/seismicity_pmtiles_decode_operation.dart`（`prefer_initializing_formals` 1 件）
+- Modify: `packages/seismicity_pmtiles/lib/src/decoder/seismicity_pmtiles_decoder_runner.dart`（`library_private_types_in_public_api` 3 件、`type_init_formals` 1 件）
+- Modify: `packages/seismicity_pmtiles/lib/src/reader/seismicity_pmtiles_network_random_access_reader.dart`（`prefer_initializing_formals` 3 件）
+
+合計 14 件。
+
+**Interfaces:**
+- Produces: このパッケージの公開 API に変更を入れる場合、利用側（`app`）のビルドを壊さないこと。
+  `library_private_types_in_public_api` の解消でプライベート型を公開する場合、
+  型名の変更が `app/lib/feature/seismicity` に波及しないか確認する。
+
+- [ ] **Step 1: 現状の診断を確認**
+
+```bash
+cd /workspace/packages/seismicity_pmtiles
+mise exec -- dart analyze lib --fatal-infos
+```
+
+Expected: 14 件の INFO。ファイルと行番号を控える。
+
+- [ ] **Step 2: 既存テストが通ることを確認（ベースライン）**
+
+```bash
+cd /workspace/packages/seismicity_pmtiles
+mise exec -- dart test
+```
+
+Expected: 全 PASS。以降の修正でこの結果が変わらないこと。
+
+- [ ] **Step 3: `prefer_initializing_formals` を修正（8 件）**
+
+コンストラクタ本体での代入を初期化仮引数に置き換える。
+
+```dart
+// 修正前
+class Foo {
+  Foo({required int value}) : _value = value;
+  final int _value;
+}
+
+// 修正後（フィールド名が引数名と同じにできる場合）
+class Foo {
+  Foo({required this.value});
+  final int value;
+}
+```
+
+プライベートフィールドのままにしたい場合は初期化仮引数にできないため、
+その箇所は `// ignore: prefer_initializing_formals` ではなく、
+フィールドを公開して `final` にするか、現状維持が妥当かを判断する。
+判断に迷う場合は報告に書くこと。
+
+- [ ] **Step 4: `type_annotate_public_apis` を修正（2 件）**
+
+公開 API の引数・戻り値に明示的な型注釈を付ける。推論されている型を
+`mise exec -- dart analyze` の出力と実装から確認して正確に書く。
+`dynamic` を書いてはいけない。
+
+- [ ] **Step 5: `library_private_types_in_public_api` と `type_init_formals` を修正（4 件）**
+
+`seismicity_pmtiles_decoder_runner.dart` の公開 API がプライベート型を露出している。
+プライベート型を公開型に格上げするか、公開 API のシグネチャを公開型に変える。
+公開型に格上げする場合は `lib/seismicity_pmtiles.dart`（バレルファイル）の
+export に追加が必要かを確認する。
+
+- [ ] **Step 6: 解析とテストを実行**
+
+```bash
+cd /workspace/packages/seismicity_pmtiles
+mise exec -- dart analyze lib --fatal-infos && mise exec -- dart test
+```
+
+Expected: `No issues found!` かつ Step 2 と同じテスト結果。
+
+- [ ] **Step 7: 利用側のビルドが壊れていないことを確認**
+
+```bash
+cd /workspace/app
+mise exec -- dart analyze lib/feature/seismicity --fatal-infos 2>&1 | grep -c 'error' || true
+```
+
+Expected: `error` が 0 件（plugin の warning は Task 8 以降で扱うため残ってよい）。
+
+- [ ] **Step 8: コミット**
+
+```bash
+cd /workspace
+git add packages/seismicity_pmtiles/lib
+git commit -m "Fix: seismicity_pmtiles の lib 配下の lint を解消"
+```
+
+---
+
+## Task 7: seismicity_pmtiles の test / benchmark 配下の lint を解消する
+
+**Files:**
+- Modify: `packages/seismicity_pmtiles/benchmark/**`（12 件）
+- Modify: `packages/seismicity_pmtiles/test/**`（47 件）
+
+内訳は次のとおり。
+
+| コード | 件数 |
+| --- | ---: |
+| `avoid_types_on_closure_parameters` | 12 |
+| `prefer_const_declarations` | 12 |
+| `type_annotate_public_apis` | 9 |
+| `unnecessary_import` | 4 |
+| `prefer_const_constructors` | 4 |
+| `lines_longer_than_80_chars` | 4 |
+| `omit_local_variable_types` | 3 |
+| `specify_nonobvious_property_types` | 3 |
+| `avoid_redundant_argument_values` | 4 |
+| `comment_references` | 1 |
+| `avoid_catches_without_on_clauses` | 1 |
+| `unnecessary_async` | 1 |
+| `unnecessary_const` | 1 |
+
+**Interfaces:**
+- Consumes: Task 6 で変更した `lib` の公開 API
+
+- [ ] **Step 1: 現状の診断一覧を取得**
+
+```bash
+cd /workspace/packages/seismicity_pmtiles
+mise exec -- dart analyze test benchmark --fatal-infos
+```
+
+Expected: 59 件の INFO。
+
+- [ ] **Step 2: ベースラインのテスト結果を記録**
+
+```bash
+cd /workspace/packages/seismicity_pmtiles
+mise exec -- dart test
+```
+
+Expected: 全 PASS。
+
+- [ ] **Step 3: 自動修正できるものを `dart fix` で処理する**
+
+```bash
+cd /workspace/packages/seismicity_pmtiles
+mise exec -- dart fix --dry-run
+```
+
+出力を確認し、意図しない変更が含まれないことを確かめてから適用する。
+
+```bash
+mise exec -- dart fix --apply
+```
+
+`dart fix` は `prefer_const_declarations` / `prefer_const_constructors` /
+`unnecessary_import` / `unnecessary_const` / `omit_local_variable_types` などを
+自動修正できる。適用後に必ず差分を確認する。
+
+```bash
+cd /workspace && git --no-pager diff packages/seismicity_pmtiles
+```
+
+- [ ] **Step 4: 残りを手で修正する**
+
+`avoid_catches_without_on_clauses`（`seismicity_pmtiles_decode_benchmark.dart`）は
+catch する例外型を特定して `on` 句を付ける。何が飛んでくるか不明な場合、
+握りつぶさずに `on Object catch (e, st)` として再送出するか、
+ベンチマーク用途として妥当な扱いを選ぶ。
+
+`lines_longer_than_80_chars` は改行位置を調整する。文字列リテラルの場合は
+隣接文字列リテラルの連結で分割する。
+
+`avoid_types_on_closure_parameters` はクロージャ引数の型注釈を外す。
+外すと型推論が効かなくなる箇所では、外側の型を明示する。
+
+- [ ] **Step 5: 解析・テスト・フォーマットを実行**
+
+```bash
+cd /workspace/packages/seismicity_pmtiles
+mise exec -- dart format . && mise exec -- dart analyze . --fatal-infos && mise exec -- dart test
+```
+
+Expected: `No issues found!` かつ Step 2 と同じテスト結果。
+
+- [ ] **Step 6: コミット**
+
+```bash
+cd /workspace
+git add packages/seismicity_pmtiles
+git commit -m "Fix: seismicity_pmtiles の test / benchmark の lint を解消"
+```
+
+---
+
+## Task 8: `orFailBecause` extension を追加する
+
+**Files:**
+- Create: `app/lib/core/util/nullable_value_requirement.dart`
+- Create: `app/test/core/util/nullable_value_requirement_test.dart`
+
+**Interfaces:**
+- Produces: `extension NullableValueRequirement<T extends Object> on T?` の
+  `T orFailBecause(String because)`。Task 9 以降の `!` 除去で使う。
+
+このタスクは Task 9 以降で使う道具を用意する。
+**この extension は最後の手段**であり、Task 9 以降では次の順に検討する。
+
+1. `?.` による null 伝播（受け手が null を許容する場合）
+2. `if (x != null)` / パターンマッチによるフロー解析
+3. 型を非 null にする構造変更
+4. ドメイン上正しい既定値がある場合のみ `??`
+5. 上記が全て不可能で、不変条件により非 null が保証される場合のみ `orFailBecause`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`app/test/core/util/nullable_value_requirement_test.dart`:
+
+```dart
+import 'package:eqmonitor/core/util/nullable_value_requirement.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('orFailBecause', () {
+    test('非 null の値はそのまま返す', () {
+      const int? value = 42;
+      expect(value.orFailBecause('テスト'), 42);
+    });
+
+    test('null の場合は理由を含む StateError を投げる', () {
+      const String? value = null;
+      expect(
+        () => value.orFailBecause('直前に containsKey で存在を確認済み'),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('直前に containsKey で存在を確認済み'),
+          ),
+        ),
+      );
+    });
+
+    test('false や 0 は null ではないのでそのまま返す', () {
+      const bool? falseValue = false;
+      const int? zero = 0;
+      expect(falseValue.orFailBecause('テスト'), isFalse);
+      expect(zero.orFailBecause('テスト'), 0);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/core/util/nullable_value_requirement_test.dart
+```
+
+Expected: FAIL（import 解決不可）。
+
+- [ ] **Step 3: 実装を書く**
+
+`app/lib/core/util/nullable_value_requirement.dart`:
+
+```dart
+/// 不変条件により非 null が保証される値を、理由付きで取り出す。
+extension NullableValueRequirement<T extends Object> on T? {
+  /// [because] には「なぜ非 null と言えるのか」を書く。
+  ///
+  /// 想定が破れた場合は理由付きの [StateError] となる。`!` の
+  /// `Null check operator used on a null value` と違い、
+  /// クラッシュログから前提条件を特定できる。
+  ///
+  /// `?.` によるnull 伝播・フロー解析・型の見直しで解決できる箇所では
+  /// これを使わないこと。
+  T orFailBecause(String because) {
+    final value = this;
+    if (value == null) {
+      throw StateError('必ず非 null のはずの値が null でした: $because');
+    }
+    return value;
+  }
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/core/util/nullable_value_requirement_test.dart
+```
+
+Expected: 3 テスト PASS。
+
+- [ ] **Step 5: 解析を確認**
+
+```bash
+cd /workspace/app
+mise exec -- dart analyze lib/core/util/nullable_value_requirement.dart --fatal-infos
+```
+
+Expected: `No issues found!`
+
+- [ ] **Step 6: コミット**
+
+```bash
+cd /workspace
+git add app/lib/core/util/nullable_value_requirement.dart app/test/core/util/nullable_value_requirement_test.dart
+git commit -m "Feat: 不変条件を明示して非 null 値を取り出す extension を追加"
+```
+
+---
+
+## Task 9: UI 層の eqmonitor_api 直接参照を解消する
+
+**Files:**
+- Modify: `app/lib/feature/tsunami/**/ui/**`（10 件）
+- Modify: `app/lib/feature/telegram_list/**/ui/**`（3 件）
+- Modify: `app/lib/feature/home/**/ui/**`（2 件）
+- Modify: `app/lib/feature/shake_detection/ui/**`（2 件）
+- Modify: `app/lib/feature/changelog/ui/**`（1 件）
+- Modify: `app/lib/feature/settings/**/ui/**`（1 件）
+- Modify: `app/lib/feature/start/ui/**`（1 件）
+- 対応する `data/model/` にドメイン型と変換 extension を追加
+
+合計 20 件。
+
+**Interfaces:**
+- Consumes: Task 8 の `orFailBecause`（必要な場合のみ）
+- Produces: 各 feature の `data/model/` に追加したドメイン型。
+  Task 10 以降で同じ feature を触るタスクがこれらを参照する。
+
+現在の違反ファイル一覧を取得する。
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib --fatal-infos 2>&1 | grep avoid_eqmonitor_api_in_ui
+```
+
+- [ ] **Step 1: 違反箇所を分類する**
+
+各 import について、UI が API 型の何を使っているかを調べる。
+
+- API 型をそのまま画面に表示している → `data/model/` にドメイン型を作り変換する
+- API の enum だけ使っている → ドメイン側の enum に変換する
+- 実は使われていない未使用 import → 削除する
+
+分類結果を報告に書くこと。
+
+- [ ] **Step 2: 未使用 import を削除する**
+
+```bash
+cd /workspace/app
+mise exec -- dart fix --dry-run
+```
+
+`unused_import` として検出されるものがあれば適用する。
+
+- [ ] **Step 3: ドメイン型への変換を実装する**
+
+プロジェクト規約に従い、`data/model/` に型を置き、API 型は `as api` で
+エイリアス import して変換 extension を書く。
+
+```dart
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+
+extension TsunamiWarningModelConverter on api.TsunamiWarning {
+  TsunamiWarningModel toModel() => TsunamiWarningModel(...);
+}
+```
+
+**新しい型を作る前に、既存の型に同じものがないか必ず検索すること。**
+同じフィールド構成の型が別 feature にあれば、それを再利用する。
+
+Freezed を使う場合は生成が必要である。
+
+```bash
+cd /workspace/app
+mise exec -- dart run build_runner build --delete-conflicting-outputs
+```
+
+- [ ] **Step 4: 該当 feature のテストを実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/tsunami test/feature/telegram_list test/feature/home test/feature/shake_detection
+```
+
+Expected: 全 PASS。
+
+- [ ] **Step 5: 診断が消えたことを確認**
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib --fatal-infos 2>&1 | grep -c avoid_eqmonitor_api_in_ui || echo 0
+```
+
+Expected: `0`
+
+- [ ] **Step 6: コミット**
+
+feature 単位で分割してコミットする（1 コミット 30〜100 行）。
+
+```bash
+cd /workspace
+git add app/lib/feature/tsunami
+git commit -m "Refactor: 津波 UI から API 型への直接依存を除去"
+```
+
+---
+
+## Task 10: freezed モデルの同居を解消する
+
+**Files:**
+- Modify: `app/lib/feature/tsunami/data/model/timeline/tsunami_timeline.dart`（6 件のうち複数）
+- Modify: `app/lib/feature/map/features/icon/data/model/intensity_icon.dart`（3 件）
+- Modify: `app/lib/core/provider/estimated_intensity/provider/estimated_intensity_provider.dart`（1 件）
+- Modify: `app/lib/feature/notification/data/model/test_notification_delivery.dart`（1 件）
+- Modify: `app/lib/feature/seismicity/data/logic/seismicity_depth_projection.dart`（1 件）
+- Create: 分離先の新規ファイル（各 freezed モデルにつき 1 ファイル）
+
+合計 12 件。
+
+**Interfaces:**
+- Produces: 分離した freezed モデルの新ファイル。import 元の修正が必要。
+
+`avoid_mixed_declaration_categories` は「freezed モデルは他の class /
+Riverpod プロバイダと同一ファイルに定義できない」というルールである。
+
+- [ ] **Step 1: 違反箇所の一覧を取得**
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib --fatal-infos 2>&1 | grep avoid_mixed_declaration_categories
+```
+
+- [ ] **Step 2: freezed モデルを専用ファイルへ移す**
+
+1 ファイル 1 モデルとし、ファイル名はモデル名の snake_case にする。
+`part 'xxx.freezed.dart';` と `part 'xxx.g.dart';` の宣言も移す。
+
+- [ ] **Step 3: コード生成をやり直す**
+
+```bash
+cd /workspace/app
+mise exec -- dart run build_runner build --delete-conflicting-outputs
+```
+
+移動前のファイルに対応する `*.freezed.dart` / `*.g.dart` が
+残っていないことを確認する（`--delete-conflicting-outputs` で削除される）。
+
+- [ ] **Step 4: import を修正する**
+
+```bash
+cd /workspace/app
+mise exec -- dart analyze lib --fatal-infos 2>&1 | grep -E 'undefined|uri_does_not_exist' || echo "import OK"
+```
+
+- [ ] **Step 5: テストを実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/tsunami test/feature/map test/feature/seismicity test/core
+```
+
+Expected: 全 PASS。
+
+- [ ] **Step 6: 診断が消えたことを確認**
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib --fatal-infos 2>&1 | grep -c avoid_mixed_declaration_categories || echo 0
+```
+
+Expected: `0`
+
+- [ ] **Step 7: コミット**
+
+```bash
+cd /workspace
+git add app/lib
+git commit -m "Refactor: freezed モデルを専用ファイルへ分離"
+```
+
+---
+
+## Task 11: StatefulWidget と ColorScheme 直接参照を解消する
+
+**Files:**
+- Modify: `app/lib/feature/home/ui/component/map/home_map_view.dart:160`
+- Modify: `app/lib/feature/map/ui/map_operation_queue_scope.dart:37`
+- Modify: `app/lib/feature/settings/features/display_settings/ui/theme/theme_editor_page.dart:260`
+- Modify: `app/lib/feature/settings/features/notification_settings/ui/page/override_edit_page.dart:392`
+- Modify: `app/lib/feature/start/ui/component/forced_update_dialog.dart:16`
+- Modify: `app/lib/feature/tsunami/ui/components/tsunami_region_list.dart:200`
+- Modify: `app/lib/feature/tsunami/ui/components/tsunami_warning_history_overlay.dart:8`
+- Modify: `app/lib/feature/live_monitor/**`（`avoid_direct_color_scheme` 4 件）
+
+合計 11 件（StatefulWidget 7 件 + ColorScheme 4 件）。
+
+**Interfaces:**
+- Consumes: `flutter_hooks` の `useState` / `useEffect` / `useAnimationController` など
+
+- [ ] **Step 1: 各 StatefulWidget の State が何を持っているか調べる**
+
+`initState` / `dispose` / `setState` の使われ方を確認し、
+対応する hook に置き換える計画を立てる。
+
+| State の要素 | 置き換え先 |
+| --- | --- |
+| `AnimationController` | `useAnimationController` |
+| `TextEditingController` | `useTextEditingController` |
+| `ScrollController` | `useScrollController` |
+| ローカルな可変値 + `setState` | `useState` |
+| `initState` / `dispose` | `useEffect`（cleanup を返す） |
+| `TickerProviderStateMixin` | `useSingleTickerProvider` |
+
+**`AnimationController` を含むものは慎重に扱うこと。** `vsync` の扱いを誤ると
+アニメーションが動かなくなる。変換後に実際の描画で確認できない環境のため、
+Widget テストで振る舞いを固定してから変換する。
+
+- [ ] **Step 2: 変換前に振る舞いを固定する Widget テストを書く**
+
+テストが無い Widget については、変換前の振る舞いを検証するテストを先に書く。
+既にテストがある場合はそれを使う。
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/tsunami test/feature/home test/feature/settings test/feature/map
+```
+
+Expected: 変換前に全 PASS すること。
+
+- [ ] **Step 3: `HookWidget` / `HookConsumerWidget` へ変換する**
+
+- [ ] **Step 4: `avoid_direct_color_scheme` 4 件を修正する**
+
+`Theme.of(context).colorScheme` を `context.designSystem.colorTheme` に置き換える。
+対応する色が `colorTheme` に無い場合は、勝手に近い色で代用せず報告すること。
+
+- [ ] **Step 5: テストと解析を実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/tsunami test/feature/home test/feature/settings test/feature/map test/feature/live_monitor
+cd /workspace
+mise exec -- dart analyze app/lib --fatal-infos 2>&1 | grep -cE 'avoid_stateful_widget|avoid_direct_color_scheme' || echo 0
+```
+
+Expected: テスト全 PASS、診断 `0`。
+
+- [ ] **Step 6: コミット**
+
+```bash
+cd /workspace
+git add app/lib app/test
+git commit -m "Refactor: StatefulWidget を Hook 化し ColorScheme 直接参照を除去"
+```
+
+---
+
+## Task 12: core 配下のトップレベル関数と `!` を解消する
+
+**Files:**
+- Modify: `app/lib/core/provider/**`（33 件: top_level 17 / null_assertion 15 / mixed 1）
+- Modify: `app/lib/core/component/**`（17 件: null_assertion 12 / top_level 5）
+- Modify: `app/lib/core/theme/**`（12 件: top_level 6 / null_assertion 6）
+- Modify: `app/lib/core/util/**`（11 件: top_level 11）
+- Modify: `app/lib/core/designsystem/**`（3 件: null_assertion 3）
+- Modify: `app/lib/core/hook/**`（2 件: top_level 2）
+- Modify: `app/lib/main.dart`（2 件: `_main` と `_registerNotificationChannelIfNeeded`）
+
+合計 80 件。
+
+**Interfaces:**
+- Consumes: Task 8 の `orFailBecause`
+- Produces: 切り出した専用クラスと Riverpod プロバイダ。
+  Task 13 以降が `core` のこれらを参照する可能性がある。
+
+**注意:** `app/lib/core/provider/estimated_intensity/worker/estimated_intensity_isolate.dart` の
+`_workerEntryPoint` は `@pragma('vm:entry-point')` 付きのため Task 3 で除外済みである。
+この関数を移動してはならない。
+
+**注意:** `app/lib/core/hook/use_*.dart` の `useXxx()` は flutter_hooks の
+規約でトップレベル関数である必要がある。クラス化すると hooks が機能しない。
+これらは Task 3 の除外条件に含まれていないため、次のいずれかで対応する。
+
+1. `// ignore: eqmonitor_lints_plugin/avoid_top_level_functions` を理由コメント付きで置く
+2. `TopLevelFunctionExemption` に hooks の除外条件を足す（Task 3 の変更を拡張）
+
+**判断が必要なため、Step 1 で必ず報告して指示を仰ぐこと。**
+
+- [ ] **Step 1: `core/hook` の扱いを確認して報告する**
+
+`app/lib/core/hook/use_map_operation_queue.dart` と
+`app/lib/core/hook/use_sheet_controller.dart` の 2 件について、
+上記 1 と 2 のどちらを採るか NEEDS_CONTEXT として報告し、指示を待つ。
+
+- [ ] **Step 2: `core/util` のトップレベル関数をクラス化する（11 件）**
+
+プロジェクト規約に従い、処理を行う専用クラスを別ファイルに切り出す。
+Riverpod の DI が必要かどうかは、その関数が状態や他の依存を必要とするかで決める。
+純粋な計算（`log10` など）は `static` を持つユーティリティクラスで十分である。
+
+```dart
+// 修正前（app/lib/core/util/xxx.dart）
+double log10(double x) => math.log(x) / math.ln10;
+
+// 修正後
+class MathUtil {
+  const MathUtil._();
+  static double log10(double x) => math.log(x) / math.ln10;
+}
+```
+
+- [ ] **Step 3: `core/provider` `core/theme` `core/component` のトップレベル関数を処理する**
+
+`showXxxDialog` / `showXxxSheet` のような UI 操作を伴うものは、
+プロジェクト規約の `data/flow/` または `ui/action/` の考え方に沿って
+`XxxAction` クラスへ切り出し、Riverpod で DI する。
+`ref` / `context` はコンストラクタではなくメソッド引数で受け取る。
+
+- [ ] **Step 4: `!` を除去する（36 件）**
+
+設計書の優先順位に従う。
+
+1. `?.` で足りるか
+2. `if (x != null)` で確定できるか
+3. 型を非 null にできるか
+4. ドメイン上正しい既定値があるか
+5. 上記が全て不可なら `orFailBecause('理由')`
+
+`orFailBecause` を使った箇所は、ファイル・行・理由を報告に列挙すること。
+
+`app/lib/core/theme/migration/theme_migration.dart` の 6 件は
+テーマ移行処理であり、`app/test/core/theme/migration/theme_migration_test.dart` に
+15 件のテストがある。変換前後でこのテストが通ることを必ず確認する。
+
+- [ ] **Step 5: `main.dart` の `_main` と `_registerNotificationChannelIfNeeded` を処理する**
+
+`_main` は `main()` から呼ばれる初期化処理である。
+`main()` 内にインライン展開するか、`AppBootstrap` のようなクラスに切り出す。
+アプリの起動シーケンスであり壊すと全機能が動かなくなるため、
+処理順序を一切変えないこと。
+
+- [ ] **Step 6: テストと解析を実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/core
+cd /workspace
+mise exec -- dart analyze app/lib/core app/lib/main.dart --fatal-infos
+```
+
+Expected: テスト全 PASS、`No issues found!`
+
+- [ ] **Step 7: コミット**
+
+ディレクトリ単位で分割してコミットする。
+
+```bash
+cd /workspace
+git add app/lib/core/util
+git commit -m "Refactor: core/util のトップレベル関数をクラス化"
+```
+
+---
+
+## Task 13: earthquake_history の data 層を解消する
+
+**Files:**
+- Modify: `app/lib/feature/earthquake_history/data/**`
+
+`feature/earthquake_history` は 160 件（null_assertion 83 / top_level 77）と最大である。
+このタスクでは `data/` 配下のみを扱う。
+
+現状の内訳（実測）:
+
+| ファイル | 件数 |
+| --- | ---: |
+| `data/model/debug/earthquake_vxse_debug_reducer.dart` | 32 |
+| `data/notifier/earthquake_vxse_debug_editor_controller.dart` | 25 |
+| その他 `data/` 配下 | 残り |
+
+**Interfaces:**
+- Consumes: Task 8 の `orFailBecause`
+- Produces: 切り出したクラス。Task 14（ui 層）が参照する可能性がある。
+
+- [ ] **Step 1: 対象一覧を取得**
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib/feature/earthquake_history/data --fatal-infos
+```
+
+- [ ] **Step 2: 既存テストのベースラインを取る**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/earthquake_history
+```
+
+Expected: 全 PASS。件数を控える。
+
+- [ ] **Step 3: トップレベル関数をクラス化する**
+
+`earthquake_vxse_debug_reducer.dart` は reducer であり、
+状態遷移ロジックがトップレベル関数に分かれている可能性が高い。
+`EarthquakeVxseDebugReducer` クラスのメソッドとしてまとめる。
+
+規約により**クラス内のプライベートメソッドも原則禁止**である。
+ただし本タスクの主目的はトップレベル関数の解消であり、
+プライベートメソッド化は診断を消すには十分である。
+過剰な分割を避け、まずはトップレベル関数の解消に集中すること。
+
+- [ ] **Step 4: `!` を除去する**
+
+震源・震度・マグニチュードを扱うコードである。
+**固定値フォールバックを絶対に入れないこと。** 値が無い場合は
+`null` のまま扱うか、呼び出し元まで `null` を伝播させる。
+
+- [ ] **Step 5: テストと解析を実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/earthquake_history
+cd /workspace
+mise exec -- dart analyze app/lib/feature/earthquake_history/data --fatal-infos
+```
+
+Expected: Step 2 と同じテスト結果、`No issues found!`
+
+- [ ] **Step 6: コミット**
+
+```bash
+cd /workspace
+git add app/lib/feature/earthquake_history/data
+git commit -m "Refactor: 地震履歴 data 層のトップレベル関数と null アサーションを解消"
+```
+
+---
+
+## Task 14: earthquake_history の ui 層を解消する
+
+**Files:**
+- Modify: `app/lib/feature/earthquake_history/ui/**`
+
+**Interfaces:**
+- Consumes: Task 13 で切り出したクラス、Task 8 の `orFailBecause`
+
+主な対象（実測）:
+
+| ファイル | 件数 |
+| --- | ---: |
+| `ui/components/shindo_db_hypocenter_information_card.dart` | 16 |
+| `ui/components/region_picker_map_page.dart` | 10 |
+| `ui/components/earthquake_history_map_popup.dart` | 9 |
+| `ui/components/modal/earthquake_vxse_debug_editor.dart` | 9 |
+
+`theme.textTheme.titleSmall!` 系の `!` が多い。これらは
+`style:` パラメータが `TextStyle?` を受け取るため `?.` で解決できる。
+
+```dart
+// 修正前
+style: theme.textTheme.titleSmall!.copyWith(color: foo)
+
+// 修正後
+style: theme.textTheme.titleSmall?.copyWith(color: foo)
+```
+
+- [ ] **Step 1: 対象一覧を取得**
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib/feature/earthquake_history/ui --fatal-infos
+```
+
+- [ ] **Step 2: `?.` で解決できるものを先に処理する**
+
+`style:` `child:` など null を受け付けるパラメータへの `!` を `?.` に変える。
+1 件ずつ、受け手の型が nullable であることを確認してから変える。
+
+- [ ] **Step 3: 残りの `!` を処理する**
+
+`region_picker_map_page.dart:48` の `city!.property!.code` のような
+連鎖は、フロー解析で解決する。
+
+```dart
+// 修正前
+resolvedCode.value = city!.property!.code;
+
+// 修正後
+final property = city?.property;
+if (property != null) {
+  resolvedCode.value = property.code;
+}
+```
+
+`null` の場合に何もしないのが正しいか、それとも別の扱いが必要かを
+その場のロジックから判断すること。判断できない場合は報告する。
+
+- [ ] **Step 4: トップレベル関数を処理する**
+
+- [ ] **Step 5: テストと解析を実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/earthquake_history
+cd /workspace
+mise exec -- dart analyze app/lib/feature/earthquake_history --fatal-infos
+```
+
+Expected: テスト全 PASS、`No issues found!`
+
+- [ ] **Step 6: コミット**
+
+```bash
+cd /workspace
+git add app/lib/feature/earthquake_history/ui
+git commit -m "Refactor: 地震履歴 UI の null アサーションを解消"
+```
+
+---
+
+## Task 15: settings feature を解消する
+
+**Files:**
+- Modify: `app/lib/feature/settings/**`（91 件: null_assertion 63 / top_level 25、StatefulWidget と API import は Task 9・11 で処理済み）
+
+主な対象（実測）:
+
+| ファイル | 件数 |
+| --- | ---: |
+| `children/config/debug/tsunami/tsunami_telegram_timeline_debug_page.dart` | 21 |
+| `children/config/debug/jma_map/debug_jma_map_page.dart` | 16 |
+| `children/config/debug/shared_preferences/debug_shared_preferences_page.dart` | 12 |
+
+デバッグ画面が中心である。これらは開発者向け機能であり、
+本番ユーザーには見えないが、コード品質基準は同じく適用する。
+
+**Interfaces:**
+- Consumes: Task 8 の `orFailBecause`
+
+- [ ] **Step 1: 対象一覧を取得**
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib/feature/settings --fatal-infos
+```
+
+- [ ] **Step 2: ベースラインのテストを実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/settings
+```
+
+- [ ] **Step 3: `!` を除去する（63 件）**
+
+- [ ] **Step 4: トップレベル関数を処理する（25 件）**
+
+- [ ] **Step 5: テストと解析を実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/settings
+cd /workspace
+mise exec -- dart analyze app/lib/feature/settings --fatal-infos
+```
+
+Expected: テスト全 PASS、`No issues found!`
+
+- [ ] **Step 6: コミット**
+
+サブディレクトリ単位で分割してコミットする。
+
+---
+
+## Task 16: tsunami / eew feature を解消する
+
+**Files:**
+- Modify: `app/lib/feature/tsunami/**`（残り: null_assertion 44）
+- Modify: `app/lib/feature/eew/**`（42 件: null_assertion 33 / top_level 9）
+
+主な対象（実測）:
+
+| ファイル | 件数 |
+| --- | ---: |
+| `tsunami/data/model/tracking/tracked_tsunami_timeline.dart` | 35 |
+| `eew/ui/components/eew_table.dart` | 8 |
+
+**津波警報と緊急地震速報を扱う、本アプリで最も生命に関わる領域である。**
+振る舞いを 1 ミリも変えてはならない。
+
+**Interfaces:**
+- Consumes: Task 8 の `orFailBecause`、Task 9 で作った津波のドメイン型、Task 10 で分離したモデル
+
+- [ ] **Step 1: ベースラインのテストを実行して件数を控える**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/tsunami test/feature/eew
+```
+
+Expected: 全 PASS。テスト数を報告に記録する。
+
+- [ ] **Step 2: `tracked_tsunami_timeline.dart` の 35 件を処理する**
+
+このファイルは津波電文の時系列追跡であり、
+`app/test/feature/tsunami/tracked_tsunami_timeline_test.dart` にテストがある。
+1 箇所直すごとにテストを回すこと。
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/tsunami/tracked_tsunami_timeline_test.dart
+```
+
+- [ ] **Step 3: 残りの tsunami / eew の違反を処理する**
+
+- [ ] **Step 4: テストと解析を実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/tsunami test/feature/eew
+cd /workspace
+mise exec -- dart analyze app/lib/feature/tsunami app/lib/feature/eew --fatal-infos
+```
+
+Expected: Step 1 と同じテスト結果、`No issues found!`
+
+- [ ] **Step 5: コミット**
+
+```bash
+cd /workspace
+git add app/lib/feature/tsunami
+git commit -m "Refactor: 津波電文追跡の null アサーションを解消"
+```
+
+---
+
+## Task 17: home / map / live_monitor feature を解消する
+
+**Files:**
+- Modify: `app/lib/feature/home/**`（残り: null_assertion 23 / top_level 8）
+- Modify: `app/lib/feature/map/**`（残り: top_level 12 / null_assertion 9）
+- Modify: `app/lib/feature/live_monitor/**`（残り: top_level 25）
+
+合計 77 件（Task 9〜11 で処理済みの分を除く）。
+
+**Interfaces:**
+- Consumes: Task 8 の `orFailBecause`、Task 10 で分離した `intensity_icon` のモデル
+
+- [ ] **Step 1: 対象一覧を取得**
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib/feature/home app/lib/feature/map app/lib/feature/live_monitor --fatal-infos
+```
+
+- [ ] **Step 2: ベースラインのテストを実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/home test/feature/map test/feature/live_monitor
+```
+
+- [ ] **Step 3: 違反を処理する**
+
+`home/ui/component/map/layer/**` は MapLibre のレイヤー操作であり、
+`_updateGeoJsonIfChanged` のような差分更新処理がトップレベル関数になっている。
+レイヤーごとの専用クラスへ切り出す。地図描画は自動テストで検証しにくいため、
+処理の順序と条件分岐を変えないこと。
+
+- [ ] **Step 4: テストと解析を実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test test/feature/home test/feature/map test/feature/live_monitor
+cd /workspace
+mise exec -- dart analyze app/lib/feature/home app/lib/feature/map app/lib/feature/live_monitor --fatal-infos
+```
+
+Expected: テスト全 PASS、`No issues found!`
+
+- [ ] **Step 5: コミット**
+
+---
+
+## Task 18: 残る feature をすべて解消する
+
+**Files:**
+- Modify: `app/lib/feature/nied/**`（14 件）
+- Modify: `app/lib/feature/location/**`（12 件）
+- Modify: `app/lib/feature/knet_waveform/**`（11 件）
+- Modify: `app/lib/feature/devices/**`（9 件）
+- Modify: `app/lib/feature/telegram_list/**`（残り 6 件）
+- Modify: `app/lib/feature/onboarding/**`（8 件）
+- Modify: `app/lib/feature/feed/**`（7 件）
+- Modify: `app/lib/feature/intensity_history/**`（7 件）
+- Modify: `app/lib/feature/seismicity/**`（残り 6 件）
+- Modify: `app/lib/feature/kyoshin_monitor/**`（6 件）
+- Modify: `app/lib/feature/parameter/**`（6 件）
+- Modify: `app/lib/feature/qzss_dcr/**`（6 件）
+- Modify: `app/lib/feature/asset_pack/**`（4 件）
+- Modify: `app/lib/feature/eew_history/**`（3 件）
+- Modify: `app/lib/feature/fnet_catalog/**`（2 件）
+- Modify: `app/lib/feature/telemetry/**`（2 件）
+- Modify: `app/lib/feature/ads/**`（1 件）
+- Modify: `app/lib/feature/debug/**`（1 件）
+- Modify: `app/lib/feature/shake_detection/**`（残り 1 件）
+
+合計 112 件程度（先行タスクの結果により前後する）。
+
+**注意:** `app/lib/feature/location/data/jma_map_isolate.dart` の
+`jmaMapWorkerEntryPoint` は `@pragma('vm:entry-point')` 付きのため
+Task 3 で除外済みである。移動してはならない。
+
+**Interfaces:**
+- Consumes: Task 8 の `orFailBecause`
+
+- [ ] **Step 1: 残っている診断の全一覧を取得する**
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib --fatal-infos 2>&1 | tee /tmp/remaining.txt | tail -3
+```
+
+Task 9〜17 の結果次第で残件が変わるため、ここで実測する。
+
+- [ ] **Step 2: ベースラインのテストを実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test
+```
+
+Expected: 全 PASS。テスト数を報告に記録する。
+
+- [ ] **Step 3: feature ごとに処理する**
+
+件数の多い順に処理し、feature 単位でコミットする。
+
+- [ ] **Step 4: app 全体の解析が通ることを確認**
+
+```bash
+cd /workspace/app
+mise exec -- dart analyze . --fatal-infos
+```
+
+Expected: `No issues found!`
+
+- [ ] **Step 5: app の全テストを実行**
+
+```bash
+cd /workspace/app
+mise exec -- flutter test
+```
+
+Expected: Step 2 と同じ結果。
+
+- [ ] **Step 6: コミット**
+
+---
+
+## Task 19: 全体検証と知見の記録
+
+**Files:**
+- Create: `docs/knowledge/20260814_analyzer-plugin-scope-and-exemptions.md`
+
+**Interfaces:**
+- Consumes: Task 1〜18 の全変更
+
+- [ ] **Step 1: 全パッケージの解析を実行**
+
+```bash
+cd /workspace
+mise exec -- dart run melos exec -c 1 -- dart analyze . --fatal-infos
+```
+
+Expected: 全 28 パッケージが `SUCCESS`。
+
+- [ ] **Step 2: 全パッケージのテストを実行**
+
+```bash
+cd /workspace
+mise exec -- dart run melos run test
+```
+
+Expected: 全 PASS。
+
+- [ ] **Step 3: plugin のテストを実行**
+
+```bash
+cd /workspace/tools/eqmonitor_lints_plugin && mise exec -- dart test
+cd /workspace/tools/eqmonitor_custom_lints && mise exec -- dart test
+```
+
+Expected: 全 PASS。
+
+- [ ] **Step 4: フォーマットを確認**
+
+```bash
+cd /workspace
+mise exec -- dart format --output=none --set-exit-if-changed app packages tools
+```
+
+Expected: 差分なし。
+
+- [ ] **Step 5: 知見を記録する**
+
+`docs/knowledge/20260814_analyzer-plugin-scope-and-exemptions.md` に次を書く。
+
+- 自作 analyzer plugin の適用範囲（テストコード除外）と、その判定を `LintTargetScope` で一元管理していること
+- `avoid_top_level_functions` の許可条件 3 つ（`main` / `@riverpod` / `@pragma('vm:entry-point')`）と、`@pragma` を第 1 引数まで検査する理由
+- `plugins:` は pub workspace のルートでのみ有効であること（`app/analysis_options.yaml` に置いても無視される）
+- `tools/` 配下は melos workspace 外のため `melos run test` の対象外であり、CI に個別ジョブが必要なこと
+- `orFailBecause` の使いどころと使ってはいけない場面
+- Linux 環境で `mise install` する際、`swift` と `gcloud` の導入に失敗する場合は
+  `MISE_DISABLE_TOOLS="swift,gcloud"` で回避できること
+
+- [ ] **Step 6: コミット**
+
+```bash
+cd /workspace
+git add docs/knowledge/20260814_analyzer-plugin-scope-and-exemptions.md
+git commit -m "Docs: Analyzer plugin の適用範囲と除外条件の知見を記録"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage**
+
+| 設計書の要件 | 対応タスク |
+| --- | --- |
+| テストコードを plugin 対象外にする | Task 1, 2, 4 |
+| `main()` を許可する | Task 3 |
+| `@pragma('vm:entry-point')` を許可する | Task 3 |
+| `@pragma` 全般は許可しない | Task 3 Step 1 のテストで担保 |
+| plugin にテストを追加する | Task 1, 3, 4 |
+| plugin を CI のテスト対象にする | Task 5 |
+| Analyzer 設定の重複を解消する | Task 5 |
+| `orFailBecause` を追加する | Task 8 |
+| `!` 除去の優先順位を守る | Task 8 の記述 + Task 12〜18 |
+| `seismicity_pmtiles` の 73 件 | Task 6, 7 |
+| `app/lib` の 643 件 | Task 9〜18 |
+| 全 28 パッケージ SUCCESS の確認 | Task 19 |
+| 知見の記録 | Task 19 |
+
+**2. Placeholder scan**
+
+Task 18 の件数「112 件程度」は先行タスクの結果に依存するため、
+Step 1 で実測する手順を置いた。これは placeholder ではなく計測手順である。
+
+Task 12 の `core/hook` の扱いは 2 案を提示し、実装者に判断させず
+NEEDS_CONTEXT で報告させる形にした。
+
+**3. Type consistency**
+
+- `LintTargetScope.isExcluded({required String path}) -> bool` は Task 1 で定義し、Task 2・4 で同じ名前・同じシグネチャで使う。
+- `TopLevelFunctionExemption.isExempt({required FunctionDeclaration node}) -> bool` は Task 3 で定義し、同 Task 内で使う。
+- `orFailBecause(String because) -> T` は Task 8 で定義し、Task 12〜18 で使う。

--- a/docs/superpowers/plans/2026-08-14-analyzer-diagnostics-cleanup.md
+++ b/docs/superpowers/plans/2026-08-14-analyzer-diagnostics-cleanup.md
@@ -29,16 +29,46 @@
 
 ### 検証コマンド
 
+**最重要:** 自作 analyzer plugin は **パッケージのルートを解析対象に指定したときしか動かない**。
+`dart analyze app/lib/feature/settings` のようにサブディレクトリを指定すると
+plugin のルールが 1 件も発火せず、`No issues found!` と表示されてしまう。
+これは実測で確認済みである（`dart analyze app` = 647 件、`dart analyze app/lib` = 0 件）。
+
+したがって `app` の診断を確認するときは、必ず次の形を使う。
+
+```bash
+cd /workspace && mise exec -- dart analyze app --fatal-infos
+```
+
+特定の feature だけを見たい場合は、全体を解析してから絞り込む。
+
+```bash
+cd /workspace && mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'lib/feature/settings'
+```
+
+件数を数える場合は machine 形式を使う。
+
+```bash
+cd /workspace
+mise exec -- dart analyze app --format machine --fatal-infos > /tmp/analyze.txt 2>&1
+grep -c '^\(ERROR\|WARNING\|INFO\)|' /tmp/analyze.txt
+grep -c 'lib/feature/settings' /tmp/analyze.txt
+```
+
+`app` 全体の解析には約 60〜90 秒かかる。これは避けられないので、
+1 箇所直すたびに実行せず、まとめて直してから確認すること。
+
 全体検証（最終確認用、約 2〜3 分）:
 
 ```bash
 cd /workspace && mise exec -- dart run melos exec -c 1 -- dart analyze . --fatal-infos
 ```
 
-パッケージ単位の検証（タスク中に使う）:
+`packages/seismicity_pmtiles` には plugin が適用されていないため、
+こちらはサブディレクトリ指定でも標準 lint が正しく出る。
 
 ```bash
-cd /workspace/app && mise exec -- dart analyze lib/feature/<name> --fatal-infos
+cd /workspace/packages/seismicity_pmtiles && mise exec -- dart analyze lib --fatal-infos
 ```
 
 テスト実行:
@@ -511,14 +541,14 @@ Expected: 全テスト PASS、`No issues found!`
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib/main.dart --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'lib/main.dart'
 ```
 
 Expected: `main` に対する `avoid_top_level_functions` が消え、
 `_main` と `_registerNotificationChannelIfNeeded` の 2 件だけが残る。
 
 ```bash
-mise exec -- dart analyze app/lib/feature/location/data/jma_map_isolate.dart --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'jma_map_isolate.dart'
 ```
 
 Expected: `jmaMapWorkerEntryPoint` の診断が消える。
@@ -622,7 +652,7 @@ git commit -m "Fix: avoid_direct_color_scheme をテストコードに適用し�
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib/core/component/chip --fatal-infos 2>&1 | tail -20
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'lib/core/component/chip'
 ```
 
 Expected: `avoid_null_assertion_operator` が複数件出る。この件数を控える。
@@ -661,7 +691,7 @@ analyzer:
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib/core/component/chip --fatal-infos 2>&1 | tail -20
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'lib/core/component/chip'
 ```
 
 Expected: Step 1 と同じ `avoid_null_assertion_operator` の件数が出る。
@@ -801,8 +831,8 @@ Expected: `No issues found!` かつ Step 2 と同じテスト結果。
 - [ ] **Step 7: 利用側のビルドが壊れていないことを確認**
 
 ```bash
-cd /workspace/app
-mise exec -- dart analyze lib/feature/seismicity --fatal-infos 2>&1 | grep -c 'error' || true
+cd /workspace
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep -c 'error' || true
 ```
 
 Expected: `error` が 0 件（plugin の warning は Task 8 以降で扱うため残ってよい）。
@@ -1019,11 +1049,11 @@ Expected: 3 テスト PASS。
 - [ ] **Step 5: 解析を確認**
 
 ```bash
-cd /workspace/app
-mise exec -- dart analyze lib/core/util/nullable_value_requirement.dart --fatal-infos
+cd /workspace
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'nullable_value_requirement'
 ```
 
-Expected: `No issues found!`
+Expected: 出力なし（この新規ファイルに対する診断が 1 件も無い）。
 
 - [ ] **Step 6: コミット**
 
@@ -1058,7 +1088,7 @@ git commit -m "Feat: 不変条件を明示して非 null 値を取り出す exte
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib --fatal-infos 2>&1 | grep avoid_eqmonitor_api_in_ui
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep avoid_eqmonitor_api_in_ui
 ```
 
 - [ ] **Step 1: 違反箇所を分類する**
@@ -1116,7 +1146,7 @@ Expected: 全 PASS。
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib --fatal-infos 2>&1 | grep -c avoid_eqmonitor_api_in_ui || echo 0
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep -c avoid_eqmonitor_api_in_ui || echo 0
 ```
 
 Expected: `0`
@@ -1155,7 +1185,7 @@ Riverpod プロバイダと同一ファイルに定義できない」という�
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib --fatal-infos 2>&1 | grep avoid_mixed_declaration_categories
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep avoid_mixed_declaration_categories
 ```
 
 - [ ] **Step 2: freezed モデルを専用ファイルへ移す**
@@ -1177,7 +1207,7 @@ mise exec -- dart run build_runner build --delete-conflicting-outputs
 
 ```bash
 cd /workspace/app
-mise exec -- dart analyze lib --fatal-infos 2>&1 | grep -E 'undefined|uri_does_not_exist' || echo "import OK"
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep -E 'undefined|uri_does_not_exist' || echo "import OK"
 ```
 
 - [ ] **Step 5: テストを実行**
@@ -1193,7 +1223,7 @@ Expected: 全 PASS。
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib --fatal-infos 2>&1 | grep -c avoid_mixed_declaration_categories || echo 0
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep -c avoid_mixed_declaration_categories || echo 0
 ```
 
 Expected: `0`
@@ -1268,7 +1298,7 @@ Expected: 変換前に全 PASS すること。
 cd /workspace/app
 mise exec -- flutter test test/feature/tsunami test/feature/home test/feature/settings test/feature/map test/feature/live_monitor
 cd /workspace
-mise exec -- dart analyze app/lib --fatal-infos 2>&1 | grep -cE 'avoid_stateful_widget|avoid_direct_color_scheme' || echo 0
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep -cE 'avoid_stateful_widget|avoid_direct_color_scheme' || echo 0
 ```
 
 Expected: テスト全 PASS、診断 `0`。
@@ -1329,7 +1359,7 @@ MapOperationScheduler useMapOperationQueue() {
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib/core/hook --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'lib/core/hook'
 ```
 
 Expected: `No issues found!`
@@ -1391,7 +1421,7 @@ class MathUtil {
 cd /workspace/app
 mise exec -- flutter test test/core
 cd /workspace
-mise exec -- dart analyze app/lib/core app/lib/main.dart --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep -E 'lib/core/|lib/main.dart'
 ```
 
 Expected: テスト全 PASS、`No issues found!`
@@ -1432,7 +1462,7 @@ git commit -m "Refactor: core/util のトップレベル関数をクラス化"
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib/feature/earthquake_history/data --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'lib/feature/earthquake_history/data'
 ```
 
 - [ ] **Step 2: 既存テストのベースラインを取る**
@@ -1467,7 +1497,7 @@ Expected: 全 PASS。件数を控える。
 cd /workspace/app
 mise exec -- flutter test test/feature/earthquake_history
 cd /workspace
-mise exec -- dart analyze app/lib/feature/earthquake_history/data --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'lib/feature/earthquake_history/data'
 ```
 
 Expected: Step 2 と同じテスト結果、`No issues found!`
@@ -1514,7 +1544,7 @@ style: theme.textTheme.titleSmall?.copyWith(color: foo)
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib/feature/earthquake_history/ui --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'lib/feature/earthquake_history/ui'
 ```
 
 - [ ] **Step 2: `?.` で解決できるものを先に処理する**
@@ -1549,7 +1579,7 @@ if (property != null) {
 cd /workspace/app
 mise exec -- flutter test test/feature/earthquake_history
 cd /workspace
-mise exec -- dart analyze app/lib/feature/earthquake_history --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'lib/feature/earthquake_history'
 ```
 
 Expected: テスト全 PASS、`No issues found!`
@@ -1587,7 +1617,7 @@ git commit -m "Refactor: 地震履歴 UI の null アサーションを解消"
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib/feature/settings --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'lib/feature/settings'
 ```
 
 - [ ] **Step 2: ベースラインのテストを実行**
@@ -1607,7 +1637,7 @@ mise exec -- flutter test test/feature/settings
 cd /workspace/app
 mise exec -- flutter test test/feature/settings
 cd /workspace
-mise exec -- dart analyze app/lib/feature/settings --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep 'lib/feature/settings'
 ```
 
 Expected: テスト全 PASS、`No issues found!`
@@ -1665,7 +1695,7 @@ mise exec -- flutter test test/feature/tsunami/tracked_tsunami_timeline_test.dar
 cd /workspace/app
 mise exec -- flutter test test/feature/tsunami test/feature/eew
 cd /workspace
-mise exec -- dart analyze app/lib/feature/tsunami app/lib/feature/eew --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep -E 'lib/feature/(tsunami|eew)/'
 ```
 
 Expected: Step 1 と同じテスト結果、`No issues found!`
@@ -1696,7 +1726,7 @@ git commit -m "Refactor: 津波電文追跡の null アサーションを解消"
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib/feature/home app/lib/feature/map app/lib/feature/live_monitor --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep -E 'lib/feature/(home|map|live_monitor)/'
 ```
 
 - [ ] **Step 2: ベースラインのテストを実行**
@@ -1719,7 +1749,7 @@ mise exec -- flutter test test/feature/home test/feature/map test/feature/live_m
 cd /workspace/app
 mise exec -- flutter test test/feature/home test/feature/map test/feature/live_monitor
 cd /workspace
-mise exec -- dart analyze app/lib/feature/home app/lib/feature/map app/lib/feature/live_monitor --fatal-infos
+mise exec -- dart analyze app --fatal-infos 2>&1 | grep -E 'lib/feature/(home|map|live_monitor)/'
 ```
 
 Expected: テスト全 PASS、`No issues found!`
@@ -1764,7 +1794,7 @@ Task 3 で除外済みである。移動してはならない。
 
 ```bash
 cd /workspace
-mise exec -- dart analyze app/lib --fatal-infos 2>&1 | tee /tmp/remaining.txt | tail -3
+mise exec -- dart analyze app --fatal-infos 2>&1 | tee /tmp/remaining.txt | tail -3
 ```
 
 Task 9〜17 の結果次第で残件が変わるため、ここで実測する。
@@ -1785,8 +1815,8 @@ Expected: 全 PASS。テスト数を報告に記録する。
 - [ ] **Step 4: app 全体の解析が通ることを確認**
 
 ```bash
-cd /workspace/app
-mise exec -- dart analyze . --fatal-infos
+cd /workspace
+mise exec -- dart analyze app --fatal-infos
 ```
 
 Expected: `No issues found!`

--- a/docs/superpowers/plans/2026-08-14-analyzer-diagnostics-cleanup.md
+++ b/docs/superpowers/plans/2026-08-14-analyzer-diagnostics-cleanup.md
@@ -1307,18 +1307,36 @@ git commit -m "Refactor: StatefulWidget を Hook 化し ColorScheme 直接参照
 
 **注意:** `app/lib/core/hook/use_*.dart` の `useXxx()` は flutter_hooks の
 規約でトップレベル関数である必要がある。クラス化すると hooks が機能しない。
-これらは Task 3 の除外条件に含まれていないため、次のいずれかで対応する。
 
-1. `// ignore: eqmonitor_lints_plugin/avoid_top_level_functions` を理由コメント付きで置く
-2. `TopLevelFunctionExemption` に hooks の除外条件を足す（Task 3 の変更を拡張）
+これらは **ルールの除外条件に足さず、抑制コメントで対応する**。
+「`use` で始まる関数」を一律に許可すると、hooks と無関係な関数名でも
+ルールを回避できてしまうため、除外条件には入れない。
 
-**判断が必要なため、Step 1 で必ず報告して指示を仰ぐこと。**
+- [ ] **Step 1: `core/hook` に抑制コメントを置く**
 
-- [ ] **Step 1: `core/hook` の扱いを確認して報告する**
+`app/lib/core/hook/use_map_operation_queue.dart:54` と
+`app/lib/core/hook/use_sheet_controller.dart:5` の 2 件に、
+理由コメント付きで抑制コメントを置く。
 
-`app/lib/core/hook/use_map_operation_queue.dart` と
-`app/lib/core/hook/use_sheet_controller.dart` の 2 件について、
-上記 1 と 2 のどちらを採るか NEEDS_CONTEXT として報告し、指示を待つ。
+```dart
+// flutter_hooks の Hook はトップレベル関数として定義する規約であり、
+// クラスのメソッドにすると Hook の登録順序が壊れて動作しない。
+// ignore: eqmonitor_lints_plugin/avoid_top_level_functions
+MapOperationScheduler useMapOperationQueue() {
+```
+
+抑制コメントを置いた後、診断が消えることを確認する。
+
+```bash
+cd /workspace
+mise exec -- dart analyze app/lib/core/hook --fatal-infos
+```
+
+Expected: `No issues found!`
+
+抑制コメントが効かない場合は、ルール名の指定形式が違う可能性がある。
+`// ignore: avoid_top_level_functions`（プラグイン名なし）も試し、
+どちらが効くかを報告に書くこと。
 
 - [ ] **Step 2: `core/util` のトップレベル関数をクラス化する（11 件）**
 

--- a/docs/superpowers/specs/2026-08-14-analyzer-diagnostics-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-14-analyzer-diagnostics-cleanup-design.md
@@ -1,0 +1,184 @@
+# Analyzer 診断ゼロ化 設計書
+
+## 背景
+
+`melos run analyze`（`dart analyze . --fatal-infos`）で **1,512 件** の診断が出ている。
+Flutter 3.48.0-0.1.pre / Dart 3.14.0 (build 3.14.0-29.0.dev) で計測した実測値である。
+
+重要な事実として **Analyzer の `ERROR` は 0 件**であり、内訳は次のとおり。
+
+| 種別 | 件数 |
+| --- | ---: |
+| `WARNING`（自作 analyzer plugin 由来 + 設定不備） | 1,439 |
+| `INFO`（標準 lint / hint） | 73 |
+
+`--fatal-infos` を付けている以上、`INFO` も CI を落とすため修正対象に含める。
+
+### 診断コード別の内訳（実測）
+
+| コード | 提供元 | 件数 |
+| --- | --- | ---: |
+| `avoid_top_level_functions` | eqmonitor_lints_plugin | 814 |
+| `avoid_null_assertion_operator` | eqmonitor_lints_plugin | 578 |
+| `avoid_eqmonitor_api_in_ui` | eqmonitor_lints_plugin | 23 |
+| `avoid_mixed_declaration_categories` | eqmonitor_lints_plugin | 12 |
+| `avoid_stateful_widget` | eqmonitor_lints_plugin | 7 |
+| `avoid_direct_color_scheme` | eqmonitor_custom_lints | 4 |
+| 標準 lint / hint（15 種） | Dart SDK / yumemi_lints | 73 |
+| `plugins_in_inner_options` | Dart SDK | 1 |
+
+### パッケージ別の内訳（実測）
+
+| パッケージ | 件数 |
+| --- | ---: |
+| `app` | 1,439 |
+| `packages/seismicity_pmtiles` | 73 |
+| その他 26 パッケージ | 0 |
+
+生成ファイル（`*.g.dart` / `*.freezed.dart` / `*.mocks.dart`）由来の診断は **0 件**であり、
+コード生成のやり直しでは 1 件も減らない。
+
+## 問題の分析
+
+### 1. plugin ルールの誤検出が全体の 52% を占める
+
+`avoid_top_level_functions` の 814 件のうち **296 件が `main()`** である。
+Dart のエントリポイントは言語仕様上トップレベル関数以外にあり得ず、
+「専用クラスに切り出して Riverpod で DI する」という是正指示は適用不可能である。
+
+同様に `@pragma('vm:entry-point')` を付けた Isolate ワーカーのエントリポイント（`app/lib` に 2 件）も、
+VM がトップレベル関数として解決するため移動できない。
+
+`avoid_eqmonitor_api_in_ui` はパスに `/ui/` を含むかだけで判定しており、
+`app/test/**/ui/**` のテストコードにも 3 件発火している。
+
+### 2. テストコードが plugin ルールの 55% を占める
+
+plugin ルール 1,438 件のうち **792 件がテストコード**である。
+テストのローカルヘルパー（`_earthquake({...})` のようなフィクスチャ生成関数）や、
+「この値は必ず存在するはずで、なければテストを失敗させたい」箇所での `!` は、
+本番コードとは要求が異なる。
+
+### 3. Analyzer 設定の重複
+
+`app/analysis_options.yaml` の `plugins:` ブロックが
+`plugins_in_inner_options` 警告を出している。pub workspace のメンバーパッケージでは
+`plugins:` を宣言できず、この設定は無視されている。
+実際に発火しているのはリポジトリルートの `analysis_options.yaml` の宣言である。
+
+## 方針
+
+### 方針 1: plugin の適用範囲を正す（設定変更）
+
+以下を **ルールの誤検出の修正**として扱い、抑制ではないことを明確にする。
+
+| 除外対象 | 理由 |
+| --- | --- |
+| `main()` | Dart 言語仕様上、エントリポイントはトップレベル関数のみ |
+| `@pragma('vm:entry-point')` 付き関数 | Dart VM が名前解決するため移動不可 |
+| `@riverpod` / `@Riverpod` 付き関数（実装済み） | 関数プロバイダは Riverpod の規定形式 |
+| テストコード全体 | 本番コードとテストで設計要求が異なる（利用者判断） |
+
+テストコードの判定は `test/` `integration_test/` `test_driver/` ディレクトリ配下とする。
+これは **自作 plugin のルールのみ**に適用し、標準 lint はテストにも従来どおり適用する。
+`analysis_options.yaml` の `exclude` は使わない（標準解析まで止まってしまうため）。
+
+`@pragma` は `vm:entry-point` に限定する。`@pragma` 全般を許可すると
+`vm:prefer-inline` のような無関係な pragma でもルールを回避できてしまう。
+
+この方針で **796 件**が解消する（誤検出 4 件 + テスト 792 件）。設定重複の修正で 1 件。
+
+### 方針 2: 残る 716 件を実コードの修正で解消する
+
+| 対象 | 件数 |
+| --- | ---: |
+| `app/lib` の plugin ルール違反 | 643 |
+| `packages/seismicity_pmtiles` の標準 lint | 73 |
+
+`app/lib` の 643 件は feature 単位で修正する。ルール単位ではなく feature 単位にするのは、
+同一ファイルを複数タスクで繰り返し編集して衝突するのを避けるためである。
+
+## `!` の除去方針（最重要）
+
+578 件中 356 件が `app/lib` にある。機械的置換は禁止とし、次の優先順位で判断する。
+
+1. **null 伝播で足りる場合は `?.` を使う**
+   Flutter の `style:` `child:` などは `null` を受け付ける。
+   `style: theme.textTheme.titleSmall!.copyWith(...)` は
+   `style: theme.textTheme.titleSmall?.copyWith(...)` で等価かつ安全になる。
+
+2. **フロー解析で非 null を確定させる**
+   `if (x != null) { ... }` / パターンマッチ / `switch` 式で、
+   コンパイラに非 null を証明させる。
+
+3. **そもそも null になり得ない型に変える**
+   ローカル変数への束縛、`required` 引数化、Freezed のモデル分割などで
+   構造的に null を排除する。
+
+4. **`??` によるフォールバックは、その値がドメイン上の正しい既定値である場合に限る**
+   「とりあえず」の固定値フォールバックはプロジェクト規約で禁止されている。
+   震度・マグニチュード・座標など、生命に関わる情報に既定値を入れてはならない。
+
+5. **不変条件により非 null が保証される箇所は、その不変条件を明示して失敗させる**
+   `map[key]!` のように「直前に `containsKey` を確認済み」といった箇所が該当する。
+   この場合のみ後述の `orFailBecause` を使う。
+
+### `orFailBecause` 拡張
+
+上記 5 のために、`app/lib/core/util/` に extension を追加する。
+
+```dart
+extension NullableValueRequirement<T extends Object> on T? {
+  /// 不変条件により非 null が保証される値を取り出す。
+  ///
+  /// [because] には「なぜ非 null と言えるのか」を書く。
+  /// 想定が破れた場合は理由付きの [StateError] となり、`!` の
+  /// `Null check operator used on a null value` より原因を特定しやすい。
+  T orFailBecause(String because) {
+    final value = this;
+    if (value == null) {
+      throw StateError('必ず非 null のはずの値が null でした: $because');
+    }
+    return value;
+  }
+}
+```
+
+`!` と失敗時の挙動（例外送出）は同じで、診断可能性のみが向上する。
+そのため「`!` を `orFailBecause` に置換して回る」ことは目的ではない。
+各タスクの実装者は使用箇所と理由を報告し、レビュアーが機械的置換になっていないか検査する。
+
+## テスト方針
+
+自作 analyzer plugin には現状テストが 1 件もない（`tools/eqmonitor_custom_lints` のみ 1 ルール分あり）。
+plugin のルールは全パッケージの解析結果を左右するため、回帰防止のテストを入れる。
+
+- ルールの判定ロジック（パス判定・アノテーション判定）は純粋な関数として切り出し、単体テストする
+- `tools/eqmonitor_lints_plugin` を CI（`wc-check-dart-analyze.yaml`）のテスト対象に追加する
+  （`tools/` は melos workspace 外のため `melos run test` では実行されない）
+
+`app` 側のコード修正では、既存テストを回帰検知に使う。
+`!` 除去やトップレベル関数のクラス化で振る舞いが変わっていないことを、
+該当 feature のテストで確認する。テストが無い箇所を触る場合は、
+振る舞いを固定するテストを先に書く。
+
+## 検証方法
+
+```bash
+mise exec -- dart run melos exec -c 1 -- dart analyze . --fatal-infos
+```
+
+最終的に全 28 パッケージが `SUCCESS` になることをもって完了とする。
+
+タスクごとの部分検証は対象パッケージのみで行う。
+
+```bash
+cd app && mise exec -- dart analyze lib/feature/<name> --fatal-infos
+```
+
+## 適用範囲外
+
+- 生成ファイルの再生成（診断 0 件のため不要）
+- `backend/`（TypeScript、本件の対象外）
+- `packages/eqmonitor_lints` が include する `yumemi_lints` のルール選定変更
+  （ルールを緩めて件数を減らすことはしない）

--- a/docs/todo/400_analyzer-plugin-coverage-for-packages.md
+++ b/docs/todo/400_analyzer-plugin-coverage-for-packages.md
@@ -1,0 +1,46 @@
+# 自作 analyzer plugin が packages/* に適用されていない
+
+## 事象
+
+`dart analyze` を全パッケージで実行したところ、自作 analyzer plugin
+（`eqmonitor_lints_plugin` / `eqmonitor_custom_lints`）の診断が
+`app` にしか出ていない。
+
+| パッケージ | plugin 由来の診断 |
+| --- | ---: |
+| `app` | 1,438 件 |
+| `packages/seismicity_pmtiles` | 0 件 |
+| その他 26 パッケージ | 0 件 |
+
+`packages/*` の Dart コードにトップレベル関数や `!` が 1 つも無いとは考えにくく、
+plugin が適用されていないと判断できる。
+
+## 原因
+
+`plugins:` 宣言は `analysis_options.yaml` の解決経路にある必要がある。
+
+- `app/analysis_options.yaml` は `include: ../analysis_options.yaml` で
+  ルートの宣言を引き継いでいる（2026-08-14 に修正）
+- `packages/seismicity_pmtiles/analysis_options.yaml` は
+  `include: package:eqmonitor_lints/recommended.yaml` のみで、
+  ルートの `analysis_options.yaml` を参照していない
+- 独自の `analysis_options.yaml` を持たないパッケージについては未調査
+
+なお `app/analysis_options.yaml` に直接 `plugins:` を書くと
+`plugins_in_inner_options` 警告が出るが、**plugin 自体は動作していた**。
+警告が出るからといって無効化されているわけではない点に注意。
+
+## 検討事項
+
+- `packages/*` にも plugin を適用するべきか（ルール自体は Flutter アプリ向けの
+  想定が強く、純粋な Dart パッケージに機械的に適用すると大量の違反が出る可能性がある）
+- 適用する場合、各パッケージの `analysis_options.yaml` に
+  `include: ../../analysis_options.yaml` を足すのか、
+  `packages/eqmonitor_lints` 側の共有設定に `plugins:` を持たせるのか
+- ルールごとに適用範囲を変えるべきか（例: `avoid_stateful_widget` は
+  Flutter パッケージにのみ意味がある）
+
+## 関連
+
+- `docs/superpowers/specs/2026-08-14-analyzer-diagnostics-cleanup-design.md`
+- `docs/superpowers/plans/2026-08-14-analyzer-diagnostics-cleanup.md`

--- a/packages/seismicity_pmtiles/benchmark/seismicity_benchmark_arguments.dart
+++ b/packages/seismicity_pmtiles/benchmark/seismicity_benchmark_arguments.dart
@@ -19,7 +19,8 @@ final class SeismicityBenchmarkArguments {
   int get tileCount => featureCount ~/ featuresPerTile;
 }
 
-/// Strict typed parser for benchmark CLI flags. Parsing only — no benchmark run.
+/// Strict typed parser for benchmark CLI flags.
+/// Parsing only — no benchmark run.
 final class SeismicityBenchmarkArgumentsParser {
   const SeismicityBenchmarkArgumentsParser();
 

--- a/packages/seismicity_pmtiles/benchmark/seismicity_pmtiles_decode_benchmark.dart
+++ b/packages/seismicity_pmtiles/benchmark/seismicity_pmtiles_decode_benchmark.dart
@@ -34,7 +34,7 @@ Future<int> runSeismicityDecodeBenchmarkCli({
   } on SeismicityBenchmarkArgumentsException catch (error) {
     stderr.writeln(error.message);
     return 64;
-  } catch (error, stackTrace) {
+  } on Object catch (error, stackTrace) {
     stderr
       ..writeln(error)
       ..writeln(stackTrace);

--- a/packages/seismicity_pmtiles/benchmark/support/counting_decoder_worker_factory.dart
+++ b/packages/seismicity_pmtiles/benchmark/support/counting_decoder_worker_factory.dart
@@ -3,7 +3,7 @@ import 'package:seismicity_pmtiles/src/model/seismicity_pmtiles_archive_descript
 
 /// Benchmark-only spawn counter that delegates unchanged to [delegate].
 ///
-/// Increments [spawnCount] once immediately before each [delegate.spawn] call,
+/// Increments [spawnCount] once immediately before each delegate.spawn call,
 /// including attempts that later fail.
 final class CountingDecoderWorkerFactory
     implements SeismicityDecoderWorkerFactory {

--- a/packages/seismicity_pmtiles/benchmark/support/seismicity_benchmark_archive.dart
+++ b/packages/seismicity_pmtiles/benchmark/support/seismicity_benchmark_archive.dart
@@ -27,7 +27,7 @@ final class SeismicityBenchmarkArchive implements SeismicityPmTilesArchive {
       );
     }
     final tileCount = featureCount ~/ featuresPerTile;
-    final tileSide = 1 << SeismicityBenchmarkFeatureSource.dataZoom;
+    const tileSide = 1 << SeismicityBenchmarkFeatureSource.dataZoom;
     if (tileCount > tileSide * tileSide) {
       throw ArgumentError(
         'tileCount $tileCount exceeds zoom '
@@ -112,7 +112,11 @@ final class SeismicityBenchmarkArchive implements SeismicityPmTilesArchive {
     required this.expectedTotalPublicBytes,
     required this.descriptor,
     required this.header,
-  });
+  }) : readCount = 0,
+       closeCount = 0,
+       maxRetainedPayloads = 0,
+       _retainedPayloads = 0,
+       _closed = false;
 
   final int featureCount;
   final int featuresPerTile;
@@ -130,11 +134,11 @@ final class SeismicityBenchmarkArchive implements SeismicityPmTilesArchive {
   final Uint8List lastHypocenterId;
   final int expectedTotalPublicBytes;
 
-  var readCount = 0;
-  var closeCount = 0;
-  var maxRetainedPayloads = 0;
-  var _retainedPayloads = 0;
-  var _closed = false;
+  int readCount;
+  int closeCount;
+  int maxRetainedPayloads;
+  int _retainedPayloads;
+  bool _closed;
   Future<void>? _close;
 
   Uint8List tileBytesAt({required int tileIndex}) {
@@ -269,8 +273,8 @@ final class SeismicityBenchmarkArchive implements SeismicityPmTilesArchive {
           value: createVectorTileValue(boolValue: geometryClamped),
         );
       }
-      final extent = SeismicityBenchmarkFeatureSource.extent;
-      final tileSide = 1 << SeismicityBenchmarkFeatureSource.dataZoom;
+      const extent = SeismicityBenchmarkFeatureSource.extent;
+      const tileSide = 1 << SeismicityBenchmarkFeatureSource.dataZoom;
       final tileX = tileIndex % tileSide;
       final tileY = tileIndex ~/ tileSide;
       final localX = feature.globalX - tileX * extent;

--- a/packages/seismicity_pmtiles/benchmark/support/seismicity_benchmark_feature_source.dart
+++ b/packages/seismicity_pmtiles/benchmark/support/seismicity_benchmark_feature_source.dart
@@ -4,7 +4,8 @@ import 'dart:typed_data';
 
 import 'package:uuid/uuid.dart';
 
-/// One transient deterministic benchmark hypocenter derived from a global index.
+/// One transient deterministic benchmark hypocenter derived from a global
+/// index.
 final class SeismicityBenchmarkFeature {
   const SeismicityBenchmarkFeature({
     required this.index,
@@ -47,7 +48,7 @@ final class SeismicityBenchmarkFeatureSource {
 
   static const dataZoom = 6;
   static const extent = 4096;
-  static const fixedPublicBytesPerRow = 16 + 8 + 8 + 4 + 4 + 8 + 4;
+  static const int fixedPublicBytesPerRow = 16 + 8 + 8 + 4 + 4 + 8 + 4;
 
   SeismicityBenchmarkFeature featureAt({required int index}) {
     if (index < 0) {
@@ -87,10 +88,10 @@ final class SeismicityBenchmarkFeatureSource {
     final hi = index >> 32;
     final lo = index & 0xffffffff;
     final bytes = ByteData(16)
-      ..setUint32(0, hi, Endian.big)
-      ..setUint32(4, lo, Endian.big)
-      ..setUint32(8, hi ^ 0xa5a5a5a5, Endian.big)
-      ..setUint32(12, lo ^ 0x5a5a5a5a, Endian.big);
+      ..setUint32(0, hi)
+      ..setUint32(4, lo)
+      ..setUint32(8, hi ^ 0xa5a5a5a5)
+      ..setUint32(12, lo ^ 0x5a5a5a5a);
     bytes.setUint8(6, (bytes.getUint8(6) & 0x0f) | 0x40);
     bytes.setUint8(8, (bytes.getUint8(8) & 0x3f) | 0x80);
     return Uuid.unparse(bytes.buffer.asUint8List());
@@ -99,8 +100,8 @@ final class SeismicityBenchmarkFeatureSource {
   ({int globalX, int globalY, double longitude, double latitude}) pointFor({
     required int index,
   }) {
-    final tileCount = 1 << dataZoom;
-    final worldWidth = extent * tileCount;
+    const tileCount = 1 << dataZoom;
+    const worldWidth = extent * tileCount;
     final globalX = index % worldWidth;
     final globalY = (index ~/ worldWidth) % worldWidth;
     final longitude = globalX / worldWidth * 360 - 180;

--- a/packages/seismicity_pmtiles/lib/src/decoder/seismicity_chunk_builder.dart
+++ b/packages/seismicity_pmtiles/lib/src/decoder/seismicity_chunk_builder.dart
@@ -11,11 +11,9 @@ import 'package:seismicity_pmtiles/src/model/seismicity_pmtiles_exception.dart';
 final class SeismicityChunkBuilder {
   SeismicityChunkBuilder({
     required int capacity,
-    void Function()? beforeCanonicalAdd,
-    void Function()? beforeIntensityAdd,
-  }) : _beforeCanonicalAdd = beforeCanonicalAdd,
-       _beforeIntensityAdd = beforeIntensityAdd,
-       _fixed = SeismicityChunkFixedColumns(capacity: capacity),
+    this._beforeCanonicalAdd,
+    this._beforeIntensityAdd,
+  }) : _fixed = SeismicityChunkFixedColumns(capacity: capacity),
        _canonical = SeismicityCanonicalPropertyChunk(capacity: capacity),
        _intensities = SeismicityChunkIntensityDictionary(capacity: capacity);
 

--- a/packages/seismicity_pmtiles/lib/src/decoder/seismicity_dataset_accumulator.dart
+++ b/packages/seismicity_pmtiles/lib/src/decoder/seismicity_dataset_accumulator.dart
@@ -16,12 +16,10 @@ final class SeismicityDatasetAccumulator {
   SeismicityDatasetAccumulator({
     required int expectedUniqueCount,
     required int chunkCapacity,
-    SeismicityChunkFactory createChunk = SeismicityChunkBuilder.new,
-    void Function()? beforeIndexInsert,
+    this._createChunk = SeismicityChunkBuilder.new,
+    this._beforeIndexInsert,
   }) : _expectedUniqueCount = expectedUniqueCount,
        _chunkCapacity = chunkCapacity,
-       _createChunk = createChunk,
-       _beforeIndexInsert = beforeIndexInsert,
        _index = SeismicityUuidIndex(expectedUniqueCount: expectedUniqueCount) {
     if (chunkCapacity <= 0 || chunkCapacity > 0x3fffffff) {
       throw const SeismicityPmTilesException.invalidDescriptor(

--- a/packages/seismicity_pmtiles/lib/src/decoder/seismicity_decoder_worker_entry.dart
+++ b/packages/seismicity_pmtiles/lib/src/decoder/seismicity_decoder_worker_entry.dart
@@ -17,15 +17,17 @@ void seismicityDecoderWorkerEntry(SendPort initialReplyTo) {
 }
 
 final class SeismicityDecoderWorkerSession {
-  SeismicityDecoderWorkerSession({required this.replyTo});
+  SeismicityDecoderWorkerSession({required this.replyTo})
+    : decodedTileCount = 0,
+      finished = false;
 
   final SendPort replyTo;
   final inbox = ReceivePort();
   final decoder = const SeismicityMvtTileDecoder();
   SeismicityPmTilesArchiveDescriptor? acceptedDescriptor;
   SeismicityDatasetAccumulator? accumulator;
-  var decodedTileCount = 0;
-  var finished = false;
+  int decodedTileCount;
+  bool finished;
 
   void start() {
     replyTo.send(inbox.sendPort);

--- a/packages/seismicity_pmtiles/lib/src/decoder/seismicity_pmtiles_decode_operation.dart
+++ b/packages/seismicity_pmtiles/lib/src/decoder/seismicity_pmtiles_decode_operation.dart
@@ -19,8 +19,8 @@ abstract interface class SeismicityPmTilesDecodeOperation {
 final class SeismicityPmTilesDecodeOperationController
     implements SeismicityPmTilesDecodeOperation {
   SeismicityPmTilesDecodeOperationController({
-    Future<void> Function()? onCancel,
-  }) : _onCancel = onCancel;
+    this._onCancel,
+  });
 
   final Future<void> Function()? _onCancel;
   final _result =

--- a/packages/seismicity_pmtiles/lib/src/decoder/seismicity_pmtiles_decoder_runner.dart
+++ b/packages/seismicity_pmtiles/lib/src/decoder/seismicity_pmtiles_decoder_runner.dart
@@ -13,7 +13,7 @@ import 'package:seismicity_pmtiles/src/model/seismicity_pmtiles_exception.dart';
 import 'package:seismicity_pmtiles/src/model/seismicity_pmtiles_load_state.dart';
 import 'package:seismicity_pmtiles/src/model/seismicity_pmtiles_result.dart';
 
-final class _RunnerCleanupMemo {
+final class SeismicityDecoderRunnerCleanupMemo {
   Future<void>? future;
   SeismicityDecoderWorkerHandle? handle;
 }
@@ -21,7 +21,7 @@ final class _RunnerCleanupMemo {
 /// Non-export runner: archive traversal into an injected worker factory.
 final class SeismicityPmTilesDecoderRunner {
   SeismicityPmTilesDecoderRunner({
-    required SeismicityDecoderWorkerFactory this.factory,
+    required this.factory,
     this.schemaValidator = const SeismicitySchemaV1Validator(),
     this.publicationValidator = const SeismicityDatasetPublicationValidator(),
   });
@@ -35,7 +35,7 @@ final class SeismicityPmTilesDecoderRunner {
     required int chunkCapacity,
   }) {
     final lifecycle = SeismicityDecoderRunLifecycle();
-    final cleanup = _RunnerCleanupMemo();
+    final cleanup = SeismicityDecoderRunnerCleanupMemo();
     late final SeismicityPmTilesDecodeOperationController controller;
     controller = SeismicityPmTilesDecodeOperationController(
       onCancel: () async {
@@ -74,7 +74,7 @@ final class SeismicityPmTilesDecoderRunner {
     required int chunkCapacity,
     required SeismicityPmTilesDecodeOperationController controller,
     required SeismicityDecoderRunLifecycle lifecycle,
-    required _RunnerCleanupMemo cleanup,
+    required SeismicityDecoderRunnerCleanupMemo cleanup,
   }) async {
     var classifyAsWorker = false;
     try {
@@ -144,7 +144,7 @@ final class SeismicityPmTilesDecoderRunner {
   }
 
   Future<void> settleCleanup({
-    required _RunnerCleanupMemo memo,
+    required SeismicityDecoderRunnerCleanupMemo memo,
     required SeismicityPmTilesArchive archive,
     required SeismicityDecoderRunLifecycle lifecycle,
     required SeismicityPmTilesDecodeOperationController controller,
@@ -173,7 +173,7 @@ final class SeismicityPmTilesDecoderRunner {
   }
 
   Future<void> ensureCleanup({
-    required _RunnerCleanupMemo memo,
+    required SeismicityDecoderRunnerCleanupMemo memo,
     required SeismicityPmTilesArchive archive,
     required SeismicityDecoderRunDecision decision,
   }) {

--- a/packages/seismicity_pmtiles/lib/src/reader/seismicity_pmtiles_network_random_access_reader.dart
+++ b/packages/seismicity_pmtiles/lib/src/reader/seismicity_pmtiles_network_random_access_reader.dart
@@ -17,16 +17,11 @@ final class SeismicityPmTilesNetworkRandomAccessReader
     required this.sizeBytes,
     required this.cancelToken,
     required int maxCacheBytes,
-    SeismicityPmTilesHttpRangeRequestBuilder requestBuilder =
-        const SeismicityPmTilesHttpRangeRequestBuilder(),
-    SeismicityPmTilesHttpIdentityValidator identityValidator =
-        const SeismicityPmTilesHttpIdentityValidator(),
-    SeismicityPmTilesContentRangeValidator contentRangeValidator =
+    this._requestBuilder = const SeismicityPmTilesHttpRangeRequestBuilder(),
+    this._identityValidator = const SeismicityPmTilesHttpIdentityValidator(),
+    this._contentRangeValidator =
         const SeismicityPmTilesContentRangeValidator(),
   }) : _callerCancellationWasPreexisting = cancelToken.isCancelled,
-       _requestBuilder = requestBuilder,
-       _identityValidator = identityValidator,
-       _contentRangeValidator = contentRangeValidator,
        _cache = SeismicityPmTilesNetworkRangeLruCache(
          maxBytes: maxCacheBytes,
        ) {

--- a/packages/seismicity_pmtiles/test/benchmark/seismicity_benchmark_arguments_test.dart
+++ b/packages/seismicity_pmtiles/test/benchmark/seismicity_benchmark_arguments_test.dart
@@ -36,7 +36,8 @@ void main() {
     );
   });
 
-  test('rejects missing unknown duplicate zero negative fraction overflow positional', () {
+  test('rejects missing unknown duplicate zero negative fraction overflow '
+      'positional', () {
     expect(
       () => parser.parse(arguments: const ['--features']),
       throwsA(isA<SeismicityBenchmarkArgumentsException>()),

--- a/packages/seismicity_pmtiles/test/benchmark/seismicity_pmtiles_decode_benchmark_cli_test.dart
+++ b/packages/seismicity_pmtiles/test/benchmark/seismicity_pmtiles_decode_benchmark_cli_test.dart
@@ -93,11 +93,11 @@ void main() {
       stderr: failStderr,
       runBenchmark:
           ({
-            required int featureCount,
-            required int tileCount,
-            required int chunkCapacity,
-            Duration? informationalTimeThreshold,
-          }) async {
+            required featureCount,
+            required tileCount,
+            required chunkCapacity,
+            informationalTimeThreshold,
+          }) {
             throw StateError('worker count mismatch');
           },
     );
@@ -119,10 +119,10 @@ void main() {
       stderr: StringBuffer(),
       runBenchmark:
           ({
-            required int featureCount,
-            required int tileCount,
-            required int chunkCapacity,
-            Duration? informationalTimeThreshold,
+            required featureCount,
+            required tileCount,
+            required chunkCapacity,
+            informationalTimeThreshold,
           }) async => _result(
             featureCount: featureCount,
             tileCount: tileCount,

--- a/packages/seismicity_pmtiles/test/benchmark/seismicity_pmtiles_decode_benchmark_runner_test.dart
+++ b/packages/seismicity_pmtiles/test/benchmark/seismicity_pmtiles_decode_benchmark_runner_test.dart
@@ -14,7 +14,7 @@ void main() {
       tileCount: tileCount,
       chunkCapacity: chunkCapacity,
     );
-    final source = const SeismicityBenchmarkFeatureSource();
+    const source = SeismicityBenchmarkFeatureSource();
     expect(result.workerSpawnCount, 1);
     expect(result.archiveCloseCount, 1);
     expect(result.featureCount, featureCount);

--- a/packages/seismicity_pmtiles/test/decoder/seismicity_decoder_isolate_seam_test.dart
+++ b/packages/seismicity_pmtiles/test/decoder/seismicity_decoder_isolate_seam_test.dart
@@ -38,11 +38,13 @@ final class RecordingWorkerSeam
         SeismicityDecoderIsolateLauncher,
         SeismicityDecoderWorkerEndpoint,
         SeismicityWorkerTerminalProbe {
+  RecordingWorkerSeam() : receivePortClosed = false;
+
   final sent = <SeismicityDecoderWorkerRequest>[];
   final exitCompleter = Completer<void>();
   @override
-  var counters = (errorCount: 0, exitCount: 0);
-  var receivePortClosed = false;
+  ({int errorCount, int exitCount}) counters = (errorCount: 0, exitCount: 0);
+  bool receivePortClosed;
 
   @override
   Future<SeismicityDecoderWorkerEndpoint> launch({

--- a/packages/seismicity_pmtiles/test/decoder/seismicity_pmtiles_decode_operation_test.dart
+++ b/packages/seismicity_pmtiles/test/decoder/seismicity_pmtiles_decode_operation_test.dart
@@ -11,7 +11,7 @@ void main() {
     'public view exposes ordered progress one result and closed stream',
     () async {
       final controller = SeismicityPmTilesDecodeOperationController();
-      final SeismicityPmTilesDecodeOperation operation = controller.operation;
+      final operation = controller.operation;
       final states = fixtures.collect(stream: operation.states);
 
       const firstProgress = SeismicityPmTilesDecodeProgress(
@@ -62,7 +62,7 @@ void main() {
         cancelCount += 1;
       },
     );
-    final SeismicityPmTilesDecodeOperation operation = controller.operation;
+    final operation = controller.operation;
     final first = operation.cancel();
     final second = operation.cancel();
     await Future.wait<void>([first, second]);
@@ -78,7 +78,7 @@ void main() {
         throw StateError('sync-cancel-failure');
       },
     );
-    final SeismicityPmTilesDecodeOperation operation = controller.operation;
+    final operation = controller.operation;
     final first = operation.cancel();
     final second = operation.cancel();
     await expectLater(first, throwsA(isA<StateError>()));
@@ -103,8 +103,8 @@ void main() {
       ),
     );
 
-    final cancelledException = SeismicityPmTilesException.cancelled(
-      source: const SeismicityPmTilesSource.file(path: 'archive.pmtiles'),
+    const cancelledException = SeismicityPmTilesException.cancelled(
+      source: SeismicityPmTilesSource.file(path: 'archive.pmtiles'),
     );
     final cancelled = SeismicityPmTilesDecodeOperationController();
     final cancelledStates = fixtures.collect(stream: cancelled.states);
@@ -114,7 +114,7 @@ void main() {
     ]);
     expect(
       await cancelled.result,
-      SeismicityPmTilesResult<SeismicityPmTilesDataset>.failure(
+      const SeismicityPmTilesResult<SeismicityPmTilesDataset>.failure(
         exception: cancelledException,
       ),
     );

--- a/packages/seismicity_pmtiles/test/decoder/seismicity_pmtiles_decoder_archive_test.dart
+++ b/packages/seismicity_pmtiles/test/decoder/seismicity_pmtiles_decoder_archive_test.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'package:dio/dio.dart';
 import 'package:pmtiles_v3/pmtiles_v3.dart';
 import 'package:pmtiles_v3/src/archive/pmtiles_v3_compression_decoder.dart';
-import 'package:pmtiles_v3/src/archive/pmtiles_v3_tile_id.dart';
 import 'package:seismicity_pmtiles/seismicity_pmtiles.dart';
 import 'package:seismicity_pmtiles/src/decoder/seismicity_mvt_point_decoder.dart';
 import 'package:test/test.dart';
@@ -324,7 +323,7 @@ final class _Task61Fixtures {
     required SeismicityPmTilesArchiveDescriptor descriptor,
   }) async {
     final factory = SeismicityRandomAccessReaderFactory(
-      assetLoader: ({required String assetKey}) async {
+      assetLoader: ({required assetKey}) async {
         expect(assetKey, SeismicityArchiveFixtureBuilder.assetKey);
         return bytes;
       },

--- a/packages/seismicity_pmtiles/test/decoder/seismicity_pmtiles_decoder_cancellation_terminal_test.dart
+++ b/packages/seismicity_pmtiles/test/decoder/seismicity_pmtiles_decoder_cancellation_terminal_test.dart
@@ -98,7 +98,7 @@ void main() {
   });
 
   test('spawn failure is not masked by late cancel', () async {
-    final primary = const SeismicityPmTilesException.decoderWorkerFailed(
+    const primary = SeismicityPmTilesException.decoderWorkerFailed(
       reason: 'spawn primary',
     );
     final setup = fixtures.start();
@@ -118,7 +118,7 @@ void main() {
   });
 
   test('cancel before spawn failure keeps cancelled', () async {
-    final primary = const SeismicityPmTilesException.decoderWorkerFailed(
+    const primary = SeismicityPmTilesException.decoderWorkerFailed(
       reason: 'spawn late',
     );
     final setup = fixtures.start();
@@ -163,7 +163,7 @@ void main() {
   });
 
   test('worker finish failure is not masked by late cancel', () async {
-    final primary = const SeismicityPmTilesException.decoderWorkerFailed(
+    const primary = SeismicityPmTilesException.decoderWorkerFailed(
       reason: 'finish primary',
     );
     final setup = fixtures.start();

--- a/packages/seismicity_pmtiles/test/decoder/seismicity_pmtiles_decoder_cleanup_failure_test.dart
+++ b/packages/seismicity_pmtiles/test/decoder/seismicity_pmtiles_decoder_cleanup_failure_test.dart
@@ -42,7 +42,7 @@ void main() {
   });
 
   test('worker close failure replaces success only', () async {
-    final cleanupFailure = const SeismicityPmTilesException.decoderWorkerFailed(
+    const cleanupFailure = SeismicityPmTilesException.decoderWorkerFailed(
       reason: 'close failed',
     );
     final setup = fixtures.startSuccessPath();
@@ -61,7 +61,7 @@ void main() {
   });
 
   test('retirement failure replaces success only', () async {
-    final cleanupFailure = const SeismicityPmTilesException.decoderWorkerFailed(
+    const cleanupFailure = SeismicityPmTilesException.decoderWorkerFailed(
       reason: 'retired failed',
     );
     final setup = fixtures.startSuccessPath();
@@ -109,10 +109,10 @@ void main() {
   });
 
   test('cleanup failure never masks primary worker failure', () async {
-    final primary = const SeismicityPmTilesException.decoderWorkerFailed(
+    const primary = SeismicityPmTilesException.decoderWorkerFailed(
       reason: 'decode primary',
     );
-    final cleanupFailure = const SeismicityPmTilesException.decoderWorkerFailed(
+    const cleanupFailure = SeismicityPmTilesException.decoderWorkerFailed(
       reason: 'close secondary',
     );
     final setup = fixtures.startSuccessPath();

--- a/packages/seismicity_pmtiles/test/decoder/seismicity_pmtiles_decoder_malformed_mvt_test.dart
+++ b/packages/seismicity_pmtiles/test/decoder/seismicity_pmtiles_decoder_malformed_mvt_test.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:dio/dio.dart';
 import 'package:pmtiles_v3/pmtiles_v3.dart';
 import 'package:pmtiles_v3/src/archive/pmtiles_v3_compression_decoder.dart';
-import 'package:pmtiles_v3/src/archive/pmtiles_v3_tile_id.dart';
 import 'package:seismicity_pmtiles/seismicity_pmtiles.dart';
 import 'package:test/test.dart';
 
@@ -90,11 +89,11 @@ void main() {
 }
 
 final class _CountingArchive implements SeismicityPmTilesArchive {
-  _CountingArchive({required this.inner});
+  _CountingArchive({required this.inner}) : closeCount = 0;
 
   final SeismicityPmTilesArchive inner;
   Future<void>? _close;
-  var closeCount = 0;
+  int closeCount;
 
   @override
   SeismicityPmTilesArchiveDescriptor get descriptor => inner.descriptor;
@@ -188,7 +187,7 @@ final class _Task62Fixtures {
     required SeismicityPmTilesArchiveDescriptor descriptor,
   }) async {
     final factory = SeismicityRandomAccessReaderFactory(
-      assetLoader: ({required String assetKey}) async {
+      assetLoader: ({required assetKey}) async {
         expect(assetKey, SeismicityArchiveFixtureBuilder.assetKey);
         return bytes;
       },

--- a/packages/seismicity_pmtiles/test/decoder/seismicity_pmtiles_decoder_truncated_archive_test.dart
+++ b/packages/seismicity_pmtiles/test/decoder/seismicity_pmtiles_decoder_truncated_archive_test.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
-import 'package:pmtiles_v3/pmtiles_v3.dart';
 import 'package:seismicity_pmtiles/seismicity_pmtiles.dart';
 import 'package:test/test.dart';
 
@@ -67,11 +66,11 @@ final class _Task63Case {
 }
 
 final class _CountingReader implements PmTilesRandomAccessReader {
-  _CountingReader({required this.inner});
+  _CountingReader({required this.inner}) : closeCount = 0;
 
   final PmTilesRandomAccessReader inner;
   Future<void>? _close;
-  var closeCount = 0;
+  int closeCount;
 
   @override
   int get sizeBytes => inner.sizeBytes;
@@ -150,7 +149,7 @@ final class _Task63Fixtures {
     required SeismicityPmTilesArchiveDescriptor descriptor,
   }) async {
     final factory = SeismicityRandomAccessReaderFactory(
-      assetLoader: ({required String assetKey}) async {
+      assetLoader: ({required assetKey}) async {
         expect(assetKey, SeismicityArchiveFixtureBuilder.assetKey);
         return bytes;
       },

--- a/packages/seismicity_pmtiles/test/model/public_contracts_test.dart
+++ b/packages/seismicity_pmtiles/test/model/public_contracts_test.dart
@@ -121,7 +121,7 @@ void main() {
       SeismicityPmTilesLoadState.openingSource(),
       SeismicityPmTilesLoadState.readingDirectory(),
       SeismicityPmTilesLoadState.decoding(
-        progress: const SeismicityPmTilesDecodeProgress(
+        progress: SeismicityPmTilesDecodeProgress(
           decodedTileCount: 1,
           rawFeatureCount: 1,
           uniqueFeatureCount: 1,

--- a/packages/seismicity_pmtiles/test/support/controlled_seismicity_archive.dart
+++ b/packages/seismicity_pmtiles/test/support/controlled_seismicity_archive.dart
@@ -19,7 +19,8 @@ final class ControlledSeismicityArchive implements SeismicityPmTilesArchive {
        header = header ?? ControlledSeismicityArchive.stubHeader(),
        closeReleaseFailure =
            closeReleaseFailure ??
-           SeismicityPmTilesException.closed(source: descriptor.source);
+           SeismicityPmTilesException.closed(source: descriptor.source),
+       deferCloseCompletion = false;
 
   static PmTilesV3Header stubHeader({
     int minZoom = 0,
@@ -74,7 +75,7 @@ final class ControlledSeismicityArchive implements SeismicityPmTilesArchive {
   SeismicityPmTilesException? _queuedCloseFailure;
   var _closed = false;
   var _closeCount = 0;
-  var deferCloseCompletion = false;
+  bool deferCloseCompletion;
 
   int get closeCount => _closeCount;
   bool get isClosed => _closed;

--- a/packages/seismicity_pmtiles/test/support/controlled_seismicity_archive_test.dart
+++ b/packages/seismicity_pmtiles/test/support/controlled_seismicity_archive_test.dart
@@ -50,7 +50,7 @@ void main() {
   });
 
   test('close releases blocked ops once with configured failure', () async {
-    final failure = SeismicityPmTilesException.corruptArchive(
+    const failure = SeismicityPmTilesException.corruptArchive(
       reason: 'closed-while-paused',
     );
     final archive =
@@ -85,10 +85,10 @@ void main() {
   });
 
   test('queues typed failures for enumeration and read', () async {
-    final enumFailure = SeismicityPmTilesException.corruptArchive(
+    const enumFailure = SeismicityPmTilesException.corruptArchive(
       reason: 'enum-fail',
     );
-    final readFailure = SeismicityPmTilesException.tileNotFound(tileId: 99);
+    const readFailure = SeismicityPmTilesException.tileNotFound(tileId: 99);
     final archive =
         ControlledSeismicityArchive(
             descriptor: fixtures.descriptor(),

--- a/packages/seismicity_pmtiles/test/support/controlled_seismicity_isolate_launcher.dart
+++ b/packages/seismicity_pmtiles/test/support/controlled_seismicity_isolate_launcher.dart
@@ -13,6 +13,8 @@ final class ControlledSeismicityIsolateLauncher
         SeismicityDecoderIsolateLauncher,
         SeismicityDecoderWorkerEndpoint,
         SeismicityWorkerTerminalProbe {
+  ControlledSeismicityIsolateLauncher() : deferExitedUntilReleased = false;
+
   final _responses =
       StreamController<SeismicityDecoderWorkerResponse>.broadcast();
   final _errors = StreamController<SeismicityDecoderWorkerError>.broadcast();
@@ -25,7 +27,7 @@ final class ControlledSeismicityIsolateLauncher
   var _launchCount = 0;
   var _closeReceivePortCount = 0;
   var _killCount = 0;
-  var deferExitedUntilReleased = false;
+  bool deferExitedUntilReleased;
 
   int get launchCount => _launchCount;
   int get closeReceivePortCount => _closeReceivePortCount;

--- a/packages/seismicity_pmtiles/test/support/seismicity_archive_fixture_builder.dart
+++ b/packages/seismicity_pmtiles/test/support/seismicity_archive_fixture_builder.dart
@@ -117,8 +117,10 @@ final class SeismicityArchiveFixtureBuilder {
     );
   }
 
-  List<String> get schemaKeys => 'hypocenter_id origin_time_unix_ms magnitude depth_km max_intensity determination_flag earthquake_event_id geometry_clamped'
-      .split(' ');
+  List<String> get schemaKeys =>
+      'hypocenter_id origin_time_unix_ms magnitude depth_km max_intensity '
+              'determination_flag earthquake_event_id geometry_clamped'
+          .split(' ');
 
   List<SeismicityFixtureScalar> schemaValues({
     required String hypocenterId,

--- a/packages/seismicity_pmtiles/test/support/seismicity_archive_fixture_builder_test.dart
+++ b/packages/seismicity_pmtiles/test/support/seismicity_archive_fixture_builder_test.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
-import 'package:pmtiles_v3/pmtiles_v3.dart';
 import 'package:seismicity_pmtiles/seismicity_pmtiles.dart';
 import 'package:test/test.dart';
 
@@ -78,7 +77,7 @@ final class _Task58Fixtures {
     required SeismicityPmTilesArchiveDescriptor descriptor,
   }) async {
     final factory = SeismicityRandomAccessReaderFactory(
-      assetLoader: ({required String assetKey}) async {
+      assetLoader: ({required assetKey}) async {
         expect(assetKey, SeismicityArchiveFixtureBuilder.assetKey);
         return bytes;
       },

--- a/packages/seismicity_pmtiles/test/support/seismicity_pmtiles_archive_writer.dart
+++ b/packages/seismicity_pmtiles/test/support/seismicity_pmtiles_archive_writer.dart
@@ -28,7 +28,7 @@ final class SeismicityPmTilesArchiveWriter {
   final SeismicityPmTilesDirectoryWriter directoryWriter;
 
   static const metadataJson = '{}';
-  static const mvtTileType = PmTilesV3HeaderDecoder.mvtTileType;
+  static const int mvtTileType = PmTilesV3HeaderDecoder.mvtTileType;
 
   Uint8List write({
     required List<SeismicityPmTilesArchiveTilePayload> payloads,

--- a/packages/seismicity_pmtiles/test/support/seismicity_pmtiles_directory_writer.dart
+++ b/packages/seismicity_pmtiles/test/support/seismicity_pmtiles_directory_writer.dart
@@ -7,7 +7,7 @@ final class SeismicityPmTilesDirectoryWriter {
   const SeismicityPmTilesDirectoryWriter();
 
   static const maxUnsignedVarint = 0x7FFFFFFFFFFFFFFF;
-  static const maxTileIdExclusive = PmTilesV3TileId.maxValue + 1;
+  static const int maxTileIdExclusive = PmTilesV3TileId.maxValue + 1;
 
   Uint8List write({
     required List<int> tileIds,

--- a/tools/eqmonitor_custom_lints/lib/main.dart
+++ b/tools/eqmonitor_custom_lints/lib/main.dart
@@ -14,8 +14,6 @@ class _EqmonitorCustomLintsPlugin extends Plugin {
 
   @override
   Future<void> register(PluginRegistry registry) async {
-    <AnalysisRule>[
-      AvoidDirectColorScheme(),
-    ].forEach(registry.registerLintRule);
+    <AnalysisRule>[AvoidDirectColorScheme()].forEach(registry.registerLintRule);
   }
 }

--- a/tools/eqmonitor_custom_lints/lib/rules/avoid_direct_color_scheme.dart
+++ b/tools/eqmonitor_custom_lints/lib/rules/avoid_direct_color_scheme.dart
@@ -6,20 +6,17 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
 
 import '../src/color_scheme_violation_finder.dart';
+import '../src/lint_target_scope.dart';
 
 class AvoidDirectColorScheme extends AnalysisRule {
   AvoidDirectColorScheme()
-    : super(
-        name: _code.name,
-        description: _code.problemMessage,
-      );
+    : super(name: _code.name, description: _code.problemMessage);
 
   static const _code = LintCode(
     'avoid_direct_color_scheme',
     'Theme.of(context).colorScheme を直接参照せず、'
         'designSystem.colorTheme を使用してください。',
-    correctionMessage:
-        'context.designSystem.colorTheme 経由でカラーを参照してください。',
+    correctionMessage: 'context.designSystem.colorTheme 経由でカラーを参照してください。',
     severity: DiagnosticSeverity.WARNING,
   );
 
@@ -38,7 +35,8 @@ class AvoidDirectColorScheme extends AnalysisRule {
     RuleContext context,
   ) {
     final path = context.definingUnit.unit.declaredFragment?.source.fullName;
-    if (path != null && _isAllowed(path)) {
+    if (path != null &&
+        (LintTargetScope.isExcluded(path: path) || _isAllowed(path))) {
       return;
     }
     final visitor = _Visitor(this);

--- a/tools/eqmonitor_custom_lints/lib/src/lint_target_scope.dart
+++ b/tools/eqmonitor_custom_lints/lib/src/lint_target_scope.dart
@@ -1,0 +1,18 @@
+/// 自作 lint ルールの適用対象を判定する。
+///
+/// テストコードは本番コードと設計上の要求が異なるため、
+/// 自作ルールの適用対象外とする（標準 lint は従来どおり適用される）。
+class LintTargetScope {
+  const LintTargetScope._();
+
+  static const _excludedDirectories = {
+    'test',
+    'integration_test',
+    'test_driver',
+  };
+
+  static bool isExcluded({required String path}) {
+    final segments = path.replaceAll(r'\', '/').split('/');
+    return segments.any(_excludedDirectories.contains);
+  }
+}

--- a/tools/eqmonitor_custom_lints/test/lint_target_scope_test.dart
+++ b/tools/eqmonitor_custom_lints/test/lint_target_scope_test.dart
@@ -1,0 +1,64 @@
+import 'package:eqmonitor_custom_lints/src/lint_target_scope.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LintTargetScope.isExcluded', () {
+    test('test ディレクトリ配下は除外する', () {
+      expect(
+        LintTargetScope.isExcluded(
+          path: '/repo/app/test/feature/eew/a_test.dart',
+        ),
+        isTrue,
+      );
+    });
+
+    test('integration_test 配下は除外する', () {
+      expect(
+        LintTargetScope.isExcluded(
+          path: '/repo/app/integration_test/app_test.dart',
+        ),
+        isTrue,
+      );
+    });
+
+    test('test_driver 配下は除外する', () {
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/test_driver/driver.dart'),
+        isTrue,
+      );
+    });
+
+    test('lib 配下は除外しない', () {
+      expect(
+        LintTargetScope.isExcluded(
+          path: '/repo/app/lib/feature/eew/eew_page.dart',
+        ),
+        isFalse,
+      );
+    });
+
+    test('ファイル名やディレクトリ名の部分一致では除外しない', () {
+      expect(
+        LintTargetScope.isExcluded(
+          path: '/repo/app/lib/core/util/latest_test_helper.dart',
+        ),
+        isFalse,
+      );
+      expect(
+        LintTargetScope.isExcluded(
+          path: '/repo/app/lib/feature/contest/page.dart',
+        ),
+        isFalse,
+      );
+    });
+
+    test('Windows 形式の区切り文字でも除外する', () {
+      expect(
+        LintTargetScope.isExcluded(
+          path: r'C:\repo\app\test\feature\a_test.dart',
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/tools/eqmonitor_custom_lints/test/rules/avoid_direct_color_scheme_test.dart
+++ b/tools/eqmonitor_custom_lints/test/rules/avoid_direct_color_scheme_test.dart
@@ -34,10 +34,6 @@ void main() {
 
     final violations = findColorSchemeViolations(result.unit);
 
-    expect(
-      violations,
-      isEmpty,
-      reason: 'ok.dart で誤検出が発生しています',
-    );
+    expect(violations, isEmpty, reason: 'ok.dart で誤検出が発生しています');
   });
 }

--- a/tools/eqmonitor_lints_plugin/lib/rules/avoid_eqmonitor_api_in_ui.dart
+++ b/tools/eqmonitor_lints_plugin/lib/rules/avoid_eqmonitor_api_in_ui.dart
@@ -4,13 +4,11 @@ import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
+import 'package:eqmonitor_lints_plugin/src/lint_target_scope.dart';
 
 class AvoidEqmonitorApiInUi extends AnalysisRule {
   AvoidEqmonitorApiInUi()
-    : super(
-        name: _code.name,
-        description: _code.problemMessage,
-      );
+    : super(name: _code.name, description: _code.problemMessage);
 
   static const _code = LintCode(
     'avoid_eqmonitor_api_in_ui',
@@ -30,7 +28,9 @@ class AvoidEqmonitorApiInUi extends AnalysisRule {
     RuleContext context,
   ) {
     final path = context.definingUnit.unit.declaredFragment?.source.fullName;
-    if (path == null || !_isInUiLayer(path)) {
+    if (path == null ||
+        LintTargetScope.isExcluded(path: path) ||
+        !_isInUiLayer(path)) {
       return;
     }
     registry.addImportDirective(this, _Visitor(this));

--- a/tools/eqmonitor_lints_plugin/lib/rules/avoid_mixed_declaration_categories.dart
+++ b/tools/eqmonitor_lints_plugin/lib/rules/avoid_mixed_declaration_categories.dart
@@ -4,13 +4,11 @@ import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
+import 'package:eqmonitor_lints_plugin/src/lint_target_scope.dart';
 
 class AvoidMixedDeclarationCategories extends AnalysisRule {
   AvoidMixedDeclarationCategories()
-    : super(
-        name: _code.name,
-        description: _code.problemMessage,
-      );
+    : super(name: _code.name, description: _code.problemMessage);
 
   static const _code = LintCode(
     'avoid_mixed_declaration_categories',
@@ -29,7 +27,13 @@ class AvoidMixedDeclarationCategories extends AnalysisRule {
   void registerNodeProcessors(
     RuleVisitorRegistry registry,
     RuleContext context,
-  ) => registry.addCompilationUnit(this, _Visitor(this));
+  ) {
+    final path = context.definingUnit.unit.declaredFragment?.source.fullName;
+    if (path != null && LintTargetScope.isExcluded(path: path)) {
+      return;
+    }
+    registry.addCompilationUnit(this, _Visitor(this));
+  }
 }
 
 /// ファイル内のトップレベル class 系宣言のカテゴリ。

--- a/tools/eqmonitor_lints_plugin/lib/rules/avoid_null_assertion_operator.dart
+++ b/tools/eqmonitor_lints_plugin/lib/rules/avoid_null_assertion_operator.dart
@@ -5,13 +5,11 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
+import 'package:eqmonitor_lints_plugin/src/lint_target_scope.dart';
 
 class AvoidNullAssertionOperator extends AnalysisRule {
   AvoidNullAssertionOperator()
-    : super(
-        name: _code.name,
-        description: _code.problemMessage,
-      );
+    : super(name: _code.name, description: _code.problemMessage);
 
   static const _code = LintCode(
     'avoid_null_assertion_operator',
@@ -30,7 +28,13 @@ class AvoidNullAssertionOperator extends AnalysisRule {
   void registerNodeProcessors(
     RuleVisitorRegistry registry,
     RuleContext context,
-  ) => registry.addPostfixExpression(this, _Visitor(this));
+  ) {
+    final path = context.definingUnit.unit.declaredFragment?.source.fullName;
+    if (path != null && LintTargetScope.isExcluded(path: path)) {
+      return;
+    }
+    registry.addPostfixExpression(this, _Visitor(this));
+  }
 }
 
 class _Visitor extends SimpleAstVisitor<void> {

--- a/tools/eqmonitor_lints_plugin/lib/rules/avoid_print_call.dart
+++ b/tools/eqmonitor_lints_plugin/lib/rules/avoid_print_call.dart
@@ -5,13 +5,10 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/error/error.dart';
+import 'package:eqmonitor_lints_plugin/src/lint_target_scope.dart';
 
 class AvoidPrintCall extends AnalysisRule {
-  AvoidPrintCall()
-    : super(
-        name: _code.name,
-        description: _code.problemMessage,
-      );
+  AvoidPrintCall() : super(name: _code.name, description: _code.problemMessage);
 
   static const _code = LintCode(
     'avoid_print',
@@ -29,7 +26,13 @@ class AvoidPrintCall extends AnalysisRule {
   void registerNodeProcessors(
     RuleVisitorRegistry registry,
     RuleContext context,
-  ) => registry.addMethodInvocation(this, _Visitor(this));
+  ) {
+    final path = context.definingUnit.unit.declaredFragment?.source.fullName;
+    if (path != null && LintTargetScope.isExcluded(path: path)) {
+      return;
+    }
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
 }
 
 class _Visitor extends SimpleAstVisitor<void> {

--- a/tools/eqmonitor_lints_plugin/lib/rules/avoid_stateful_widget.dart
+++ b/tools/eqmonitor_lints_plugin/lib/rules/avoid_stateful_widget.dart
@@ -4,13 +4,11 @@ import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
+import 'package:eqmonitor_lints_plugin/src/lint_target_scope.dart';
 
 class AvoidStatefulWidget extends AnalysisRule {
   AvoidStatefulWidget()
-    : super(
-        name: _code.name,
-        description: _code.problemMessage,
-      );
+    : super(name: _code.name, description: _code.problemMessage);
 
   static const _code = LintCode(
     'avoid_stateful_widget',
@@ -29,7 +27,13 @@ class AvoidStatefulWidget extends AnalysisRule {
   void registerNodeProcessors(
     RuleVisitorRegistry registry,
     RuleContext context,
-  ) => registry.addClassDeclaration(this, _Visitor(this));
+  ) {
+    final path = context.definingUnit.unit.declaredFragment?.source.fullName;
+    if (path != null && LintTargetScope.isExcluded(path: path)) {
+      return;
+    }
+    registry.addClassDeclaration(this, _Visitor(this));
+  }
 }
 
 class _Visitor extends SimpleAstVisitor<void> {

--- a/tools/eqmonitor_lints_plugin/lib/rules/avoid_top_level_functions.dart
+++ b/tools/eqmonitor_lints_plugin/lib/rules/avoid_top_level_functions.dart
@@ -4,13 +4,11 @@ import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
+import 'package:eqmonitor_lints_plugin/src/lint_target_scope.dart';
 
 class AvoidTopLevelFunctions extends AnalysisRule {
   AvoidTopLevelFunctions()
-    : super(
-        name: _code.name,
-        description: _code.problemMessage,
-      );
+    : super(name: _code.name, description: _code.problemMessage);
 
   static const _code = LintCode(
     'avoid_top_level_functions',
@@ -30,7 +28,13 @@ class AvoidTopLevelFunctions extends AnalysisRule {
   void registerNodeProcessors(
     RuleVisitorRegistry registry,
     RuleContext context,
-  ) => registry.addFunctionDeclaration(this, _Visitor(this));
+  ) {
+    final path = context.definingUnit.unit.declaredFragment?.source.fullName;
+    if (path != null && LintTargetScope.isExcluded(path: path)) {
+      return;
+    }
+    registry.addFunctionDeclaration(this, _Visitor(this));
+  }
 }
 
 class _Visitor extends SimpleAstVisitor<void> {

--- a/tools/eqmonitor_lints_plugin/lib/rules/avoid_top_level_functions.dart
+++ b/tools/eqmonitor_lints_plugin/lib/rules/avoid_top_level_functions.dart
@@ -5,6 +5,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:eqmonitor_lints_plugin/src/lint_target_scope.dart';
+import 'package:eqmonitor_lints_plugin/src/top_level_function_exemption.dart';
 
 class AvoidTopLevelFunctions extends AnalysisRule {
   AvoidTopLevelFunctions()
@@ -42,26 +43,14 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   final AnalysisRule rule;
 
-  static const _riverpodNames = {'riverpod', 'Riverpod'};
-
   @override
   void visitFunctionDeclaration(FunctionDeclaration node) {
     if (node.parent is! CompilationUnit) {
       return;
     }
-    // @riverpod / @Riverpod 付き関数プロバイダは慣用的なため自動で除外する。
-    if (_hasRiverpodAnnotation(node.metadata)) {
+    if (TopLevelFunctionExemption.isExempt(node: node)) {
       return;
     }
     rule.reportAtToken(node.name);
-  }
-
-  bool _hasRiverpodAnnotation(NodeList<Annotation> metadata) {
-    for (final annotation in metadata) {
-      if (_riverpodNames.contains(annotation.name.name)) {
-        return true;
-      }
-    }
-    return false;
   }
 }

--- a/tools/eqmonitor_lints_plugin/lib/src/lint_target_scope.dart
+++ b/tools/eqmonitor_lints_plugin/lib/src/lint_target_scope.dart
@@ -1,0 +1,18 @@
+/// 自作 lint ルールの適用対象を判定する。
+///
+/// テストコードは本番コードと設計上の要求が異なるため、
+/// 自作ルールの適用対象外とする（標準 lint は従来どおり適用される）。
+class LintTargetScope {
+  const LintTargetScope._();
+
+  static const _excludedDirectories = {
+    'test',
+    'integration_test',
+    'test_driver',
+  };
+
+  static bool isExcluded({required String path}) {
+    final segments = path.replaceAll(r'\', '/').split('/');
+    return segments.any(_excludedDirectories.contains);
+  }
+}

--- a/tools/eqmonitor_lints_plugin/lib/src/top_level_function_exemption.dart
+++ b/tools/eqmonitor_lints_plugin/lib/src/top_level_function_exemption.dart
@@ -1,0 +1,36 @@
+import 'package:analyzer/dart/ast/ast.dart';
+
+/// トップレベル関数のうち、言語仕様・フレームワーク上その形でしか
+/// 書けないものを [AvoidTopLevelFunctions] の対象外と判定する。
+class TopLevelFunctionExemption {
+  const TopLevelFunctionExemption._();
+
+  static const _entryPointFunctionName = 'main';
+  static const _riverpodAnnotationNames = {'riverpod', 'Riverpod'};
+  static const _pragmaAnnotationName = 'pragma';
+  static const _vmEntryPointPragma = 'vm:entry-point';
+
+  static bool isExempt({required FunctionDeclaration node}) {
+    if (node.name.lexeme == _entryPointFunctionName) {
+      return true;
+    }
+    return node.metadata.any(_isExemptAnnotation);
+  }
+
+  static bool _isExemptAnnotation(Annotation annotation) {
+    final name = annotation.name.name;
+    if (_riverpodAnnotationNames.contains(name)) {
+      return true;
+    }
+    if (name != _pragmaAnnotationName) {
+      return false;
+    }
+    final arguments = annotation.arguments?.arguments;
+    if (arguments == null || arguments.isEmpty) {
+      return false;
+    }
+    final firstArgument = arguments.first;
+    return firstArgument is SimpleStringLiteral &&
+        firstArgument.value == _vmEntryPointPragma;
+  }
+}

--- a/tools/eqmonitor_lints_plugin/pubspec.lock
+++ b/tools/eqmonitor_lints_plugin/pubspec.lock
@@ -49,6 +49,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  boolean_selector:
+    dependency: transitive
+    description:
+      name: boolean_selector
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   collection:
     dependency: transitive
     description:
@@ -65,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.15.1"
   crypto:
     dependency: transitive
     description:
@@ -89,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -97,6 +129,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  http_multi_server:
+    dependency: transitive
+    description:
+      name: http_multi_server
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
+  io:
+    dependency: transitive
+    description:
+      name: io
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  matcher:
+    dependency: transitive
+    description:
+      name: matcher
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.20"
   meta:
     dependency: transitive
     description:
@@ -105,6 +177,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -121,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  pool:
+    dependency: transitive
+    description:
+      name: pool
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.2"
   pub_semver:
     dependency: transitive
     description:
@@ -129,6 +225,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  shelf:
+    dependency: transitive
+    description:
+      name: shelf
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.2"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  shelf_static:
+    dependency: transitive
+    description:
+      name: shelf_static
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
+  shelf_web_socket:
+    dependency: transitive
+    description:
+      name: shelf_web_socket
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  source_map_stack_trace:
+    dependency: transitive
+    description:
+      name: source_map_stack_trace
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -137,6 +281,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  stack_trace:
+    dependency: transitive
+    description:
+      name: stack_trace
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.12.1"
+  stream_channel:
+    dependency: transitive
+    description:
+      name: stream_channel
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -153,6 +313,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test:
+    dependency: "direct dev"
+    description:
+      name: test
+      sha256: "0d5ba5602ec3baa28c8ce365e1efc5575969c765f45c554a3e167dc7945b9c30"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.31.2"
+  test_api:
+    dependency: transitive
+    description:
+      name: test_api
+      sha256: "475610b2aa23c19687cce2961e44b0cc57cafe220f67c2b80201231b2a07fbe7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.13"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      sha256: a39c204a4fc7a7ccb04a2b985e359fda3cc37e45e0b8ac61c3fb1a05aa832132
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.19"
   typed_data:
     dependency: transitive
     description:
@@ -161,11 +345,51 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  web_socket_channel:
+    dependency: transitive
+    description:
+      name: web_socket_channel
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"

--- a/tools/eqmonitor_lints_plugin/pubspec.yaml
+++ b/tools/eqmonitor_lints_plugin/pubspec.yaml
@@ -8,3 +8,5 @@ environment:
 dependencies:
   analysis_server_plugin: ^0.3.8
   analyzer: ^13.0.0
+dev_dependencies:
+  test: ^1.31.2

--- a/tools/eqmonitor_lints_plugin/test/lint_target_scope_test.dart
+++ b/tools/eqmonitor_lints_plugin/test/lint_target_scope_test.dart
@@ -5,14 +5,18 @@ void main() {
   group('LintTargetScope.isExcluded', () {
     test('test ディレクトリ配下は除外する', () {
       expect(
-        LintTargetScope.isExcluded(path: '/repo/app/test/feature/eew/a_test.dart'),
+        LintTargetScope.isExcluded(
+          path: '/repo/app/test/feature/eew/a_test.dart',
+        ),
         isTrue,
       );
     });
 
     test('integration_test 配下は除外する', () {
       expect(
-        LintTargetScope.isExcluded(path: '/repo/app/integration_test/app_test.dart'),
+        LintTargetScope.isExcluded(
+          path: '/repo/app/integration_test/app_test.dart',
+        ),
         isTrue,
       );
     });
@@ -26,25 +30,33 @@ void main() {
 
     test('lib 配下は除外しない', () {
       expect(
-        LintTargetScope.isExcluded(path: '/repo/app/lib/feature/eew/eew_page.dart'),
+        LintTargetScope.isExcluded(
+          path: '/repo/app/lib/feature/eew/eew_page.dart',
+        ),
         isFalse,
       );
     });
 
     test('ファイル名やディレクトリ名の部分一致では除外しない', () {
       expect(
-        LintTargetScope.isExcluded(path: '/repo/app/lib/core/util/latest_test_helper.dart'),
+        LintTargetScope.isExcluded(
+          path: '/repo/app/lib/core/util/latest_test_helper.dart',
+        ),
         isFalse,
       );
       expect(
-        LintTargetScope.isExcluded(path: '/repo/app/lib/feature/contest/page.dart'),
+        LintTargetScope.isExcluded(
+          path: '/repo/app/lib/feature/contest/page.dart',
+        ),
         isFalse,
       );
     });
 
     test('Windows 形式の区切り文字でも除外する', () {
       expect(
-        LintTargetScope.isExcluded(path: r'C:\repo\app\test\feature\a_test.dart'),
+        LintTargetScope.isExcluded(
+          path: r'C:\repo\app\test\feature\a_test.dart',
+        ),
         isTrue,
       );
     });

--- a/tools/eqmonitor_lints_plugin/test/lint_target_scope_test.dart
+++ b/tools/eqmonitor_lints_plugin/test/lint_target_scope_test.dart
@@ -1,0 +1,52 @@
+import 'package:eqmonitor_lints_plugin/src/lint_target_scope.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LintTargetScope.isExcluded', () {
+    test('test ディレクトリ配下は除外する', () {
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/test/feature/eew/a_test.dart'),
+        isTrue,
+      );
+    });
+
+    test('integration_test 配下は除外する', () {
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/integration_test/app_test.dart'),
+        isTrue,
+      );
+    });
+
+    test('test_driver 配下は除外する', () {
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/test_driver/driver.dart'),
+        isTrue,
+      );
+    });
+
+    test('lib 配下は除外しない', () {
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/lib/feature/eew/eew_page.dart'),
+        isFalse,
+      );
+    });
+
+    test('ファイル名やディレクトリ名の部分一致では除外しない', () {
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/lib/core/util/latest_test_helper.dart'),
+        isFalse,
+      );
+      expect(
+        LintTargetScope.isExcluded(path: '/repo/app/lib/feature/contest/page.dart'),
+        isFalse,
+      );
+    });
+
+    test('Windows 形式の区切り文字でも除外する', () {
+      expect(
+        LintTargetScope.isExcluded(path: r'C:\repo\app\test\feature\a_test.dart'),
+        isTrue,
+      );
+    });
+  });
+}

--- a/tools/eqmonitor_lints_plugin/test/top_level_function_exemption_test.dart
+++ b/tools/eqmonitor_lints_plugin/test/top_level_function_exemption_test.dart
@@ -1,0 +1,83 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:eqmonitor_lints_plugin/src/top_level_function_exemption.dart';
+import 'package:test/test.dart';
+
+List<FunctionDeclaration> _declarationsOf(String source) {
+  final unit = parseString(content: source, throwIfDiagnostics: false).unit;
+  return unit.declarations.whereType<FunctionDeclaration>().toList();
+}
+
+void main() {
+  group('TopLevelFunctionExemption.isExempt', () {
+    test('main は許可する', () {
+      final declarations = _declarationsOf('void main() {}');
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isTrue,
+      );
+    });
+
+    test('@riverpod は許可する', () {
+      final declarations = _declarationsOf('@riverpod\nint foo(Ref ref) => 0;');
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isTrue,
+      );
+    });
+
+    test('@Riverpod(keepAlive: true) は許可する', () {
+      final declarations = _declarationsOf(
+        '@Riverpod(keepAlive: true)\nint foo(Ref ref) => 0;',
+      );
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isTrue,
+      );
+    });
+
+    test("@pragma('vm:entry-point') は許可する", () {
+      final declarations = _declarationsOf(
+        "@pragma('vm:entry-point')\nvoid worker(SendPort port) {}",
+      );
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isTrue,
+      );
+    });
+
+    test("@pragma('vm:prefer-inline') は許可しない", () {
+      final declarations = _declarationsOf(
+        "@pragma('vm:prefer-inline')\nvoid helper() {}",
+      );
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isFalse,
+      );
+    });
+
+    test('引数のない @pragma は許可しない', () {
+      final declarations = _declarationsOf('@pragma\nvoid helper() {}');
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isFalse,
+      );
+    });
+
+    test('素のトップレベル関数は許可しない', () {
+      final declarations = _declarationsOf('void helper() {}');
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isFalse,
+      );
+    });
+
+    test('main という名前でもクラスのメソッドは対象外（トップレベルのみ判定）', () {
+      final declarations = _declarationsOf('void mainHandler() {}');
+      expect(
+        TopLevelFunctionExemption.isExempt(node: declarations.single),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`melos run analyze`（`dart analyze . --fatal-infos`）で出ている **1,512 件** の診断を 0 件にする。

Analyzer の `ERROR` は 0 件で、内訳は `WARNING 1,439 件` / `INFO 73 件`。538 ファイルに分布している。
生成ファイル（`*.g.dart` / `*.freezed.dart`）由来の診断は 0 件であり、コード生成のやり直しでは 1 件も減らない。

## 診断の内訳（実測）

| コード | 提供元 | 件数 |
| --- | --- | ---: |
| `avoid_top_level_functions` | eqmonitor_lints_plugin | 814 |
| `avoid_null_assertion_operator` | eqmonitor_lints_plugin | 578 |
| `avoid_eqmonitor_api_in_ui` | eqmonitor_lints_plugin | 23 |
| `avoid_mixed_declaration_categories` | eqmonitor_lints_plugin | 12 |
| `avoid_stateful_widget` | eqmonitor_lints_plugin | 7 |
| `avoid_direct_color_scheme` | eqmonitor_custom_lints | 4 |
| 標準 lint / hint（15 種） | Dart SDK / yumemi_lints | 73 |
| `plugins_in_inner_options` | Dart SDK | 1 |

## 方針

### 1. 自作 analyzer plugin の誤検出を正す（796 件）

- `avoid_top_level_functions` の 814 件のうち **296 件が `main()`**。Dart のエントリポイントは言語仕様上トップレベル関数以外にあり得ず、是正指示が適用不可能だった
- `@pragma('vm:entry-point')` 付きの Isolate ワーカーも VM が名前解決するため移動できない
- テストコードは本番コードと設計要求が異なるため、自作ルールの対象外にする（標準 lint は従来どおり適用）
- `@pragma` は第 1 引数まで検査し `vm:entry-point` のみ許可する。`@pragma` 全般を許可すると `vm:prefer-inline` などで回避できてしまうため

`analysis_options.yaml` の `exclude` は使わない（標準解析まで止まるため）。判定は plugin 側の `LintTargetScope` に集約する。

### 2. Analyzer 設定の重複を解消する（1 件）

`app/analysis_options.yaml` の `plugins:` ブロックは pub workspace のメンバーパッケージでは宣言できず無視されている。実際に効いているのはリポジトリルートの宣言。

### 3. 残る 716 件を実コードの修正で解消する

- `app/lib` の plugin ルール違反 643 件を feature 単位で修正
- `packages/seismicity_pmtiles` の標準 lint 73 件を修正

ルール単位ではなく feature 単位にするのは、同一ファイルを複数タスクで繰り返し編集して衝突するのを避けるため。

## `!` の除去方針

578 件中 356 件が `app/lib` にある。機械的置換は禁止とし、次の優先順位で判断する。

1. `?.` による null 伝播（`style:` などは `null` を受け付ける）
2. `if (x != null)` / パターンマッチによるフロー解析
3. 型を非 null にする構造変更
4. ドメイン上正しい既定値がある場合のみ `??`
5. 不変条件により非 null が保証される場合のみ `orFailBecause('理由')`

震度・マグニチュード・座標など生命に関わる情報に、その場しのぎの固定値フォールバックは入れない。

`orFailBecause` は `!` と失敗時の挙動（例外送出）が同じで、クラッシュログから前提条件を特定できる点だけが違う。機械的置換にならないよう、使用箇所と理由をタスクごとに報告・レビューする。

## 回帰防止

自作 analyzer plugin には現状テストが 1 件もない（`eqmonitor_custom_lints` の 1 ルール分を除く）。plugin のルールは全パッケージの解析結果を左右するため、判定ロジックを純粋なクラスへ切り出して単体テストを追加し、CI（`wc-check-dart-analyze.yaml`）のテスト対象にする。`tools/` は melos workspace 外のため `melos run test` では実行されない。

## 完了条件

```bash
mise exec -- dart run melos exec -c 1 -- dart analyze . --fatal-infos
```

全 28 パッケージが `SUCCESS` になること。

## 設計書・実装計画

- `docs/superpowers/specs/2026-08-14-analyzer-diagnostics-cleanup-design.md`
- `docs/superpowers/plans/2026-08-14-analyzer-diagnostics-cleanup.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e52c2b42-27ad-46df-aaf5-73bbc39fc6ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e52c2b42-27ad-46df-aaf5-73bbc39fc6ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

