### PR TITLE
Fix: Live Activity・ホーム画面ウィジェットのバグとデザイン不備を修正

### DIFF
--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		D11333333333333333333333 /* EarthquakeDetailURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11222222222222222222222 /* EarthquakeDetailURL.swift */; };
 		D11444444444444444444444 /* EarthquakeDetailURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11222222222222222222222 /* EarthquakeDetailURL.swift */; };
 		EQ0000000000000000000065 /* LiveActivityDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000001 /* LiveActivityDate.swift */; };
+		EQ00000000000000000000C8 /* LiveActivityDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000001 /* LiveActivityDate.swift */; };
 		EQ0000000000000000000066 /* LiveActivityDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000001 /* LiveActivityDate.swift */; };
 		EQ0000000000000000000067 /* WidgetErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000002 /* WidgetErrorMessage.swift */; };
 		EQ0000000000000000000068 /* WidgetErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000002 /* WidgetErrorMessage.swift */; };
@@ -788,6 +789,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EQ00000000000000000000C8 /* LiveActivityDate.swift in Sources */,
 				EQ0000000000000000000069 /* WidgetErrorMessage.swift in Sources */,
 				010DC8E64C7C76B8F4F166D5 /* EarthquakeDisplayItem.swift in Sources */,
 				BFEAEC9B65D462419D75AB02 /* IntensityValue.swift in Sources */,

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -74,6 +74,13 @@
 		D11222222222222222222222 /* WidgetLayoutPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11111111111111111111111 /* WidgetLayoutPolicy.swift */; };
 		D11333333333333333333333 /* EarthquakeDetailURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11222222222222222222222 /* EarthquakeDetailURL.swift */; };
 		D11444444444444444444444 /* EarthquakeDetailURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11222222222222222222222 /* EarthquakeDetailURL.swift */; };
+		EQ0000000000000000000065 /* LiveActivityDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000001 /* LiveActivityDate.swift */; };
+		EQ0000000000000000000066 /* LiveActivityDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000001 /* LiveActivityDate.swift */; };
+		EQ0000000000000000000067 /* WidgetErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000002 /* WidgetErrorMessage.swift */; };
+		EQ0000000000000000000068 /* WidgetErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000002 /* WidgetErrorMessage.swift */; };
+		EQ0000000000000000000069 /* WidgetErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000002 /* WidgetErrorMessage.swift */; };
+		EQ000000000000000000006A /* LiveActivityDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000003 /* LiveActivityDateTests.swift */; };
+		EQ000000000000000000006B /* WidgetErrorMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000004 /* WidgetErrorMessageTests.swift */; };
 		D11555555555555555555555 /* WidgetBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11333333333333333333333 /* WidgetBehaviorTests.swift */; };
 		E8CFD3E6506B946469164594 /* ColorRGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687B9A2C44EF493FAA2AA83C /* ColorRGB.swift */; };
 /* End PBXBuildFile section */
@@ -203,6 +210,10 @@
 		CEF843E9B82869CED39772C0 /* DesignTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DesignTokens.swift; sourceTree = "<group>"; };
 		E11111111111111111111111 /* WidgetLayoutPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetLayoutPolicy.swift; sourceTree = "<group>"; };
 		E11222222222222222222222 /* EarthquakeDetailURL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EarthquakeDetailURL.swift; sourceTree = "<group>"; };
+		EQ0000000000000000000001 /* LiveActivityDate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveActivityDate.swift; sourceTree = "<group>"; };
+		EQ0000000000000000000002 /* WidgetErrorMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetErrorMessage.swift; sourceTree = "<group>"; };
+		EQ0000000000000000000003 /* LiveActivityDateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveActivityDateTests.swift; sourceTree = "<group>"; };
+		EQ0000000000000000000004 /* WidgetErrorMessageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetErrorMessageTests.swift; sourceTree = "<group>"; };
 		E11333333333333333333333 /* WidgetBehaviorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetBehaviorTests.swift; sourceTree = "<group>"; };
 		FB4211733B19AA27C617F8A5 /* TelegramStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TelegramStatus.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -328,6 +339,8 @@
 			children = (
 				C983AB8FC2BFED453E240464 /* EarthquakeDisplayItemTests.swift */,
 				E11333333333333333333333 /* WidgetBehaviorTests.swift */,
+				EQ0000000000000000000003 /* LiveActivityDateTests.swift */,
+				EQ0000000000000000000004 /* WidgetErrorMessageTests.swift */,
 			);
 			path = WidgetModelsTests;
 			sourceTree = "<group>";
@@ -444,6 +457,8 @@
 				4569B747204EE74872C7E9DB /* IntensityBadge.swift */,
 				E11111111111111111111111 /* WidgetLayoutPolicy.swift */,
 				E11222222222222222222222 /* EarthquakeDetailURL.swift */,
+				EQ0000000000000000000001 /* LiveActivityDate.swift */,
+				EQ0000000000000000000002 /* WidgetErrorMessage.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -773,6 +788,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EQ0000000000000000000069 /* WidgetErrorMessage.swift in Sources */,
 				010DC8E64C7C76B8F4F166D5 /* EarthquakeDisplayItem.swift in Sources */,
 				BFEAEC9B65D462419D75AB02 /* IntensityValue.swift in Sources */,
 				7BECFE11CAB325714CACA5EC /* TelegramStatus.swift in Sources */,
@@ -796,6 +812,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EQ0000000000000000000066 /* LiveActivityDate.swift in Sources */,
+				EQ0000000000000000000068 /* WidgetErrorMessage.swift in Sources */,
+				EQ000000000000000000006A /* LiveActivityDateTests.swift in Sources */,
+				EQ000000000000000000006B /* WidgetErrorMessageTests.swift in Sources */,
 				06C54F953E3BD230BCDE7A3F /* EarthquakeDisplayItem.swift in Sources */,
 				A47F6602271A89052A753BD0 /* IntensityValue.swift in Sources */,
 				8EF4AB3495DB7B973CA66ECE /* TelegramStatus.swift in Sources */,
@@ -813,6 +833,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EQ0000000000000000000065 /* LiveActivityDate.swift in Sources */,
+				EQ0000000000000000000067 /* WidgetErrorMessage.swift in Sources */,
 				2C755225A37C4C6116012293 /* EarthquakeDisplayItem.swift in Sources */,
 				0653ECA8737307C2CA836FC7 /* IntensityValue.swift in Sources */,
 				47E5E897BFDE09208D2DBE5F /* TelegramStatus.swift in Sources */,

--- a/app/ios/Shared/EarthquakeAPIClient.swift
+++ b/app/ios/Shared/EarthquakeAPIClient.swift
@@ -12,25 +12,38 @@ import OpenAPIRuntime
 // MARK: - API Error Types
 
 enum APIError: Error, LocalizedError {
-    case networkError(Error)
-    case invalidResponse
-    case decodingError(String)
+    case networkError(URLError)
     case serverError(Int)
-    case invalidURL
+    /// 通信・デコードのいずれとも判別できなかった失敗
+    case unexpected
 
+    /// ウィジェットに表示する文言。開発者向けの詳細は含めない。
     var errorDescription: String? {
         switch self {
         case .networkError(let error):
-            return "ネットワークエラー: \(error.localizedDescription)"
-        case .invalidResponse:
-            return "無効なレスポンス"
-        case .decodingError(let detail):
-            return "データ解析エラー: \(detail)"
+            return WidgetErrorMessage.network(error.code)
         case .serverError(let code):
-            return "サーバーエラー (\(code))"
-        case .invalidURL:
-            return "無効なURL"
+            return WidgetErrorMessage.server(statusCode: code)
+        case .unexpected:
+            return WidgetErrorMessage.unknown
         }
+    }
+
+    /// 任意の Error を APIError へ正規化する。
+    /// swift-openapi-runtime は transport の失敗を `ClientError` で包むため、
+    /// 中の `URLError` を取り出して圏外・タイムアウトを判別できるようにする。
+    static func from(_ error: Error) -> APIError {
+        if let apiError = error as? APIError {
+            return apiError
+        }
+        if let urlError = error as? URLError {
+            return .networkError(urlError)
+        }
+        if let clientError = error as? ClientError,
+           let urlError = clientError.underlyingError as? URLError {
+            return .networkError(urlError)
+        }
+        return .unexpected
     }
 }
 

--- a/app/ios/Shared/EarthquakeDisplayItem.swift
+++ b/app/ios/Shared/EarthquakeDisplayItem.swift
@@ -222,7 +222,7 @@ struct EarthquakeDisplayItem: Identifiable, Equatable {
     ) -> String {
         if let detailedName { return detailedName }
         if let name { return name }
-        if let maxIntensity { return "最大震度\(maxIntensity.displayString)を観測" }
+        if let maxIntensity { return "最大震度\(maxIntensity.titleText)を観測" }
         return ""
     }
 

