### PR TITLE
docs: ホームシート調整の知見・残課題を記録し余白整列テストを追加

### DIFF
--- a/app/test/feature/home/ui/component/sheet/component/home_sheet_card_test.dart
+++ b/app/test/feature/home/ui/component/sheet/component/home_sheet_card_test.dart
@@ -28,17 +28,25 @@ void main() {
     expect(find.text('本文'), findsOneWidget);
   });
 
-  testWidgets('ヘッダーとカード内容の左端の余白が揃う', (tester) async {
+  testWidgets('ヘッダーのタイトルとフッターの文字がカード内容の余白に揃う', (tester) async {
     await tester.pumpWidget(
       _wrap(
-        const HomeSheetCard(children: [HomeSheetCardHeader(title: 'カードタイトル')]),
+        HomeSheetCard(
+          children: [
+            const HomeSheetCardHeader(title: 'カードタイトル'),
+            HomeSheetCardFooter(onPressed: () {}),
+          ],
+        ),
       ),
     );
 
     final spacing = DesignSystemThemeExtension.light().spacing.lg;
     final card = tester.getRect(find.byType(HomeSheetCard));
     final title = tester.getRect(find.text('カードタイトル'));
+    final footerLabel = tester.getRect(find.text('さらに表示'));
     expect(title.left - card.left, spacing);
+    // TextButton は自身の内側余白を持つため、文字の右端が揃うかを見る
+    expect(card.right - footerLabel.right, spacing);
   });
 
   testWidgets('フッターは onPressed が null なら無効化される', (tester) async {

--- a/docs/knowledge/20260815_column_spacing_phantom_gap.md
+++ b/docs/knowledge/20260815_column_spacing_phantom_gap.md
@@ -1,0 +1,52 @@
+---
+globs: app/lib/**/*.dart
+---
+
+# 条件付き表示の Widget を `Column(spacing:)` で並べると余白だけが残る
+
+## 事象
+
+`Column` / `Row` の `spacing` は、子が `SizedBox.shrink()` を返して 0px でも
+子の個数から間隔を計算する（`spacing * (childCount - 1)`）。
+
+そのため「条件を満たさないときは `SizedBox.shrink()` を返す」タイプの Widget を
+`spacing` 付きの `Column` に並べると、**非表示のときも間隔だけが残る**。
+
+ホームシートでは、非表示が既定状態の What's New バナー・デバイス初期設定バナーの
+ぶんだけ、常に余分な余白が入っていた。
+
+```dart
+// ❌ 非表示のバナーのぶんも余白が残る
+Column(
+  spacing: spacing.md,
+  children: [
+    WhatsNewBanner(), // 未更新時は SizedBox.shrink()
+    DeviceProvisioningBanner(), // 正常時は SizedBox.shrink()
+    const HomeFeedSheet(),
+  ],
+)
+```
+
+## 対処方針
+
+- 表示条件を親側で判定できるものは、`if (condition) Banner()` として
+  **children に載せないようにする**（`spacing` はそのまま使える）。
+- 親が判定できない（Widget 内部で provider を見て決める）場合は、
+  **間隔を Widget 自身の下余白として持たせる**。
+  ホームシートのバナーは `AppBanner`（`app/lib/core/component/banner/app_banner.dart`）が
+  `EdgeInsets.only(bottom: spacing.md)` を持つことで統一している。
+- 常に表示されるカード群だけを内側の `Column(spacing:)` にまとめるのは問題ない。
+
+## 確認方法
+
+Widget テストで、間に `SizedBox.shrink()` を挟んだ状態の実効間隔を検証できる。
+
+```dart
+Rect surfaceOf(int index) => tester.getRect(
+  find.descendant(
+    of: find.byType(AppBanner).at(index),
+    matching: find.byType(Material),
+  ),
+);
+expect(surfaceOf(1).top - surfaceOf(0).bottom, spacing.md);
+```

--- a/docs/knowledge/20260815_widget_test_font_loading_and_screenshot.md
+++ b/docs/knowledge/20260815_widget_test_font_loading_and_screenshot.md
@@ -1,0 +1,65 @@
+---
+globs: app/test/**/*.dart
+---
+
+# Widget テストでのフォント読み込みとレイアウト目視確認
+
+## `FontLoader` を `testWidgets` の中で await するとハングする
+
+`testWidgets` のボディは FakeAsync ゾーンで動くため、`File.readAsBytes()` のような
+**実 I/O の Future が完了せず、`FontLoader.load()` の await で永久に止まる**
+（タイムアウトまでテストが返らない）。
+
+```dart
+// ❌ testWidgets の中で実 I/O を await → ハングする
+testWidgets('...', (tester) async {
+  final loader = FontLoader('NotoSansJP')
+    ..addFont(File(path).readAsBytes().then((b) => b.buffer.asByteData()));
+  await loader.load();
+});
+
+// ✅ setUpAll（FakeAsync 外）で読み込む。バイト列は同期読みにしておく
+void main() {
+  setUpAll(() async {
+    final loader = FontLoader('NotoSansJP')
+      ..addFont(
+        Future.value(File(path).readAsBytesSync().buffer.asByteData()),
+      );
+    await loader.load();
+  });
+}
+```
+
+`FontLoader` は `package:flutter/services.dart` にある。このリポジトリの UI は
+`package:material_ui/material_ui.dart` を import しているため、テストでは
+`package:flutter/services.dart` を明示的に import する必要がある。
+
+## レイアウトを画像で確認する（golden をコミットせずに使う）
+
+余白やデザインの調整では、一時的な golden テストで PNG を書き出して目視確認できる。
+
+```bash
+cd app
+mise exec flutter -- flutter test --update-goldens test/tmp_visual_test.dart
+# → test/tmp_visual_test.png が生成される。確認後、テストと PNG は削除する
+```
+
+注意点:
+
+- `flutter test` は `--use-test-fonts --disable-asset-fonts` で動くため、
+  上記のフォント読み込みをしないと日本語は □ になる。
+- MaterialIcons もアセットフォント扱いのため、アイコンは □ のまま描画される。
+  アイコン形状の確認には向かず、余白・整列の確認用途に限る。
+- `MaterialApp(debugShowCheckedModeBanner: false)` にしないと右上に DEBUG リボンが写る。
+- リポジトリに golden 運用は無いので、確認用のテストと PNG は**必ず削除する**。
+
+## `mise exec` はツールを絞って使う
+
+`mise exec -- <cmd>` は `mise.toml` の全ツールを解決しようとし、Linux 環境では
+`swift` のインストールに失敗してコマンド自体が実行できない。Flutter / Dart を使うときは
+ツールを明示する。
+
+```bash
+mise exec flutter -- flutter test
+mise exec flutter -- dart analyze lib
+```

--- a/docs/todo/400_home_sheet_scroll_and_sheet_header.md
+++ b/docs/todo/400_home_sheet_scroll_and_sheet_header.md
@@ -1,0 +1,28 @@
+# ホームシートの残課題（スクロール実装・`SheetHeader` の置き場所）
+
+ホームシートの余白・デザイン調整（`HomeSheetCard` / `AppBanner` の導入）の際に
+残した課題。
+
+## 1. `SingleChildScrollView` のまま残っている
+
+`app/lib/page/home_page.dart` の `_SheetBody` は `SingleChildScrollView` を使っている。
+コーディング規約では `ListView.builder` / `SliverList` を推奨している。
+
+- 現状の子は「EEW カード・バナー数件・カード 3 枚」で件数が少なく、
+  すべて常時レイアウトされても実害が小さいため据え置いた。
+- ただし `sheet` パッケージのドラッグと `BottomBouncingScrollPhysics` の
+  組み合わせに依存しているため、`CustomScrollView` へ置き換える場合は
+  シートの追従・バウンス挙動の回帰確認が必要。
+
+## 2. `SheetHeader` の置き場所
+
+`app/lib/feature/home/ui/component/sheet/sheet_header.dart` の `SheetHeader` は
+home feature 配下にありながら、実際の利用箇所は
+
+- `app/lib/feature/earthquake_history/ui/components/earthquake_intensity_card.dart`
+- `app/lib/feature/kyoshin_monitor/page/components/kyoshin_monitor_maintenance_card.dart`
+
+で、home からは使われていない（home のカード見出しは `HomeSheetCardHeader`）。
+規約どおり feature をまたぐ Widget は `lib/core/component/` へ移すのが望ましい。
+また余白が `EdgeInsets.all(8)` 固定・スタイルが `titleMedium` 固定で、
+デザイントークン（`spacing` / `typography`）に寄せる余地がある。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

[#1647](https://github.com/YumNumm/EQMonitor/pull/1647)（ホームシートの余白・デザイン調整）のマージ後に用意した分の追加。コードの挙動変更はなく、ドキュメントとテストのみ。

## 変更点

### ドキュメント

- `docs/knowledge/20260815_column_spacing_phantom_gap.md`
  `Column(spacing:)` は子が `SizedBox.shrink()` でも間隔を確保するため、条件付き表示の Widget を並べると余白だけが残る。#1647 でホームシートのバナーに実際に起きていた問題と、その回避方針（親で表示判定する / Widget 自身に下余白を持たせる）をまとめた。
- `docs/knowledge/20260815_widget_test_font_loading_and_screenshot.md`
  `testWidgets` の中で `FontLoader` を await するとハングする（FakeAsync 内では実 I/O の Future が完了しない）ため `setUpAll` で読み込む。あわせて、一時的な golden で余白を目視確認する手順と、`mise exec` はツールを絞って呼ぶ必要がある点（Linux では `swift` の解決に失敗する）を記録。
- `docs/todo/400_home_sheet_scroll_and_sheet_header.md`
  ホームシートに残した課題（`SingleChildScrollView` のまま据え置いた理由と置き換え時の注意、home feature 配下にありながら他 feature からのみ使われている `SheetHeader` の置き場所）。

### テスト

- `HomeSheetCardHeader` のタイトル左端と `HomeSheetCardFooter` の文字右端が、どちらもカード内容の余白（`spacing.lg`）に揃うことを検証する assertion を追加。`TextButton` の内側余白のぶんフッターの `Padding` を詰めている前提が崩れないようにするため。

## テスト結果

`flutter test test/feature/home/ui/component/sheet/component test/core/component/banner`: 17 件成功。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00309-28a2-79bb-bfd1-47548d3f4290?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00309-28a2-79bb-bfd1-47548d3f4290&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

