### PR TITLE
[map] flutter_scene を fork の submodule へ切り替える（#1602 準備）

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -209,6 +209,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          # third_party/flutter_scene は pubspec の path 依存なので pub 解決に必須
+          submodules: true
 
       - name: Extract SOPS Age Key File
         run: |
@@ -584,6 +586,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # third_party/flutter_scene は pubspec の path 依存なので pub 解決に必須
+          submodules: true
 
       - name: Extract SOPS Age Key File
         run: |

--- a/.github/workflows/wc-check-dart-analyze.yaml
+++ b/.github/workflows/wc-check-dart-analyze.yaml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # third_party/flutter_scene は pubspec の path 依存なので pub 解決に必須
+          submodules: true
 
       - name: Install Mise dependencies
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4

--- a/.github/workflows/wc-check-dart-test.yaml
+++ b/.github/workflows/wc-check-dart-test.yaml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # third_party/flutter_scene は pubspec の path 依存なので pub 解決に必須
+          submodules: true
 
       - name: Fetch base for diff tests
         env:

--- a/.github/workflows/wc-check-eqmonitor-map-scene-spike.yaml
+++ b/.github/workflows/wc-check-eqmonitor-map-scene-spike.yaml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # third_party/flutter_scene は pubspec の path 依存なので pub 解決に必須
+          submodules: true
 
       - name: Install Mise dependencies
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
@@ -56,6 +58,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # third_party/flutter_scene は pubspec の path 依存なので pub 解決に必須
+          submodules: true
 
       - name: Install Mise dependencies
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "backend"]
 	path = backend
 	url = git@github.com:YumNumm/eqmonitor-backend.git
+[submodule "third_party/flutter_scene"]
+	path = third_party/flutter_scene
+	url = https://github.com/YumNumm/flutter_scene.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,13 @@ EQMonitor is a Flutter-based earthquake monitoring and early warning app for Jap
 ```bash
 mise install                                      # Install Flutter, Java, Node, etc.
 flutter config --enable-swift-package-manager     # Enable SPM for iOS
+git submodule update --init third_party/flutter_scene  # Required by pub (path dep)
 dart pub global activate melos                    # Install Melos
 melos bootstrap                                   # Resolve workspace dependencies
 mv environment/.env.example environment/.env.dev  # Configure environment
 ```
+
+`third_party/flutter_scene` は `YumNumm/flutter_scene`（`bdero/flutter_scene` の fork）の submodule で、`eqmonitor_map` が `path:` 依存で参照します。初期化しないと `pub get` が失敗します。fork の pin は submodule commit が正本です。
 
 ## Build Commands (Flutter / Dart)
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,6 +12,8 @@ analyzer:
     - "**/DerivedData/**"
     - "**/build/**"
     - "build/**"
