### PR TITLE
fix: 地震詳細マップレイヤーの既定値を調整済みの値に更新

### DIFF
--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart
@@ -11,7 +11,7 @@ abstract class EarthquakeHistoryMapLayerParameter
     // 市区町村ポリゴンがタイルに存在する最小ズーム
     // (BaseMapTileSpec.cityMinZoom) に合わせる。
     @Default(6) double regionToCity,
-    @Default(8) double stationMinZoom,
+    @Default(6) double stationMinZoom,
     @Default(9) double stationLabelMinZoom,
     @Default(9) double stationTextZoom,
     @Default(8) double hypocenterFadeZoom,
@@ -23,13 +23,13 @@ abstract class EarthquakeHistoryMapLayerParameter
     @Default(0.6) double cityFillOpacity,
 
     // 観測点サイズ (circle-radius interpolation)
-    @Default(2) double stationCircleRadiusMin,
-    @Default(8) double stationCircleRadiusMax,
+    @Default(0.8) double stationCircleRadiusMin,
+    @Default(6.7) double stationCircleRadiusMax,
 
     // 観測点アイコンサイズ (icon-size interpolation)
-    @Default(0.025) double stationIconSizeMin,
-    @Default(0.18) double stationIconSizeMid,
-    @Default(0.6) double stationIconSizeMax,
+    @Default(0.03) double stationIconSizeMin,
+    @Default(0.13) double stationIconSizeMid,
+    @Default(0.5) double stationIconSizeMax,
 
     // 震央マーカー
     @Default(0.15) double hypocenterIconSizeMin,

