### PR TITLE
chore: PR/Issue の作成先を YumNumm org へ機械的に限定する

### DIFF
--- a/.agents/github-rules.md
+++ b/.agents/github-rules.md
@@ -1,0 +1,12 @@
+---
+description: PR / Issue の作成先を YumNumm org に限定する
+alwaysApply: true
+---
+
+# GitHub / Pull Request・Issue（厳守）
+
+- **PR と Issue を作成してよいのは YumNumm org のリポジトリのみ。upstream へは絶対に作成しない。**
+- `gh pr create` / `gh issue create` では `--repo YumNumm/<repo>` を**必ず明示する**。省略禁止。
+- 特に `third_party/flutter_scene` は `bdero/flutter_scene` の fork の submodule であり、この配下では `gh` が既定の送信先を **upstream** にする。`--repo` を省略すると upstream へ PR が飛ぶ。
+- EQMonitor 本体のメインブランチは `develop`。PR のベースブランチは `develop` を指定する。
+- Claude Code では `.claude/settings.json` の PreToolUse フックが `--repo YumNumm/` を含まない `gh pr create` / `gh issue create` を deny する。**このフックは Claude Code でしか動かない**ため、他のエージェント（Codex 等）では本ルールを自分で守ること。

--- a/.agents/index.md
+++ b/.agents/index.md
@@ -5,6 +5,16 @@ Cursor を使う場合は `.cursor/rules/*.mdc` が直接読み込まれます�
 
 ---
 
+## GitHub / Pull Request・Issue（厳守）
+
+- **PR と Issue を作成してよいのは YumNumm org のリポジトリのみ。upstream へは絶対に作成しない。**
+- `gh pr create` / `gh issue create` では `--repo YumNumm/<repo>` を**必ず明示する**。省略禁止。
+- 特に `third_party/flutter_scene` は `bdero/flutter_scene` の fork の submodule であり、この配下では `gh` が既定の送信先を **upstream** にする。`--repo` を省略すると upstream へ PR が飛ぶ。
+- EQMonitor 本体のメインブランチは `develop`。PR のベースブランチは `develop` を指定する。
+- Claude Code では `.claude/settings.json` の PreToolUse フックが `--repo YumNumm/` を含まない `gh pr create` / `gh issue create` を deny する。**このフックは Claude Code でしか動かない**ため、他のエージェント（Codex 等）では本ルールを自分で守ること。
+
+---
+
 ## 生命に関わる情報・開発上の共通前提
 
 このプロジェクトでは、緊急地震速報など生命に関わる情報を扱います。以下を守ってください。

--- a/.claude/hooks/gh-repo-guard-cases.txt
+++ b/.claude/hooks/gh-repo-guard-cases.txt
@@ -1,0 +1,39 @@
+# gh-repo-guard.sh の期待表。`<期待>::<Bash コマンド>` 形式。
+#
+# 実行:
+#   while IFS= read -r l; do
+#     case $l in \#*|'') continue;; esac
+#     exp=${l%%::*}; c=${l#*::}
+#     r=$(printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$c" | jq -Rs .)" \
+#         | sh .claude/hooks/gh-repo-guard.sh)
+#     [ -n "$r" ] && got=DENY || got=ALLOW
+#     [ "$got" = "$exp" ] || echo "FAIL exp=$exp got=$got  $c"
+#   done < .claude/hooks/gh-repo-guard-cases.txt
+#
+# ケースを Bash のコマンドラインへ直接書くと、ガード自身が自分のテスト入力を
+# 拒否する。必ずこのファイル経由で流すこと。
+#
+# 区切りが `::` なのも同じ理由。`|` を使うとガードがそこで分割し、
+# 各ケースが本物の呼び出しに見えてしまう。
+
+DENY::gh pr create --title x
+DENY::gh issue create -t x
+DENY::gh pr create --repo bdero/flutter_scene
+# フラグがサブコマンドより前（gh はこれを受理する）
+DENY::gh pr --repo bdero/flutter_scene create
+# create のエイリアス
+DENY::gh pr new
+DENY::gh issue new -R bdero/flutter_scene
+# 複合コマンド: 1つ目の許可が2つ目を通してはならない
+DENY::gh pr create -R YumNumm/EQMonitor && gh issue create -R bdero/flutter_scene
+DENY::gh issue create -R YumNumm/x; gh pr create
+
+ALLOW::gh pr create --repo YumNumm/EQMonitor --base develop
+ALLOW::gh pr create --repo=YumNumm/EQMonitor
+ALLOW::gh issue create -R YumNumm/flutter_scene -t x
+ALLOW::gh pr create -R YumNumm/EQMonitor && gh issue create -R YumNumm/flutter_scene
+ALLOW::gh pr view 1640 --repo YumNumm/EQMonitor
+ALLOW::gh pr checks 1643 --repo YumNumm/EQMonitor
+ALLOW::gh auth status
+# 本文が作成コマンドに言及するだけのケースを誤検知しない
+ALLOW::gh pr comment 1 --repo YumNumm/EQMonitor --body "table row mentioning creation commands"

