### PR TITLE
feat: ホーム画面に推計震度・到達予想時刻を表示するデバッグトグルを追加

### DIFF
--- a/app/lib/core/data/preferences/secure/secure_preferences_data_source.dart
+++ b/app/lib/core/data/preferences/secure/secure_preferences_data_source.dart
@@ -30,10 +30,8 @@ class SecurePreferencesDataSource
       _secureStorage.read(key: key.key);
 
   @override
-  Future<void> setInt({
-    required SecureStorageKey key,
-    required int value,
-  }) => _secureStorage.write(key: key.key, value: value.toString());
+  Future<void> setInt({required SecureStorageKey key, required int value}) =>
+      _secureStorage.write(key: key.key, value: value.toString());
 
   @override
   Future<int?> getInt({required SecureStorageKey key}) => _secureStorage
@@ -52,10 +50,8 @@ class SecurePreferencesDataSource
       .then((value) => value != null ? double.tryParse(value) : null);
 
   @override
-  Future<void> setBool({
-    required SecureStorageKey key,
-    required bool value,
-  }) => _secureStorage.write(key: key.key, value: value.toString());
+  Future<void> setBool({required SecureStorageKey key, required bool value}) =>
+      _secureStorage.write(key: key.key, value: value.toString());
 
   @override
   Future<bool?> getBool({required SecureStorageKey key}) => _secureStorage

