### PR TITLE
[map] remote reader の sha256 非照合を契約として明示する（todo 815）

### DIFF
--- a/docs/todo/815_eqmonitor_map_remote_digest_binding.md
+++ b/docs/todo/815_eqmonitor_map_remote_digest_binding.md
@@ -1,31 +1,47 @@
-# eqmonitor_map: remote PMTiles を検証済み digest へ束縛する
+# eqmonitor_map: remote PMTiles を per-chunk attestation で digest 束縛する
+
+## 状態（2026-08-15 更新）
+
+**whole-file digest による束縛は採らないと決めた。** reader の doc・
+`VerifiedTileSource.sha256` の doc・negative test で「照合しない」ことを明示し、
+恒久対策を per-chunk attestation（#1592 の signed sidecar）へ送った。
 
 ## 背景
 
 `MapRemotePmTilesRandomAccessReader`（#1591 Task 8）は Range framing・identity
 encoding・strong ETag の安定性・厳密 Content-Range・body 長を検証するが、
-**受信内容が `VerifiedRemotePmTilesSource.sha256` の attested archive と一致するか**
-は検証していない。
+受信内容が `VerifiedRemotePmTilesSource.sha256` の attested archive と一致するかは
+検証していない。CDN/origin が安定した ETag のまま別の archive を返すと通る。
 
-strong ETag は「同一 URL への複数リクエスト間の整合性」を保証するだけで、
-attested asset との対応は保証しない。CDN/origin が安定した ETag のまま古い/別の
-archive を返した場合、reader はそれを受理してしまう。
+`sha256` は archive **全体**の digest なので、照合するには全 `sizeBytes` を読む
+必要がある。random-access reader の存在理由は全体を落とさないことなので、両者は
+原理的に両立しない（全体を落として hash するなら local descriptor を使えばよい）。
 
-## やること
+設計書
+`docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md` は remote range
+の信頼境界を HTTPS + allowlist host + strong ETag + identity encoding + 厳密
+Content-Range と定義しており、whole-file digest 照合は要求していない。現状の
+reader はこの定義を満たしている。
 
-1. archive を open した後（または全 byte を読める文脈で）、検証済み範囲の
-   digest を計算し `source.sha256` と突き合わせる。
-   - full-archive digest は random-access reader の趣旨（部分取得）と相反するため、
-     header + root directory など**取得済みの検証済み範囲**の digest を
-     `source.sha256`（または別途 attested な部分 digest）と照合する設計を検討する。
-   - 設計は `docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md`
-     の trust 境界と整合させる。
-2. 不一致は typed exception（`MapRemoteTile...` 系）で fail closed。空 tile へ
-   丸めない。
-3. controlled server で「ETag 据え置き・内容だけ差し替え」を模した回帰テスト。
+## 残る穴
+
+ETag は「同一 URL への複数リクエスト間の整合性」しか保証しない。ETag 据え置きで
+中身を差し替えた origin/CDN を reader は検出できない。
+
+## やること（#1592 の sidecar 拡張が前提）
+
+1. signed sidecar payload へ range 単位の attested digest（per-chunk digest または
+   Merkle root + proof）を追加する。archive SHA-256 / byte size と同じ署名対象に
+   含め、署名なしの変更を許さない。
+2. app が sidecar を検証したうえで、chunk digest を
+   `VerifiedRemotePmTilesSource` へ渡す。
+3. reader は各 range 応答をその chunk digest と突き合わせ、不一致は
+   `MapRemoteTile...` 系 typed exception で fail closed（空 tile へ丸めない）。
+4. controlled server で「ETag 据え置き・内容だけ差し替え」の回帰テスト。既存の
+   negative test `does not bind response bytes to source.sha256` を差し替える。
 
 ## 参照
 
 - PR #1627 review コメント（P1: "Bind remote range responses to the expected digest"）
 - `packages/eqmonitor_map/lib/src/tile/remote/map_remote_pm_tiles_reader.dart`
-- Issue #1591 / parent #1611
+- Issue #1592（signed sidecar）/ #1591 / parent #1611

--- a/packages/eqmonitor_map/lib/src/tile/remote/map_remote_pm_tiles_reader.dart
+++ b/packages/eqmonitor_map/lib/src/tile/remote/map_remote_pm_tiles_reader.dart
@@ -23,6 +23,14 @@ import 'package:pmtiles_v3/pmtiles_v3.dart';
 ///   直近の範囲は `maxCacheBytes` の LRU で再利用する。
 /// - snapshot drift(ETag 不一致 / 412)は terminal 失敗にして cache を捨てる。
 /// - [close] 後の read は [MapRemoteTileClosedException]。
