### PR TITLE
feat: デバッグ画面から EEW / 揺れ検知 Live Activity をローカル開始

### DIFF
--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		859DF75C2BBE9FFC00B827B1 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 859DF75B2BBE9FFC00B827B1 /* StoreKit.framework */; };
 		859DF75E2BBEA0F000B827B1 /* Synced - EQMonitor.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 859DF75D2BBEA0F000B827B1 /* Synced - EQMonitor.storekit */; };
 		85A1B0012F59A00000000001 /* AppGroupMethodChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A1B0002F59A00000000001 /* AppGroupMethodChannel.swift */; };
+		85A1B0212F59C00000000021 /* LiveActivityDebugMethodChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A1B0202F59C00000000020 /* LiveActivityDebugMethodChannel.swift */; };
 		85A1B0102F59B00000000010 /* TelemetryWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A1B0112F59B00000000011 /* TelemetryWriter.swift */; };
 		85A2A5E4E14A505A334823DE /* EarthquakeAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5330C1132EC785A60DE272 /* EarthquakeAPIClient.swift */; };
 		85B4051A2C08E73300EB3835 /* Gzip in Frameworks */ = {isa = PBXBuildFile; productRef = 85B405192C08E73300EB3835 /* Gzip */; };
@@ -176,6 +177,7 @@
 		859DF75B2BBE9FFC00B827B1 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		859DF75D2BBEA0F000B827B1 /* Synced - EQMonitor.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Synced - EQMonitor.storekit"; sourceTree = "<group>"; };
 		85A1B0002F59A00000000001 /* AppGroupMethodChannel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppGroupMethodChannel.swift; sourceTree = "<group>"; };
+		85A1B0202F59C00000000020 /* LiveActivityDebugMethodChannel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveActivityDebugMethodChannel.swift; sourceTree = "<group>"; };
 		85A1B0112F59B00000000011 /* TelemetryWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryWriter.swift; sourceTree = "<group>"; };
 		85C54CF92E96C7E700BFBBAB /* WidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		85C54CFA2E96C7E700BFBBAB /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
@@ -424,6 +426,7 @@
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				85A1B0002F59A00000000001 /* AppGroupMethodChannel.swift */,
+				85A1B0202F59C00000000020 /* LiveActivityDebugMethodChannel.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 				4F115C452BE9682B00DAAD73 /* PrivacyInfo.xcprivacy */,
 			);