+    # fork した上流コード。lint はこのリポジトリの規約ではなく上流に従う。
+    - third_party/**
     - android/**
     - ios/**
     - web/**

--- a/docs/knowledge/20260802_flutter_scene_scene_source_pin.md
+++ b/docs/knowledge/20260802_flutter_scene_scene_source_pin.md
@@ -1,28 +1,36 @@
 # Flutter Sceneの`scene` source pin
 
-Flutter Scene `7f71993b7e2a0ab1d2f59726a406098709be7291`は、同じmonorepo内の
-`scene`と組み合わせて使う。hosted版や異なるrevisionへのfallbackは行わない。
+Flutter Sceneは同じmonorepo内の`scene`と組み合わせて使う。hosted版や異なる
+revisionへのfallbackは行わない。
 
-固定revisionの正本は`packages/eqmonitor_map/pubspec.yaml`とroot
-`pubspec.lock`である。packageの`dependency_overrides`で`scene`を同一repo、
-同一revision、`packages/scene`へ固定する。
+2026-08-15以降、source は fork `YumNumm/flutter_scene` の submodule
+`third_party/flutter_scene`（#1602）であり、**固定revisionの正本は submodule の
+commit**である。`packages/eqmonitor_map/pubspec.yaml`は`path`で参照するだけなので、
+revisionを変えるときは submodule を動かして commit する。
 
 ```yaml
+dependencies:
+  flutter_scene:
+    path: ../../third_party/flutter_scene/packages/flutter_scene
 dependency_overrides:
   scene:
-    git:
-      url: https://github.com/bdero/flutter_scene.git
-      ref: 7f71993b7e2a0ab1d2f59726a406098709be7291
-      path: packages/scene
+    path: ../../third_party/flutter_scene/packages/scene
 ```
 
 依存関係を更新した後は、root lockfileの`flutter_scene`と`scene`が
-どちらも同じ`resolved-ref`を持つことを確認する。
+どちらも submodule 配下の`path`を指すことを確認する。
 
 ```bash
+git submodule status third_party/flutter_scene
 mise exec -- dart pub get --enforce-lockfile
-rg -n -A 8 "^  (flutter_scene|scene):" pubspec.lock
+rg -n -A 6 "^  (flutter_scene|scene):" pubspec.lock
 ```
 
 Flutter Sceneがhosted `scene`の必要APIを持つversion/sourceを正しく宣言した
 revisionへ更新できた場合のみ、overrideの削除を別changeで検討する。
+
+## 履歴
+
+`7f71993b7e2a0ab1d2f59726a406098709be7291`までは`bdero/flutter_scene`への
+git依存だった。#1602で永続 instance buffer と resource lifecycle API をfork側へ
+追加するため、submodule + `path`依存へ移した。

--- a/packages/eqmonitor_map/example/pubspec.yaml
+++ b/packages/eqmonitor_map/example/pubspec.yaml
@@ -15,10 +15,7 @@ dependencies:
     sdk: flutter
   flutter_hooks: ^0.21.3+1
   flutter_scene:
-    git:
-      url: https://github.com/bdero/flutter_scene.git
-      ref: 7f71993b7e2a0ab1d2f59726a406098709be7291 # 2026.08.03
-      path: packages/flutter_scene
+    path: ../../../third_party/flutter_scene/packages/flutter_scene
   hooks: ^2.1.0
 
 dev_dependencies:

--- a/packages/eqmonitor_map/pubspec.yaml
+++ b/packages/eqmonitor_map/pubspec.yaml
@@ -14,11 +14,10 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks: ^0.21.3+1
+  # YumNumm/flutter_scene fork の submodule。pin は third_party/flutter_scene の
+  # submodule commit が正本（#1602）。
   flutter_scene:
-    git:
-      url: https://github.com/bdero/flutter_scene.git
-      ref: 7f71993b7e2a0ab1d2f59726a406098709be7291 # 2026.08.03
-      path: packages/flutter_scene
+    path: ../../third_party/flutter_scene/packages/flutter_scene
   freezed_annotation: ^3.1.0
   hooks: ^2.1.0
   pmtiles_v3:
@@ -34,7 +33,4 @@ dev_dependencies:
   freezed: ^4.0.0-dev.3
 dependency_overrides:
   scene:
-    git:
-      url: https://github.com/bdero/flutter_scene.git
-      ref: 7f71993b7e2a0ab1d2f59726a406098709be7291 # 2026.08.03
-      path: packages/scene
+    path: ../../third_party/flutter_scene/packages/scene

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -940,11 +940,9 @@ packages:
   flutter_scene:
     dependency: transitive
     description:
-      path: "packages/flutter_scene"
-      ref: "7f71993b7e2a0ab1d2f59726a406098709be7291"
-      resolved-ref: "7f71993b7e2a0ab1d2f59726a406098709be7291"
-      url: "https://github.com/bdero/flutter_scene.git"
-    source: git
+      path: "third_party/flutter_scene/packages/flutter_scene"
+      relative: true
+    source: path
     version: "0.21.0"
   flutter_secure_storage:
     dependency: transitive
@@ -2038,11 +2036,9 @@ packages:
   scene:
     dependency: "direct overridden"
     description:
-      path: "packages/scene"
-      ref: "7f71993b7e2a0ab1d2f59726a406098709be7291"
-      resolved-ref: "7f71993b7e2a0ab1d2f59726a406098709be7291"
-      url: "https://github.com/bdero/flutter_scene.git"
-    source: git
+      path: "third_party/flutter_scene/packages/scene"
+      relative: true
+    source: path
     version: "0.1.1"
   screenshot:
     dependency: transitive


### PR DESCRIPTION
## 概要

#1602 の前提整備です。`bdero/flutter_scene` への git 依存を、fork `YumNumm/flutter_scene` の submodule + `path` 依存へ切り替えます。#1602 本体（永続 packed instance buffer と resource lifecycle 公開 API）はこの PR に含みません。

fork: https://github.com/YumNumm/flutter_scene （`bdero/flutter_scene` の fork、MIT）

## 変更内容

### submodule

`third_party/flutter_scene` を追加し、従来と同じ commit `7f71993b7e2a0ab1d2f59726a406098709be7291` に固定しました。`vendor/` は `.gitignore` されているため `third_party/` を使っています。

### pubspec

`packages/eqmonitor_map/pubspec.yaml` と `example/pubspec.yaml` の `flutter_scene` / `scene` override を `git:` から `path:` へ変更しました。**pin の正本は submodule commit になります**（従来は pubspec の `ref`）。`pubspec.lock` も path 依存へ再解決済みです。

### CI

`pub get` を実行する checkout 6 箇所へ `submodules: true` を追加しました。

| ワークフロー | ジョブ |
|---|---|
| `wc-check-dart-analyze.yaml` | `flutter-analyze` |
| `wc-check-dart-test.yaml` | `flutter-test` |
| `wc-check-eqmonitor-map-scene-spike.yaml` | `android-build` / `ios-build` |
| `deploy-app.yaml` | `build-ios` / `build-android` |

`define-matrix`・release note 生成・`deploy-*`・`upload-asset-pack`・`create-beta-release` は pub を解決しない（artifact の受け渡しのみ）ため対象外です。`wc-check-integration.yaml` は backend submodule のために既に `submodules: true` です。

### その他

- `analysis_options.yaml` の `exclude` へ `third_party/**` を追加（fork のコードはこのリポジトリの lint 規約に従わせない）。
- `CLAUDE.md` のセットアップ手順へ `git submodule update --init third_party/flutter_scene` を追加。
- `docs/knowledge/20260802_flutter_scene_scene_source_pin.md` を submodule 前提へ更新。

## 検証

```
$ git submodule status third_party/flutter_scene
 7f71993b7e2a0ab1d2f59726a406098709be7291 third_party/flutter_scene

$ mise exec -- flutter pub get     # ルートワークスペース
Changed 1 dependency!

$ cd packages/eqmonitor_map && mise exec -- flutter test test/flutter_scene
00:01 +34: All tests passed!

$ mise exec -- dart analyze . --fatal-infos
No issues found!
```

## 注意

このブランチを checkout する際は submodule の初期化が必要です。

```bash
git submodule update --init third_party/flutter_scene
```

https://claude.ai/code/session_012PeDKkyZK9vjnWcY7orPGY