--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.freezed.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.freezed.dart
@@ -226,7 +226,7 @@ return $default(_that.regionToCity,_that.stationMinZoom,_that.stationLabelMinZoo
 @JsonSerializable()
 
 class _EarthquakeHistoryMapLayerParameter implements EarthquakeHistoryMapLayerParameter {
-  const _EarthquakeHistoryMapLayerParameter({this.regionToCity = 6, this.stationMinZoom = 8, this.stationLabelMinZoom = 9, this.stationTextZoom = 9, this.hypocenterFadeZoom = 8, this.hypocenterErrorMinZoom = 8, this.regionFillOpacity = 0.6, this.regionLineOpacity = 0.8, this.cityFillOpacity = 0.6, this.stationCircleRadiusMin = 2, this.stationCircleRadiusMax = 8, this.stationIconSizeMin = 0.025, this.stationIconSizeMid = 0.18, this.stationIconSizeMax = 0.6, this.hypocenterIconSizeMin = 0.15, this.hypocenterIconSizeMax = 0.4, this.hypocenterFadeOpacity = 0.6});
+  const _EarthquakeHistoryMapLayerParameter({this.regionToCity = 6, this.stationMinZoom = 6, this.stationLabelMinZoom = 9, this.stationTextZoom = 9, this.hypocenterFadeZoom = 8, this.hypocenterErrorMinZoom = 8, this.regionFillOpacity = 0.6, this.regionLineOpacity = 0.8, this.cityFillOpacity = 0.6, this.stationCircleRadiusMin = 0.8, this.stationCircleRadiusMax = 6.7, this.stationIconSizeMin = 0.03, this.stationIconSizeMid = 0.13, this.stationIconSizeMax = 0.5, this.hypocenterIconSizeMin = 0.15, this.hypocenterIconSizeMax = 0.4, this.hypocenterFadeOpacity = 0.6});
   factory _EarthquakeHistoryMapLayerParameter.fromJson(Map<String, dynamic> json) => _$EarthquakeHistoryMapLayerParameterFromJson(json);
 
 @override@JsonKey() final  double regionToCity;

--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.g.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.g.dart
@@ -21,7 +21,7 @@ _$EarthquakeHistoryMapLayerParameterFromJson(Map<String, dynamic> json) =>
           ),
           stationMinZoom: $checkedConvert(
             'station_min_zoom',
-            (v) => (v as num?)?.toDouble() ?? 8,
+            (v) => (v as num?)?.toDouble() ?? 6,
           ),
           stationLabelMinZoom: $checkedConvert(
             'station_label_min_zoom',
@@ -53,23 +53,23 @@ _$EarthquakeHistoryMapLayerParameterFromJson(Map<String, dynamic> json) =>
           ),
           stationCircleRadiusMin: $checkedConvert(
             'station_circle_radius_min',
-            (v) => (v as num?)?.toDouble() ?? 2,
+            (v) => (v as num?)?.toDouble() ?? 0.8,
           ),
           stationCircleRadiusMax: $checkedConvert(
             'station_circle_radius_max',
-            (v) => (v as num?)?.toDouble() ?? 8,
+            (v) => (v as num?)?.toDouble() ?? 6.7,
           ),
           stationIconSizeMin: $checkedConvert(
             'station_icon_size_min',
-            (v) => (v as num?)?.toDouble() ?? 0.025,
+            (v) => (v as num?)?.toDouble() ?? 0.03,
           ),
           stationIconSizeMid: $checkedConvert(
             'station_icon_size_mid',
-            (v) => (v as num?)?.toDouble() ?? 0.18,
+            (v) => (v as num?)?.toDouble() ?? 0.13,
           ),
           stationIconSizeMax: $checkedConvert(
             'station_icon_size_max',
-            (v) => (v as num?)?.toDouble() ?? 0.6,
+            (v) => (v as num?)?.toDouble() ?? 0.5,
           ),
           hypocenterIconSizeMin: $checkedConvert(
             'hypocenter_icon_size_min',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

地震詳細画面の「マップレイヤー」デバッグシート（`EarthquakeHistoryDebugModal`）で調整した値を、`EarthquakeHistoryMapLayerParameter` の既定値として反映する。

## 変更内容

`app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart` の既定値を以下に更新（`build_runner` で生成ファイルも再生成）。

| パラメータ | 変更前 | 変更後 |
| --- | --- | --- |
| `stationMinZoom`（観測点 表示開始） | 8 | 6 |
| `stationCircleRadiusMin`（観測点サイズ 最小 z4） | 2 | 0.8 |
| `stationCircleRadiusMax`（観測点サイズ 最大 z10） | 8 | 6.7 |
| `stationIconSizeMin`（アイコンサイズ 最小 z3） | 0.025 | 0.03 |
| `stationIconSizeMid`（アイコンサイズ 中間 z7） | 0.18 | 0.13 |
| `stationIconSizeMax`（アイコンサイズ 最大 z20） | 0.6 | 0.5 |

その他の項目（透明度・ズーム閾値の一部・震央マーカー）はスクリーンショットの値と現行既定値が一致しているため変更なし。

## `regionToCity` を 3.0 にしなかった理由

スクリーンショットでは `地域→市区町村` が 3.0 だが、以下の理由により既定値は `cityMinZoom`（6）のまま維持した。

- `EarthquakeHistoryMapLayerModeResolver.effectiveRegionToCityZoom` が `max(regionToCity, BaseMapTileSpec.cityMinZoom)` で下限まで切り上げるため、3 にしても描画結果は 6 と完全に同一（no-op）。
- ベース地図タイルの市区町村ポリゴンは z6 未満に存在しない（`docs/knowledge/20260804_base_map_city_polygon_minzoom.md`）。
- 「既定の `regionToCity` はタイルの市区町村最小ズームと一致する」という不変条件テストが存在する。

視覚的に意図した結果を保ちつつ規約・テストを維持するため、`regionToCity` はそのままとした。

## テスト

- `flutter test test/feature/earthquake_history/ui/layer/earthquake_history_map_layer_mode_test.dart` → 全 13 件パス

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00310-2031-7df9-ab7c-7eac30bd6fd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00310-2031-7df9-ab7c-7eac30bd6fd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