--- a/app/ios/Shared/IntensityBadge.swift
+++ b/app/ios/Shared/IntensityBadge.swift
@@ -28,7 +28,12 @@ struct IntensityBadge: View {
         .minimumScaleFactor(0.5)
         .lineLimit(1)
         .foregroundStyle(textColor)
-        .frame(width: size, height: size)
+        .padding(.horizontal, size * 0.08)
+        // 未入電（「5弱以上」等）はサブ文字が長く正方形に収まらない。
+        // 高さだけ固定し、幅は最小 size として横方向に伸ばす
+        // （固定幅にすると背景の外へ文字がはみ出す）。
+        .frame(height: size)
+        .frame(minWidth: size)
         .background(
             RoundedRectangle(cornerRadius: size * cornerRatio, style: .continuous)
                 .fill(backgroundColor)

--- a/app/ios/Shared/IntensityValue.swift
+++ b/app/ios/Shared/IntensityValue.swift
@@ -66,6 +66,17 @@ enum IntensityValue: String, Codable, CaseIterable, Comparable {
         }
     }
 
+    /// 震源名が無いときの見出し（「最大震度◯を観測」）に埋める文字列。
+    /// 「未入電」は電文の受信状況を指す内部事情で、見出しに混ぜると
+    /// 「最大震度5弱以上未入電を観測」のような読みづらい文になるため落とす。
+    var titleText: String {
+        switch self {
+        case .fiveLowerNoInput: return "5弱以上"
+        case .sixLowerNoInput: return "6弱以上"
+        default: return displayString
+        }
+    }
+
     /// 震度のメイン数字部分
     var mainNumber: String {
         switch self {

--- a/app/ios/Shared/LiveActivityDate.swift
+++ b/app/ios/Shared/LiveActivityDate.swift
@@ -88,6 +88,11 @@ enum JSTDateFormat {
         string(from: date, format: "HH:mm:ss")
     }
 
+    /// `HH:mm`（Dynamic Island など幅が限られる場所向け）
+    static func timeShort(_ date: Date) -> String {
+        string(from: date, format: "HH:mm")
+    }
+
     private static func string(from date: Date, format: String) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = format

--- a/app/ios/Shared/LiveActivityDate.swift
+++ b/app/ios/Shared/LiveActivityDate.swift
@@ -1,0 +1,84 @@
+//
+//  LiveActivityDate.swift
+//  Shared (WidgetExtension / WidgetModelsTests)
+//
+//  Live Activity の APNs content-state に含まれる日時文字列をパースする。
+//
+//  backend の日時表現は経路によって揺れる（`LenientISO8601DateTranscoder` と同じ事情）。
+//  ActivityKit の content-state は `String` で受け取ってから View 側で Date に変換するため、
+//  OpenAPI クライアントの DateTranscoder が効かない。パースに失敗すると発生時刻や
+//  主要動到達までのカウントダウンが丸ごと消えるため、受理できる表現を広く取る。
+//
+
+import Foundation
+
+enum LiveActivityDate {
+    /// ISO8601 由来の日時文字列を Date に変換する。
+    ///
+    /// 受理する表現:
+    /// - fractional seconds あり/なし (`...T16:10:00.123+09:00` / `...T16:10:00+09:00`)
+    /// - UTC 表記 (`...T07:10:00Z`)
+    /// - PostgreSQL timestamptz テキスト表現 (`2026-06-26 18:59:00+00`)
+    static func parse(_ raw: String?) -> Date? {
+        guard let raw, !raw.isEmpty else { return nil }
+        let normalized = normalize(raw)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: normalized) {
+            return date
+        }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: normalized)
+    }
+
+    /// ISO8601 パーサが受理できる形へ寄せる。
+    /// - 日付と時刻の区切りスペースを `T` に置換
+    /// - 末尾のオフセットが 2 桁のみ（`+00` / `-09`）なら `:00` を補って `HH:mm` にする
+    private static func normalize(_ raw: String) -> String {
+        var value = raw
+        if let space = value.firstIndex(of: " ") {
+            value.replaceSubrange(space...space, with: "T")
+        }
+        if let offset = shortOffsetRange(in: value) {
+            value.insert(contentsOf: ":00", at: offset.upperBound)
+        }
+        return value
+    }
+
+    /// 末尾が `+HH` / `-HH`（分を伴わない 2 桁オフセット）ならその範囲を返す。
+    private static func shortOffsetRange(in value: String) -> Range<String.Index>? {
+        guard value.count >= 3 else { return nil }
+        let offsetStart = value.index(value.endIndex, offsetBy: -3)
+        let sign = value[offsetStart]
+        guard sign == "+" || sign == "-" else { return nil }
+        let digits = value[value.index(after: offsetStart)...]
+        guard digits.count == 2, digits.allSatisfy(\.isNumber) else { return nil }
+        return offsetStart..<value.endIndex
+    }
+}
+
+// MARK: - 表示用フォーマット
+
+/// JMA が発表する日時は JST を正とするため、端末のタイムゾーンに依存させない。
+enum JSTDateFormat {
+    private static let timeZone = TimeZone(identifier: "Asia/Tokyo")
+    private static let locale = Locale(identifier: "ja_JP")
+
+    /// `MM/dd`
+    static func monthDay(_ date: Date) -> String {
+        string(from: date, format: "MM/dd")
+    }
+
+    /// `HH:mm:ss`
+    static func timeWithSeconds(_ date: Date) -> String {
+        string(from: date, format: "HH:mm:ss")
+    }
+
+    private static func string(from date: Date, format: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = format
+        formatter.locale = locale
+        formatter.timeZone = timeZone
+        return formatter.string(from: date)
+    }
+}

--- a/app/ios/Shared/LiveActivityDate.swift
+++ b/app/ios/Shared/LiveActivityDate.swift
@@ -57,6 +57,20 @@ enum LiveActivityDate {
     }
 }
 
+// MARK: - 到達カウントダウン
+
+enum ArrivalCountdown {
+    /// `Text(timerInterval:)` に渡す残り時間の範囲。到達済み・未設定なら nil。
+    ///
+    /// `now > arrivalDate` の範囲を作ると `ClosedRange` の事前条件違反でクラッシュする。
+    /// 「到達したか」の判定と範囲生成で別々に `Date()` を取ると、ちょうど到達した
+    /// 瞬間（ユーザが最も画面を見ているタイミング）に踏み抜くため、同じ時刻で判定する。
+    static func remaining(until arrivalDate: Date?, now: Date = Date()) -> ClosedRange<Date>? {
+        guard let arrivalDate, arrivalDate > now else { return nil }
+        return now...arrivalDate
+    }
+}
+
 // MARK: - 表示用フォーマット
 
 /// JMA が発表する日時は JST を正とするため、端末のタイムゾーンに依存させない。

--- a/app/ios/Shared/WidgetErrorMessage.swift
+++ b/app/ios/Shared/WidgetErrorMessage.swift
@@ -1,0 +1,44 @@
+//
+//  WidgetErrorMessage.swift
+//  Shared (WidgetExtension / AppIntentExtension / WidgetModelsTests)
+//
+//  ウィジェットに表示する取得失敗メッセージ。
+//
+//  ウィジェットは面積が限られており、開発者向けの例外文言（swift-openapi-runtime の
+//  ClientError や NSError の debugDescription など）をそのまま出すとレイアウトが崩れ、
+//  ユーザにとって意味のない情報になる。原因を数語で示す文言へ正規化する。
+//
+
+import Foundation
+
+enum WidgetErrorMessage {
+    /// 原因を特定できないときに表示する既定の文言
+    static let unknown = "地震情報を取得できませんでした"
+
+    /// 通信エラーの文言。URLError の code から原因を絞り込む。
+    static func network(_ code: URLError.Code) -> String {
+        switch code {
+        case .notConnectedToInternet, .dataNotAllowed:
+            return "インターネットに接続されていません"
+        case .networkConnectionLost, .cannotConnectToHost, .cannotFindHost,
+             .dnsLookupFailed:
+            return "サーバーに接続できませんでした"
+        case .timedOut:
+            return "通信がタイムアウトしました"
+        default:
+            return "通信エラーが発生しました"
+        }
+    }
+
+    /// HTTP ステータスコードの文言
+    static func server(statusCode: Int) -> String {
+        switch statusCode {
+        case 429:
+            return "アクセスが集中しています"
+        case 500...599:
+            return "サーバーが応答していません"
+        default:
+            return unknown
+        }
+    }
+}

--- a/app/ios/Widget/LiveActivity/Common/LocationInfo.swift
+++ b/app/ios/Widget/LiveActivity/Common/LocationInfo.swift
@@ -18,7 +18,6 @@ struct LocationInfo: Codable, Hashable {
     }
 
     var arrivalDate: Date? {
-        guard let arrivalTime = arrivalTime else { return nil }
-        return ISO8601DateFormatter().date(from: arrivalTime)
+        LiveActivityDate.parse(arrivalTime)
     }
 }

--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -480,26 +480,24 @@ struct ArrivalInfoView: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
 