+///
+/// **保証しないこと**: 受信 byte を[VerifiedRemotePmTilesSource.sha256]と
+/// 照合しない。全体 digest は全 `sizeBytes` を読まないと計算できず、部分取得と
+/// 両立しないため。保証は「pin した ETag が同一の間、各 range が同一 snapshot に
+/// 属すること」までで、その snapshot が attest された archive そのものである
+/// ことは保証しない(ETag 据え置きの差し替えは検出できない)。全体束縛には
+/// per-chunk attestation が要る。
+/// `docs/todo/815_eqmonitor_map_remote_digest_binding.md`
 final class MapRemotePmTilesRandomAccessReader
     implements PmTilesRandomAccessReader {
   MapRemotePmTilesRandomAccessReader({

--- a/packages/eqmonitor_map/lib/src/tile/verified_pm_tiles_source.dart
+++ b/packages/eqmonitor_map/lib/src/tile/verified_pm_tiles_source.dart
@@ -24,7 +24,11 @@ sealed class VerifiedTileSource {
   /// downloadを別物として扱うために使う。
   String get sourceInstanceId;
 
-  /// 検証済み archive の内容 digest(64桁hex)。
+  /// app が attest した archive 全体の内容 digest(64桁hex)。
+  ///
+  /// **package はこの値と実データを突き合わせない。** package 内の用途は
+  /// [VerifiedTileSourceCacheIdentity.cacheIdentity]だけである。remote で
+  /// 照合できない理由は`MapRemotePmTilesRandomAccessReader`の doc を参照。
   String get sha256;
 }
 

--- a/packages/eqmonitor_map/test/tile/remote/map_remote_pm_tiles_reader_test.dart
+++ b/packages/eqmonitor_map/test/tile/remote/map_remote_pm_tiles_reader_test.dart
@@ -207,4 +207,23 @@ void main() {
       throwsArgumentError,
     );
   });
+
+  // 既知の境界をピン留めする。RED になったら digest 束縛が入った合図なので、
+  // expectation を緩めずに reader の doc と todo 815 を併せて更新すること。
+  test(
+    'does not bind response bytes to source.sha256 (known gap #1592)',
+    () async {
+      final reader = await readerOf();
+      addTearDown(reader.close);
+
+      // ETag は据え置いたまま archive の中身だけ差し替える。
+      server.archiveBytes.setAll(0, List.filled(16, 0xEE));
+
+      expect(
+        await reader.readAt(offset: 0, length: 16),
+        everyElement(0xEE),
+        reason: 'sha256 束縛が入るまでは差し替えられた byte も受理される',
+      );
+    },
+  );
 }


### PR DESCRIPTION
## 背景

PR #1627 の review P1「Bind remote range responses to the expected digest」への対応です。`MapRemotePmTilesRandomAccessReader` は Range framing・identity encoding・strong ETag・厳密 Content-Range・body 長を検証しますが、受信内容が `VerifiedRemotePmTilesSource.sha256` の attested archive と一致するかは検証していませんでした。

## 判断: whole-file digest 束縛は採らない

`sha256` は archive 全体の digest なので、照合するには全 `sizeBytes` を読む必要があります。random-access reader の存在理由は全体を落とさないことなので、両者は原理的に両立しません（全体を落として hash するなら local descriptor を使えば済みます）。

設計書 `2026-08-02-eqmonitor-map-renderer-design.md` も remote range の信頼境界を HTTPS + allowlist host + strong ETag + identity encoding + 厳密 Content-Range と定義しており、whole-file digest 照合は要求していません。現状の reader はこの定義を満たしています。

そのため本 PR では **穴を塞ぐのではなく、穴の位置を契約として固定** します。恒久対策（per-chunk attestation）は #1592 の signed sidecar へ送ります。

## 変更内容

- `map_remote_pm_tiles_reader.dart`: 「受信 byte を `sha256` と照合しない」ことと、その理由・残る穴・恒久対策の所在を class doc へ追記。
- `verified_pm_tiles_source.dart`: `VerifiedTileSource.sha256` の doc を「app が attest した digest。package は実データと突き合わせず、`cacheIdentity` にしか使わない」へ修正。従来の「検証済み archive の内容 digest」は package 側が検証しているようにも読めました。
- `map_remote_pm_tiles_reader_test.dart`: ETag 据え置きで中身だけ差し替えたサーバの byte がそのまま返ることを固定する negative test を追加。ここが RED になったら digest 束縛が入った合図で、expectation を緩めずに doc と todo を更新する旨をコメントで残しています。
- `docs/todo/815_...md`: 判断と、#1592 sidecar への per-chunk digest 追加という具体的な残作業へ書き直し。

## 残る穴

ETag は同一 URL への複数リクエスト間の整合性しか保証しないため、ETag 据え置きで中身を差し替えた origin/CDN は検出できません。`VerifiedRemotePmTilesSource` は app 側でまだ未使用のため、本番影響はありません。

## 検証

```
$ mise exec -- flutter test test/tile
00:02 +157: All tests passed!

$ mise exec -- dart analyze . --fatal-infos
No issues found!
```

## 依存

base は #1640（#1591 Task 15/16）です。#1640 のマージ後に base が `develop` へ切り替わります。

https://claude.ai/code/session_012PeDKkyZK9vjnWcY7orPGY