@@ -842,6 +845,7 @@
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				85A1B0012F59A00000000001 /* AppGroupMethodChannel.swift in Sources */,
+				85A1B0212F59C00000000021 /* LiveActivityDebugMethodChannel.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -38,6 +38,13 @@ import background_location_tracker
       AppGroupMethodChannel.register(with: registrar)
     }
 
+    // Register the debug-only Live Activity local start/update/end channel.
+    if let registrar = engineBridge.pluginRegistry.registrar(
+      forPlugin: "LiveActivityDebugMethodChannel"
+    ) {
+      LiveActivityDebugMethodChannel.register(with: registrar)
+    }
+
     // Register the widget reload method channel.
     // Flutter が App Group UserDefaults を更新したあとに `reloadTimelines` を
     // 呼び出すと、ホーム画面ウィジェットのタイムラインを再読み込みする。

--- a/app/ios/Runner/LiveActivityDebugMethodChannel.swift
+++ b/app/ios/Runner/LiveActivityDebugMethodChannel.swift
@@ -1,0 +1,305 @@
+import Flutter
+import Foundation
+
+#if canImport(ActivityKit)
+    import ActivityKit
+#endif
+
+/// アプリ内から ActivityKit を用いて Live Activity をローカル開始・更新・終了する
+/// デバッグ用 MethodChannel。
+///
+/// Push-to-Start（サーバー経由）とは別経路で、開発時の表示検証に用いる。
+///
+/// Channel name: `net.yumnumm.eqmonitor/live_activity_debug`
+/// Methods:
+///   - `isSupported` → `Bool`
+///   - `start`  (kind, eventId, contentState[JSON String]) → `String`(activityId)
+///   - `update` (kind, activityId, contentState[JSON String]) → `nil`
+///   - `end`    (kind, activityId, contentState[JSON String?]) → `nil`
+///
+/// - Important: ここで定義する `EewLiveActivityAttributes` /
+///   `ShakeDetectionLiveActivityAttributes` は、Widget Extension 側の同名型
+///   （`app/ios/Widget/LiveActivity/...`）と **型名・Codable フィールド名** を
+///   一致させている。ActivityKit は ActivityAttributes 型名で Widget の
+///   `ActivityConfiguration` と紐付けるため、ローカル開始した Activity は既存の
+///   Widget レイアウトで描画される。フィールドを変更する場合は両方を同期すること。
+final class LiveActivityDebugMethodChannel: NSObject, FlutterPlugin {
+    private static let channelName = "net.yumnumm.eqmonitor/live_activity_debug"
+
+    static func register(with registrar: any FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(
+            name: channelName,
+            binaryMessenger: registrar.messenger()
+        )
+        let instance = LiveActivityDebugMethodChannel()
+        registrar.addMethodCallDelegate(instance, channel: channel)
+    }
+
+    func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "isSupported":
+            result(Self.isSupported())
+        case "start":
+            handleStart(call, result: result)
+        case "update":
+            handleUpdate(call, result: result)
+        case "end":
+            handleEnd(call, result: result)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private static func isSupported() -> Bool {
+        if #available(iOS 16.1, *) {
+            return ActivityAuthorizationInfo().areActivitiesEnabled
+        }
+        return false
+    }
+
+    // MARK: - start
+
+    private func handleStart(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard #available(iOS 16.1, *) else {
+            result(Self.unsupportedError())
+            return
+        }
+        guard
+            let args = call.arguments as? [String: Any],
+            let kind = args["kind"] as? String,
+            let eventId = args["eventId"] as? String,
+            let contentStateJson = args["contentState"] as? String,
+            let stateData = contentStateJson.data(using: .utf8)
+        else {
+            result(Self.argumentError())
+            return
+        }
+
+        do {
+            switch kind {
+            case "eew":
+                let state = try JSONDecoder().decode(
+                    EewLiveActivityAttributes.ContentState.self, from: stateData
+                )
+                let activity = try Activity.request(
+                    attributes: EewLiveActivityAttributes(eventId: eventId),
+                    content: ActivityContent(state: state, staleDate: Self.eewStaleDate()),
+                    pushType: nil
+                )
+                result(activity.id)
+            case "shake_detection":
+                let state = try JSONDecoder().decode(
+                    ShakeDetectionLiveActivityAttributes.ContentState.self, from: stateData
+                )
+                let activity = try Activity.request(
+                    attributes: ShakeDetectionLiveActivityAttributes(eventId: eventId),
+                    content: ActivityContent(state: state, staleDate: Self.shakeStaleDate()),
+                    pushType: nil
+                )
+                result(activity.id)
+            default:
+                result(Self.argumentError("unknown kind: \(kind)"))
+            }
+        } catch {
+            result(Self.failure("start failed: \(error.localizedDescription)"))
+        }
+    }
+
+    // MARK: - update
+
+    private func handleUpdate(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard #available(iOS 16.1, *) else {
+            result(Self.unsupportedError())
+            return
+        }
+        guard
+            let args = call.arguments as? [String: Any],
+            let kind = args["kind"] as? String,
+            let activityId = args["activityId"] as? String,
+            let contentStateJson = args["contentState"] as? String,
+            let stateData = contentStateJson.data(using: .utf8)
+        else {
+            result(Self.argumentError())
+            return
+        }
+
+        Task {
+            do {
+                switch kind {
+                case "eew":
+                    let state = try JSONDecoder().decode(
+                        EewLiveActivityAttributes.ContentState.self, from: stateData
+                    )
+                    for activity in Activity<EewLiveActivityAttributes>.activities
+                    where activity.id == activityId {
+                        await activity.update(
+                            ActivityContent(state: state, staleDate: Self.eewStaleDate())
+                        )
+                    }
+                case "shake_detection":
+                    let state = try JSONDecoder().decode(
+                        ShakeDetectionLiveActivityAttributes.ContentState.self, from: stateData
+                    )
+                    for activity in Activity<ShakeDetectionLiveActivityAttributes>.activities
+                    where activity.id == activityId {
+                        await activity.update(
+                            ActivityContent(state: state, staleDate: Self.shakeStaleDate())
+                        )
+                    }
+                default:
+                    result(Self.argumentError("unknown kind: \(kind)"))
+                    return
+                }
+                result(nil)
+            } catch {
+                result(Self.failure("update failed: \(error.localizedDescription)"))
+            }
+        }
+    }
+
+    // MARK: - end
+
+    private func handleEnd(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard #available(iOS 16.1, *) else {
+            result(Self.unsupportedError())
+            return
+        }
+        guard
+            let args = call.arguments as? [String: Any],
+            let kind = args["kind"] as? String,
+            let activityId = args["activityId"] as? String
+        else {
+            result(Self.argumentError())
+            return
+        }
+        let contentStateJson = args["contentState"] as? String
+
+        Task {
+            do {
+                switch kind {
+                case "eew":
+                    let state = try Self.decodeOptional(
+                        EewLiveActivityAttributes.ContentState.self, json: contentStateJson
+                    )
+                    for activity in Activity<EewLiveActivityAttributes>.activities
+                    where activity.id == activityId {
+                        await activity.end(
+                            state.map { ActivityContent(state: $0, staleDate: nil) },
+                            dismissalPolicy: .immediate
+                        )
+                    }
+                case "shake_detection":
+                    let state = try Self.decodeOptional(
+                        ShakeDetectionLiveActivityAttributes.ContentState.self, json: contentStateJson
+                    )
+                    for activity in Activity<ShakeDetectionLiveActivityAttributes>.activities
+                    where activity.id == activityId {
+                        await activity.end(
+                            state.map { ActivityContent(state: $0, staleDate: nil) },
+                            dismissalPolicy: .immediate
+                        )
+                    }
+                default:
+                    result(Self.argumentError("unknown kind: \(kind)"))
+                    return
+                }
+                result(nil)
+            } catch {
+                result(Self.failure("end failed: \(error.localizedDescription)"))
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func decodeOptional<T: Decodable>(_ type: T.Type, json: String?) throws -> T? {
+        guard let json, let data = json.data(using: .utf8), !json.isEmpty else {
+            return nil
+        }
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    @available(iOS 16.1, *)
+    private static func eewStaleDate() -> Date {
+        // 仕様書 9.3: EEW 開始/更新時の stale-date は 30 分後。
+        Date().addingTimeInterval(30 * 60)
+    }
+
+    @available(iOS 16.1, *)
+    private static func shakeStaleDate() -> Date {
+        // 仕様書 9.2: 揺れ検知開始時の stale-date は 10 分後。
+        Date().addingTimeInterval(10 * 60)
+    }
+
+    private static func argumentError(_ message: String = "invalid arguments") -> FlutterError {
+        FlutterError(code: "invalid_arguments", message: message, details: nil)
+    }
+
+    private static func unsupportedError() -> FlutterError {
+        FlutterError(
+            code: "unsupported",
+            message: "Live Activity is not supported on this device (iOS 16.1+ required)",
+            details: nil
+        )
+    }
+
+    private static func failure(_ message: String) -> FlutterError {
+        FlutterError(code: "live_activity_error", message: message, details: nil)
+    }
+}
+
+#if canImport(ActivityKit)
+
+    // MARK: - Attributes (Widget Extension と型名・フィールドを一致させる)
+
+    @available(iOS 16.1, *)
+    struct EewLiveActivityAttributes: ActivityAttributes, Identifiable {
+        struct ContentState: Codable, Hashable {
+            let eventId: String
+            let type: String
+            let hypocenterName: String?
+            let magnitude: Double?
+            let depth: Double?
+            let time: String?
+            let isOriginTime: Bool?
+            let maxIntensity: String?
+            let serialNo: Int?
+            let isFinal: Bool?
+            let isWarning: Bool?
+            let isCanceled: Bool?
+            let headline: String?
+            let isPlum: Bool?
+            let isLevel: Bool?
+            let isOnePoint: Bool?
+            let location: DebugLiveActivityLocationInfo?
+        }
+
+        var id = UUID()
+        let eventId: String
+    }
+
+    @available(iOS 16.1, *)
+    struct ShakeDetectionLiveActivityAttributes: ActivityAttributes, Identifiable {
+        struct ContentState: Codable, Hashable {
+            let eventId: String
+            let type: String
+            let level: String?
+            let detectedAt: String?
+            let location: DebugLiveActivityLocationInfo?
+        }
+
+        var id = UUID()
+        let eventId: String
+    }
+
+    /// Widget 側 `LocationInfo` と同一の JSON 形状。型名の衝突を避けるため別名で定義する
+    /// （ActivityKit の紐付けには ContentState の型名は不要で、フィールドの一致のみが要件）。
+    struct DebugLiveActivityLocationInfo: Codable, Hashable {
+        let regionName: String
+        let forecastIntensity: String?
+        let forecastLpgmIntensity: String?
+        let arrivalTime: String?
+        let intensity: Double?
+    }
+
+#endif

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -19,6 +19,7 @@ import 'package:eqmonitor/feature/onboarding/data/notifier/onboarding_notifier.d
 import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/app_check/app_check_debug_provider.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/hypocenter_icon/hypocenter_icon_page.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/ui/page/debug_live_activity_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/startup/debug_startup_timing_page.dart';
 import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
 import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
@@ -134,6 +135,17 @@ class _DebugWidget extends ConsumerWidget {
                 subtitle: const Text('Widget が参照する UserDefaults を直接操作'),
                 leading: const Icon(Icons.widgets_outlined),
                 onTap: () => const DebugAppGroupRoute().push<void>(context),
+              ),
+            if (Platform.isIOS)
+              ListTile(
+                title: const Text('Live Activity テスト'),
+                subtitle: const Text('アプリ内から EEW / 揺れ検知の Live Activity を開始・更新・終了'),
+                leading: const Icon(Icons.bolt_outlined),
+                onTap: () => Navigator.of(context).push<void>(
+                  MaterialPageRoute(
+                    builder: (_) => const DebugLiveActivityPage(),
+                  ),
+                ),
               ),
             ListTile(
               title: const Text('Asset Pack'),

--- a/app/lib/feature/settings/children/config/debug/live_activity/data/controller/live_activity_local_controller.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/data/controller/live_activity_local_controller.dart
@@ -1,0 +1,157 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_kind.dart';
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final liveActivityLocalControllerProvider =
+    Provider<LiveActivityLocalController>((ref) {
+      if (Platform.isIOS) {
+        return const MethodChannelLiveActivityLocalController();
+      }
+      return const UnsupportedLiveActivityLocalController();
+    });
+
+/// アプリ内から ActivityKit を用いて Live Activity をローカル開始・更新・終了する。
+///
+/// Push-to-Start（サーバー経由）とは別経路で、開発時の表示検証に用いる。
+abstract interface class LiveActivityLocalController {
+  /// この端末で Live Activity のローカル開始がサポートされているか。
+  Future<bool> isSupported();
+
+  /// Live Activity を開始し、払い出された `activityId` を返す。
+  Future<String> start({
+    required DebugLiveActivityKind kind,
+    required String eventId,
+    required Map<String, dynamic> contentState,
+  });
+
+  /// 既存の Live Activity を更新する。
+  Future<void> update({
+    required DebugLiveActivityKind kind,
+    required String activityId,
+    required Map<String, dynamic> contentState,
+  });
+
+  /// Live Activity を終了する。
+  Future<void> end({
+    required DebugLiveActivityKind kind,
+    required String activityId,
+    Map<String, dynamic>? contentState,
+  });
+}
+
+/// iOS 以外のプラットフォーム向けの no-op 実装。
+class UnsupportedLiveActivityLocalController
+    implements LiveActivityLocalController {
+  const UnsupportedLiveActivityLocalController();
+
+  @override
+  Future<bool> isSupported() async => false;
+
+  @override
+  Future<String> start({
+    required DebugLiveActivityKind kind,
+    required String eventId,
+    required Map<String, dynamic> contentState,
+  }) => throw const LiveActivityLocalException('この端末ではサポートされていません');
+
+  @override
+  Future<void> update({
+    required DebugLiveActivityKind kind,
+    required String activityId,
+    required Map<String, dynamic> contentState,
+  }) => throw const LiveActivityLocalException('この端末ではサポートされていません');
+
+  @override
+  Future<void> end({
+    required DebugLiveActivityKind kind,
+    required String activityId,
+    Map<String, dynamic>? contentState,
+  }) => throw const LiveActivityLocalException('この端末ではサポートされていません');
+}
+
+/// `net.yumnumm.eqmonitor/live_activity_debug` MethodChannel 経由の iOS 実装。
+class MethodChannelLiveActivityLocalController
+    implements LiveActivityLocalController {
+  const MethodChannelLiveActivityLocalController();
+
+  static const MethodChannel _channel = MethodChannel(
+    'net.yumnumm.eqmonitor/live_activity_debug',
+  );
+
+  @override
+  Future<bool> isSupported() async {
+    final result = await _invoke<bool>('isSupported');
+    return result ?? false;
+  }
+
+  @override
+  Future<String> start({
+    required DebugLiveActivityKind kind,
+    required String eventId,
+    required Map<String, dynamic> contentState,
+  }) async {
+    final activityId = await _invoke<String>('start', <String, dynamic>{
+      'kind': kind.wireName,
+      'eventId': eventId,
+      'contentState': jsonEncode(contentState),
+    });
+    if (activityId == null || activityId.isEmpty) {
+      throw const LiveActivityLocalException('activityId を取得できませんでした');
+    }
+    return activityId;
+  }
+
+  @override
+  Future<void> update({
+    required DebugLiveActivityKind kind,
+    required String activityId,
+    required Map<String, dynamic> contentState,
+  }) async {
+    await _invoke<void>('update', <String, dynamic>{
+      'kind': kind.wireName,
+      'activityId': activityId,
+      'contentState': jsonEncode(contentState),
+    });
+  }
+
+  @override
+  Future<void> end({
+    required DebugLiveActivityKind kind,
+    required String activityId,
+    Map<String, dynamic>? contentState,
+  }) async {
+    await _invoke<void>('end', <String, dynamic>{
+      'kind': kind.wireName,
+      'activityId': activityId,
+      'contentState': contentState == null ? null : jsonEncode(contentState),
+    });
+  }
+
+  Future<T?> _invoke<T>(String method, [Map<String, dynamic>? arguments]) async {
+    try {
+      return await _channel.invokeMethod<T>(method, arguments);
+    } on PlatformException catch (e) {
+      throw LiveActivityLocalException(e.message ?? e.code, code: e.code);
+    } on MissingPluginException catch (e) {
+      throw LiveActivityLocalException(
+        e.message ?? 'ネイティブ実装が見つかりません',
+        code: 'missing_plugin',
+      );
+    }
+  }
+}
+
+/// Live Activity のローカル操作で発生した例外。
+class LiveActivityLocalException implements Exception {
+  const LiveActivityLocalException(this.message, {this.code});
+
+  final String message;
+  final String? code;
+
+  @override
+  String toString() =>
+      code == null ? message : 'LiveActivityLocalException($code): $message';
+}

--- a/app/lib/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_kind.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_kind.dart
@@ -1,0 +1,16 @@
+/// デバッグ用 Live Activity の種別。
+///
+/// ネイティブ (`net.yumnumm.eqmonitor/live_activity_debug` MethodChannel) へ渡す
+/// `kind` 文字列は Widget Extension 側の `attributes-type` と対応する。
+enum DebugLiveActivityKind {
+  eew('eew', 'EEW（緊急地震速報）'),
+  shakeDetection('shake_detection', '揺れ検知');
+
+  const DebugLiveActivityKind(this.wireName, this.label);
+
+  /// MethodChannel / ContentState `type` フィールドで使用する識別子。
+  final String wireName;
+
+  /// UI 表示用ラベル。
+  final String label;
+}

--- a/app/lib/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_preset.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_preset.dart
@@ -1,0 +1,31 @@
+/// EEW Live Activity のデバッグプリセット。
+///
+/// Widget Extension の `EewContentState` プレビューデータ
+/// (`app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift`) と
+/// 対応するケースを網羅し、表示検証を容易にする。
+enum DebugEewPreset {
+  warning('警報（第32報・北陸）'),
+  finalReport('最終報'),
+  forecast('予報（茨城県沖）'),
+  plum('PLUM法による検知'),
+  levelMethod('レベル法による検知'),
+  onePoint('1点検知（低精度）'),
+  canceled('取消報');
+
+  const DebugEewPreset(this.label);
+
+  final String label;
+}
+
+/// 揺れ検知 Live Activity のデバッグプリセット。
+enum DebugShakePreset {
+  weaker('微弱な揺れ (Weaker)'),
+  weak('弱い揺れ (Weak)'),
+  medium('揺れ (Medium)'),
+  strong('強い揺れ (Strong)'),
+  stronger('非常に強い揺れ (Stronger)');
+
+  const DebugShakePreset(this.label);
+
+  final String label;
+}

--- a/app/lib/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_session.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_session.dart
@@ -1,0 +1,17 @@
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_kind.dart';
+
+/// ローカル開始した Live Activity の識別情報。
+///
+/// `activityId` は iOS の `Activity.id`（開始時にネイティブが払い出す）。
+/// 更新・終了時に同じ ID を指定する。
+class DebugLiveActivitySession {
+  const DebugLiveActivitySession({
+    required this.activityId,
+    required this.kind,
+    required this.eventId,
+  });
+
+  final String activityId;
+  final DebugLiveActivityKind kind;
+  final String eventId;
+}

--- a/app/lib/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_content_builder.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_content_builder.dart
@@ -1,0 +1,348 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/intensity/jma_lpgm_intensity.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_preset.dart';
+import 'package:eqmonitor/feature/shake_detection/data/model/shake_detection_event.dart';
+import 'package:eqmonitor/feature/shake_detection/data/model/shake_detection_level.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final debugLiveActivityContentBuilderProvider =
+    Provider<DebugLiveActivityContentBuilder>(
+      (ref) => const DebugLiveActivityContentBuilder(),
+    );
+
+/// Live Activity の ContentState (`Map<String, dynamic>`) を組み立てる。
+///
+/// 生成される JSON のキーは Widget Extension の Swift `Codable` 構造体
+/// (`EewContentState` / `ShakeDetectionContentState` / `LocationInfo`) の
+/// プロパティ名と一致させる（デフォルトの CodingKeys = プロパティ名）。
+class DebugLiveActivityContentBuilder {
+  const DebugLiveActivityContentBuilder();
+
+  // --- EEW: プリセット ---
+
+  Map<String, dynamic> eewFromPreset({
+    required DebugEewPreset preset,
+    required String eventId,
+    required DateTime now,
+  }) {
+    return switch (preset) {
+      DebugEewPreset.warning => _eew(
+        eventId: eventId,
+        hypocenterName: '石川県能登地方',
+        magnitude: 7.6,
+        depth: 10,
+        time: now,
+        isOriginTime: true,
+        maxIntensity: JmaIntensity.sixUpper,
+        serialNo: 32,
+        isFinal: false,
+        isWarning: true,
+        isCanceled: false,
+        headline: '石川県で地震 北陸で強い揺れ',
+        isPlum: false,
+        isLevel: false,
+        isOnePoint: false,
+        location: _location(
+          regionName: '東京都23区',
+          forecastIntensity: JmaIntensity.fiveLower,
+          forecastLpgmIntensity: JmaLpgmIntensity.two,
+          arrivalTime: now.add(const Duration(seconds: 30)),
+        ),
+      ),
+      DebugEewPreset.finalReport => _eew(
+        eventId: eventId,
+        hypocenterName: '石川県能登地方',
+        magnitude: 7.6,
+        depth: 16,
+        time: now,
+        isOriginTime: true,
+        maxIntensity: JmaIntensity.seven,
+        serialNo: 47,
+        isFinal: true,
+        isWarning: true,
+        isCanceled: false,
+        headline: '石川県で地震 北陸で強い揺れ',
+        isPlum: false,
+        isLevel: false,
+        isOnePoint: false,
+      ),
+      DebugEewPreset.forecast => _eew(
+        eventId: eventId,
+        hypocenterName: '茨城県沖',
+        magnitude: 4.2,
+        depth: 40,
+        time: now,
+        isOriginTime: true,
+        maxIntensity: JmaIntensity.three,
+        serialNo: 1,
+        isFinal: false,
+        isWarning: false,
+        isCanceled: false,
+        headline: '茨城県沖で地震',
+        isPlum: false,
+        isLevel: false,
+        isOnePoint: false,
+      ),
+      DebugEewPreset.plum => _eew(
+        eventId: eventId,
+        hypocenterName: '関東地方',
+        time: now,
+        isOriginTime: true,
+        maxIntensity: JmaIntensity.fiveLower,
+        serialNo: 1,
+        isFinal: false,
+        isWarning: false,
+        isCanceled: false,
+        headline: '関東地方で地震',
+        isPlum: true,
+        isLevel: false,
+        isOnePoint: false,
+        location: _location(
+          regionName: '東京都23区',
+          forecastIntensity: JmaIntensity.four,
+        ),
+      ),
+      DebugEewPreset.levelMethod => _eew(
+        eventId: eventId,
+        hypocenterName: '仮定震源',
+        time: now,
+        isOriginTime: false,
+        maxIntensity: JmaIntensity.four,
+        serialNo: 1,
+        isFinal: false,
+        isWarning: false,
+        isCanceled: false,
+        headline: '地震発生',
+        isPlum: false,
+        isLevel: true,
+        isOnePoint: false,
+        location: _location(
+          regionName: '神奈川県東部',
+          forecastIntensity: JmaIntensity.three,
+        ),
+      ),
+      DebugEewPreset.onePoint => _eew(
+        eventId: eventId,
+        hypocenterName: '茨城県沖',
+        magnitude: 4,
+        depth: 30,
+        time: now,
+        isOriginTime: true,
+        maxIntensity: JmaIntensity.three,
+        serialNo: 1,
+        isFinal: false,
+        isWarning: false,
+        isCanceled: false,
+        headline: '茨城県沖で地震',
+        isPlum: false,
+        isLevel: false,
+        isOnePoint: true,
+      ),
+      DebugEewPreset.canceled => _eew(
+        eventId: eventId,
+        isOriginTime: false,
+        serialNo: 2,
+        isFinal: true,
+        isWarning: false,
+        isCanceled: true,
+        headline: '地震発生',
+        isPlum: false,
+        isLevel: false,
+        isOnePoint: false,
+      ),
+    };
+  }
+
+  // --- EEW: 実データ変換 ---
+
+  Map<String, dynamic> eewFromTelegram(EewTelegramItem eew) {
+    final hideHypocenterDetail = eew.shouldHideMagnitudeAndDepth;
+    final happenedTime = eew.originTime ?? eew.arrivalTime;
+    return _eew(
+      eventId: eew.eventId,
+      hypocenterName: eew.isCanceled ? null : eew.hypocenter?.name,
+      magnitude: (eew.isCanceled || hideHypocenterDetail)
+          ? null
+          : eew.hypocenter?.magnitude,
+      depth: (eew.isCanceled || hideHypocenterDetail)
+          ? null
+          : eew.hypocenter?.depth?.toDouble(),
+      time: eew.isCanceled ? null : happenedTime,
+      isOriginTime: eew.originTime != null,
+      maxIntensity: eew.isCanceled
+          ? null
+          : eew.forecastIntensity?.maxIntensity,
+      serialNo: eew.serialNo,
+      isFinal: eew.isLastInfo,
+      isWarning: eew.isWarning ?? false,
+      isCanceled: eew.isCanceled,
+      headline: eew.headline,
+      isPlum: eew.isPlum,
+      isLevel: eew.isLevelMethod,
+      isOnePoint: eew.isOnePointDetection,
+    );
+  }
+
+  // --- 揺れ検知: プリセット ---
+
+  Map<String, dynamic> shakeFromPreset({
+    required DebugShakePreset preset,
+    required String eventId,
+    required DateTime now,
+  }) {
+    final level = switch (preset) {
+      DebugShakePreset.weaker => ShakeDetectionLevel.weaker,
+      DebugShakePreset.weak => ShakeDetectionLevel.weak,
+      DebugShakePreset.medium => ShakeDetectionLevel.medium,
+      DebugShakePreset.strong => ShakeDetectionLevel.strong,
+      DebugShakePreset.stronger => ShakeDetectionLevel.stronger,
+    };
+    final intensity = switch (preset) {
+      DebugShakePreset.weaker => 0.4,
+      DebugShakePreset.weak => 0.8,
+      DebugShakePreset.medium => 1.6,
+      DebugShakePreset.strong => 3.2,
+      DebugShakePreset.stronger => 4.8,
+    };
+    return _shake(
+      eventId: eventId,
+      level: level,
+      detectedAt: now,
+      location: _location(regionName: '東京都23区', intensity: intensity),
+    );
+  }
+
+  // --- 揺れ検知: 実データ変換 ---
+
+  Map<String, dynamic> shakeFromEvent(ShakeDetectionEvent event) {
+    return _shake(
+      eventId: event.eventId,
+      level: event.level,
+      detectedAt: event.createdAt,
+    );
+  }
+
+  // --- 内部ヘルパー ---
+
+  Map<String, dynamic> _eew({
+    required String eventId,
+    required bool isOriginTime,
+    required int serialNo,
+    required bool isFinal,
+    required bool isWarning,
+    required bool isCanceled,
+    required bool isPlum,
+    required bool isLevel,
+    required bool isOnePoint,
+    String? hypocenterName,
+    double? magnitude,
+    double? depth,
+    DateTime? time,
+    JmaIntensity? maxIntensity,
+    String? headline,
+    Map<String, dynamic>? location,
+  }) {
+    return <String, dynamic>{
+      'eventId': eventId,
+      'type': 'eew',
+      'hypocenterName': hypocenterName,
+      'magnitude': magnitude,
+      'depth': depth,
+      'time': time == null ? null : _iso8601Jst(time),
+      'isOriginTime': isOriginTime,
+      'maxIntensity': maxIntensity == null
+          ? null
+          : _intensityWireValue(maxIntensity),
+      'serialNo': serialNo,
+      'isFinal': isFinal,
+      'isWarning': isWarning,
+      'isCanceled': isCanceled,
+      'headline': headline,
+      'isPlum': isPlum,
+      'isLevel': isLevel,
+      'isOnePoint': isOnePoint,
+      'location': location,
+    };
+  }
+
+  Map<String, dynamic> _shake({
+    required String eventId,
+    required ShakeDetectionLevel level,
+    required DateTime detectedAt,
+    Map<String, dynamic>? location,
+  }) {
+    return <String, dynamic>{
+      'eventId': eventId,
+      'type': 'shake_detection',
+      'level': _shakeLevelWireValue(level),
+      'detectedAt': _iso8601Jst(detectedAt),
+      'location': location,
+    };
+  }
+
+  Map<String, dynamic> _location({
+    required String regionName,
+    JmaIntensity? forecastIntensity,
+    JmaLpgmIntensity? forecastLpgmIntensity,
+    DateTime? arrivalTime,
+    double? intensity,
+  }) {
+    return <String, dynamic>{
+      'regionName': regionName,
+      'forecastIntensity': forecastIntensity == null
+          ? null
+          : _intensityWireValue(forecastIntensity),
+      'forecastLpgmIntensity': forecastLpgmIntensity == null
+          ? null
+          : _lpgmWireValue(forecastLpgmIntensity),
+      'arrivalTime': arrivalTime == null ? null : _iso8601Jst(arrivalTime),
+      'intensity': intensity,
+    };
+  }
+
+  /// Widget 側 `IntensityValue`(rawValue) と一致する文字列に変換する。
+  /// `unknown` は Swift 側でバッジ非表示になるため null を返す。
+  String? _intensityWireValue(JmaIntensity intensity) => switch (intensity) {
+    JmaIntensity.unknown => null,
+    JmaIntensity.zero => '0',
+    JmaIntensity.one => '1',
+    JmaIntensity.two => '2',
+    JmaIntensity.three => '3',
+    JmaIntensity.four => '4',
+    JmaIntensity.fiveUnknown => '!5-',
+    JmaIntensity.fiveLower => '5-',
+    JmaIntensity.fiveUpper => '5+',
+    JmaIntensity.sixUnknown => '!6-',
+    JmaIntensity.sixLower => '6-',
+    JmaIntensity.sixUpper => '6+',
+    JmaIntensity.seven => '7',
+  };
+
+  String? _lpgmWireValue(JmaLpgmIntensity lpgm) => switch (lpgm) {
+    JmaLpgmIntensity.unknown => null,
+    JmaLpgmIntensity.zero => '0',
+    JmaLpgmIntensity.one => '1',
+    JmaLpgmIntensity.two => '2',
+    JmaLpgmIntensity.three => '3',
+    JmaLpgmIntensity.four => '4',
+  };
+
+  String _shakeLevelWireValue(ShakeDetectionLevel level) => switch (level) {
+    ShakeDetectionLevel.weaker => 'Weaker',
+    ShakeDetectionLevel.weak => 'Weak',
+    ShakeDetectionLevel.medium => 'Medium',
+    ShakeDetectionLevel.strong => 'Strong',
+    ShakeDetectionLevel.stronger => 'Stronger',
+  };
+
+  /// Swift の `ISO8601DateFormatter`（既定オプション = 小数秒なし）で
+  /// パース可能な JST オフセット付き文字列を生成する。
+  String _iso8601Jst(DateTime dateTime) {
+    final jst = dateTime.toUtc().add(const Duration(hours: 9));
+    String two(int value) => value.toString().padLeft(2, '0');
+    final year = jst.year.toString().padLeft(4, '0');
+    return '$year-${two(jst.month)}-${two(jst.day)}'
+        'T${two(jst.hour)}:${two(jst.minute)}:${two(jst.second)}+09:00';
+  }
+}

--- a/app/lib/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_json_codec.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_json_codec.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final debugLiveActivityJsonCodecProvider =
+    Provider<DebugLiveActivityJsonCodec>(
+      (ref) => const DebugLiveActivityJsonCodec(),
+    );
+
+/// ContentState の `Map` と、UI で編集する JSON 文字列を相互変換する。
+class DebugLiveActivityJsonCodec {
+  const DebugLiveActivityJsonCodec();
+
+  /// 人間が編集しやすいようインデント付きで整形する。
+  String encode(Map<String, dynamic> contentState) =>
+      const JsonEncoder.withIndent('  ').convert(contentState);
+
+  /// JSON 文字列をオブジェクトとして解釈する。
+  ///
+  /// - オブジェクト以外（配列・数値・null 等）は [FormatException] を返す。
+  /// - パース失敗も [FormatException] を返す。
+  Result<Map<String, dynamic>, FormatException> parse(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) {
+      return const Failure(FormatException('JSON が空です'));
+    }
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(trimmed);
+    } on FormatException catch (e, stackTrace) {
+      return Failure(e, stackTrace);
+    }
+    if (decoded is! Map<String, dynamic>) {
+      return const Failure(
+        FormatException('ContentState は JSON オブジェクトである必要があります'),
+      );
+    }
+    return Success(decoded);
+  }
+}

--- a/app/lib/feature/settings/children/config/debug/live_activity/ui/action/debug_live_activity_action.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/ui/action/debug_live_activity_action.dart
@@ -1,0 +1,152 @@
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/controller/live_activity_local_controller.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_kind.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_session.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_json_codec.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final debugLiveActivityActionProvider = Provider<DebugLiveActivityAction>(
+  (ref) => const DebugLiveActivityAction(),
+);
+
+/// Live Activity デバッグ画面のイベントハンドラ。
+///
+/// JSON の検証 → ネイティブ操作 → SnackBar 表示までを担う。
+class DebugLiveActivityAction {
+  const DebugLiveActivityAction();
+
+  /// Live Activity を開始する。成功時のみ [DebugLiveActivitySession] を返す。
+  Future<DebugLiveActivitySession?> start({
+    required WidgetRef ref,
+    required BuildContext context,
+    required DebugLiveActivityKind kind,
+    required String rawJson,
+  }) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final contentState = _parseOrNotify(ref, messenger, rawJson);
+    if (contentState == null) {
+      return null;
+    }
+    final eventId = _eventIdOrNotify(messenger, contentState);
+    if (eventId == null) {
+      return null;
+    }
+
+    try {
+      final activityId = await ref
+          .read(liveActivityLocalControllerProvider)
+          .start(kind: kind, eventId: eventId, contentState: contentState);
+      messenger.showSnackBar(
+        SnackBar(content: Text('開始しました: $activityId')),
+      );
+      return DebugLiveActivitySession(
+        activityId: activityId,
+        kind: kind,
+        eventId: eventId,
+      );
+    } on LiveActivityLocalException catch (e) {
+      messenger.showSnackBar(SnackBar(content: Text('開始に失敗しました: ${e.message}')));
+      return null;
+    }
+  }
+
+  /// Live Activity を更新する。
+  Future<bool> update({
+    required WidgetRef ref,
+    required BuildContext context,
+    required DebugLiveActivityKind kind,
+    required String activityId,
+    required String rawJson,
+  }) async {
+    final messenger = ScaffoldMessenger.of(context);
+    if (activityId.isEmpty) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('activityId が未設定です（先に開始してください）')),
+      );
+      return false;
+    }
+    final contentState = _parseOrNotify(ref, messenger, rawJson);
+    if (contentState == null) {
+      return false;
+    }
+
+    try {
+      await ref
+          .read(liveActivityLocalControllerProvider)
+          .update(kind: kind, activityId: activityId, contentState: contentState);
+      messenger.showSnackBar(const SnackBar(content: Text('更新しました')));
+      return true;
+    } on LiveActivityLocalException catch (e) {
+      messenger.showSnackBar(SnackBar(content: Text('更新に失敗しました: ${e.message}')));
+      return false;
+    }
+  }
+
+  /// Live Activity を終了する。ContentState は任意（空なら現在の内容で終了）。
+  Future<bool> end({
+    required WidgetRef ref,
+    required BuildContext context,
+    required DebugLiveActivityKind kind,
+    required String activityId,
+    required String rawJson,
+  }) async {
+    final messenger = ScaffoldMessenger.of(context);
+    if (activityId.isEmpty) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('activityId が未設定です（先に開始してください）')),
+      );
+      return false;
+    }
+
+    Map<String, dynamic>? contentState;
+    if (rawJson.trim().isNotEmpty) {
+      contentState = _parseOrNotify(ref, messenger, rawJson);
+      if (contentState == null) {
+        return false;
+      }
+    }
+
+    try {
+      await ref
+          .read(liveActivityLocalControllerProvider)
+          .end(kind: kind, activityId: activityId, contentState: contentState);
+      messenger.showSnackBar(const SnackBar(content: Text('終了しました')));
+      return true;
+    } on LiveActivityLocalException catch (e) {
+      messenger.showSnackBar(SnackBar(content: Text('終了に失敗しました: ${e.message}')));
+      return false;
+    }
+  }
+
+  Map<String, dynamic>? _parseOrNotify(
+    WidgetRef ref,
+    ScaffoldMessengerState messenger,
+    String rawJson,
+  ) {
+    final result = ref.read(debugLiveActivityJsonCodecProvider).parse(rawJson);
+    switch (result) {
+      case Success(:final value):
+        return value;
+      case Failure(:final exception):
+        messenger.showSnackBar(
+          SnackBar(content: Text('JSON が不正です: ${exception.message}')),
+        );
+        return null;
+    }
+  }
+
+  String? _eventIdOrNotify(
+    ScaffoldMessengerState messenger,
+    Map<String, dynamic> contentState,
+  ) {
+    final eventId = contentState['eventId'];
+    if (eventId is String && eventId.isNotEmpty) {
+      return eventId;
+    }
+    messenger.showSnackBar(
+      const SnackBar(content: Text('ContentState に eventId (String) が必要です')),
+    );
+    return null;
+  }
+}

--- a/app/lib/feature/settings/children/config/debug/live_activity/ui/page/debug_live_activity_page.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/ui/page/debug_live_activity_page.dart
@@ -1,0 +1,337 @@
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
+import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/controller/live_activity_local_controller.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_kind.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_preset.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_session.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_content_builder.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_json_codec.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/ui/action/debug_live_activity_action.dart';
+import 'package:eqmonitor/feature/shake_detection/data/model/shake_detection_event.dart';
+import 'package:eqmonitor/feature/shake_detection/data/provider/shake_detection_provider.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// デバッグ用。アプリ内から ActivityKit を用いて EEW / 揺れ検知の
+/// Live Activity をローカル開始・更新・終了し、表示を検証する。
+class DebugLiveActivityPage extends HookConsumerWidget {
+  const DebugLiveActivityPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final kind = useState(DebugLiveActivityKind.eew);
+    final jsonController = useTextEditingController();
+    final activityIdController = useTextEditingController();
+    final session = useState<DebugLiveActivitySession?>(null);
+    final isBusy = useState(false);
+
+    final builder = ref.watch(debugLiveActivityContentBuilderProvider);
+    final codec = ref.watch(debugLiveActivityJsonCodecProvider);
+    final action = ref.watch(debugLiveActivityActionProvider);
+
+    void fill(Map<String, dynamic> contentState) =>
+        jsonController.text = codec.encode(contentState);
+
+    Future<void> run(Future<void> Function() task) async {
+      if (isBusy.value) {
+        return;
+      }
+      isBusy.value = true;
+      try {
+        await task();
+      } finally {
+        isBusy.value = false;
+      }
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Live Activity テスト')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text('種別', style: Theme.of(context).textTheme.titleSmall),
+          const SizedBox(height: 8),
+          SegmentedButton<DebugLiveActivityKind>(
+            segments: [
+              for (final value in DebugLiveActivityKind.values)
+                ButtonSegment(value: value, label: Text(value.label)),
+            ],
+            selected: {kind.value},
+            onSelectionChanged: isBusy.value
+                ? null
+                : (selected) {
+                    kind.value = selected.first;
+                    session.value = null;
+                    activityIdController.clear();
+                    jsonController.clear();
+                  },
+          ),
+          const SizedBox(height: 24),
+          Text('プリセット', style: Theme.of(context).textTheme.titleSmall),
+          const SizedBox(height: 8),
+          _PresetChips(
+            kind: kind.value,
+            onEewPreset: (preset) => fill(
+              builder.eewFromPreset(
+                preset: preset,
+                eventId: _generateEventId(ref, 'eew'),
+                now: ref.read(appClockProvider.notifier).now(),
+              ),
+            ),
+            onShakePreset: (preset) => fill(
+              builder.shakeFromPreset(
+                preset: preset,
+                eventId: _generateEventId(ref, 'shake'),
+                now: ref.read(appClockProvider.notifier).now(),
+              ),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text('実データから読み込み', style: Theme.of(context).textTheme.titleSmall),
+          const SizedBox(height: 8),
+          _RealDataSection(
+            kind: kind.value,
+            onEewSelected: (eew) => fill(builder.eewFromTelegram(eew)),
+            onShakeSelected: (event) => fill(builder.shakeFromEvent(event)),
+          ),
+          const SizedBox(height: 24),
+          TextField(
+            controller: activityIdController,
+            decoration: const InputDecoration(
+              labelText: 'activityId（更新・終了に使用）',
+              helperText: '開始成功時に自動入力されます',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: jsonController,
+            minLines: 6,
+            maxLines: 20,
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+            decoration: const InputDecoration(
+              labelText: 'ContentState (JSON)',
+              alignLabelWithHint: true,
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              FilledButton.icon(
+                icon: const Icon(Icons.play_arrow),
+                label: const Text('開始'),
+                onPressed: isBusy.value
+                    ? null
+                    : () => run(() async {
+                        final result = await action.start(
+                          ref: ref,
+                          context: context,
+                          kind: kind.value,
+                          rawJson: jsonController.text,
+                        );
+                        if (result != null) {
+                          session.value = result;
+                          activityIdController.text = result.activityId;
+                        }
+                      }),
+              ),
+              FilledButton.tonalIcon(
+                icon: const Icon(Icons.refresh),
+                label: const Text('更新'),
+                onPressed: isBusy.value
+                    ? null
+                    : () => run(() async {
+                        await action.update(
+                          ref: ref,
+                          context: context,
+                          kind: kind.value,
+                          activityId: activityIdController.text.trim(),
+                          rawJson: jsonController.text,
+                        );
+                      }),
+              ),
+              OutlinedButton.icon(
+                icon: const Icon(Icons.stop),
+                label: const Text('終了'),
+                onPressed: isBusy.value
+                    ? null
+                    : () => run(() async {
+                        final ended = await action.end(
+                          ref: ref,
+                          context: context,
+                          kind: kind.value,
+                          activityId: activityIdController.text.trim(),
+                          rawJson: jsonController.text,
+                        );
+                        if (ended) {
+                          session.value = null;
+                        }
+                      }),
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          if (session.value case final current?)
+            _SessionCard(session: current),
+          const _SupportabilityTile(),
+        ],
+      ),
+    );
+  }
+
+  String _generateEventId(WidgetRef ref, String prefix) {
+    final now = ref.read(appClockProvider.notifier).now();
+    return 'debug-$prefix-${now.millisecondsSinceEpoch}';
+  }
+}
+
+class _PresetChips extends StatelessWidget {
+  const _PresetChips({
+    required this.kind,
+    required this.onEewPreset,
+    required this.onShakePreset,
+  });
+
+  final DebugLiveActivityKind kind;
+  final ValueChanged<DebugEewPreset> onEewPreset;
+  final ValueChanged<DebugShakePreset> onShakePreset;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 4,
+      children: switch (kind) {
+        DebugLiveActivityKind.eew => [
+          for (final preset in DebugEewPreset.values)
+            ActionChip(
+              label: Text(preset.label),
+              onPressed: () => onEewPreset(preset),
+            ),
+        ],
+        DebugLiveActivityKind.shakeDetection => [
+          for (final preset in DebugShakePreset.values)
+            ActionChip(
+              label: Text(preset.label),
+              onPressed: () => onShakePreset(preset),
+            ),
+        ],
+      },
+    );
+  }
+}
+
+class _RealDataSection extends ConsumerWidget {
+  const _RealDataSection({
+    required this.kind,
+    required this.onEewSelected,
+    required this.onShakeSelected,
+  });
+
+  final DebugLiveActivityKind kind;
+  final ValueChanged<EewTelegramItem> onEewSelected;
+  final ValueChanged<ShakeDetectionEvent> onShakeSelected;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return switch (kind) {
+      DebugLiveActivityKind.eew => _buildEew(context, ref),
+      DebugLiveActivityKind.shakeDetection => _buildShake(context, ref),
+    };
+  }
+
+  Widget _buildEew(BuildContext context, WidgetRef ref) {
+    final eews = ref.watch(eewAliveTelegramProvider) ?? const <EewTelegramItem>[];
+    if (eews.isEmpty) {
+      return const Text('発表中の EEW はありません');
+    }
+    return Column(
+      children: [
+        for (final eew in eews)
+          ListTile(
+            dense: true,
+            title: Text('${eew.hypocenter?.name ?? eew.headline ?? '(不明)'} '
+                '第${eew.serialNo}報'),
+            subtitle: Text(eew.eventId),
+            trailing: const Icon(Icons.download),
+            onTap: () => onEewSelected(eew),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildShake(BuildContext context, WidgetRef ref) {
+    final events = ref.watch(shakeDetectionProvider);
+    if (events.isEmpty) {
+      return const Text('進行中の揺れ検知はありません');
+    }
+    return Column(
+      children: [
+        for (final event in events)
+          ListTile(
+            dense: true,
+            title: Text('${event.level.name} 第${event.serialNo}報'),
+            subtitle: Text(event.eventId),
+            trailing: const Icon(Icons.download),
+            onTap: () => onShakeSelected(event),
+          ),
+      ],
+    );
+  }
+}
+
+class _SessionCard extends StatelessWidget {
+  const _SessionCard({required this.session});
+
+  final DebugLiveActivitySession session;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        leading: const Icon(Icons.bolt),
+        title: Text(session.activityId),
+        subtitle: Text('${session.kind.label} / ${session.eventId}'),
+        trailing: const Icon(Icons.copy),
+        onTap: () async {
+          await Clipboard.setData(ClipboardData(text: session.activityId));
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('activityId をコピーしました')),
+            );
+          }
+        },
+      ),
+    );
+  }
+}
+
+class _SupportabilityTile extends ConsumerWidget {
+  const _SupportabilityTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.watch(liveActivityLocalControllerProvider);
+    return FutureBuilder<bool>(
+      future: controller.isSupported(),
+      builder: (context, snapshot) {
+        final supported = snapshot.data;
+        final text = switch (supported) {
+          null => '対応状況を確認中...',
+          true => 'この端末は Live Activity のローカル開始に対応しています',
+          false => 'この端末は Live Activity のローカル開始に非対応です（iOS 16.1+ が必要）',
+        };
+        return Padding(
+          padding: const EdgeInsets.only(top: 16),
+          child: Text(text, style: Theme.of(context).textTheme.bodySmall),
+        );
+      },
+    );
+  }
+}

--- a/app/test/feature/settings/children/config/debug/live_activity/debug_live_activity_content_builder_test.dart
+++ b/app/test/feature/settings/children/config/debug/live_activity/debug_live_activity_content_builder_test.dart
@@ -1,0 +1,195 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_info_type.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_preset.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_content_builder.dart';
+import 'package:eqmonitor/feature/shake_detection/data/model/shake_detection_event.dart';
+import 'package:eqmonitor/feature/shake_detection/data/model/shake_detection_level.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const builder = DebugLiveActivityContentBuilder();
+  final now = DateTime.utc(2024, 1, 1, 7, 10); // = 16:10 JST
+
+  group('eewFromPreset', () {
+    test('warning プリセットは警報フィールドと現在地予想を含む', () {
+      final map = builder.eewFromPreset(
+        preset: DebugEewPreset.warning,
+        eventId: 'ev-1',
+        now: now,
+      );
+
+      expect(map['eventId'], 'ev-1');
+      expect(map['type'], 'eew');
+      expect(map['isWarning'], true);
+      expect(map['maxIntensity'], '6+');
+      expect(map['magnitude'], 7.6);
+      expect(map['serialNo'], 32);
+      final location = map['location'] as Map<String, dynamic>;
+      expect(location['regionName'], '東京都23区');
+      expect(location['forecastIntensity'], '5-');
+      expect(location['forecastLpgmIntensity'], '2');
+    });
+
+    test('canceled プリセットは震源情報を null にする', () {
+      final map = builder.eewFromPreset(
+        preset: DebugEewPreset.canceled,
+        eventId: 'ev-2',
+        now: now,
+      );
+
+      expect(map['isCanceled'], true);
+      expect(map['hypocenterName'], isNull);
+      expect(map['magnitude'], isNull);
+      expect(map['depth'], isNull);
+      expect(map['time'], isNull);
+      expect(map['maxIntensity'], isNull);
+    });
+
+    test('time は JST オフセット付き・小数秒なしの ISO8601', () {
+      final map = builder.eewFromPreset(
+        preset: DebugEewPreset.warning,
+        eventId: 'ev-1',
+        now: now,
+      );
+
+      expect(map['time'], '2024-01-01T16:10:00+09:00');
+    });
+  });
+
+  group('eewFromTelegram', () {
+    test('通常の警報 EEW を変換する', () {
+      final eew = EewTelegramItem(
+        eventId: 'tel-1',
+        status: TelegramStatus.normal,
+        infoType: TelegramInfoType.publication,
+        serialNo: 5,
+        isCanceled: false,
+        isLastInfo: true,
+        reportTime: now,
+        isPlum: false,
+        isWarning: true,
+        originTime: now,
+        headline: 'テスト見出し',
+        hypocenter: const EewHypocenterInfo(
+          code: '100',
+          name: '三陸沖',
+          magnitude: 7.2,
+          depth: 24,
+        ),
+        forecastIntensity: const EewForecastIntensityInfo(
+          regions: [],
+          maxIntensity: JmaIntensity.fiveUpper,
+        ),
+        accuracy: const EewAccuracyInfo(
+          epicenter: 3,
+          hypocenter: 3,
+          depth: 3,
+          magnitudeCalculation: 5,
+          numberOfMagnitudeCalculation: 5,
+        ),
+      );
+
+      final map = builder.eewFromTelegram(eew);
+
+      expect(map['eventId'], 'tel-1');
+      expect(map['hypocenterName'], '三陸沖');
+      expect(map['magnitude'], 7.2);
+      expect(map['depth'], 24.0);
+      expect(map['maxIntensity'], '5+');
+      expect(map['isFinal'], true);
+      expect(map['isWarning'], true);
+      expect(map['isOriginTime'], true);
+      expect(map['isPlum'], false);
+      expect(map['headline'], 'テスト見出し');
+    });
+
+    test('PLUM は M・深さを隠す', () {
+      final eew = EewTelegramItem(
+        eventId: 'tel-2',
+        status: TelegramStatus.normal,
+        infoType: TelegramInfoType.publication,
+        serialNo: 1,
+        isCanceled: false,
+        isLastInfo: false,
+        reportTime: now,
+        isPlum: true,
+        isWarning: false,
+        originTime: now,
+        hypocenter: const EewHypocenterInfo(
+          code: '100',
+          name: '関東地方',
+          magnitude: 5,
+          depth: 10,
+        ),
+      );
+
+      final map = builder.eewFromTelegram(eew);
+
+      expect(map['isPlum'], true);
+      expect(map['magnitude'], isNull);
+      expect(map['depth'], isNull);
+    });
+
+    test('取消報は震源情報を null にする', () {
+      final eew = EewTelegramItem(
+        eventId: 'tel-3',
+        status: TelegramStatus.normal,
+        infoType: TelegramInfoType.publication,
+        serialNo: 2,
+        isCanceled: true,
+        isLastInfo: true,
+        reportTime: now,
+        isPlum: false,
+      );
+
+      final map = builder.eewFromTelegram(eew);
+
+      expect(map['isCanceled'], true);
+      expect(map['hypocenterName'], isNull);
+      expect(map['magnitude'], isNull);
+      expect(map['time'], isNull);
+      expect(map['maxIntensity'], isNull);
+    });
+  });
+
+  group('shake', () {
+    test('shakeFromPreset は Level を大文字始まりの文字列に変換する', () {
+      final map = builder.shakeFromPreset(
+        preset: DebugShakePreset.strong,
+        eventId: 'shake-1',
+        now: now,
+      );
+
+      expect(map['type'], 'shake_detection');
+      expect(map['level'], 'Strong');
+      final location = map['location'] as Map<String, dynamic>;
+      expect(location['intensity'], 3.2);
+    });
+
+    test('shakeFromEvent は実データを変換する', () {
+      final event = ShakeDetectionEvent(
+        eventId: 'shake-2',
+        serialNo: 3,
+        createdAt: now,
+        updatedAt: now,
+        expiresAt: now,
+        level: ShakeDetectionLevel.stronger,
+        pointCount: 4,
+        minLat: 35,
+        maxLat: 36,
+        minLng: 139,
+        maxLng: 140,
+        changeReasons: const [],
+      );
+
+      final map = builder.shakeFromEvent(event);
+
+      expect(map['eventId'], 'shake-2');
+      expect(map['level'], 'Stronger');
+      expect(map['detectedAt'], '2024-01-01T16:10:00+09:00');
+      expect(map['location'], isNull);
+    });
+  });
+}

--- a/app/test/feature/settings/children/config/debug/live_activity/debug_live_activity_json_codec_test.dart
+++ b/app/test/feature/settings/children/config/debug/live_activity/debug_live_activity_json_codec_test.dart
@@ -1,0 +1,37 @@
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_json_codec.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const codec = DebugLiveActivityJsonCodec();
+
+  test('encode → parse でオブジェクトが往復する', () {
+    final source = <String, dynamic>{
+      'eventId': 'ev-1',
+      'serialNo': 3,
+      'isWarning': true,
+      'location': <String, dynamic>{'regionName': '東京都23区'},
+    };
+
+    final encoded = codec.encode(source);
+    final result = codec.parse(encoded);
+
+    expect(result, isA<Success<Map<String, dynamic>, FormatException>>());
+    final parsed = (result as Success).value as Map<String, dynamic>;
+    expect(parsed['eventId'], 'ev-1');
+    expect(parsed['serialNo'], 3);
+    expect((parsed['location'] as Map)['regionName'], '東京都23区');
+  });
+
+  test('空文字は Failure', () {
+    expect(codec.parse('   '), isA<Failure<Map<String, dynamic>, FormatException>>());
+  });
+
+  test('不正な JSON は Failure', () {
+    expect(codec.parse('{ not json '), isA<Failure<Map<String, dynamic>, FormatException>>());
+  });
+
+  test('オブジェクト以外（配列）は Failure', () {
+    expect(codec.parse('[1, 2, 3]'), isA<Failure<Map<String, dynamic>, FormatException>>());
+  });
+}

--- a/app/test/feature/settings/children/config/debug/live_activity/live_activity_local_controller_test.dart
+++ b/app/test/feature/settings/children/config/debug/live_activity/live_activity_local_controller_test.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/controller/live_activity_local_controller.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_kind.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('net.yumnumm.eqmonitor/live_activity_debug');
+  const controller = MethodChannelLiveActivityLocalController();
+  final calls = <MethodCall>[];
+
+  void mock(Future<Object?>? Function(MethodCall call) handler) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return handler(call);
+        });
+  }
+
+  setUp(calls.clear);
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('start は kind / eventId / contentState(JSON) を送り activityId を返す', () async {
+    mock((call) async => call.method == 'start' ? 'activity-123' : null);
+
+    final activityId = await controller.start(
+      kind: DebugLiveActivityKind.eew,
+      eventId: 'ev-1',
+      contentState: <String, dynamic>{'eventId': 'ev-1', 'type': 'eew'},
+    );
+
+    expect(activityId, 'activity-123');
+    final args = calls.single.arguments as Map;
+    expect(calls.single.method, 'start');
+    expect(args['kind'], 'eew');
+    expect(args['eventId'], 'ev-1');
+    final decoded = jsonDecode(args['contentState'] as String) as Map;
+    expect(decoded['type'], 'eew');
+  });
+
+  test('start で activityId が空なら例外', () async {
+    mock((call) async => '');
+
+    expect(
+      () => controller.start(
+        kind: DebugLiveActivityKind.eew,
+        eventId: 'ev-1',
+        contentState: const <String, dynamic>{},
+      ),
+      throwsA(isA<LiveActivityLocalException>()),
+    );
+  });
+
+  test('update は activityId と contentState を送る', () async {
+    mock((call) async => null);
+
+    await controller.update(
+      kind: DebugLiveActivityKind.shakeDetection,
+      activityId: 'activity-9',
+      contentState: <String, dynamic>{'eventId': 'ev-2'},
+    );
+
+    final args = calls.single.arguments as Map;
+    expect(calls.single.method, 'update');
+    expect(args['kind'], 'shake_detection');
+    expect(args['activityId'], 'activity-9');
+  });
+
+  test('end は contentState を省略できる', () async {
+    mock((call) async => null);
+
+    await controller.end(
+      kind: DebugLiveActivityKind.eew,
+      activityId: 'activity-9',
+    );
+
+    final args = calls.single.arguments as Map;
+    expect(calls.single.method, 'end');
+    expect(args['contentState'], isNull);
+  });
+
+  test('PlatformException は LiveActivityLocalException に変換される', () async {
+    mock((call) async => throw PlatformException(code: 'boom', message: '失敗'));
+
+    expect(
+      () => controller.update(
+        kind: DebugLiveActivityKind.eew,
+        activityId: 'a',
+        contentState: const <String, dynamic>{},
+      ),
+      throwsA(
+        isA<LiveActivityLocalException>().having(
+          (e) => e.code,
+          'code',
+          'boom',
+        ),
+      ),
+    );
+  });
+}

--- a/docs/knowledge/20260815_live_activity_local_debug.md
+++ b/docs/knowledge/20260815_live_activity_local_debug.md
@@ -1,0 +1,67 @@
+---
+alwaysApply: false
+globs: app/lib/feature/settings/children/config/debug/live_activity/**,app/ios/Runner/LiveActivityDebugMethodChannel.swift
+---
+
+# Live Activity ローカル開始（デバッグ）
+
+デバッグ画面（`設定 > デバッグ > Live Activity テスト`, iOS のみ）から、アプリ内で
+ActivityKit を用いて EEW / 揺れ検知の Live Activity を **ローカル開始・更新・終了**
+できる。Push-to-Start（サーバー経由）とは別経路で、開発時の表示検証に用いる。
+
+## 構成
+
+- Dart 側は MethodChannel `net.yumnumm.eqmonitor/live_activity_debug` を叩くだけ。
+  - `LiveActivityLocalController`（iOS のみ MethodChannel 実装、他は no-op）
+  - `DebugLiveActivityContentBuilder`（プリセット + 実データ変換 → `Map`）
+  - `DebugLiveActivityJsonCodec`（JSON 整形・検証）
+  - `DebugLiveActivityAction`（検証 → ネイティブ → SnackBar）
+- ネイティブは `app/ios/Runner/LiveActivityDebugMethodChannel.swift`。
+  `Activity.request` / `update` / `end` を呼ぶ。
+
+## ContentState JSON はネイティブ Codable とキーを一致させる
+
+Widget Extension の `EewContentState` / `ShakeDetectionContentState` /
+`LocationInfo`（Swift）は既定 CodingKeys = プロパティ名（camelCase）。
+`DebugLiveActivityContentBuilder` が生成する `Map` のキーはこれに一致させること。
+
+- EEW: `eventId,type,hypocenterName,magnitude,depth,time,isOriginTime,maxIntensity,serialNo,isFinal,isWarning,isCanceled,headline,isPlum,isLevel,isOnePoint,location`
+- 揺れ検知: `eventId,type,level,detectedAt,location`
+- `location`: `regionName,forecastIntensity,forecastLpgmIntensity,arrivalTime,intensity`
+- `maxIntensity` / `forecastIntensity` は Widget の `IntensityValue` rawValue
+  （`0..7`, `5-`, `5+`, `6-`, `6+`, `!5-`, `!6-`）に一致させる。
+- 時刻は Swift 既定 `ISO8601DateFormatter`（**小数秒なし**）でパースできる
+  JST オフセット付き文字列 `yyyy-MM-ddTHH:mm:ss+09:00` を送る。
+
+## ActivityKit 型の紐付け（重要・macOS 検証必須）
+
+ローカル `Activity<EewLiveActivityAttributes>.request` した Activity を既存 Widget
+（`app/ios/Widget/LiveActivity/...` の `ActivityConfiguration`）で描画させるには、
+`ActivityAttributes` の **型名** が一致している必要がある。
+
+現状は `LiveActivityDebugMethodChannel.swift` 内に、Widget と型名・Codable
+フィールドを一致させた `EewLiveActivityAttributes` /
+`ShakeDetectionLiveActivityAttributes` を **重複定義** している（Runner モジュール）。
+
+- ActivityKit の Widget 紐付けは Attributes 型名ベースのため、通常はこれで
+  既存 Widget レイアウトに描画される。
+- **もし macOS 実機検証でローカル開始した Activity が Widget に描画されない場合**、
+  クロスモジュールの型同一性が原因。その際は Widget の Attributes ソース
+  （`EewLiveActivityAttributes.swift` 等）を Runner ターゲットにも所属させる
+  （共有ソース化）にフォールバックする。
+
+## この環境（Linux Cloud Agent）で検証できたこと / できないこと
+
+- 検証済み: Dart 静的解析（`dart analyze`）、ユニットテスト（`flutter test`）
+  17 件パス。MethodChannel の引数・JSON 契約、プリセット/実データ変換、JSON 検証。
+- 未検証（macOS 必須）: iOS ビルド、Swift コンパイル、`Runner.xcodeproj`
+  への 1 ファイル追加（`LiveActivityDebugMethodChannel.swift`）、実機での
+  Live Activity 表示。**macOS でのビルド・実機確認が必要。**
+
+## ツール実行メモ（この環境）
+
+- `mise install` は `swift` のインストールに失敗する（`libncurses.so.6` 欠如）。
+  Dart/Flutter 作業では Flutter を直接 PATH に通して回避した。
+  `export PATH="$HOME/.local/share/mise/installs/flutter/<rev>/bin:...:$PATH"`
+- `flutter_scene` submodule 初期化（`git submodule update --init third_party/flutter_scene`）
+  が pub get の前提。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

デバッグ画面（`設定 > デバッグ > Live Activity テスト`, iOS のみ）から、アプリ内で ActivityKit を用いて **EEW / 揺れ検知の Live Activity をローカル開始・更新・終了**できるようにしました。Push-to-Start（サーバー経由）とは別経路で、開発時の表示検証を目的とします。

ブレインストーミングでの合意事項:
- 開始方法: デバッグ画面から（本番 UI やサーバー test API は対象外）
- 操作範囲: 開始・更新・終了
- ContentState: プリセット + 実データ（発表中 EEW / 進行中の揺れ検知）からの変換、加えて JSON 手編集
- 種別: EEW と揺れ検知の両方

## 変更点

**Dart（`app/lib/feature/settings/children/config/debug/live_activity/`）**
- `LiveActivityLocalController`: MethodChannel `net.yumnumm.eqmonitor/live_activity_debug` の薄いラッパ（iOS 実装 / 非 iOS は no-op）
- `DebugLiveActivityContentBuilder`: プリセット・実データ → ContentState `Map`（Widget の Swift `Codable` とキー一致）
- `DebugLiveActivityJsonCodec`: JSON 整形・検証
- `DebugLiveActivityAction`: 検証 → ネイティブ → SnackBar
- `DebugLiveActivityPage`: 種別切替・プリセット・実データ選択・JSON 編集・開始/更新/終了・セッション表示
- `debug_page.dart` に iOS 限定の入口（`MaterialPageRoute` で遷移。go_router_builder 再生成不要）

**iOS（`app/ios/Runner/`）**
- `LiveActivityDebugMethodChannel.swift`: `Activity.request/update/end` を実装
- `AppDelegate.swift` にチャンネル登録を追加
- `Runner.xcodeproj/project.pbxproj` に新規ファイル1件を追加（既存 `AppGroupMethodChannel` と同一パターン）

**テスト / ドキュメント**
- ユニットテスト 17 件（ビルダー / codec / MethodChannel 契約）
- `docs/knowledge/20260815_live_activity_local_debug.md`

## 設計メモ

- コード生成に依存しない構成（プレーンクラス + 手動 `Provider`、`MaterialPageRoute` 遷移）にし、iOS ビルドで FFI/router を再生成する前でも Dart がコンパイル可能。
- ContentState JSON のキー・`IntensityValue` rawValue・ISO8601（JST・小数秒なし）は Widget の Swift `Codable` に一致させています。

## 検証状況

- ✅ `dart analyze`（新規ファイル）: エラーなし
- ✅ `flutter test`（新規テスト）: 17 件パス
- ⚠️ **未検証（macOS 必須・Linux Cloud Agent 環境のため）**:
  - iOS ビルド / Swift コンパイル / `Runner.xcodeproj` へのファイル追加
  - 実機での Live Activity 表示

## macOS でのレビュー観点

- Xcode プロジェクトに `LiveActivityDebugMethodChannel.swift` が正しく Runner ターゲットに追加されているか。
- **ActivityKit の型同一性**: 本 PR は Runner 内に Widget と型名・フィールドを一致させた `EewLiveActivityAttributes` / `ShakeDetectionLiveActivityAttributes` を重複定義しています。通常は型名一致で既存 Widget レイアウトに描画されますが、**もし実機でローカル開始した Activity が描画されない場合**は、Widget の Attributes ソースを Runner ターゲットにも所属させる（共有ソース化）へフォールバックしてください（詳細は knowledge ドキュメント）。

Draft で作成しています。macOS での実機確認後に Ready へ変更する想定です。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0030e-4873-7700-b65d-260b2d9f32e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0030e-4873-7700-b65d-260b2d9f32e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