-            if let arrivalDate = location.arrivalDate {
-                if arrivalDate > Date() {
-                    // Workaround: timerInterval が横方向に広がるのを防ぐ
-                    Text("00:00")
-                        .font(AppFonts.code(size: 12, weight: .bold))
-                        .hidden()
-                        .overlay(alignment: .trailing) {
-                            Text(timerInterval: Date()...arrivalDate, countsDown: true)
-                                .font(AppFonts.code(size: 12, weight: .bold))
-                                .monospacedDigit()
-                                .foregroundStyle(Color.eqTextPrimary)
-                                .contentTransition(.numericText(countsDown: true))
-                        }
-                } else {
-                    Text("主要動到達済み")
-                        .font(AppFonts.flex(size: 12, weight: .bold))
-                        .foregroundStyle(Color.eqTextPrimary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
-                }
+            if let remaining = ArrivalCountdown.remaining(until: location.arrivalDate) {
+                // Workaround: timerInterval が横方向に広がるのを防ぐ
+                Text("00:00")
+                    .font(AppFonts.code(size: 12, weight: .bold))
+                    .hidden()
+                    .overlay(alignment: .trailing) {
+                        Text(timerInterval: remaining, countsDown: true)
+                            .font(AppFonts.code(size: 12, weight: .bold))
+                            .monospacedDigit()
+                            .foregroundStyle(Color.eqTextPrimary)
+                            .contentTransition(.numericText(countsDown: true))
+                    }
+            } else if location.arrivalDate != nil {
+                Text("主要動到達済み")
+                    .font(AppFonts.flex(size: 12, weight: .bold))
+                    .foregroundStyle(Color.eqTextPrimary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
             }
         }
     }

--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -191,18 +191,16 @@ struct EewExpandedCenterView: View {
                 .foregroundStyle(Color.eqTextPrimary)
                 .lineLimit(2)
                 .minimumScaleFactor(0.75)
-        } else {
+        } else if let hypocenterName = state.hypocenterName {
             VStack(alignment: .leading, spacing: 2) {
                 Text(state.isPlum == true || state.isLevel == true ? "検知観測点" : "震源地")
                     .font(AppFonts.flex(size: 9, weight: .medium))
                     .foregroundStyle(Color.eqTextSecondary)
-                if let hypocenterName = state.hypocenterName {
-                    Text(hypocenterName)
-                        .font(AppFonts.flex(size: 16, weight: .bold))
-                        .foregroundStyle(Color.eqTextPrimary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
-                }
+                Text(hypocenterName)
+                    .font(AppFonts.flex(size: 16, weight: .bold))
+                    .foregroundStyle(Color.eqTextPrimary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
             }
         }
     }
@@ -287,7 +285,7 @@ struct ShakeCompactTrailingView: View {
 
     var body: some View {
         if let date = state.detectedDate {
-            Text(date, style: .time)
+            Text(JSTDateFormat.timeShort(date))
                 .font(AppFonts.code(size: 11, weight: .semibold))
                 .monospacedDigit()
                 .foregroundStyle(Color.eqTextPrimary)
@@ -350,7 +348,7 @@ struct ShakeExpandedTrailingView: View {
                 Text("検知")
                     .font(AppFonts.flex(size: 9, weight: .medium))
                     .foregroundStyle(Color.eqTextSecondary)
-                Text(date, style: .time)
+                Text(JSTDateFormat.timeShort(date))
                     .font(AppFonts.code(size: 13, weight: .bold))
                     .monospacedDigit()
                     .foregroundStyle(Color.eqTextPrimary)
@@ -411,7 +409,7 @@ struct ShakeExpandedBottomView: View {
                         .foregroundStyle(Color.eqTextPrimary)
                 }
             } else if let date = state.detectedDate {
-                Text(date, style: .time)
+                Text(JSTDateFormat.timeShort(date))
                     .font(AppFonts.code(size: 13, weight: .bold))
                     .monospacedDigit()
                     .foregroundStyle(Color.eqTextPrimary)

--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -42,7 +42,7 @@ struct EewLiveActivityWidget: Widget {
 
 @available(iOS 16.1, *)
 private func eewKeylineTint(for state: EewContentState) -> Color {
-    if state.isCanceled == true {
+    if state.isCanceledReport {
         return .gray
     }
     return state.isWarning == true ? .red : .orange
@@ -88,9 +88,7 @@ struct EewCompactLeadingView: View {
     let state: EewContentState
 
     var body: some View {
-        if let location = state.location, let intensity = location.forecastIntensityValue {
-            DynamicIslandIntensityBadge(intensity: intensity, size: 24)
-        } else if let intensity = state.intensityValue {
+        if let intensity = state.displayIntensity {
             DynamicIslandIntensityBadge(intensity: intensity, size: 24)
         } else {
             Image("AppIconForeground")
@@ -109,7 +107,7 @@ struct EewCompactTrailingView: View {
     var body: some View {
         EewStatusPill(
             isWarning: state.isWarning ?? false,
-            isCanceled: state.isCanceled == true,
+            isCanceled: state.isCanceledReport,
             compact: true
         )
     }
@@ -120,9 +118,7 @@ struct EewMinimalView: View {
     let state: EewContentState
 
     var body: some View {
-        if let location = state.location, let intensity = location.forecastIntensityValue {
-            DynamicIslandIntensityBadge(intensity: intensity, size: 22)
-        } else if let intensity = state.intensityValue {
+        if let intensity = state.displayIntensity {
             DynamicIslandIntensityBadge(intensity: intensity, size: 22)
         } else {
             Image("AppIconForeground")
@@ -139,17 +135,9 @@ struct EewExpandedLeadingView: View {
     let state: EewContentState
 
     var body: some View {
-        if let location = state.location, let intensity = location.forecastIntensityValue {
+        if let intensity = state.displayIntensity {
             VStack(alignment: .leading, spacing: 4) {
-                Text("予想震度")
-                    .font(AppFonts.flex(size: 9, weight: .medium))
-                    .foregroundStyle(Color.eqTextSecondary)
-                DynamicIslandIntensityBadge(intensity: intensity, size: 36)
-            }
-            .padding(.leading, 4)
-        } else if let intensity = state.intensityValue {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("最大震度")
+                Text(state.displayIntensityLabel)
                     .font(AppFonts.flex(size: 9, weight: .medium))
                     .foregroundStyle(Color.eqTextSecondary)
                 DynamicIslandIntensityBadge(intensity: intensity, size: 36)
@@ -165,7 +153,7 @@ struct EewExpandedTrailingView: View {
 
     var body: some View {
         VStack(alignment: .trailing, spacing: 6) {
-            if state.isCanceled == true {
+            if state.isCanceledReport {
                 EewStatusPill(isWarning: false, isCanceled: true)
             } else if let isWarning = state.isWarning {
                 EewStatusPill(isWarning: isWarning, isCanceled: false)
@@ -197,7 +185,7 @@ struct EewExpandedCenterView: View {
     let state: EewContentState
 
     var body: some View {
-        if state.isCanceled == true {
+        if state.isCanceledReport {
             Text("緊急地震速報は取り消されました")
                 .font(AppFonts.flex(size: 13, weight: .bold))
                 .foregroundStyle(Color.eqTextPrimary)
@@ -225,47 +213,52 @@ struct EewExpandedBottomView: View {
     let state: EewContentState
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            if state.isPlum == true {
-                detectionMethodLabel("PLUM法による検知")
-            } else if state.isLevel == true {
-                detectionMethodLabel("レベル法による検知")
-            } else if state.isOnePoint == true {
-                detectionMethodLabel("低精度の緊急地震速報")
-            } else {
-                HStack(spacing: 12) {
-                    if let magnitude = state.magnitude {
-                        HStack(alignment: .firstTextBaseline, spacing: 1) {
-                            Text("M")
-                                .font(AppFonts.flex(size: 11, weight: .semibold))
-                                .foregroundStyle(Color.eqTextSecondary)
-                            Text(String(format: "%.1f", magnitude))
-                                .font(AppFonts.code(size: 16, weight: .bold))
-                                .monospacedDigit()
-                                .tracking(-1)
+        // 取消報では震源・規模・到達予想がすべて無効なため、ヘッダーの取消表示に任せる
+        if state.isCanceledReport {
+            EmptyView()
+        } else {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                if state.isPlum == true {
+                    detectionMethodLabel("PLUM法による検知")
+                } else if state.isLevel == true {
+                    detectionMethodLabel("レベル法による検知")
+                } else if state.isOnePoint == true {
+                    detectionMethodLabel("低精度の緊急地震速報")
+                } else {
+                    HStack(spacing: 12) {
+                        if let magnitude = state.magnitude {
+                            HStack(alignment: .firstTextBaseline, spacing: 1) {
+                                Text("M")
+                                    .font(AppFonts.flex(size: 11, weight: .semibold))
+                                    .foregroundStyle(Color.eqTextSecondary)
+                                Text(String(format: "%.1f", magnitude))
+                                    .font(AppFonts.code(size: 16, weight: .bold))
+                                    .monospacedDigit()
+                                    .tracking(-1)
+                            }
                         }
-                    }
-                    if let depth = state.depth {
-                        HStack(alignment: .firstTextBaseline, spacing: 1) {
-                            Text("深さ")
-                                .font(AppFonts.flex(size: 11, weight: .medium))
-                                .foregroundStyle(Color.eqTextSecondary)
-                            Text("\(Int(depth))")
-                                .font(AppFonts.code(size: 16, weight: .bold))
-                                .monospacedDigit()
-                            Text("km")
-                                .font(AppFonts.flex(size: 11, weight: .medium))
-                                .foregroundStyle(Color.eqTextSecondary)
+                        if let depth = state.depth {
+                            HStack(alignment: .firstTextBaseline, spacing: 1) {
+                                Text("深さ")
+                                    .font(AppFonts.flex(size: 11, weight: .medium))
+                                    .foregroundStyle(Color.eqTextSecondary)
+                                Text("\(Int(depth))")
+                                    .font(AppFonts.code(size: 16, weight: .bold))
+                                    .monospacedDigit()
+                                Text("km")
+                                    .font(AppFonts.flex(size: 11, weight: .medium))
+                                    .foregroundStyle(Color.eqTextSecondary)
+                            }
                         }
                     }
                 }
+                Spacer(minLength: 4)
+                if let location = state.location {
+                    ArrivalInfoView(location: location)
+                }
             }
-            Spacer(minLength: 4)
-            if let location = state.location {
-                ArrivalInfoView(location: location)
-            }
+            .padding(.leading, 4)
         }
-        .padding(.leading, 4)
     }
 
     private func detectionMethodLabel(_ text: String) -> some View {
@@ -284,16 +277,7 @@ struct ShakeCompactLeadingView: View {
     let state: ShakeDetectionContentState
 
     var body: some View {
-        if let level = state.shakeLevel {
-            Text(level.shortDisplayString)
-                .font(AppFonts.code(size: 14, weight: .bold))
-                .foregroundStyle(level.textColor)
-                .frame(width: 24, height: 24)
-                .background(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(level.backgroundColor)
-                )
-        }
+        ShakeLevelBadge(level: state.shakeLevel, size: 24)
     }
 }
 
@@ -316,16 +300,7 @@ struct ShakeMinimalView: View {
     let state: ShakeDetectionContentState
 
     var body: some View {
-        if let level = state.shakeLevel {
-            Text(level.shortDisplayString)
-                .font(AppFonts.code(size: 13, weight: .bold))
-                .foregroundStyle(level.textColor)
-                .frame(width: 22, height: 22)
-                .background(
-                    RoundedRectangle(cornerRadius: 5.5, style: .continuous)
-                        .fill(level.backgroundColor)
-                )
-        }
+        ShakeLevelBadge(level: state.shakeLevel, size: 22)
     }
 }
 
@@ -334,22 +309,34 @@ struct ShakeExpandedLeadingView: View {
     let state: ShakeDetectionContentState
 
     var body: some View {
-        if let level = state.shakeLevel {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("揺れ")
-                    .font(AppFonts.flex(size: 9, weight: .medium))
-                    .foregroundStyle(Color.eqTextSecondary)
-                Text(level.shortDisplayString)
-                    .font(AppFonts.code(size: 22, weight: .bold))
-                    .foregroundStyle(level.textColor)
-                    .frame(width: 36, height: 36)
-                    .background(
-                        RoundedRectangle(cornerRadius: 9, style: .continuous)
-                            .fill(level.backgroundColor)
-                    )
-            }
-            .padding(.leading, 4)
+        VStack(alignment: .leading, spacing: 4) {
+            Text("揺れ")
+                .font(AppFonts.flex(size: 9, weight: .medium))
+                .foregroundStyle(Color.eqTextSecondary)
+            ShakeLevelBadge(level: state.shakeLevel, size: 36)
         }
+        .padding(.leading, 4)
+    }
+}
+
+/// 揺れの強さバッジ。未知の level が届いても Dynamic Island が空になら
+/// ないよう、判別できない場合はグレーの「?」で「揺れ検知中だが強さ不明」を示す。
+@available(iOS 16.1, *)
+struct ShakeLevelBadge: View {
+    let level: ShakeDetectionLevel?
+    let size: CGFloat
+
+    var body: some View {
+        Text(level?.shortDisplayString ?? "?")
+            .font(AppFonts.code(size: size * 0.58, weight: .bold))
+            .lineLimit(1)
+            .minimumScaleFactor(0.6)
+            .foregroundStyle(level?.textColor ?? .white)
+            .frame(width: size, height: size)
+            .background(
+                RoundedRectangle(cornerRadius: size * 0.25, style: .continuous)
+                    .fill(level?.backgroundColor ?? Color.gray)
+            )
     }
 }
 

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
@@ -196,6 +196,54 @@ extension EewContentState {
         )
     )
 
+    static let canceled = EewContentState(
+        eventId: "20240106123456",
+        type: "eew",
+        hypocenterName: nil,
+        magnitude: nil,
+        depth: nil,
+        time: nil,
+        isOriginTime: false,
+        maxIntensity: nil,
+        serialNo: 2,
+        isFinal: true,
+        isWarning: false,
+        isCanceled: true,
+        headline: "地震発生",
+        isPlum: false,
+        isLevel: false,
+        isOnePoint: false,
+        location: nil
+    )
+
+    /// 取消報だが backend が震源・予想震度・到達予想を残したまま送ってきたケース。
+    /// 取消なのに「最大震度6強」「到達まで」が出ないことを確認するためのプレビュー。
+    static let canceledWithStaleValues = EewContentState(
+        eventId: "20240106123456",
+        type: "eew",
+        hypocenterName: "石川県能登地方",
+        magnitude: 7.6,
+        depth: 10,
+        time: "2024-01-06T16:10:00+09:00",
+        isOriginTime: true,
+        maxIntensity: "6+",
+        serialNo: 2,
+        isFinal: true,
+        isWarning: true,
+        isCanceled: true,
+        headline: "石川県で地震 北陸で強い揺れ",
+        isPlum: false,
+        isLevel: false,
+        isOnePoint: false,
+        location: LocationInfo(
+            regionName: "東京都23区",
+            forecastIntensity: "5-",
+            forecastLpgmIntensity: "2",
+            arrivalTime: "2024-01-06T16:12:30+09:00",
+            intensity: nil
+        )
+    )
+
     static let onePoint = EewContentState(
         eventId: "20240105123456",
         type: "eew",

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
@@ -15,8 +15,10 @@ struct EewLiveActivityAttributes: ActivityAttributes, Identifiable {
 
 struct EewContentState: Codable, Hashable {
     let eventId: String
-    /// イベント種別（backendは常に "eew" を送る）
-    let type: String
+    /// イベント種別（backend は "eew" を送る）。
+    /// UI では使わないため optional。必須にすると backend が欠落させた瞬間に
+    /// content-state 全体のデコードが失敗し Live Activity が表示されなくなる。
+    let type: String?
     let hypocenterName: String?
     let magnitude: Double?
     let depth: Double?
@@ -39,8 +41,7 @@ struct EewContentState: Codable, Hashable {
     }
 
     var timeDate: Date? {
-        guard let time = time else { return nil }
-        return ISO8601DateFormatter().date(from: time)
+        LiveActivityDate.parse(time)
     }
 
     var timeLabel: String {
@@ -49,8 +50,23 @@ struct EewContentState: Codable, Hashable {
         }
         return (isOriginTime ?? true) ? "地震発生" : "地震検知"
     }
-    
-    
+
+    /// 取消報。震源・規模・震度・到達予想はすべて無効な値として扱い、表示しない。
+    var isCanceledReport: Bool {
+        isCanceled == true
+    }
+
+    /// Dynamic Island の限られた面積に出す震度。
+    /// 現在地の予想震度を優先し、無ければ全国の最大震度にフォールバックする。
+    var displayIntensity: IntensityValue? {
+        guard !isCanceledReport else { return nil }
+        return location?.forecastIntensityValue ?? intensityValue
+    }
+
+    /// [displayIntensity] がどちらの震度かを示すラベル
+    var displayIntensityLabel: String {
+        location?.forecastIntensityValue != nil ? "予想震度" : "最大震度"
+    }
 }
 
 extension EewLiveActivityAttributes {

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
@@ -65,40 +65,35 @@ struct HeaderContainer: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 // 主要動到達までのカウントダウン / 到達済み
-                if let arrivalDate = arrivalDate {
-                    if arrivalDate > Date() {
-                        VStack(alignment: .trailing, spacing: 0) {
-                            Text("主要動到達まで")
-                                .eewLabelStyle(.header)
-                            // Workaround: countsDownの時に、横いっぱいに広がろうとするのを防ぐ
-                            // See: https://stackoverflow.com/questions/66210592/widgetkit-timer-text-style-expands-it-to-fill-the-width-instead-of-taking-spa
-                            Text("00:00")
-                                .font(
-                                    .system(
-                                        size: 18,
-                                        weight: .black,
-                                        design: .monospaced
-                                    )
+                if let remaining = ArrivalCountdown.remaining(until: arrivalDate) {
+                    VStack(alignment: .trailing, spacing: 0) {
+                        Text("主要動到達まで")
+                            .eewLabelStyle(.header)
+                        // Workaround: countsDownの時に、横いっぱいに広がろうとするのを防ぐ
+                        // See: https://stackoverflow.com/questions/66210592/widgetkit-timer-text-style-expands-it-to-fill-the-width-instead-of-taking-spa
+                        Text("00:00")
+                            .font(
+                                .system(
+                                    size: 18,
+                                    weight: .black,
+                                    design: .monospaced
                                 )
-                                .tracking(-0.5)
-                                .hidden()
-                                .overlay(alignment: .trailing) {
-                                    Text(
-                                        timerInterval: Date()...arrivalDate,
-                                        countsDown: true
-                                    )
+                            )
+                            .tracking(-0.5)
+                            .hidden()
+                            .overlay(alignment: .trailing) {
+                                Text(timerInterval: remaining, countsDown: true)
                                     .contentTransition(.numericText(countsDown: true))
                                     .font(.system(size: 18, weight: .black))
                                     .foregroundColor(.white)
                                     .monospacedDigit()
                                     .tracking(-0.5)
-                                }
-                        }
-                    } else {
-                        Text("主要動到達済み")
-                            .font(.system(size: 14, weight: .heavy))
-                            .foregroundColor(.white)
+                            }
                     }
+                } else if arrivalDate != nil {
+                    Text("主要動到達済み")
+                        .font(.system(size: 14, weight: .heavy))
+                        .foregroundColor(.white)
                 }
             }
             .padding(.horizontal, 12)

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
@@ -157,11 +157,12 @@ struct EewLockScreenView: View {
         VStack(spacing: 0) {
             HeaderContainer(
                 isWarning: state.isWarning ?? false,
-                isCanceled: state.isCanceled == true,
+                isCanceled: state.isCanceledReport,
                 headline: state.headline,
                 serialNo: state.serialNo,
                 isFinal: state.isFinal ?? false,
-                arrivalDate: state.location?.arrivalDate
+                // 取消報では到達予想は無効。カウントダウンを出すと誤情報になる。
+                arrivalDate: state.isCanceledReport ? nil : state.location?.arrivalDate
             )
             .padding(.horizontal, standardMargin)
             .padding(.top, standardMargin)
@@ -169,8 +170,8 @@ struct EewLockScreenView: View {
 
             // メインコンテンツ
             HStack(alignment: .bottom, spacing: 10) {
-                // 左側: 最大震度（正方形）
-                if let intensity = state.intensityValue {
+                // 左側: 最大震度（正方形）。取消報では予想震度自体が無効
+                if !state.isCanceledReport, let intensity = state.intensityValue {
                     VStack(spacing: 2) {
                         Text("最大震度")
                             .font(.system(size: 12, weight: .semibold))
@@ -185,8 +186,10 @@ struct EewLockScreenView: View {
                 detailsView
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-                if let location = state.location {
-                    arrivalView(location: location)
+                if !state.isCanceledReport,
+                   let intensity = state.location?.forecastIntensityValue,
+                   let regionName = state.location?.regionName {
+                    forecastIntensityView(regionName: regionName, intensity: intensity)
                 }
             }
             .padding(.horizontal, standardMargin)
@@ -194,32 +197,25 @@ struct EewLockScreenView: View {
         }
     }
 
-    // MARK: - Date Formatter
-
-    private func formatDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MM/dd"
-        formatter.locale = Locale(identifier: "ja_JP")
-        return formatter.string(from: date)
-    }
-
-    private func formatTime(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm:ss"
-        formatter.locale = Locale(identifier: "ja_JP")
-        return formatter.string(from: date)
-    }
-
     // MARK: - Details (震源地, M, 深さ, 発生時刻)
 
     private var detailsView: some View {
         VStack(alignment: .leading, spacing: 4) {
-            if state.isCanceled == true {
+            if state.isCanceledReport {
                 Text("緊急地震速報は取り消されました")
                     .font(.system(size: 14, weight: .bold))
                     .foregroundColor(.primary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.75)
+            } else {
+                uncanceledDetailsView
             }
+        }
+    }
 
+    /// 取消報以外で表示する震源・規模・時刻。取消報ではこれらの値がすべて無効なため出さない。
+    private var uncanceledDetailsView: some View {
+        VStack(alignment: .leading, spacing: 4) {
             if let hypocenterName = state.hypocenterName {
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text(
@@ -270,7 +266,7 @@ struct EewLockScreenView: View {
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text(state.timeLabel)
                         .eewLabelStyle()
-                    Text(formatDate(date))
+                    Text(JSTDateFormat.monthDay(date))
                         .font(
                             .system(
                                 size: 12,
@@ -280,7 +276,7 @@ struct EewLockScreenView: View {
                         )
                         .foregroundColor(.primary)
                         .tracking(-1)
-                    Text(formatTime(date))
+                    Text(JSTDateFormat.timeWithSeconds(date))
                         .font(
                             .system(
                                 size: 14,
@@ -317,29 +313,25 @@ struct EewLockScreenView: View {
         }
     }
 
-    // MARK: - Arrival Info
+    // MARK: - 現在地の予想震度
 
-    private func arrivalView(location: LocationInfo) -> some View {
-        VStack(alignment: .trailing, spacing: 4) {
-            // 現在地予想震度（地名と結合）
-            if let intensity = location.forecastIntensityValue {
-                VStack(spacing: 2) {
-                    // 地名の予想震度（アイコン付き）
-                    HStack(spacing: 2) {
-                        Image(systemName: "location.fill")
-                            .font(.system(size: 9, weight: .semibold))
-                            .foregroundColor(eewSecondaryTextColor)
-                            .symbolEffect(.pulse)
-                        Text("\(location.regionName)")
-                            .font(.system(size: 10, weight: .semibold))
-                            .foregroundColor(.primary)
-                    }
-                    SquareIntensityBadge(intensity: intensity, size: .normal)
-                }
+    private func forecastIntensityView(
+        regionName: String,
+        intensity: IntensityValue
+    ) -> some View {
+        VStack(spacing: 2) {
+            HStack(spacing: 2) {
+                Image(systemName: "location.fill")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(eewSecondaryTextColor)
+                    .symbolEffect(.pulse)
+                Text(regionName)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
             }
-
-            // 上揃えにするためのSpacer
-            Spacer(minLength: 0)
+            SquareIntensityBadge(intensity: intensity, size: .normal)
         }
     }
 }
@@ -423,29 +415,6 @@ struct SquareIntensityBadge: View {
                 style: .continuous
             )
         )
-    }
-}
-
-// MARK: - Arrival Countdown View
-
-@available(iOS 16.1, *)
-struct ArrivalCountdownView: View {
-    let arrivalDate: Date
-
-    var body: some View {
-
-        VStack(alignment: .trailing, spacing: 0) {
-            Text("到達まで")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundColor(eewSecondaryTextColor)
-            Text(timerInterval: Date()...arrivalDate, countsDown: true)
-                .font(.system(size: 16, weight: .bold, design: .monospaced))
-                .foregroundColor(.primary)
-                .multilineTextAlignment(.trailing)
-                .contentTransition(.numericText(countsDown: true))
-        }
-        .frame(alignment: .trailing)
-
     }
 }
 

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
@@ -182,9 +182,13 @@ struct EewLockScreenView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 if !state.isCanceledReport,
-                   let intensity = state.location?.forecastIntensityValue,
-                   let regionName = state.location?.regionName {
-                    forecastIntensityView(regionName: regionName, intensity: intensity)
+                   let location = state.location,
+                   let intensity = location.forecastIntensityValue,
+                   !location.regionName.isEmpty {
+                    forecastIntensityView(
+                        regionName: location.regionName,
+                        intensity: intensity
+                    )
                 }
             }
             .padding(.horizontal, standardMargin)
@@ -194,17 +198,16 @@ struct EewLockScreenView: View {
 
     // MARK: - Details (震源地, M, 深さ, 発生時刻)
 
+    @ViewBuilder
     private var detailsView: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            if state.isCanceledReport {
-                Text("緊急地震速報は取り消されました")
-                    .font(.system(size: 14, weight: .bold))
-                    .foregroundColor(.primary)
-                    .lineLimit(2)
-                    .minimumScaleFactor(0.75)
-            } else {
-                uncanceledDetailsView
-            }
+        if state.isCanceledReport {
+            Text("緊急地震速報は取り消されました")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundColor(.primary)
+                .lineLimit(2)
+                .minimumScaleFactor(0.75)
+        } else {
+            uncanceledDetailsView
         }
     }
 
@@ -443,6 +446,18 @@ struct EewLiveActivityWidget_Previews: PreviewProvider {
         attributes
             .previewContext(.onePoint, viewKind: .content)
             .previewDisplayName("Lock Screen - 1点検知")
+
+        attributes
+            .previewContext(.canceled, viewKind: .content)
+            .previewDisplayName("Lock Screen - 取消")
+
+        attributes
+            .previewContext(.canceledWithStaleValues, viewKind: .content)
+            .previewDisplayName("Lock Screen - 取消(値が残存)")
+
+        attributes
+            .previewContext(.canceledWithStaleValues, viewKind: .dynamicIsland(.expanded))
+            .previewDisplayName("Expanded - 取消(値が残存)")
 
         // Dynamic Island - Compact
         attributes

--- a/app/ios/Widget/LiveActivity/ShakeDetection/ShakeDetectionLiveActivityAttributes.swift
+++ b/app/ios/Widget/LiveActivity/ShakeDetection/ShakeDetectionLiveActivityAttributes.swift
@@ -15,8 +15,10 @@ struct ShakeDetectionLiveActivityAttributes: ActivityAttributes, Identifiable {
 
 struct ShakeDetectionContentState: Codable, Hashable {
     let eventId: String
-    /// イベント種別（backendは常に "shake_detection" を送る）
-    let type: String
+    /// イベント種別（backend は "shake_detection" を送る）。
+    /// UI では使わないため optional。必須にすると backend が欠落させた瞬間に
+    /// content-state 全体のデコードが失敗し Live Activity が表示されなくなる。
+    let type: String?
     let level: String?
     let detectedAt: String?
     let location: LocationInfo?
@@ -27,12 +29,7 @@ struct ShakeDetectionContentState: Codable, Hashable {
     }
 
     var detectedDate: Date? {
-        guard let detectedAt = detectedAt else { return nil }
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        if let date = formatter.date(from: detectedAt) { return date }
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter.date(from: detectedAt)
+        LiveActivityDate.parse(detectedAt)
     }
 }
 

--- a/app/ios/Widget/LiveActivity/ShakeDetection/ShakeDetectionLiveActivityView.swift
+++ b/app/ios/Widget/LiveActivity/ShakeDetection/ShakeDetectionLiveActivityView.swift
@@ -17,13 +17,16 @@ struct ShakeDetectionHeaderContainer: View {
 
     private let stripeHeight: CGFloat = 8
 
+    private static let unknownLevelStripeColors: [Color] = [
+        Color(red: 0.5, green: 0.5, blue: 0.5),
+        Color(red: 0.3, green: 0.3, blue: 0.3),
+    ]
+
     var body: some View {
         VStack(spacing: 0) {
-            // ストライプパターン
-            if let level = level {
-                StripePattern(colors: level.stripeColors)
-                    .frame(height: stripeHeight)
-            }
+            // ストライプパターン。level 不明でもヘッダーの高さを変えないため常に描く
+            StripePattern(colors: level?.stripeColors ?? Self.unknownLevelStripeColors)
+                .frame(height: stripeHeight)
 
             HStack(alignment: .center, spacing: 8) {
                 // 左側: 「揺れ検知」ラベル + 揺れレベル説明
@@ -53,7 +56,7 @@ struct ShakeDetectionHeaderContainer: View {
                     VStack(alignment: .trailing, spacing: 0) {
                         Text("検知時刻")
                             .liveActivityLabelStyle(.header)
-                        Text(formatTime(detectedDate))
+                        Text(JSTDateFormat.timeWithSeconds(detectedDate))
                             .font(
                                 .system(
                                     size: 14,
@@ -74,14 +77,6 @@ struct ShakeDetectionHeaderContainer: View {
 
     private var backgroundColor: Color {
         level?.headerBackgroundColor ?? Color(red: 0.5, green: 0.5, blue: 0.5)
-    }
-
-    private func formatTime(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm:ss"
-        formatter.locale = Locale(identifier: "ja_JP")
-        formatter.timeZone = TimeZone(identifier: "Asia/Tokyo")
-        return formatter.string(from: date)
     }
 }
 
@@ -110,11 +105,13 @@ struct ShakeDetectionLocationSummaryView: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 10) {
+            // ロック画面の Live Activity はライト/ダーク両方で描画されるため、
+            // 白固定にすると明るい背景で不可視になる。
             Image(systemName: "location.fill")
                 .font(.system(size: 14, weight: .bold))
-                .foregroundColor(.white.opacity(0.86))
+                .foregroundColor(.primary.opacity(0.86))
                 .frame(width: 28, height: 28)
-                .background(Color.white.opacity(0.12))
+                .background(Color.primary.opacity(0.08))
                 .clipShape(Circle())
 
             VStack(alignment: .leading, spacing: 2) {

--- a/app/ios/Widget/Views/EarthquakeWidgetView.swift
+++ b/app/ios/Widget/Views/EarthquakeWidgetView.swift
@@ -439,6 +439,38 @@ struct IntensityView: View {
     )
 }
 
+/// 震度速報は震源未確定 + 未入電（「5弱以上」）になりやすい。
+/// バッジから文字がはみ出さないか確認するためのプレビュー。
+#Preview("Small - 未入電", as: .systemSmall) {
+    EarthquakeWidget()
+} timeline: {
+    EarthquakeEntry(
+        date: .now,
+        configuration: EarthquakeWidgetIntent(regionType: .nationwide),
+        earthquakes: [
+            EarthquakeDisplayItem(
+                id: "20260106130000",
+                hypocenterName: "最大震度5弱以上を観測",
+                magnitude: "M不明",
+                magnitudeValue: nil,
+                maxIntensity: .fiveLowerNoInput,
+                depth: "",
+                originTime: Date().addingTimeInterval(-120)
+            ),
+            EarthquakeDisplayItem(
+                id: "20260106125500",
+                hypocenterName: "最大震度6弱以上を観測",
+                magnitude: "M不明",
+                magnitudeValue: nil,
+                maxIntensity: .sixLowerNoInput,
+                depth: "",
+                originTime: Date().addingTimeInterval(-300)
+            )
+        ],
+        error: nil
+    )
+}
+
 #Preview("Large - 震度6強", as: .systemLarge) {
     EarthquakeWidget()
 } timeline: {

--- a/app/ios/Widget/Views/EarthquakeWidgetView.swift
+++ b/app/ios/Widget/Views/EarthquakeWidgetView.swift
@@ -161,7 +161,8 @@ private struct WidgetHeader: View {
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)
 
-                Text("更新 \(formattedTime)")
+                // 行に並ぶ発生時刻が JST 固定なので、更新時刻も JST に揃える
+                Text("更新 \(JSTDateFormat.timeShort(updateTime))")
                     .font(AppFonts.code(size: compact ? 9 : 10))
                     .foregroundStyle(.white.opacity(0.7))
             }
@@ -172,14 +173,6 @@ private struct WidgetHeader: View {
         .padding(.vertical, compact ? 8 : 10)
         .frame(width: width, alignment: .leading)
         .background(Color.eqBrand)
-    }
-
-    private var formattedTime: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        formatter.locale = Locale(identifier: "ja_JP")
-        formatter.timeZone = TimeZone.current
-        return formatter.string(from: updateTime)
     }
 }
 

--- a/app/ios/Widget/Widget.swift
+++ b/app/ios/Widget/Widget.swift
@@ -75,28 +75,16 @@ struct EarthquakeTimelineProvider: AppIntentTimelineProvider {
             let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: currentDate)!
             return Timeline(entries: [entry], policy: .after(nextUpdate))
 
-        } catch let error as APIError {
-            let entry = EarthquakeEntry(
-                date: currentDate,
-                configuration: configuration,
-                earthquakes: [],
-                error: error.errorDescription,
-                resolved: resolved
-            )
-
-            // エラー時は5分後に再試行
-            let nextUpdate = Calendar.current.date(byAdding: .minute, value: 5, to: currentDate)!
-            return Timeline(entries: [entry], policy: .after(nextUpdate))
-
         } catch {
             let entry = EarthquakeEntry(
                 date: currentDate,
                 configuration: configuration,
                 earthquakes: [],
-                error: "不明なエラー: \(error.localizedDescription)",
+                error: APIError.from(error).errorDescription ?? WidgetErrorMessage.unknown,
                 resolved: resolved
             )
 
+            // エラー時は5分後に再試行
             let nextUpdate = Calendar.current.date(byAdding: .minute, value: 5, to: currentDate)!
             return Timeline(entries: [entry], policy: .after(nextUpdate))
         }

--- a/app/ios/WidgetModelsTests/EarthquakeDisplayItemTests.swift
+++ b/app/ios/WidgetModelsTests/EarthquakeDisplayItemTests.swift
@@ -75,6 +75,14 @@ struct EarthquakeDisplayItemFormatTests {
             name: nil, detailedName: nil, maxIntensity: nil) == "")
     }
 
+    /// 震度速報は震源未確定 + 未入電になりやすい組み合わせ。
+    /// 「最大震度5弱以上未入電を観測」のような電文事情まで含む文にしない。
+    @Test func hypocenterFallbackOmitsNoInputWording() {
+        #expect(EarthquakeDisplayItem.resolveTitle(
+            name: nil, detailedName: nil, maxIntensity: .fiveLowerNoInput)
+                == "最大震度5弱以上を観測")
+    }
+
     private func makeDate(
         _ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int
     ) -> Date? {

--- a/app/ios/WidgetModelsTests/LiveActivityDateTests.swift
+++ b/app/ios/WidgetModelsTests/LiveActivityDateTests.swift
@@ -1,0 +1,58 @@
+//
+//  LiveActivityDateTests.swift
+//  WidgetModelsTests
+//
+//  Live Activity の日時パースは主要動到達カウントダウンと発生時刻表示の前提であり、
+//  失敗すると生命に関わる情報が丸ごと欠落する。backend が返しうる表現を網羅する。
+//
+
+import Foundation
+import Testing
+
+struct LiveActivityDateTests {
+    /// backend が JS の Date.toISOString() 相当を返す場合。
+    /// ISO8601DateFormatter のデフォルト設定では小数秒を受理できずパースが失敗していた。
+    @Test func parsesFractionalSecondsWithUTC() throws {
+        let date = try #require(LiveActivityDate.parse("2024-01-01T07:10:00.123Z"))
+        #expect(abs(date.timeIntervalSince1970 - 1_704_093_000.123) < 0.001)
+    }
+
+    @Test func parsesFractionalSecondsWithOffset() throws {
+        let date = try #require(LiveActivityDate.parse("2024-01-01T16:10:00.000+09:00"))
+        #expect(date.timeIntervalSince1970 == 1_704_093_000)
+    }
+
+    @Test func parsesInternetDateTimeWithOffset() throws {
+        let date = try #require(LiveActivityDate.parse("2024-01-01T16:10:00+09:00"))
+        #expect(date.timeIntervalSince1970 == 1_704_093_000)
+    }
+
+    @Test func parsesInternetDateTimeWithZulu() throws {
+        let date = try #require(LiveActivityDate.parse("2024-01-01T07:10:00Z"))
+        #expect(date.timeIntervalSince1970 == 1_704_093_000)
+    }
+
+    /// PostgreSQL timestamptz のテキスト表現（スペース区切り・2 桁オフセット）
+    @Test func parsesPostgresTimestamptzText() throws {
+        let date = try #require(LiveActivityDate.parse("2024-01-01 16:10:00+09"))
+        #expect(date.timeIntervalSince1970 == 1_704_093_000)
+    }
+
+    @Test func returnsNilForMissingOrBlankValue() {
+        #expect(LiveActivityDate.parse(nil) == nil)
+        #expect(LiveActivityDate.parse("") == nil)
+    }
+
+    @Test func returnsNilForUnparsableValue() {
+        #expect(LiveActivityDate.parse("not-a-date") == nil)
+        // 日付のみは時刻が確定しないため受理しない
+        #expect(LiveActivityDate.parse("2024-01-01") == nil)
+    }
+
+    /// 端末のタイムゾーンに依存せず JST で表示する（JMA 発表時刻は JST が正）
+    @Test func formatsInJapanStandardTimeRegardlessOfDeviceTimeZone() throws {
+        let date = try #require(LiveActivityDate.parse("2024-01-01T16:10:05+09:00"))
+        #expect(JSTDateFormat.monthDay(date) == "01/01")
+        #expect(JSTDateFormat.timeWithSeconds(date) == "16:10:05")
+    }
+}

--- a/app/ios/WidgetModelsTests/LiveActivityDateTests.swift
+++ b/app/ios/WidgetModelsTests/LiveActivityDateTests.swift
@@ -56,3 +56,27 @@ struct LiveActivityDateTests {
         #expect(JSTDateFormat.timeWithSeconds(date) == "16:10:05")
     }
 }
+
+struct ArrivalCountdownTests {
+    @Test func returnsRangeWhileMainShockIsStillApproaching() throws {
+        let now = Date(timeIntervalSince1970: 1_704_093_000)
+        let range = try #require(
+            ArrivalCountdown.remaining(until: now.addingTimeInterval(30), now: now)
+        )
+        #expect(range.lowerBound == now)
+        #expect(range.upperBound == now.addingTimeInterval(30))
+    }
+
+    /// 到達時刻を過ぎた瞬間に `now...arrival` を作ると ClosedRange の事前条件違反で
+    /// クラッシュする。境界（同時刻・過去）で必ず nil になることを保証する。
+    @Test func returnsNilOnceMainShockHasArrived() {
+        let now = Date(timeIntervalSince1970: 1_704_093_000)
+        #expect(ArrivalCountdown.remaining(until: now, now: now) == nil)
+        #expect(ArrivalCountdown.remaining(until: now.addingTimeInterval(-0.001), now: now) == nil)
+        #expect(ArrivalCountdown.remaining(until: now.addingTimeInterval(-60), now: now) == nil)
+    }
+
+    @Test func returnsNilWhenArrivalTimeIsUnknown() {
+        #expect(ArrivalCountdown.remaining(until: nil) == nil)
+    }
+}

--- a/app/ios/WidgetModelsTests/WidgetBehaviorTests.swift
+++ b/app/ios/WidgetModelsTests/WidgetBehaviorTests.swift
@@ -19,3 +19,34 @@ struct WidgetBehaviorTests {
         )
     }
 }
+
+/// 震度バッジ・見出しの表記。Flutter の JmaIntensity（mainText / suffix）が正。
+struct IntensityValueDisplayTests {
+    @Test func splitsIntensityIntoMainAndSuffix() {
+        #expect(IntensityValue.four.formattedParts == ("4", nil))
+        #expect(IntensityValue.fiveLower.formattedParts == ("5", "弱"))
+        #expect(IntensityValue.sixUpper.formattedParts == ("6", "強"))
+        #expect(IntensityValue.seven.formattedParts == ("7", nil))
+    }
+
+    /// 未入電はサブ文字が 3 文字になり正方形バッジに収まらない。
+    /// IntensityBadge が幅を伸ばせる実装であることの根拠。
+    @Test func noInputIntensityHasLongSuffix() {
+        #expect(IntensityValue.fiveLowerNoInput.formattedParts == ("5", "弱以上"))
+        #expect(IntensityValue.sixLowerNoInput.formattedParts == ("6", "弱以上"))
+    }
+
+    /// 震度速報は震源が未確定かつ未入電になりやすく、この組み合わせが実際に出る。
+    @Test func titleTextDropsNoInputWording() {
+        #expect(IntensityValue.fiveLowerNoInput.titleText == "5弱以上")
+        #expect(IntensityValue.sixLowerNoInput.titleText == "6弱以上")
+        #expect(IntensityValue.fiveLower.titleText == "5弱")
+        #expect(IntensityValue.seven.titleText == "7")
+    }
+
+    @Test func noInputIntensityIsOrderedWithItsLowerBound() {
+        #expect(IntensityValue.four < IntensityValue.fiveLowerNoInput)
+        #expect(IntensityValue.fiveLowerNoInput < IntensityValue.fiveUpper)
+        #expect(IntensityValue.fiveUpper < IntensityValue.sixLowerNoInput)
+    }
+}

--- a/app/ios/WidgetModelsTests/WidgetErrorMessageTests.swift
+++ b/app/ios/WidgetModelsTests/WidgetErrorMessageTests.swift
@@ -1,0 +1,59 @@
+//
+//  WidgetErrorMessageTests.swift
+//  WidgetModelsTests
+//
+//  ウィジェットのエラー表示に開発者向けの生の例外文言が出ないことを保証する。
+//
+
+import Foundation
+import Testing
+
+struct WidgetErrorMessageTests {
+    @Test func offlineTellsUserToCheckConnection() {
+        #expect(WidgetErrorMessage.network(.notConnectedToInternet)
+                == "インターネットに接続されていません")
+        #expect(WidgetErrorMessage.network(.dataNotAllowed)
+                == "インターネットに接続されていません")
+    }
+
+    @Test func hostFailuresAreReportedAsServerUnreachable() {
+        #expect(WidgetErrorMessage.network(.cannotFindHost)
+                == "サーバーに接続できませんでした")
+        #expect(WidgetErrorMessage.network(.networkConnectionLost)
+                == "サーバーに接続できませんでした")
+    }
+
+    @Test func timeoutHasDedicatedMessage() {
+        #expect(WidgetErrorMessage.network(.timedOut) == "通信がタイムアウトしました")
+    }
+
+    @Test func unclassifiedNetworkErrorFallsBackToGenericMessage() {
+        #expect(WidgetErrorMessage.network(.badServerResponse)
+                == "通信エラーが発生しました")
+    }
+
+    @Test func serverErrorsAreMappedByStatusCode() {
+        #expect(WidgetErrorMessage.server(statusCode: 500) == "サーバーが応答していません")
+        #expect(WidgetErrorMessage.server(statusCode: 503) == "サーバーが応答していません")
+        #expect(WidgetErrorMessage.server(statusCode: 429) == "アクセスが集中しています")
+        #expect(WidgetErrorMessage.server(statusCode: 400) == WidgetErrorMessage.unknown)
+    }
+
+    /// どの分岐でも改行や例外の debugDescription を含まない短文であること。
+    /// ウィジェットは面積が狭く、長文が入るとレイアウトが崩れる。
+    @Test func allMessagesAreShortSingleLine() {
+        let messages = [
+            WidgetErrorMessage.unknown,
+            WidgetErrorMessage.network(.notConnectedToInternet),
+            WidgetErrorMessage.network(.cannotFindHost),
+            WidgetErrorMessage.network(.timedOut),
+            WidgetErrorMessage.network(.badServerResponse),
+            WidgetErrorMessage.server(statusCode: 500),
+            WidgetErrorMessage.server(statusCode: 429),
+        ]
+        for message in messages {
+            #expect(!message.contains("\n"))
+            #expect(message.count <= 20)
+        }
+    }
+}

--- a/docs/knowledge/20260815_live_activity_content_state_robustness.md
+++ b/docs/knowledge/20260815_live_activity_content_state_robustness.md
@@ -1,0 +1,103 @@
+# Live Activity content-state を扱うときの注意点
+
+Live Activity の表示データは APNs の `content-state` JSON が唯一の入力で、Widget Extension の
+`Codable` へ直接マッピングされる。**デコードに 1 箇所でも失敗すると Live Activity 全体が
+表示されない**ため、通常の API レスポンスより厳しく堅牢性を意識する必要がある。
+
+## 1. ContentState のフィールドは原則 optional にする
+
+UI で使わないフィールドを non-optional にすると、backend がそのキーを落とした瞬間に
+content-state 全体のデコードが失敗し、緊急地震速報が一切出なくなる。
+
+```swift
+// ❌ 悪い例: UI 未使用なのに必須
+let type: String
+
+// ✅ 良い例
+/// UI 未使用。必須にすると backend の欠落でデコードごと失敗する
+let type: String?
+```
+
+`docs/live-activity-specification.md` の APNs ペイロード例に載っていないキーを必須にしていないか、
+`ActivityAttributes` / `ContentState` を触るたびに確認する。
+
+## 2. 日時は `ISO8601DateFormatter()` の既定設定でパースしない
+
+既定の `formatOptions` は `.withInternetDateTime` のみで、**小数秒を受理しない**。
+backend の日時表現は経路によって揺れる（JS の `Date.toISOString()` は必ず小数秒付き、
+PostgreSQL `timestamptz` のテキストはスペース区切り + 2 桁オフセット）。
+
+`app/ios/Shared/LiveActivityDate.swift` の `LiveActivityDate.parse(_:)` を必ず使う。
+
+```swift
+// ❌ 悪い例: "2024-01-01T07:10:00.123Z" が nil になる
+ISO8601DateFormatter().date(from: time)
+
+// ✅ 良い例
+LiveActivityDate.parse(time)
+```
+
+同じ理由で API クライアント側には `LenientISO8601DateTranscoder` がある。
+Live Activity は content-state を `String` で受けるため transcoder が効かず、別途対処が必要。
+
+## 3. 表示時刻は JST 固定にする
+
+JMA の発表時刻は JST が正。`DateFormatter` に `timeZone` を設定し忘れると端末の
+タイムゾーンで表示され、同じ画面内で JST 固定の値と混在する。
+`JSTDateFormat.monthDay / timeWithSeconds / timeShort` を使う。
+
+`Text(date, style: .time)` も端末タイムゾーンになるので、固定時刻の表示には使わない。
+
+## 4. `Text(timerInterval:)` の範囲は同一時刻から作る
+
+```swift
+// ❌ 悪い例: 判定と範囲生成で Date() を 2 回取るため、
+//            到達した瞬間に lowerBound > upperBound で事前条件違反（クラッシュ）
+if arrivalDate > Date() {
+    Text(timerInterval: Date()...arrivalDate, countsDown: true)
+}
+
+// ✅ 良い例
+if let remaining = ArrivalCountdown.remaining(until: arrivalDate) {
+    Text(timerInterval: remaining, countsDown: true)
+}
+```
+
+## 5. 取消報では値が残っていても表示しない
+
+取消報（`isCanceled == true`）は震源・規模・予想震度・到達予想がすべて無効。
+backend は `null` を送る仕様だが、値が残って届いた場合でもクライアント側で抑止する。
+取消済みなのに「最大震度6強」「主要動到達まで 00:12」が出ると誤情報になる。
+
+`EewContentState.isCanceledReport` / `displayIntensity` を経由すること。
+
+## 6. ロック画面はライト / ダーク両方で描画される
+
+ロック画面の Live Activity は `.white` 固定の前景色だと明るい背景で不可視になる。
+ヘッダーのように背景色を自前で塗っている領域以外では `.primary` ベースの色を使う。
+
+## 7. 未知の enum 値で Dynamic Island が空にならないようにする
+
+`ShakeDetectionLevel(rawValue:)` のように文字列から enum へ変換する箇所は、
+backend が値を追加すると nil になる。`compactLeading` / `minimal` を
+`if let` だけで組むと Dynamic Island が真っ白になるため、必ずフォールバック表示を置く。
+
+## 検証方法
+
+Linux では SwiftUI / ActivityKit を含むファイルはビルドできないが、Foundation のみに
+依存するロジック（`LiveActivityDate` / `WidgetErrorMessage` / `IntensityValue` など）は
+SwiftPM の一時パッケージへコピーして `swift test` で検証できる。
+
+```bash
+# Swift ツールチェーン（Linux）
+curl -fsSL -o /tmp/swift.tar.gz \
+  https://download.swift.org/swift-6.0.3-release/ubuntu2204/swift-6.0.3-RELEASE/swift-6.0.3-RELEASE-ubuntu22.04.tar.gz
+mkdir -p ~/swift && tar xzf /tmp/swift.tar.gz -C ~/swift --strip-components=1
+sudo apt-get install -y libncurses6 libtinfo6 libcurl4 libxml2
+~/swift/usr/bin/swift --version
+```
+
+macOS では通常どおり `WidgetModelsTests` を実行する。
+`Shared/` は file-system synchronized group ではないため、ファイルを追加したら
+`project.pbxproj` の PBXFileReference / PBXBuildFile / 各ターゲットの Sources phase へ
+手で登録する（`Widget/` 配下は synchronized group なので登録不要）。

--- a/docs/live-activity-specification.md
+++ b/docs/live-activity-specification.md
@@ -30,6 +30,7 @@ Live Activityは以下の2つのトリガーで開始されます。
 | フィールド | 型 | 説明 |
 |-----------|-----|------|
 | `eventId` | `string` | イベントID（Primary Key） |
+| `type` | `string?` | イベント種別（`"shake_detection"`）。クライアントは未使用で、欠落しても表示は継続する |
 | `level` | `ShakeDetectionLevel` | 観測した揺れの強さ |
 | `detectedAt` | `ISO8601 string?` | 検知した日時（JSTで表示） |
 | `location` | `LocationInfo?` | 現在地情報（現在地で検知された場合） |
@@ -64,6 +65,7 @@ type ShakeDetectionLevel =
 | フィールド | 型 | 説明 |
 |-----------|-----|------|
 | `eventId` | `string` | イベントID（Primary Key） |
+| `type` | `string?` | イベント種別（`"eew"`）。クライアントは未使用で、欠落しても表示は継続する |
 | `serialNo` | `number?` | 報番号 |
 | `headline` | `string?` | 見出し（後述のルールで生成） |
 | `hypocenterName` | `string?` | 震源地名（キャンセル時はnull） |
@@ -108,6 +110,20 @@ type ShakeDetectionLevel =
 3. キャンセル報の場合 → `time = null`, `isOriginTime = false`
 
 > **Note:** PLUM法やレベル法では発生時刻が特定できない場合があります。その場合は検知時刻を使用し、`isOriginTime = false`となります。クライアント側ではこのフラグを参照して「発生」「検知」の表示を切り替えてください。
+
+#### 日時文字列の表現
+
+`time` / `arrivalTime` / `detectedAt` はいずれも文字列として `content-state` に載り、クライアント側で `Date` に変換します。パースに失敗すると発生時刻や主要動到達カウントダウンが丸ごと欠落するため、クライアントは次の表現をすべて受理します（`app/ios/Shared/LiveActivityDate.swift`）。
+
+- 小数秒あり / なし（`...T16:10:00.123+09:00` / `...T16:10:00+09:00`）
+- UTC 表記（`...T07:10:00Z`）
+- PostgreSQL `timestamptz` のテキスト表現（`2024-01-01 16:10:00+09`）
+
+表示は端末のタイムゾーンではなく **JST 固定** です（JMA の発表時刻が JST を正とするため）。
+
+#### キャンセル報の扱い
+
+キャンセル報では `hypocenterName` / `magnitude` / `depth` / `time` / `maxIntensity` / `location` を `null` で送ります。クライアントは `isCanceled === true` のとき、これらの値が残っていても**予想震度・M・深さ・発生時刻・主要動到達カウントダウンを表示しません**。取消済みの速報で秒読みが動き続けると誤情報になるためです。
 
 #### headline生成ルール
 
@@ -753,9 +769,12 @@ struct EewLiveActivityAttributes: ActivityAttributes, Identifiable {
 
 struct EewContentState: Codable, Hashable {
     let eventId: String
+    /// UI 未使用。必須にすると backend が欠落させた瞬間に
+    /// content-state 全体のデコードが失敗するため optional
+    let type: String?
     let hypocenterName: String?
     let magnitude: Double?
-    let depth: Int?
+    let depth: Double?
     let time: String?
     let isOriginTime: Bool?
     let maxIntensity: String?
@@ -800,6 +819,8 @@ struct ShakeDetectionLiveActivityAttributes: ActivityAttributes, Identifiable {
 
 struct ShakeDetectionContentState: Codable, Hashable {
     let eventId: String
+    /// UI 未使用。欠落してもデコードが落ちないよう optional
+    let type: String?
     let level: String?
     let detectedAt: String?
     let location: LocationInfo?
@@ -811,8 +832,7 @@ struct ShakeDetectionContentState: Codable, Hashable {
     }
 
     var detectedDate: Date? {
-        guard let detectedAt = detectedAt else { return nil }
-        return ISO8601DateFormatter().date(from: detectedAt)
+        LiveActivityDate.parse(detectedAt)
     }
 }
 
@@ -854,8 +874,7 @@ struct LocationInfo: Codable, Hashable {
     }
 
     var arrivalDate: Date? {
-        guard let arrivalTime = arrivalTime else { return nil }
-        return ISO8601DateFormatter().date(from: arrivalTime)
+        LiveActivityDate.parse(arrivalTime)
     }
 }
 ```

--- a/docs/todo/400_widget_live_activity_followups.md
+++ b/docs/todo/400_widget_live_activity_followups.md
@@ -1,0 +1,44 @@
+# ホーム画面ウィジェット / Live Activity の残課題
+
+調査（Live Activity・ホーム画面ウィジェットのバグ / デザイン不備の洗い出し）で見つけたが、
+今回は影響が小さいと判断して手を付けなかったもの。
+
+## 1. Widget Extension が API ベース URL をプロセス内でキャッシュし続ける
+
+`EarthquakeAPIService.shared` は `static let` なので、拡張プロセスが生きている間は
+`ConfigReader.getAPIBaseURL()` の結果（= App Group の `apiServerUrl`）を再読み込みしない。
+
+```swift
+extension EarthquakeAPIService {
+    static let shared = EarthquakeAPIService(baseURL: ConfigReader.getAPIBaseURL())
+}
+```
+
+アプリ側でデバッグ用 API URL を切り替えても、`WidgetCenter.reloadAllTimelines()` は走るが
+Client のベース URL は古いままになる。Widget Extension は OS に頻繁に kill されるため実害は
+自然回復するが、デバッグ時に「切り替えたのに反映されない」と誤解しやすい。
+
+対応するなら、ベース URL をキーにしたキャッシュへ変更する（Swift 6 の並行性チェックに
+合わせて `NSLock` などで保護する必要がある）。
+
+## 2. `WidgetRegionResolver` が `region` / `station` の searchType を解釈しない
+
+`RegionSearchType`（Dart 側）は `prefecture` / `region` / `city` / `station` の 4 値だが、
+Swift 側は `prefecture` / `city` のみを扱い、他は全国へフォールバックする。
+
+現在の任意地域ピッカー（`home_widget_settings_page.dart`）は都道府県・市区町村しか
+選ばせないため到達しないが、ピッカーを拡張したときに「設定したのに全国が出る」形で
+静かに壊れる。ピッカーを拡張する場合は Swift 側の `plan(forSearchType:)` も同時に更新する。
+
+## 3. Widget Extension の UI に対する回帰テストがない
+
+`WidgetModelsTests` はモデル・表記・レイアウト件数のみを検証しており、SwiftUI View の
+スナップショットテストは無い。取消報での抑止や未入電バッジの収まりは Xcode Preview で
+目視確認する運用になっている（`docs/knowledge/20260717_home_widget_worktree_validation.md`）。
+
+## 4. Android のホーム画面ウィジェットは未実装
+
+`app/android/app/src/main/res/values/` にテンプレート由来の AppWidget スタイル定義だけが
+残っており、`AppWidgetProvider` / Glance の実装は無い。実装しないなら未使用の
+`Widget.Android.AppWidget.*` / `Theme.Android.AppWidgetContainer` / `AppWidgetAttrs` /
+`widget_margin` を削除して誤解を防ぐ。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Live Activity（EEW / 揺れ検知）とホーム画面ウィジェットを調査し、見つかったバグ・デザイン不備を修正しました。Swift のみの変更で、Dart 側の差分はありません。

## 修正内容

### 1. Live Activity の日時パースが小数秒付き ISO8601 を取りこぼす（最重要）

`EewContentState.timeDate` と `LocationInfo.arrivalDate` が `ISO8601DateFormatter()` の既定設定を使っていました。既定の `formatOptions` は `.withInternetDateTime` のみで**小数秒を受理しません**。backend は TypeScript 実装で `Date.toISOString()` 相当（必ず小数秒付き）や PostgreSQL `timestamptz` のテキスト表現を返す経路があり（`LenientISO8601DateTranscoder` が存在するのがその証拠）、その場合は

- 「地震発生 MM/dd HH:mm:ss」
- 「主要動到達まで 00:12」のカウントダウン

が**丸ごと消えます**。揺れ検知側（`detectedDate`）だけは小数秒フォールバックが入っており、EEW 側が取り残されていました。

小数秒あり / なし・`Z` 表記・PostgreSQL 形式をすべて受理する `LiveActivityDate.parse(_:)` を `app/ios/Shared/` に切り出し、3 箇所を差し替えました。

### 2. `ContentState.type` が必須でデコードごと失敗しうる

`type` は UI で一切使っていないのに non-optional でした。仕様書（`docs/live-activity-specification.md`）の APNs ペイロード例にも `type` は含まれていません。backend が落とした瞬間に `content-state` 全体のデコードが失敗し、**緊急地震速報の Live Activity が一切表示されなくなります**。EEW / 揺れ検知の両方を optional 化しました。

### 3. 取消報で最大震度・M・深さ・到達カウントダウンが残る

`isCanceled == true` でも、Lock Screen は「最大震度」バッジ・M・深さ・発生時刻・現在地の予想震度を、ヘッダーは「主要動到達まで」の秒読みを表示していました。Dynamic Island も center だけが取消に対応し、leading の震度バッジと bottom の M / 深さ / 到達情報は残っていました。

取消済みの速報で「最大震度6強」「到達まで 00:12」が動き続けるのは誤情報なので、`EewContentState.isCanceledReport` / `displayIntensity` を経由して抑止しました。backend は `null` を送る仕様ですが、値が残って届いても表示しません。

### 4. 主要動到達カウントダウンでクラッシュしうる経路

```swift
if arrivalDate > Date() {
    Text(timerInterval: Date()...arrivalDate, countsDown: true)
}
```

判定と `ClosedRange` 生成で別々に `Date()` を取っており、**ちょうど到達した瞬間**（ユーザが最も画面を見ているタイミング）に `lowerBound > upperBound` となり `ClosedRange` の事前条件違反で落ちます。同一時刻で判定する `ArrivalCountdown.remaining(until:now:)` に切り出しました。

### 5. ホーム画面ウィジェットが生の例外文言を表示する

`APIError.networkError` はどこからも生成されておらず、オフライン時は swift-openapi-runtime の `ClientError` が汎用 `catch` に落ちて

> 不明なエラー: Client encountered an error invoking the operation "getV2Earthquake", caused by "...", underlying error: ...

がウィジェットに表示されていました。`ClientError.underlyingError` から `URLError` を取り出し、「インターネットに接続されていません」「通信がタイムアウトしました」などの短文へ正規化する `WidgetErrorMessage` を追加しました。

### 6. 未入電震度でバッジから文字がはみ出す

`IntensityBadge` は `.frame(width: size, height: size)` の固定正方形でしたが、未入電（`!5-` / `!6-`）のサブ文字は「弱以上」の 3 文字あり収まりません。`frame(width:height:)` はクリップしないため、背景の外へ文字が飛び出します。**震度速報は震源未確定かつ未入電になりやすく、実際に出る組み合わせです。**

アプリ本体の `JmaIntensityIcon`（`FittedBox(scaleDown)`）や Live Activity の `SquareIntensityBadge` と同様に、高さのみ固定して幅を伸ばすようにしました。あわせて震源未確定時の見出しから電文事情の「未入電」を落としています（「最大震度5弱以上未入電を観測」→「最大震度5弱以上を観測」）。

### 7. 揺れ検知 Lock Screen がライトモードで不可視

観測地点アイコンが `.white.opacity(0.86)` を `.white.opacity(0.12)` の丸背景に載せており、ロック画面がライト外観のとき見えませんでした。同じ View 内の他要素と同じ `.primary` ベースに変更しました。あわせて `level` 不明時もヘッダーのストライプを描き、高さが変わらないようにしています。

### 8. 揺れ検知 Dynamic Island が空になりうる

`compactLeading` / `minimal` / `expandedLeading` が `if let level = state.shakeLevel` だけで組まれており、backend が未知の level を送ると **Dynamic Island が真っ白**になります。グレーの「?」でフォールバックする `ShakeLevelBadge` を追加しました。

### 9. 時刻表示のタイムゾーンが混在

一覧の発生時刻は JST 固定なのに、EEW Lock Screen の発生時刻は `timeZone` 未設定（端末依存）、ウィジェットの更新時刻は `TimeZone.current`、揺れ検知 Dynamic Island は `Text(date, style: .time)`（端末依存）でした。JMA の発表時刻は JST が正なので `JSTDateFormat` に統一しました。

## テスト

`WidgetModelsTests` に 19 件追加し、既存分と合わせて **37 件 pass**。

- `LiveActivityDateTests` — 小数秒 / `Z` / PostgreSQL 形式のパース、JST 固定表示
- `ArrivalCountdownTests` — 到達境界（同時刻・過去）で必ず nil になる（4 のクラッシュ回帰防止）
- `WidgetErrorMessageTests` — 全分岐が改行なし 20 文字以内の短文であること
- `IntensityValueDisplayTests` — 震度バッジの分割表記・未入電の見出し・順序比較
- `EarthquakeDisplayItemTests` — 未入電の見出しフォールバック

Xcode Preview も追加しました（取消報 / 値が残った取消報 / 未入電バッジ）。

macOS 環境がないため、Foundation のみに依存するロジックを SwiftPM の一時パッケージへ写して Linux の Swift 6.0.3 で実行して検証しています（手順は知見ドキュメントに記載）。**SwiftUI / ActivityKit を含む View のビルドは未検証なので、macOS 側での Widget Extension ビルド確認をお願いします。**

## ドキュメント

- `docs/knowledge/20260815_live_activity_content_state_robustness.md` — content-state を扱うときの注意点（optional 原則・日時パース・JST・timerInterval・取消報・ライト/ダーク・未知 enum・検証手順）
- `docs/live-activity-specification.md` — `type` の optional 化、`depth` の型、日時表現、取消報の扱いを追記
- `docs/todo/400_widget_live_activity_followups.md` — 今回手を付けなかった残課題（API ベース URL のプロセス内キャッシュ、`region` / `station` searchType 未対応、View のスナップショットテスト不在、Android ウィジェット未実装）

## 補足

`app/ios/Shared/` は file-system synchronized group ではないため、新規ファイルを `project.pbxproj` に手で登録しています（PBXFileReference / PBXBuildFile / WidgetExtension・AppIntentExtension・WidgetModelsTests の Sources phase）。登録漏れがないことはスクリプトで検証済みです。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00305-547f-775f-8094-f1a8f3ded617?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00305-547f-775f-8094-f1a8f3ded617&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