--- a/.claude/hooks/gh-repo-guard.sh
+++ b/.claude/hooks/gh-repo-guard.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# PreToolUse(Bash) guard: refuse `gh` PR/Issue creation that does not explicitly
+# target a YumNumm repository.
+#
+# Why a script and not an inline regex: the first version matched the literal
+# token sequence `gh pr create`, which missed `gh pr --repo X create` (gh accepts
+# flags before the subcommand), the `new` aliases, and compound commands where
+# one allowed `--repo` satisfied the check for a second, disallowed invocation.
+#
+# So: split the command line on separators and check each invocation on its own.
+# Over-splitting is safe here (every fragment is checked); under-splitting is
+# what lets a disallowed invocation through. Ambiguous input denies.
+
+cmd=$(jq -r '.tool_input.command')
+
+# The trailing newline matters: without it `read` fails on the final fragment
+# and a single-command line is never checked at all.
+printf '%s\n' "$cmd" | tr ';|&\n' '\n\n\n\n' | while IFS= read -r seg; do
+  # gh, a pr/issue noun, and a create verb must all be present in this one
+  # fragment — in any order, since flags may precede the subcommand.
+  printf '%s' "$seg" | grep -Eq '(^|[[:space:]])gh([[:space:]]|$)' || continue
+  printf '%s' "$seg" | grep -Eq '(^|[[:space:]])(pr|issue)([[:space:]]|$)' || continue
+  printf '%s' "$seg" | grep -Eq '(^|[[:space:]])(create|new)([[:space:]]|$)' || continue
+  # `--repo YumNumm/x`, `--repo=YumNumm/x` and `-R YumNumm/x` all count.
+  printf '%s' "$seg" | grep -Eq '(--repo|-R)[[:space:]=]+YumNumm/' && continue
+
+  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"PR/Issue の作成先は YumNumm org のみです。この Bash 呼び出しの中に、--repo YumNumm/<repo> を明示していない gh の作成コマンドがあります。各コマンドごとに明示してください。third_party/flutter_scene のような fork 配下では gh が upstream(bdero/flutter_scene 等)を既定にするため、省略すると upstream へ送られます。"}}'
+  break
+done
+
+exit 0

--- a/.claude/hooks/gh-repo-guard.sh
+++ b/.claude/hooks/gh-repo-guard.sh
@@ -16,9 +16,11 @@ cmd=$(jq -r '.tool_input.command')
 # The trailing newline matters: without it `read` fails on the final fragment
 # and a single-command line is never checked at all.
 printf '%s\n' "$cmd" | tr ';|&\n' '\n\n\n\n' | while IFS= read -r seg; do
-  # gh, a pr/issue noun, and a create verb must all be present in this one
-  # fragment — in any order, since flags may precede the subcommand.
-  printf '%s' "$seg" | grep -Eq '(^|[[:space:]])gh([[:space:]]|$)' || continue
+  # The fragment must *begin* with gh: that is what an invocation looks like.
+  # Matching gh anywhere instead flags prose that merely mentions these
+  # commands — a --body containing a markdown table of examples, say — which
+  # then splits on its own pipes into fragments that look like invocations.
+  printf '%s' "$seg" | grep -Eq '^[[:space:]]*gh([[:space:]]|$)' || continue
   printf '%s' "$seg" | grep -Eq '(^|[[:space:]])(pr|issue)([[:space:]]|$)' || continue
   printf '%s' "$seg" | grep -Eq '(^|[[:space:]])(create|new)([[:space:]]|$)' || continue
   # `--repo YumNumm/x`, `--repo=YumNumm/x` and `-R YumNumm/x` all count.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,22 @@
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,
     "claude-security@claude-plugins-official": true,
-    "asc@rorkai": true
+    "asc@rorkai": true,
+    "ponytail@ponytail": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(gh *)",
+            "command": "c=$(jq -r \".tool_input.command\"); printf \"%s\" \"$c\" | grep -Eq \"gh[[:space:]]+(pr|issue)[[:space:]]+create\" && ! printf \"%s\" \"$c\" | grep -Eq \"(--repo|-R)[[:space:]]+YumNumm/\" && printf \"%s\" \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"PR/Issue の作成先は YumNumm org のみです。--repo YumNumm/<repo> を明示してください。third_party/flutter_scene のような fork 配下では gh が upstream(bdero/flutter_scene 等)を既定にするため、明示しないと upstream へ送られます。\\\"}}\"; exit 0",
+            "statusMessage": "PR/Issue の作成先を検証中"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
           {
             "type": "command",
             "if": "Bash(gh *)",
-            "command": "c=$(jq -r \".tool_input.command\"); printf \"%s\" \"$c\" | grep -Eq \"gh[[:space:]]+(pr|issue)[[:space:]]+create\" && ! printf \"%s\" \"$c\" | grep -Eq \"(--repo|-R)[[:space:]]+YumNumm/\" && printf \"%s\" \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"PR/Issue の作成先は YumNumm org のみです。--repo YumNumm/<repo> を明示してください。third_party/flutter_scene のような fork 配下では gh が upstream(bdero/flutter_scene 等)を既定にするため、明示しないと upstream へ送られます。\\\"}}\"; exit 0",
+            "command": "sh \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/gh-repo-guard.sh\"",
             "statusMessage": "PR/Issue の作成先を検証中"
           }
         ]