--- a/app/lib/core/data/preferences/secure/secure_storage_key.dart
+++ b/app/lib/core/data/preferences/secure/secure_storage_key.dart
@@ -4,8 +4,7 @@ enum SecureStorageKey {
   hinetBosaiUserId('hinet_bosai_user_id'),
   hinetBosaiPassword('hinet_bosai_password'),
   knetBosaiUserId('knet_bosai_user_id'),
-  knetBosaiPassword('knet_bosai_password'),
-  ;
+  knetBosaiPassword('knet_bosai_password');
 
   const SecureStorageKey(this.key);
   final String key;

--- a/app/lib/core/data/preferences/shared/shared_preferences_data_source.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences_data_source.dart
@@ -14,9 +14,8 @@ Future<SharedPreferencesDataSource> sharedPreferencesDataSource(Ref ref) async {
 
 class SharedPreferencesDataSource
     implements PreferencesDataSource<SharedPreferencesKey> {
-  SharedPreferencesDataSource({
-    required SharedPreferences sharedPreferences,
-  }) : _sharedPreferences = sharedPreferences;
+  SharedPreferencesDataSource({required SharedPreferences sharedPreferences})
+    : _sharedPreferences = sharedPreferences;
 
   final SharedPreferences _sharedPreferences;
 

--- a/app/lib/core/data/preferences/shared/shared_preferences_key.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences_key.dart
@@ -31,6 +31,7 @@ enum SharedPreferencesKey {
   isEstimatedIntensityOnEewReplayAllowed(
     'is_estimated_intensity_on_eew_replay_allowed',
   ),
+  isHomeEewEstimationDebugEnabled('is_home_eew_estimation_debug_enabled'),
   widgetRegionSelection('widget_region_selection'),
   httpCacheDisabled('http_cache_disabled'),
   httpCacheScopeMigrationVersion('http_cache_scope_migration_version'),

--- a/app/lib/feature/devices/data/exception/device_provisioning_exception.dart
+++ b/app/lib/feature/devices/data/exception/device_provisioning_exception.dart
@@ -90,11 +90,7 @@ final class AuthorizationException extends DeviceProvisioningException {
 
 /// 429 レート制限。[retryAfter] が非 null の場合は優先的に使用する。
 final class RateLimitedException extends DeviceProvisioningException {
-  const RateLimitedException({
-    this.retryAfter,
-    super.cause,
-    super.stackTrace,
-  });
+  const RateLimitedException({this.retryAfter, super.cause, super.stackTrace});
   final Duration? retryAfter;
 
   @override

--- a/app/lib/feature/devices/data/model/device_role.dart
+++ b/app/lib/feature/devices/data/model/device_role.dart
@@ -1,0 +1,21 @@
+/// Device API が返すデバイス所有者のロール。
+///
+/// backend では better-auth の `user.role` として管理されており、
+/// `role === 'admin'` のみが管理者向け機能の判定に使われる。
+enum DeviceRole {
+  admin('admin'),
+  user('user');
+
+  const DeviceRole(this.value);
+
+  final String value;
+
+  /// API の値から [DeviceRole] へ変換する。
+  ///
+  /// 未知の値・未提供(null)は、権限を推測せず null を返す。
+  static DeviceRole? fromApiValue(String? value) => switch (value) {
+    'admin' => DeviceRole.admin,
+    'user' => DeviceRole.user,
+    _ => null,
+  };
+}

--- a/app/lib/feature/devices/data/model/push_token_sync_snapshot.dart
+++ b/app/lib/feature/devices/data/model/push_token_sync_snapshot.dart
@@ -53,7 +53,7 @@ final class PushTokenSyncSnapshot {
         return RetryRunning(attempt: attempt);
       }
     }
-    return  RetryIdle();
+    return RetryIdle();
   }
 
   Iterable<MapEntry<PushTokenKind, PushTokenKindState>> get kindEntries => [

--- a/app/lib/feature/devices/data/model/registered_device.dart
+++ b/app/lib/feature/devices/data/model/registered_device.dart
@@ -15,16 +15,9 @@ abstract class RegisteredDevice with _$RegisteredDevice {
   }) = _RegisteredDevice;
 }
 
-enum DevicePlatform {
-  ios,
-  android,
-}
+enum DevicePlatform { ios, android }
 
-enum DeviceLocale {
-  ja,
-  en,
-  zh,
-}
+enum DeviceLocale { ja, en, zh }
 
 extension DevicePlatformDisplay on DevicePlatform {
   String get displayLabel => switch (this) {

--- a/app/lib/feature/devices/data/provider/device_role_provider.dart
+++ b/app/lib/feature/devices/data/provider/device_role_provider.dart
@@ -1,0 +1,33 @@
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/feature/devices/data/model/device_role.dart';
+import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
+import 'package:eqmonitor/feature/devices/data/repository/device_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'device_role_provider.g.dart';
+
+/// このデバイスに紐づくユーザーのロール。
+///
+/// デバイス未登録時・取得失敗時・ロール未提供時は null を返す。
+/// 権限判定に使うため、取得できない場合に権限ありへフォールバックしない。
+@Riverpod(keepAlive: true)
+Future<DeviceRole?> deviceRole(Ref ref) async {
+  final provisioning = await ref.watch(deviceProvisioningProvider.future);
+  if (provisioning != DeviceProvisioningStatus.notRequired) {
+    return null;
+  }
+
+  final repository = await ref.watch(deviceRepositoryProvider.future);
+  switch (await repository.getDeviceRole()) {
+    case Success(:final value):
+      return value;
+    case Failure(:final exception, :final stackTrace):
+      talker.warning(
+        '[DeviceRole] failed to fetch role',
+        exception,
+        stackTrace,
+      );
+      return null;
+  }
+}

--- a/app/lib/feature/devices/data/provider/device_role_provider.g.dart
+++ b/app/lib/feature/devices/data/provider/device_role_provider.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'device_role_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// このデバイスに紐づくユーザーのロール。
+///
+/// デバイス未登録時・取得失敗時・ロール未提供時は null を返す。
+/// 権限判定に使うため、取得できない場合に権限ありへフォールバックしない。
+
+@ProviderFor(deviceRole)
+final deviceRoleProvider = DeviceRoleProvider._();
+
+/// このデバイスに紐づくユーザーのロール。
+///
+/// デバイス未登録時・取得失敗時・ロール未提供時は null を返す。
+/// 権限判定に使うため、取得できない場合に権限ありへフォールバックしない。
+
+final class DeviceRoleProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<DeviceRole?>,
+          DeviceRole?,
+          FutureOr<DeviceRole?>
+        >
+    with $FutureModifier<DeviceRole?>, $FutureProvider<DeviceRole?> {
+  /// このデバイスに紐づくユーザーのロール。
+  ///
+  /// デバイス未登録時・取得失敗時・ロール未提供時は null を返す。
+  /// 権限判定に使うため、取得できない場合に権限ありへフォールバックしない。
+  DeviceRoleProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'deviceRoleProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$deviceRoleHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<DeviceRole?> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<DeviceRole?> create(Ref ref) {
+    return deviceRole(ref);
+  }
+}
+
+String _$deviceRoleHash() => r'c7a303a48fdd0416d77917bc8e9503a40deb4701';

--- a/app/lib/feature/devices/data/repository/device_auth_repository.dart
+++ b/app/lib/feature/devices/data/repository/device_auth_repository.dart
@@ -8,27 +8,19 @@ part 'device_auth_repository.g.dart';
 @Riverpod(keepAlive: true)
 Future<DeviceAuthRepository> deviceAuthRepository(Ref ref) async =>
     DeviceAuthRepository(
-      await ref.watch(
-        securePreferencesDataSourceProvider.future,
-      ),
+      await ref.watch(securePreferencesDataSourceProvider.future),
     );
 
 class DeviceAuthRepository {
-  const DeviceAuthRepository(
-    this._preferences,
-  );
+  const DeviceAuthRepository(this._preferences);
 
   final PreferencesDataSource<SecureStorageKey> _preferences;
 
   Future<String?> readToken() =>
       _preferences.getString(key: SecureStorageKey.deviceToken);
 
-  Future<void> saveToken({
-    required String token,
-  }) => _preferences.setString(
-    key: SecureStorageKey.deviceToken,
-    value: token,
-  );
+  Future<void> saveToken({required String token}) =>
+      _preferences.setString(key: SecureStorageKey.deviceToken, value: token);
 
   Future<void> clearToken() =>
       _preferences.remove(key: SecureStorageKey.deviceToken);

--- a/app/lib/feature/devices/data/repository/device_repository.dart
+++ b/app/lib/feature/devices/data/repository/device_repository.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/core/api/api_client_provider.dart';
 import 'package:eqmonitor/core/foundation/result.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/feature/devices/data/exception/device_provisioning_exception.dart';
+import 'package:eqmonitor/feature/devices/data/model/device_role.dart';
 import 'package:eqmonitor/feature/devices/data/model/registered_device.dart';
 import 'package:eqmonitor/feature/devices/data/provider/apns_environment.dart';
 import 'package:eqmonitor/feature/devices/data/repository/device_auth_repository.dart';
@@ -38,6 +39,24 @@ class DeviceRepository {
       Result.capture(() async {
         final response = await _api.device.getV2DeviceMe();
         return response.data.toRegisteredDevice;
+      });
+
+  /// デバイスに紐づくユーザーのロールを取得する。
+  ///
+  /// `role` は OpenAPI の `DeviceMeResponse` に未定義のため、生成モデルではなく
+  /// レスポンスの生 JSON から読む。backend がフィールドを追加し次第、生成モデル
+  /// 経由へ置き換える(`docs/todo/300_device_role_api_field.md`)。
+  ///
+  /// ロールを判定できない場合(フィールド未提供・未知の値)は null を返す。
+  Future<Result<DeviceRole?, Exception>> getDeviceRole() =>
+      Result.capture(() async {
+        final response = await _api.device.getV2DeviceMe();
+        final body = response.response.data;
+        if (body is! Map<String, dynamic>) {
+          return null;
+        }
+        final role = body['role'];
+        return DeviceRole.fromApiValue(role is String ? role : null);
       });
 
   Future<Result<RegisteredDevice, Exception>> registerDevice({

--- a/app/lib/feature/devices/data/workflow/device_migration_workflow.dart
+++ b/app/lib/feature/devices/data/workflow/device_migration_workflow.dart
@@ -66,38 +66,15 @@ Future<void> runV3MigrationWorkflow({
 
       // Step 2 — register only when absent
       if (!alreadyRegistered) {
-        await step<void>(
-          'registerDevice',
-          () async {
-            final result = await repository.registerDevice(
-              deviceId: deviceId,
-              devicePlatform: kIsWeb
-                  ? .ios
-                  : Platform.isIOS
-                  ? .ios
-                  : .android,
-              deviceLocale: .ja,
-            );
-            switch (result) {
-              case Success():
-                break;
-              case Failure(:final exception, :final stackTrace):
-                Error.throwWithStackTrace(
-                  exception,
-                  stackTrace ?? StackTrace.empty,
-                );
-            }
-          },
-        );
-      }
-
-      // Step 3 — migrate legacy settings
-      await step<void>(
-        'migrateLegacySettings',
-        () async {
-          final result = await repository.migrateFromLegacy(
+        await step<void>('registerDevice', () async {
+          final result = await repository.registerDevice(
             deviceId: deviceId,
-            oldDeviceId: oldDeviceId,
+            devicePlatform: kIsWeb
+                ? .ios
+                : Platform.isIOS
+                ? .ios
+                : .android,
+            deviceLocale: .ja,
           );
           switch (result) {
             case Success():
@@ -108,8 +85,25 @@ Future<void> runV3MigrationWorkflow({
                 stackTrace ?? StackTrace.empty,
               );
           }
-        },
-      );
+        });
+      }
+
+      // Step 3 — migrate legacy settings
+      await step<void>('migrateLegacySettings', () async {
+        final result = await repository.migrateFromLegacy(
+          deviceId: deviceId,
+          oldDeviceId: oldDeviceId,
+        );
+        switch (result) {
+          case Success():
+            break;
+          case Failure(:final exception, :final stackTrace):
+            Error.throwWithStackTrace(
+              exception,
+              stackTrace ?? StackTrace.empty,
+            );
+        }
+      });
 
       // Step 4 — persist completion flag
       await step<bool>(_kMarkComplete, () => true);

--- a/app/lib/feature/devices/ui/component/device_provisioning_banner.dart
+++ b/app/lib/feature/devices/ui/component/device_provisioning_banner.dart
@@ -26,7 +26,7 @@ class DeviceProvisioningBanner extends ConsumerWidget {
 
     final notifier = ref.watch(deviceProvisioningProvider.notifier);
     final provisionRetry = notifier.retryState;
-    final syncRetry = syncSnapshot?.value?.retryState ??  RetryIdle();
+    final syncRetry = syncSnapshot?.value?.retryState ?? RetryIdle();
 
     // アクティブなリトライ状態（provisioning 優先）
     final activeRetry = provisionRetry is! RetryIdle
@@ -215,9 +215,8 @@ class _BannerTile extends StatelessWidget {
             Expanded(
               child: Text(
                 message,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodySmall?.copyWith(color: foregroundColor),
+                style: Theme.of(context).textTheme.bodySmall
+                    ?.copyWith(color: foregroundColor),
               ),
             ),
             if (trailing != null) ...[const SizedBox(width: 8), trailing!],

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -195,9 +195,8 @@ class _ProvisioningStartupSection extends HookConsumerWidget {
             children: [
               Text(
                 'リトライ状態: ',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: colorTheme.onSurfaceVariant,
-                ),
+                style: Theme.of(context).textTheme.bodySmall
+                    ?.copyWith(color: colorTheme.onSurfaceVariant),
               ),
               const SizedBox(width: 4),
               retryChip,
@@ -207,9 +206,8 @@ class _ProvisioningStartupSection extends HookConsumerWidget {
             const SizedBox(height: 4),
             Text(
               (retryState.value as RetryWaiting).lastError.userMessage,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: colorTheme.onSurfaceVariant,
-              ),
+              style: Theme.of(context).textTheme.bodySmall
+                  ?.copyWith(color: colorTheme.onSurfaceVariant),
             ),
           ],
           if (isLoading) ...[
@@ -280,9 +278,8 @@ class _StatusChip extends StatelessWidget {
           Flexible(
             child: Text(
               label,
-              style: Theme.of(
-                context,
-              ).textTheme.labelSmall?.copyWith(color: textColor),
+              style: Theme.of(context).textTheme.labelSmall
+                  ?.copyWith(color: textColor),
               overflow: TextOverflow.ellipsis,
             ),
           ),

--- a/app/lib/feature/eew/data/model/eew_telegram_item.dart
+++ b/app/lib/feature/eew/data/model/eew_telegram_item.dart
@@ -34,8 +34,7 @@ abstract class EewTelegramItem with _$EewTelegramItem {
       isPlum || accuracy == null || accuracy?.epicenter == 1;
 
   /// レベル法: 震央精度が1点相当かつ発震時刻なし（Live Activity `isLevel` と同義）
-  bool get isLevelMethod =>
-      accuracy?.epicenter == 1 && originTime == null;
+  bool get isLevelMethod => accuracy?.epicenter == 1 && originTime == null;
 
   /// IPF法1点検知: 震央精度1点相当・発震時刻あり・PLUMでない（Live Activity `isOnePoint` と同義）
   bool get isOnePointDetection =>
@@ -260,11 +259,8 @@ extension on api.EewWarning {
 }
 
 extension on api.EewWarningZoneItem {
-  EewWarningZoneInfo _toEewWarningZoneInfo() => EewWarningZoneInfo(
-    code: code,
-    name: name,
-    hadWarning: hadWarning,
-  );
+  EewWarningZoneInfo _toEewWarningZoneInfo() =>
+      EewWarningZoneInfo(code: code, name: name, hadWarning: hadWarning);
 }
 
 extension on api.EewAccuracy {

--- a/app/lib/feature/eew/ui/components/eew_table.dart
+++ b/app/lib/feature/eew/ui/components/eew_table.dart
@@ -67,7 +67,9 @@ class EewTable extends StatelessWidget {
                     return designSystem.colorTheme.primaryContainer;
                   }
                   return eew.isWarning ?? false
-                      ? designSystem.colorTheme.errorContainer.withValues(alpha: 0.7)
+                      ? designSystem.colorTheme.errorContainer.withValues(
+                          alpha: 0.7,
+                        )
                       : designSystem.colorTheme.surfaceContainer;
                 }),
                 cells: _EewTableColumn.values
@@ -204,10 +206,7 @@ extension _EewTableColumnEx on _EewTableColumn {
       value: '${eew.accuracy!.depth}',
       isNumeric: true,
     ),
-    .accuracy => const _EewTableColumnValue(
-      value: '',
-      isNumeric: false,
-    ),
+    .accuracy => const _EewTableColumnValue(value: '', isNumeric: false),
     .type => _EewTableColumnValue(
       value: (eew.isWarning ?? false) ? '緊急地震速報 (警報)' : '緊急地震速報 (予報)',
       isNumeric: false,

--- a/app/lib/feature/eew/ui/page/eew_details_by_event_id_page.dart
+++ b/app/lib/feature/eew/ui/page/eew_details_by_event_id_page.dart
@@ -14,12 +14,9 @@ import 'package:eqmonitor/feature/eew/ui/components/eew_details_map_view.dart';
 import 'package:eqmonitor/feature/eew/ui/components/eew_table.dart';
 import 'package:eqmonitor/feature/eew/ui/hook/use_eew_estimated_regions.dart';
 import 'package:eqmonitor/feature/home/ui/component/eew/eew_card.dart';
-import 'package:eqmonitor/feature/location/data/location.dart';
-import 'package:eqmonitor/feature/location/data/nearest_jma_feature.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:lat_lng/lat_lng.dart' as lat_lng;
 import 'package:maplibre/maplibre.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
@@ -184,29 +181,6 @@ class _SimulationView extends HookConsumerWidget {
       return estimatedRegions.additionalForecastRegionsFor(eew: currentEew);
     }, [estimatedRegions, currentEew]);
 
-    // ユーザー現在地regionの推定値
-    final positionAsync = ref.watch(locationStreamProvider);
-    final position = positionAsync.value;
-    final regionItem = position != null
-        ? ref
-              .watch(
-                jmaMapAreaForecastLocalEInsideProvider(
-                  lat_lng.LatLng(position.latitude, position.longitude),
-                ),
-              )
-              .value
-        : null;
-    final userRegionCode = regionItem?.property?.code;
-
-    final userEstimate = useMemoized(() {
-      if (estimatedRegions == null || userRegionCode == null) {
-        return null;
-      }
-      return estimatedRegions.firstWhereOrNull(
-        (e) => e.regionCode == userRegionCode,
-      );
-    }, [estimatedRegions, userRegionCode]);
-
     return Stack(
       children: [
         Positioned.fill(
@@ -228,7 +202,7 @@ class _SimulationView extends HookConsumerWidget {
               eew: currentEew,
               index: null,
               nowOverride: virtualNow,
-              userRegionEstimate: isEstimatedAllowed ? userEstimate : null,
+              estimatedRegions: isEstimatedAllowed ? estimatedRegions : null,
             ),
           ),
       ],

--- a/app/lib/feature/home/data/notifier/home_eew_estimation_debug_notifier.dart
+++ b/app/lib/feature/home/data/notifier/home_eew_estimation_debug_notifier.dart
@@ -1,0 +1,32 @@
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'home_eew_estimation_debug_notifier.g.dart';
+
+/// ホーム画面のEEWカードに、距離減衰式による推計震度と到達予想時刻を
+/// 表示するかどうかのデバッグ設定。
+///
+/// この設定単体では表示可否を決めない。実際の表示可否は
+/// `isHomeEewEstimationVisibleProvider` を参照する。
+@Riverpod(keepAlive: true)
+class HomeEewEstimationDebug extends _$HomeEewEstimationDebug {
+  static const SharedPreferencesKey _key =
+      SharedPreferencesKey.isHomeEewEstimationDebugEnabled;
+
+  @override
+  Future<bool> build() async {
+    final dataSource = await ref.watch(
+      sharedPreferencesDataSourceProvider.future,
+    );
+    return await dataSource.getBool(key: _key) ?? false;
+  }
+
+  Future<void> save({required bool isEnabled}) async {
+    final dataSource = await ref.read(
+      sharedPreferencesDataSourceProvider.future,
+    );
+    await dataSource.setBool(key: _key, value: isEnabled);
+    state = AsyncData(isEnabled);
+  }
+}

--- a/app/lib/feature/home/data/notifier/home_eew_estimation_debug_notifier.g.dart
+++ b/app/lib/feature/home/data/notifier/home_eew_estimation_debug_notifier.g.dart
@@ -1,0 +1,78 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'home_eew_estimation_debug_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// ホーム画面のEEWカードに、距離減衰式による推計震度と到達予想時刻を
+/// 表示するかどうかのデバッグ設定。
+///
+/// この設定単体では表示可否を決めない。実際の表示可否は
+/// `isHomeEewEstimationVisibleProvider` を参照する。
+
+@ProviderFor(HomeEewEstimationDebug)
+final homeEewEstimationDebugProvider = HomeEewEstimationDebugProvider._();
+
+/// ホーム画面のEEWカードに、距離減衰式による推計震度と到達予想時刻を
+/// 表示するかどうかのデバッグ設定。
+///
+/// この設定単体では表示可否を決めない。実際の表示可否は
+/// `isHomeEewEstimationVisibleProvider` を参照する。
+final class HomeEewEstimationDebugProvider
+    extends $AsyncNotifierProvider<HomeEewEstimationDebug, bool> {
+  /// ホーム画面のEEWカードに、距離減衰式による推計震度と到達予想時刻を
+  /// 表示するかどうかのデバッグ設定。
+  ///
+  /// この設定単体では表示可否を決めない。実際の表示可否は
+  /// `isHomeEewEstimationVisibleProvider` を参照する。
+  HomeEewEstimationDebugProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'homeEewEstimationDebugProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$homeEewEstimationDebugHash();
+
+  @$internal
+  @override
+  HomeEewEstimationDebug create() => HomeEewEstimationDebug();
+}
+
+String _$homeEewEstimationDebugHash() =>
+    r'326bf9587dc69edcd3e57afc9bc3f5d13c2b77d3';
+
+/// ホーム画面のEEWカードに、距離減衰式による推計震度と到達予想時刻を
+/// 表示するかどうかのデバッグ設定。
+///
+/// この設定単体では表示可否を決めない。実際の表示可否は
+/// `isHomeEewEstimationVisibleProvider` を参照する。
+
+abstract class _$HomeEewEstimationDebug extends $AsyncNotifier<bool> {
+  FutureOr<bool> build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<bool>, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<bool>, bool>,
+              AsyncValue<bool>,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/home/data/provider/home_eew_estimation_debug_provider.dart
+++ b/app/lib/feature/home/data/provider/home_eew_estimation_debug_provider.dart
@@ -22,13 +22,13 @@ Future<bool> isHomeEewEstimationDebugAvailable(Ref ref) async {
 /// ホーム画面のEEWカードに推計震度・到達予想時刻を表示するかどうか。
 ///
 /// 設定が有効でも、変更権限を失った場合は表示しない。
+/// EEW 受信中にロール取得の API 呼び出しを発生させないため、
+/// ローカルに保存された設定を先に確認する。
 @riverpod
 Future<bool> isHomeEewEstimationVisible(Ref ref) async {
-  final isAvailable = await ref.watch(
-    isHomeEewEstimationDebugAvailableProvider.future,
-  );
-  if (!isAvailable) {
+  final isEnabled = await ref.watch(homeEewEstimationDebugProvider.future);
+  if (!isEnabled) {
     return false;
   }
-  return ref.watch(homeEewEstimationDebugProvider.future);
+  return ref.watch(isHomeEewEstimationDebugAvailableProvider.future);
 }

--- a/app/lib/feature/home/data/provider/home_eew_estimation_debug_provider.dart
+++ b/app/lib/feature/home/data/provider/home_eew_estimation_debug_provider.dart
@@ -1,0 +1,34 @@
+import 'package:eqmonitor/feature/devices/data/model/device_role.dart';
+import 'package:eqmonitor/feature/devices/data/provider/device_role_provider.dart';
+import 'package:eqmonitor/feature/home/data/notifier/home_eew_estimation_debug_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'home_eew_estimation_debug_provider.g.dart';
+
+/// ホーム画面の推計震度・到達予想時刻の表示設定を変更できるかどうか。
+///
+/// Device API のロールが Admin であり、かつデバッグモードが有効な場合のみ true。
+@riverpod
+Future<bool> isHomeEewEstimationDebugAvailable(Ref ref) async {
+  final isDebugEnabled = await ref.watch(debugProvider.future);
+  if (!isDebugEnabled) {
+    return false;
+  }
+  final role = await ref.watch(deviceRoleProvider.future);
+  return role == DeviceRole.admin;
+}
+
+/// ホーム画面のEEWカードに推計震度・到達予想時刻を表示するかどうか。
+///
+/// 設定が有効でも、変更権限を失った場合は表示しない。
+@riverpod
+Future<bool> isHomeEewEstimationVisible(Ref ref) async {
+  final isAvailable = await ref.watch(
+    isHomeEewEstimationDebugAvailableProvider.future,
+  );
+  if (!isAvailable) {
+    return false;
+  }
+  return ref.watch(homeEewEstimationDebugProvider.future);
+}

--- a/app/lib/feature/home/data/provider/home_eew_estimation_debug_provider.g.dart
+++ b/app/lib/feature/home/data/provider/home_eew_estimation_debug_provider.g.dart
@@ -1,0 +1,104 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'home_eew_estimation_debug_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// ホーム画面の推計震度・到達予想時刻の表示設定を変更できるかどうか。
+///
+/// Device API のロールが Admin であり、かつデバッグモードが有効な場合のみ true。
+
+@ProviderFor(isHomeEewEstimationDebugAvailable)
+final isHomeEewEstimationDebugAvailableProvider =
+    IsHomeEewEstimationDebugAvailableProvider._();
+
+/// ホーム画面の推計震度・到達予想時刻の表示設定を変更できるかどうか。
+///
+/// Device API のロールが Admin であり、かつデバッグモードが有効な場合のみ true。
+
+final class IsHomeEewEstimationDebugAvailableProvider
+    extends $FunctionalProvider<AsyncValue<bool>, bool, FutureOr<bool>>
+    with $FutureModifier<bool>, $FutureProvider<bool> {
+  /// ホーム画面の推計震度・到達予想時刻の表示設定を変更できるかどうか。
+  ///
+  /// Device API のロールが Admin であり、かつデバッグモードが有効な場合のみ true。
+  IsHomeEewEstimationDebugAvailableProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'isHomeEewEstimationDebugAvailableProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$isHomeEewEstimationDebugAvailableHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<bool> create(Ref ref) {
+    return isHomeEewEstimationDebugAvailable(ref);
+  }
+}
+
+String _$isHomeEewEstimationDebugAvailableHash() =>
+    r'1144b14eab0876a9654a0d28535af6a692ee2648';
+
+/// ホーム画面のEEWカードに推計震度・到達予想時刻を表示するかどうか。
+///
+/// 設定が有効でも、変更権限を失った場合は表示しない。
+
+@ProviderFor(isHomeEewEstimationVisible)
+final isHomeEewEstimationVisibleProvider =
+    IsHomeEewEstimationVisibleProvider._();
+
+/// ホーム画面のEEWカードに推計震度・到達予想時刻を表示するかどうか。
+///
+/// 設定が有効でも、変更権限を失った場合は表示しない。
+
+final class IsHomeEewEstimationVisibleProvider
+    extends $FunctionalProvider<AsyncValue<bool>, bool, FutureOr<bool>>
+    with $FutureModifier<bool>, $FutureProvider<bool> {
+  /// ホーム画面のEEWカードに推計震度・到達予想時刻を表示するかどうか。
+  ///
+  /// 設定が有効でも、変更権限を失った場合は表示しない。
+  IsHomeEewEstimationVisibleProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'isHomeEewEstimationVisibleProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$isHomeEewEstimationVisibleHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<bool> create(Ref ref) {
+    return isHomeEewEstimationVisible(ref);
+  }
+}
+
+String _$isHomeEewEstimationVisibleHash() =>
+    r'ce484783483cbf50d68e1dfd6b874b2bcfe749e0';

--- a/app/lib/feature/home/ui/component/eew/eew_card.dart
+++ b/app/lib/feature/home/ui/component/eew/eew_card.dart
@@ -21,14 +21,17 @@ class EewCard extends ConsumerWidget {
     required this.eew,
     required this.index,
     this.nowOverride,
-    this.userRegionEstimate,
+    this.estimatedRegions,
     super.key,
   });
 
   final EewTelegramItem eew;
   final String? index;
   final DateTime? nowOverride;
-  final EewEstimatedRegion? userRegionEstimate;
+
+  /// 距離減衰式による推計震度。JMAが現在地の予想震度を発表していない場合の
+  /// フォールバックとして利用する。
+  final List<EewEstimatedRegion>? estimatedRegions;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -72,7 +75,9 @@ class EewCard extends ConsumerWidget {
     final localRegion = localForecastRegion(eew, regionCode);
 
     // JMAのlocalRegionがない場合、推定値をフォールバック
-    final estimate = userRegionEstimate;
+    final estimate = regionCode != null
+        ? estimatedRegions?.firstWhereOrNull((e) => e.regionCode == regionCode)
+        : null;
     final effectiveLocalIntensity =
         localRegion?.intensity ?? estimate?.jmaIntensity;
     final effectiveRegionName = regionDisplayName ?? estimate?.regionName;

--- a/app/lib/feature/home/ui/component/eew/home_eew_card.dart
+++ b/app/lib/feature/home/ui/component/eew/home_eew_card.dart
@@ -1,0 +1,30 @@
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/eew/ui/hook/use_eew_estimated_regions.dart';
+import 'package:eqmonitor/feature/home/data/provider/home_eew_estimation_debug_provider.dart';
+import 'package:eqmonitor/feature/home/ui/component/eew/eew_card.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// ホーム画面に表示するEEWカード。
+///
+/// デバッグ設定が有効な場合のみ、JMAが現在地の予想震度を発表していないときの
+/// フォールバックとして、距離減衰式による推計震度とS波到達予想時刻を表示する。
+class HomeEewCard extends HookConsumerWidget {
+  const HomeEewCard({required this.eew, required this.index, super.key});
+
+  final EewTelegramItem eew;
+  final String? index;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isEstimationVisible =
+        ref.watch(isHomeEewEstimationVisibleProvider).value ?? false;
+    final estimatedRegions = useEewEstimatedRegionsWithStaleCache(
+      ref: ref,
+      eew: eew,
+      isEnabled: isEstimationVisible,
+    );
+
+    return EewCard(eew: eew, index: index, estimatedRegions: estimatedRegions);
+  }
+}

--- a/app/lib/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart
+++ b/app/lib/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart
@@ -155,9 +155,9 @@ class HomeEarthquakeHistorySheet extends HookConsumerWidget {
                     // 上の HomeScopeUnavailableBody が担当する）。
                     onPressed: paramAsync.value == null
                         ? null
-                        : () async => EarthquakeHistoryRoute(
-                            $extra: paramAsync.value,
-                          ).push<void>(context),
+                        : () async =>
+                              EarthquakeHistoryRoute($extra: paramAsync.value)
+                                  .push<void>(context),
                     child: const Text('さらに表示'),
                   ),
                 ),

--- a/app/lib/feature/home/ui/page/home_designated_region_picker_page.dart
+++ b/app/lib/feature/home/ui/page/home_designated_region_picker_page.dart
@@ -55,7 +55,9 @@ class HomeDesignatedRegionPickerPage extends HookConsumerWidget {
     final resolvedName =
         (selectedCode.value != null && selectedCode.value!.isNotEmpty)
         ? ref
-              .watch(regionNameProvider(selectedType.value, selectedCode.value!))
+              .watch(
+                regionNameProvider(selectedType.value, selectedCode.value!),
+              )
               .value
         : null;
     final displayName = selectedName.value ?? resolvedName;
@@ -114,8 +116,7 @@ class HomeDesignatedRegionPickerPage extends HookConsumerWidget {
         actions: [
           if (canApply)
             TextButton(
-              onPressed: () =>
-                  Navigator.of(context).pop(buildParameter()),
+              onPressed: () => Navigator.of(context).pop(buildParameter()),
               child: const Text('決定'),
             ),
         ],

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -9,8 +9,11 @@ import 'package:eqmonitor/core/provider/environment/environment.dart';
 import 'package:eqmonitor/core/provider/estimated_intensity/provider/estimated_intensity_on_eew_replay_allowed_provider.dart';
 import 'package:eqmonitor/core/provider/telegram_url/provider/telegram_url_provider.dart';
 import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/devices/data/provider/device_role_provider.dart';
 import 'package:eqmonitor/feature/devices/data/provider/notification_token_stream.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/modal/earthquake_history_debug_modal.dart';
+import 'package:eqmonitor/feature/home/data/notifier/home_eew_estimation_debug_notifier.dart';
+import 'package:eqmonitor/feature/home/data/provider/home_eew_estimation_debug_provider.dart';
 import 'package:eqmonitor/feature/location/data/background_location_debug_settings_provider.dart';
 import 'package:eqmonitor/feature/onboarding/data/notifier/onboarding_notifier.dart';
 import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
@@ -236,6 +239,7 @@ class _DebugWidget extends ConsumerWidget {
                 );
               },
             ),
+            const _HomeEewEstimationTile(),
             ListTile(
               title: const Text('EEW Card'),
               subtitle: Text(
@@ -483,15 +487,13 @@ class _AppCheckSection extends ConsumerWidget {
               final token = await FirebaseAppCheck.instance
                   .getLimitedUseToken();
               if (context.mounted) {
-                ScaffoldMessenger.of(
-                  context,
-                ).showSnackBar(SnackBar(content: Text('Token: $token')));
+                ScaffoldMessenger.of(context)
+                    .showSnackBar(SnackBar(content: Text('Token: $token')));
               }
             } on Exception catch (e) {
               if (context.mounted) {
-                ScaffoldMessenger.of(
-                  context,
-                ).showSnackBar(SnackBar(content: Text('エラー: $e')));
+                ScaffoldMessenger.of(context)
+                    .showSnackBar(SnackBar(content: Text('エラー: $e')));
               }
             }
           },
@@ -596,6 +598,49 @@ class _ParameterDebugSection extends HookConsumerWidget {
           ),
         },
       ],
+    );
+  }
+}
+
+class _HomeEewEstimationTile extends ConsumerWidget {
+  const _HomeEewEstimationTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isDebugEnabled = ref.watch(debugProvider).value ?? false;
+    final roleAsync = ref.watch(deviceRoleProvider);
+    final isAvailable =
+        ref.watch(isHomeEewEstimationDebugAvailableProvider).value ?? false;
+    final isEnabled = ref.watch(homeEewEstimationDebugProvider).value ?? false;
+
+    final subtitle = isAvailable
+        ? 'JMAが現在地の予想震度を発表していない場合に、推計震度とS波到達予想時刻をホームのEEWカードへ表示'
+        : switch ((isDebugEnabled, roleAsync)) {
+            (false, _) => 'デバッグモードが無効のため変更できません',
+            (_, AsyncLoading()) => 'デバイスのロールを確認中です',
+            (_, AsyncError()) => 'デバイスのロールを取得できませんでした',
+            (_, AsyncData(:final value)) =>
+              'Admin ロールのデバイスのみ変更できます'
+                  '(現在のロール: ${value?.value ?? '未提供'})',
+          };
+
+    return ListTile(
+      title: const Text('ホームに推計震度・到達予想時刻を表示'),
+      subtitle: Text(subtitle, style: Theme.of(context).textTheme.bodySmall),
+      leading: const Icon(Icons.speed),
+      trailing: AppSwitch(
+        value: isEnabled && isAvailable,
+        onChanged: isAvailable
+            ? (value) async => ref
+                  .read(homeEewEstimationDebugProvider.notifier)
+                  .save(isEnabled: value)
+            : null,
+      ),
+      onTap: isAvailable
+          ? () async => ref
+                .read(homeEewEstimationDebugProvider.notifier)
+                .save(isEnabled: !isEnabled)
+          : null,
     );
   }
 }

--- a/app/lib/page/home_page.dart
+++ b/app/lib/page/home_page.dart
@@ -7,7 +7,7 @@ import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/devices/ui/component/device_provisioning_banner.dart';
 import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
-import 'package:eqmonitor/feature/home/ui/component/eew/eew_card.dart';
+import 'package:eqmonitor/feature/home/ui/component/eew/home_eew_card.dart';
 import 'package:eqmonitor/feature/home/ui/component/map/home_map_view.dart';
 import 'package:eqmonitor/feature/home/ui/component/shake_detection/shake_detection_card.dart';
 import 'package:eqmonitor/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart';
@@ -87,7 +87,7 @@ class _SheetBody extends ConsumerWidget {
         .mapIndexed(
           (index, element) => Padding(
             padding: EdgeInsets.only(bottom: spacing.md),
-            child: EewCard(
+            child: HomeEewCard(
               eew: element,
               index: (state.length > 1) ? '${index + 1}' : null,
             ),
@@ -246,16 +246,14 @@ class _LocationPermissionBanner extends ConsumerWidget {
                   children: [
                     Text(
                       message.$1,
-                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                        color: colorTheme.onPrimaryContainer,
-                      ),
+                      style: Theme.of(context).textTheme.titleSmall
+                          ?.copyWith(color: colorTheme.onPrimaryContainer),
                     ),
                     if (message.$2.isNotEmpty)
                       Text(
                         message.$2,
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: colorTheme.onPrimaryContainer,
-                        ),
+                        style: Theme.of(context).textTheme.bodySmall
+                            ?.copyWith(color: colorTheme.onPrimaryContainer),
                       ),
                   ],
                 ),

--- a/app/test/feature/devices/device_repository_role_test.dart
+++ b/app/test/feature/devices/device_repository_role_test.dart
@@ -1,0 +1,180 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/data/preferences/preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/feature/devices/data/model/device_role.dart';
+import 'package:eqmonitor/feature/devices/data/repository/device_auth_repository.dart';
+import 'package:eqmonitor/feature/devices/data/repository/device_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DeviceRepository.getDeviceRole', () {
+    test('admin ロールを返す', () async {
+      final repository = _repository(role: 'admin');
+
+      final result = await repository.getDeviceRole();
+
+      expect(result, isA<Success<DeviceRole?, Exception>>());
+      expect(
+        (result as Success<DeviceRole?, Exception>).value,
+        DeviceRole.admin,
+      );
+    });
+
+    test('user ロールを返す', () async {
+      final repository = _repository(role: 'user');
+
+      final result = await repository.getDeviceRole();
+
+      expect(
+        (result as Success<DeviceRole?, Exception>).value,
+        DeviceRole.user,
+      );
+    });
+
+    test('role が未提供の場合は null を返す', () async {
+      final repository = _repository();
+
+      final result = await repository.getDeviceRole();
+
+      expect((result as Success<DeviceRole?, Exception>).value, isNull);
+    });
+
+    test('未知の role は権限を推測せず null を返す', () async {
+      final repository = _repository(role: 'moderator');
+
+      final result = await repository.getDeviceRole();
+
+      expect((result as Success<DeviceRole?, Exception>).value, isNull);
+    });
+
+    test('API が失敗した場合は Failure を返す', () async {
+      final repository = _repository(statusCode: 401);
+
+      final result = await repository.getDeviceRole();
+
+      expect(result, isA<Failure<DeviceRole?, Exception>>());
+    });
+  });
+}
+
+DeviceRepository _repository({String? role, int statusCode = 200}) {
+  final dio = Dio(BaseOptions(baseUrl: 'https://example.com'))
+    ..httpClientAdapter = _DeviceMeAdapter(role: role, statusCode: statusCode);
+  return DeviceRepository(
+    api: api.ApiClient(dio),
+    authRepository: DeviceAuthRepository(_MemorySecurePreferencesDataSource()),
+    apnsEnvironment: api.ApnsEnvironment.development,
+  );
+}
+
+final class _DeviceMeAdapter implements HttpClientAdapter {
+  _DeviceMeAdapter({required this.role, required this.statusCode});
+
+  final String? role;
+  final int statusCode;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (options.path != '/v2/device/me' || statusCode != 200) {
+      return ResponseBody.fromString('', statusCode);
+    }
+    return ResponseBody.fromString(
+      jsonEncode({
+        'id': 'server-device-id',
+        'type': 'IOS',
+        'locale': 'ja',
+        'registrationType': 'APP_CHECK',
+        'userId': null,
+        'is_pro': false,
+        if (role != null) 'role': role,
+        'createdAt': '2026-08-14T00:00:00.000Z',
+        'updatedAt': '2026-08-14T00:00:00.000Z',
+      }),
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+final class _MemorySecurePreferencesDataSource
+    implements PreferencesDataSource<SecureStorageKey> {
+  final values = <SecureStorageKey, String>{};
+
+  @override
+  Future<void> setString({
+    required SecureStorageKey key,
+    required String value,
+  }) async {
+    values[key] = value;
+  }
+
+  @override
+  Future<String?> getString({required SecureStorageKey key}) async =>
+      values[key];
+
+  @override
+  Future<void> setInt({
+    required SecureStorageKey key,
+    required int value,
+  }) async {
+    values[key] = value.toString();
+  }
+
+  @override
+  Future<int?> getInt({required SecureStorageKey key}) async {
+    final value = values[key];
+    return value == null ? null : int.tryParse(value);
+  }
+
+  @override
+  Future<void> setDouble({
+    required SecureStorageKey key,
+    required double value,
+  }) async {
+    values[key] = value.toString();
+  }
+
+  @override
+  Future<double?> getDouble({required SecureStorageKey key}) async {
+    final value = values[key];
+    return value == null ? null : double.tryParse(value);
+  }
+
+  @override
+  Future<void> setBool({
+    required SecureStorageKey key,
+    required bool value,
+  }) async {
+    values[key] = value.toString();
+  }
+
+  @override
+  Future<bool?> getBool({required SecureStorageKey key}) async {
+    final value = values[key];
+    return value == null ? null : bool.tryParse(value);
+  }
+
+  @override
+  Future<void> remove({required SecureStorageKey key}) async {
+    values.remove(key);
+  }
+
+  @override
+  Future<void> clear() async {
+    values.clear();
+  }
+}

--- a/app/test/feature/home/data/provider/home_eew_estimation_debug_provider_test.dart
+++ b/app/test/feature/home/data/provider/home_eew_estimation_debug_provider_test.dart
@@ -30,11 +30,15 @@ ProviderContainer _container({
   required bool isDebugEnabled,
   required DeviceRole? role,
   required bool isSettingEnabled,
+  List<DeviceRole?>? roleReads,
 }) {
   final container = ProviderContainer(
     overrides: [
       debugProvider.overrideWith(() => _StubDebug(isEnabled: isDebugEnabled)),
-      deviceRoleProvider.overrideWith((ref) async => role),
+      deviceRoleProvider.overrideWith((ref) async {
+        roleReads?.add(role);
+        return role;
+      }),
       homeEewEstimationDebugProvider.overrideWith(
         () => _StubHomeEewEstimationDebug(isEnabled: isSettingEnabled),
       ),
@@ -137,6 +141,22 @@ void main() {
         container.read(isHomeEewEstimationVisibleProvider.future),
         completion(isFalse),
       );
+    });
+
+    test('設定が無効ならロールを取得しない', () async {
+      final roleReads = <DeviceRole?>[];
+      final container = _container(
+        isDebugEnabled: true,
+        role: DeviceRole.admin,
+        isSettingEnabled: false,
+        roleReads: roleReads,
+      );
+
+      await expectLater(
+        container.read(isHomeEewEstimationVisibleProvider.future),
+        completion(isFalse),
+      );
+      expect(roleReads, isEmpty);
     });
   });
 }

--- a/app/test/feature/home/data/provider/home_eew_estimation_debug_provider_test.dart
+++ b/app/test/feature/home/data/provider/home_eew_estimation_debug_provider_test.dart
@@ -1,0 +1,142 @@
+import 'package:eqmonitor/feature/devices/data/model/device_role.dart';
+import 'package:eqmonitor/feature/devices/data/provider/device_role_provider.dart';
+import 'package:eqmonitor/feature/home/data/notifier/home_eew_estimation_debug_notifier.dart';
+import 'package:eqmonitor/feature/home/data/provider/home_eew_estimation_debug_provider.dart';
+import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// `debugProvider` を固定するスタブ。
+class _StubDebug extends Debug {
+  _StubDebug({required this.isEnabled});
+
+  final bool isEnabled;
+
+  @override
+  Future<bool> build() async => isEnabled;
+}
+
+/// `homeEewEstimationDebugProvider` を固定するスタブ。
+class _StubHomeEewEstimationDebug extends HomeEewEstimationDebug {
+  _StubHomeEewEstimationDebug({required this.isEnabled});
+
+  final bool isEnabled;
+
+  @override
+  Future<bool> build() async => isEnabled;
+}
+
+ProviderContainer _container({
+  required bool isDebugEnabled,
+  required DeviceRole? role,
+  required bool isSettingEnabled,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      debugProvider.overrideWith(() => _StubDebug(isEnabled: isDebugEnabled)),
+      deviceRoleProvider.overrideWith((ref) async => role),
+      homeEewEstimationDebugProvider.overrideWith(
+        () => _StubHomeEewEstimationDebug(isEnabled: isSettingEnabled),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('isHomeEewEstimationDebugAvailableProvider', () {
+    test('Admin ロール かつ デバッグモード有効なら変更できる', () async {
+      final container = _container(
+        isDebugEnabled: true,
+        role: DeviceRole.admin,
+        isSettingEnabled: false,
+      );
+
+      await expectLater(
+        container.read(isHomeEewEstimationDebugAvailableProvider.future),
+        completion(isTrue),
+      );
+    });
+
+    test('デバッグモードが無効なら変更できない', () async {
+      final container = _container(
+        isDebugEnabled: false,
+        role: DeviceRole.admin,
+        isSettingEnabled: true,
+      );
+
+      await expectLater(
+        container.read(isHomeEewEstimationDebugAvailableProvider.future),
+        completion(isFalse),
+      );
+    });
+
+    test('Admin 以外のロールでは変更できない', () async {
+      final container = _container(
+        isDebugEnabled: true,
+        role: DeviceRole.user,
+        isSettingEnabled: true,
+      );
+
+      await expectLater(
+        container.read(isHomeEewEstimationDebugAvailableProvider.future),
+        completion(isFalse),
+      );
+    });
+
+    test('ロールを取得できない場合は変更できない', () async {
+      final container = _container(
+        isDebugEnabled: true,
+        role: null,
+        isSettingEnabled: true,
+      );
+
+      await expectLater(
+        container.read(isHomeEewEstimationDebugAvailableProvider.future),
+        completion(isFalse),
+      );
+    });
+  });
+
+  group('isHomeEewEstimationVisibleProvider', () {
+    test('変更権限があり設定が有効なら表示する', () async {
+      final container = _container(
+        isDebugEnabled: true,
+        role: DeviceRole.admin,
+        isSettingEnabled: true,
+      );
+
+      await expectLater(
+        container.read(isHomeEewEstimationVisibleProvider.future),
+        completion(isTrue),
+      );
+    });
+
+    test('変更権限があっても設定が無効なら表示しない', () async {
+      final container = _container(
+        isDebugEnabled: true,
+        role: DeviceRole.admin,
+        isSettingEnabled: false,
+      );
+
+      await expectLater(
+        container.read(isHomeEewEstimationVisibleProvider.future),
+        completion(isFalse),
+      );
+    });
+
+    test('設定が有効でも変更権限を失っていれば表示しない', () async {
+      final container = _container(
+        isDebugEnabled: true,
+        role: DeviceRole.user,
+        isSettingEnabled: true,
+      );
+
+      await expectLater(
+        container.read(isHomeEewEstimationVisibleProvider.future),
+        completion(isFalse),
+      );
+    });
+  });
+}

--- a/app/test/feature/home/ui/eew_card_estimated_region_test.dart
+++ b/app/test/feature/home/ui/eew_card_estimated_region_test.dart
@@ -1,0 +1,135 @@
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_info_type.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/core/provider/time_ticker.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_estimated_region.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/home/ui/component/eew/eew_card.dart';
+import 'package:eqmonitor/feature/location/data/location.dart';
+import 'package:eqmonitor/feature/location/data/model/map_data_item.dart';
+import 'package:eqmonitor/feature/location/data/nearest_jma_feature.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:material_ui/material_ui.dart';
+
+final _now = DateTime.utc(2026, 8, 14, 12);
+
+/// 現在地の予報区(東京都)がJMAの予想震度に含まれないEEW。
+final _eew = EewTelegramItem(
+  eventId: 'test-1',
+  status: TelegramStatus.normal,
+  infoType: TelegramInfoType.publication,
+  serialNo: 1,
+  isCanceled: false,
+  isLastInfo: false,
+  reportTime: _now,
+  isPlum: false,
+  isWarning: false,
+  originTime: _now.subtract(const Duration(seconds: 10)),
+  hypocenter: const EewHypocenterInfo(
+    code: 'h1',
+    name: '東京湾',
+    magnitude: 5.4,
+    depth: 30,
+  ),
+  forecastIntensity: const EewForecastIntensityInfo(
+    regions: [],
+    maxIntensity: JmaIntensity.four,
+  ),
+  accuracy: const EewAccuracyInfo(
+    epicenter: 4,
+    hypocenter: 4,
+    depth: 4,
+    magnitudeCalculation: 8,
+    numberOfMagnitudeCalculation: 5,
+  ),
+);
+
+final _estimatedRegion = EewEstimatedRegion(
+  regionCode: '130010',
+  regionName: '東京都23区',
+  intensity: 3.6,
+  jmaIntensity: JmaIntensity.four,
+  sWaveArrivalTime: _now.add(const Duration(seconds: 30)),
+);
+
+Position _position() => Position(
+  latitude: 35.681,
+  longitude: 139.767,
+  timestamp: _now,
+  accuracy: 0,
+  altitude: 0,
+  altitudeAccuracy: 0,
+  heading: 0,
+  headingAccuracy: 0,
+  speed: 0,
+  speedAccuracy: 0,
+);
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required List<EewEstimatedRegion>? estimatedRegions,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        locationStreamProvider.overrideWith((ref) => Stream.value(_position())),
+        jmaMapAreaForecastLocalEInsideProvider.overrideWith(
+          (ref, latLng) async => const MapDataItem(
+            property: MapDataProperty(
+              code: '130010',
+              name: '東京都23区',
+              nameKana: 'トウキョウトニジュウサンク',
+            ),
+          ),
+        ),
+        timeTickerProvider().overrideWith((ref) => Stream.value(_now)),
+      ],
+      child: MaterialApp(
+        theme: ThemeData.light().copyWith(
+          extensions: <ThemeExtension<dynamic>>[
+            DesignSystemThemeExtension.light(),
+          ],
+        ),
+        home: Scaffold(
+          body: EewCard(
+            eew: _eew,
+            index: null,
+            nowOverride: _now,
+            estimatedRegions: estimatedRegions,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('推計震度が渡されると現在地の予報区名と到達予想を表示する', (tester) async {
+    await _pump(tester, estimatedRegions: [_estimatedRegion]);
+
+    expect(find.text('東京都23区'), findsOneWidget);
+    expect(find.text('主要動到達まで'), findsOneWidget);
+    expect(find.text('30秒'), findsOneWidget);
+  });
+
+  testWidgets('推計震度が渡されないと到達予想を表示しない', (tester) async {
+    await _pump(tester, estimatedRegions: null);
+
+    expect(find.text('主要動到達まで'), findsNothing);
+    expect(find.text('30秒'), findsNothing);
+  });
+
+  testWidgets('現在地の予報区と一致しない推計震度は使わない', (tester) async {
+    await _pump(
+      tester,
+      estimatedRegions: [_estimatedRegion.copyWith(regionCode: '270000')],
+    );
+
+    expect(find.text('主要動到達まで'), findsNothing);
+  });
+}

--- a/app/test/feature/home/ui/home_eew_card_test.dart
+++ b/app/test/feature/home/ui/home_eew_card_test.dart
@@ -1,0 +1,118 @@
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_info_type.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/core/provider/time_ticker.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_estimated_region.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/eew/data/provider/eew_estimated_region_intensity_provider.dart';
+import 'package:eqmonitor/feature/home/data/provider/home_eew_estimation_debug_provider.dart';
+import 'package:eqmonitor/feature/home/ui/component/eew/home_eew_card.dart';
+import 'package:eqmonitor/feature/location/data/location.dart';
+import 'package:eqmonitor/feature/location/data/model/map_data_item.dart';
+import 'package:eqmonitor/feature/location/data/nearest_jma_feature.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
+
+final _now = DateTime.utc(2026, 8, 14, 12);
+
+/// 現在地の予報区がJMAの予想震度に含まれないEEW。
+final _eew = EewTelegramItem(
+  eventId: 'test-1',
+  status: TelegramStatus.normal,
+  infoType: TelegramInfoType.publication,
+  serialNo: 1,
+  isCanceled: false,
+  isLastInfo: false,
+  reportTime: _now,
+  isPlum: false,
+  isWarning: false,
+  originTime: _now.subtract(const Duration(seconds: 10)),
+  hypocenter: const EewHypocenterInfo(
+    code: 'h1',
+    name: '東京湾',
+    magnitude: 5.4,
+    depth: 30,
+  ),
+  forecastIntensity: const EewForecastIntensityInfo(
+    regions: [],
+    maxIntensity: JmaIntensity.four,
+  ),
+);
+
+final _estimatedRegions = [
+  EewEstimatedRegion(
+    regionCode: '130010',
+    regionName: '東京都23区',
+    intensity: 3.6,
+    jmaIntensity: JmaIntensity.four,
+    sWaveArrivalTime: _now.add(const Duration(seconds: 30)),
+  ),
+];
+
+Position _position() => Position(
+  latitude: 35.681,
+  longitude: 139.767,
+  timestamp: _now,
+  accuracy: 0,
+  altitude: 0,
+  altitudeAccuracy: 0,
+  heading: 0,
+  headingAccuracy: 0,
+  speed: 0,
+  speedAccuracy: 0,
+);
+
+Future<void> _pump(WidgetTester tester, {required bool isVisible}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        isHomeEewEstimationVisibleProvider.overrideWith(
+          (ref) async => isVisible,
+        ),
+        eewEstimatedRegionIntensityProvider.overrideWith(
+          (ref, eew) async => _estimatedRegions,
+        ),
+        locationStreamProvider.overrideWith((ref) => Stream.value(_position())),
+        jmaMapAreaForecastLocalEInsideProvider.overrideWith(
+          (ref, latLng) async => const MapDataItem(
+            property: MapDataProperty(
+              code: '130010',
+              name: '東京都23区',
+              nameKana: 'トウキョウトニジュウサンク',
+            ),
+          ),
+        ),
+        timeTickerProvider().overrideWith((ref) => Stream.value(_now)),
+      ],
+      child: MaterialApp(
+        theme: ThemeData.light().copyWith(
+          extensions: <ThemeExtension<dynamic>>[
+            DesignSystemThemeExtension.light(),
+          ],
+        ),
+        home: Scaffold(body: HomeEewCard(eew: _eew, index: null)),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('設定が有効なら推計震度と到達予想時刻を表示する', (tester) async {
+    await _pump(tester, isVisible: true);
+
+    expect(find.text('東京都23区'), findsOneWidget);
+    expect(find.text('主要動到達まで'), findsOneWidget);
+  });
+
+  testWidgets('設定が無効なら推計震度と到達予想時刻を表示しない', (tester) async {
+    await _pump(tester, isVisible: false);
+
+    expect(find.text('主要動到達まで'), findsNothing);
+  });
+}

--- a/docs/knowledge/20260814_device_role_admin_gate.md
+++ b/docs/knowledge/20260814_device_role_admin_gate.md
@@ -1,0 +1,38 @@
+# デバイスの Admin ロール判定と、デバッグ機能のゲート方法
+
+**作成日**: 2026-08-14
+
+## 結論
+
+アプリから「このデバイスは Admin か」を判定する経路は、現状 **存在しない**。
+Admin 限定のデバッグ機能を追加する場合は、判定が取れないケースを
+「権限なし」として扱い、UI に理由を表示する前提で設計する。
+
+## backend の認証・権限の構造
+
+| 認証方式 | 使う場所 | role を取れるか |
+| --- | --- | --- |
+| デバイス JWT（`POST /v2/device` 発行、HS256） | `/v2/device/me/*`、`/v2/subscription/*` | 取れない（クレームに role なし） |
+| better-auth セッション / JWT | `/v2/user/me*`、`/v2/admin/*`、`/v2/feeds/admin` | 取れる（`user.role === 'admin'`） |
+
+- ロールは better-auth の `admin()` プラグインが持つ `user.role`。
+- `GET /v2/device/me`（`DeviceMeResponse`）は `role` を返さない。
+- アプリにはアカウントログインが無く、better-auth セッションを保持していない。
+  そのため `/v2/user/me` は 401 になる。
+
+## 実装上の指針
+
+- ロール取得は `DeviceRepository.getDeviceRole()`（`GET /v2/device/me`）に集約する。
+  backend が `role` を返し始めたら、生 JSON 読み取りから生成モデル経由へ移す。
+- 未提供・未知の値・通信失敗はすべて `null`（= 非 Admin）として扱う。
+  生命に関わる情報を扱うアプリなので、権限を推測するフォールバックは書かない。
+- ゲートは「設定値」と「操作できるか」を別 provider に分ける。
+  - `isHomeEewEstimationDebugAvailableProvider`: Admin かつデバッグモード有効
+  - `isHomeEewEstimationVisibleProvider`: 上記 かつ 設定が ON
+  - こうすると、権限を失ったときに保存済み設定が残っていても表示されない。
+- デバッグ画面のトグルは `onChanged: null` で非活性にし、
+  サブタイトルに「デバッグモード無効」「ロール取得中」「Admin 以外」などの理由を出す。
+
+## 残課題
+
+`docs/todo/300_device_role_api_field.md` に backend 側の対応内容を記載した。

--- a/docs/todo/300_device_role_api_field.md
+++ b/docs/todo/300_device_role_api_field.md
@@ -1,0 +1,59 @@
+# Device API に role フィールドを追加する
+
+**作成日**: 2026-08-14
+**対象ブランチ**: develop
+**ステータス**: backend 対応待ち（アプリ側は先行実装済み）
+
+---
+
+## 背景
+
+ホーム画面のデバッグ用トグル「ホームに推計震度・到達予想時刻を表示」は、
+`Device API のロールが Admin` かつ `デバッグモードが有効` の場合のみ操作できる仕様で実装した。
+
+しかし backend の現状は次のとおりで、**アプリからは Admin ロールを判定できない**。
+
+- `GET /v2/device/me`（`DeviceMeResponse`）は `id` / `type` / `locale` /
+  `registrationType` / `userId` / `is_pro` / `createdAt` / `updatedAt` のみを返し、
+  `role` を含まない（backend: `api/api/src/features/device/routes/device.ts`）。
+- ロールは better-auth の `user.role` にあり、`role === 'admin'` の判定は
+  `sessionMiddleware`（Cookie セッション / better-auth JWT）配下のルート
+  （`/v2/admin/*`、`/v2/user/me` 等）でのみ行われている。
+- アプリはデバイス JWT のみを持ち、better-auth セッションを持たない。
+  デバイス JWT のクレームにも role は含まれない。
+
+そのため、**backend が対応するまでトグルは常に非活性**（サブタイトルに理由を表示）となる。
+
+---
+
+## 必要な対応
+
+1. backend: `DeviceMeResponse` に `role`（`admin` / `user` などの文字列）を追加する。
+   デバイスに紐づく `userId` から better-auth の `user.role` を引く。
+   - 未ログインデバイスは `null` を返す設計にする（アプリ側は null を非 Admin として扱う）。
+2. OpenAPI を再生成し、`packages/eqmonitor_api` の生成クライアントを更新する。
+3. アプリ: `DeviceRepository.getDeviceRole()` の生 JSON 読み取りを、
+   生成モデル（`DeviceMeResponse.role`）経由へ置き換える。
+   - 対象: `app/lib/feature/devices/data/repository/device_repository.dart`
+   - `app/lib/feature/devices/data/model/device_role.dart` の
+     `DeviceRole.fromApiValue` はそのまま流用できる。
+4. `app/test/feature/devices/device_repository_role_test.dart` を
+   生成モデル経由の実装に合わせて更新する。
+
+---
+
+## 現在のアプリ側実装（暫定）
+
+`DeviceRepository.getDeviceRole()` は `GET /v2/device/me` のレスポンス生 JSON から
+`role` を読む。フィールドが存在しない現状では常に `null` を返し、
+`isHomeEewEstimationDebugAvailableProvider` は false になる。
+
+権限を推測して Admin 扱いにするフォールバックは意図的に入れていない。
+
+---
+
+## 判断が必要なこと
+
+- Admin 判定をデバイス単位で返してよいか（アカウント情報の露出範囲）。
+- アプリにアカウントログインを導入し `/v2/user/me` を使う方針にするか
+  （`docs/todo/091_user_api_app_scope.md` と合わせて検討する）。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

ホーム画面のEEWカードに、距離減衰式による**推計震度**と**S波到達予想時刻**を表示するデバッグトグルを追加しました。
トグルはデバッグ画面（`/settings/debug`）から操作し、**Device API のロールが Admin かつデバッグモードが有効**な場合のみ変更できます。

これまでこの推計値は EEW 詳細画面（シミュレーション）でのみ表示されており、ホームでは JMA が現在地の予報区の予想震度を発表していない場合に何も出ませんでした。

## 変更点

### 権限判定（Device ロール）

- `DeviceRole`（`admin` / `user`）を追加。未提供・未知の値は権限を推測せず `null`
- `DeviceRepository.getDeviceRole()` で `GET /v2/device/me` からロールを取得
- `deviceRoleProvider`: 未登録・取得失敗時は `null`（= 非 Admin）

### 表示設定

- `SharedPreferencesKey.isHomeEewEstimationDebugEnabled` を追加
- `HomeEewEstimationDebug`（設定値の保存）
- `isHomeEewEstimationDebugAvailableProvider`: Admin かつデバッグモード有効
- `isHomeEewEstimationVisibleProvider`: 上記 かつ 設定 ON
  - 権限を失った場合は保存済み設定が ON でも表示しない
  - EEW 受信中に不要な API 呼び出しを起こさないよう、ローカル設定を先に評価する

### UI

- `HomeEewCard` を追加し、ホームの `EewCard` をラップして推計震度を渡す
- `EewCard` の `userRegionEstimate`（単一区域）を `estimatedRegions`（一覧）に変更し、現在地の予報区とのマッチングをカード内に集約
  - EEW 詳細画面側の重複していた現在地マッチング処理を削除
- デバッグ画面にトグルを追加。操作できない場合は非活性にし、理由（デバッグモード無効 / ロール取得中 / Admin 以外）をサブタイトルに表示

## ⚠️ backend 対応が必要（現状トグルは常に非活性）

`GET /v2/device/me` は現在 `role` を返しません。ロールは better-auth の `user.role` にあり、`sessionMiddleware` 配下（`/v2/user/me`、`/v2/admin/*`）でのみ参照されています。アプリはデバイス JWT のみを保持し better-auth セッションを持たないため、**backend が `DeviceMeResponse` に `role` を追加するまで Admin 判定は常に false** になります。

アプリ側は `role` が来た時点でそのまま動作するよう実装済みです（暫定的にレスポンスの生 JSON から `role` を読んでいます。フィールド追加後は生成モデル経由に置き換え）。固定値で Admin 扱いにするフォールバックは入れていません。

- 必要な対応と移行手順: `docs/todo/300_device_role_api_field.md`
- 認証・権限構造の調査結果: `docs/knowledge/20260814_device_role_admin_gate.md`

## テスト

`flutter test test/feature/home test/feature/devices/device_repository_role_test.dart` → 55 passed

- `device_repository_role_test.dart`: admin / user / 未提供 / 未知の値 / API 失敗
- `home_eew_estimation_debug_provider_test.dart`: ゲート条件の組み合わせ、設定 OFF 時にロールを取得しないこと
- `eew_card_estimated_region_test.dart`: 推計震度からの予報区名・到達カウントダウン表示、区域コード不一致時は使わないこと
- `home_eew_card_test.dart`: 設定 ON / OFF による表示切り替え

`dart analyze` は変更・追加ファイルで新規の警告なし（既存の `!` 演算子等の debt は残存）。

## 備考

`style:` コミットに、`dart format`（mise.toml が pin している Flutter）で差分が出た未整形ファイルの整形が含まれています。機能変更とは独立しているため、不要であればそのコミットのみ落とせます。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a000a1-051e-7cf7-a426-5fd6a1558389?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a000a1-051e-7cf7-a426-5fd6a1558389&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