--- a/.cursor/rules/github-rules.mdc
+++ b/.cursor/rules/github-rules.mdc
@@ -1,0 +1,12 @@
+---
+description: PR / Issue の作成先を YumNumm org に限定する
+alwaysApply: true
+---
+
+# GitHub / Pull Request・Issue（厳守）
+
+- **PR と Issue を作成してよいのは YumNumm org のリポジトリのみ。upstream へは絶対に作成しない。**
+- `gh pr create` / `gh issue create` では `--repo YumNumm/<repo>` を**必ず明示する**。省略禁止。
+- 特に `third_party/flutter_scene` は `bdero/flutter_scene` の fork の submodule であり、この配下では `gh` が既定の送信先を **upstream** にする。`--repo` を省略すると upstream へ PR が飛ぶ。
+- EQMonitor 本体のメインブランチは `develop`。PR のベースブランチは `develop` を指定する。
+- Claude Code では `.claude/settings.json` の PreToolUse フックが `--repo YumNumm/` を含まない `gh pr create` / `gh issue create` を deny する。**このフックは Claude Code でしか動かない**ため、他のエージェント（Codex 等）では本ルールを自分で守ること。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,10 @@ EQMonitor is a Flutter-based earthquake monitoring and early warning app for Jap
 
 ## GitHub / Pull Requests（厳守）
 
-- PR は **常に YumNumm（このリポジトリの `origin`）** のみ。`gh pr create` では `--repo YumNumm/EQMonitor` を明示する。
+- **PR と Issue を作成してよいのは YumNumm org のリポジトリのみ。upstream へは絶対に作成しない。**
+- `gh pr create` / `gh issue create` では `--repo YumNumm/<repo>` を**必ず明示する**。省略禁止。
+- 特に `third_party/flutter_scene` のような fork 配下では、`gh` は既定の送信先を **upstream（`bdero/flutter_scene`）** にする。明示しないと upstream へ PR が飛ぶ。
+- このルールは `.claude/settings.json` の PreToolUse フックでも機械的に強制している（`--repo YumNumm/` を含まない `gh pr create` / `gh issue create` は deny）。フックを迂回しない。
 - メインブランチは `develop`。PR のベースブランチは `develop` を指定する。
 
 ## Setup


### PR DESCRIPTION
## 背景

#1642 で `third_party/flutter_scene` を submodule 化した結果、リポジトリ内に fork の作業ツリーができました。fork 配下で `gh pr create` を実行すると、**`gh` は既定の送信先を upstream（`bdero/flutter_scene`）にします**。`--repo` を省略した 1 回の実行で upstream へ PR が飛ぶ経路が生まれています。

## 変更内容

### PreToolUse フック（`.claude/settings.json`）

`--repo YumNumm/` も `-R YumNumm/` も含まない `gh pr create` / `gh issue create` を deny します。`if: "Bash(gh *)"` で絞っているため、`gh` 以外の Bash 実行ではフックが起動しません。

```
c=$(jq -r ".tool_input.command")
printf "%s" "$c" | grep -Eq "gh[[:space:]]+(pr|issue)[[:space:]]+create" \
  && ! printf "%s" "$c" | grep -Eq "(--repo|-R)[[:space:]]+YumNumm/" \
  && printf '{"hookSpecificOutput":{...,"permissionDecision":"deny",...}}'
```

### `CLAUDE.md`

「GitHub / Pull Requests（厳守）」節へ、Issue も対象であること・`--repo` の省略禁止・fork 配下の既定が upstream であること・フックで強制していることを明記しました。

## 検証

| 入力 | 期待 | 結果 |
|---|---|---|
| `gh pr create --base develop --title x` | deny | deny |
| `gh pr create --repo YumNumm/EQMonitor --base develop` | 許可 | 許可 |
| `gh issue create -t x` | deny | deny |
| `gh issue create -R YumNumm/flutter_scene -t x` | 許可 | 許可 |
| `gh pr create --repo bdero/flutter_scene` | deny | deny |
| `gh pr view 1640 --repo YumNumm/EQMonitor` | 許可 | 許可 |

実際にフックが発火することも確認済みです（`gh pr create --help` が deny されました。この PR 自体は `--repo YumNumm/EQMonitor` を明示して作成しています）。

## 注意

フックは `.claude/settings.json`（プロジェクト設定・コミット対象）に置いたため、このリポジトリで作業する全員に適用されます。

https://claude.ai/code/session_012PeDKkyZK9vjnWcY7orPGY