### PR TITLE
fix: iOS のページ遷移アニメーションとスワイプバックを復元する

### DIFF
--- a/app/lib/core/router/material_page_mixin.dart
+++ b/app/lib/core/router/material_page_mixin.dart
@@ -1,0 +1,27 @@
+import 'package:go_router/go_router.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// go_router のルートに `material_ui` の [MaterialPage] を割り当てる mixin。
+///
+/// go_router は Flutter SDK (`package:flutter/material.dart`) の `MaterialApp`
+/// が祖先に存在するかどうかで既定の [Page] を決めている。本アプリの `MaterialApp`
+/// は `material_ui` パッケージの別クラスであるため検出されず、遷移アニメーションも
+/// iOS のスワイプバックも持たない `NoTransitionPage` にフォールバックしてしまう。
+///
+/// そのため [GoRouteData.build] のみを実装するルートには必ずこの mixin を適用し、
+/// [MaterialPage] を明示的に生成する。[Page] に渡すキーやリストア ID・遷移ログ用の
+/// 名前は、go_router 本体が既定のページを組み立てるときと同じ値を与える。
+mixin MaterialPageMixin on GoRouteData {
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) =>
+      MaterialPage<void>(
+        key: state.pageKey,
+        name: state.name ?? state.path,
+        arguments: <String, String>{
+          ...state.pathParameters,
+          ...state.uri.queryParameters,
+        },
+        restorationId: state.pageKey.value,
+        child: Builder(builder: (context) => build(context, state)),
+      );
+}

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -4,6 +4,7 @@ import 'package:eqmonitor/app.dart';
 import 'package:eqmonitor/core/component/error/fatal_error_screen.dart';
 import 'package:eqmonitor/core/provider/environment/environment.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/core/router/material_page_mixin.dart';
 import 'package:eqmonitor/core/theme/model/app_theme.dart';
 import 'package:eqmonitor/feature/beta_testing/data/notifier/beta_testing_notifier.dart';
 import 'package:eqmonitor/feature/beta_testing/ui/page/beta_testing_warning_page.dart';
@@ -163,7 +164,7 @@ class GoRouterRedirectException implements Exception {
 }
 
 @TypedGoRoute<SplashRoute>(path: '/splash')
-class SplashRoute extends GoRouteData with $SplashRoute {
+class SplashRoute extends GoRouteData with $SplashRoute, MaterialPageMixin {
   const SplashRoute();
 
   @override
@@ -171,7 +172,8 @@ class SplashRoute extends GoRouteData with $SplashRoute {
 }
 
 @TypedGoRoute<OnboardingRoute>(path: '/onboarding')
-class OnboardingRoute extends GoRouteData with $OnboardingRoute {
+class OnboardingRoute extends GoRouteData
+    with $OnboardingRoute, MaterialPageMixin {
   const OnboardingRoute();
 
   @override
@@ -180,7 +182,8 @@ class OnboardingRoute extends GoRouteData with $OnboardingRoute {
 }
 
 @TypedGoRoute<OnboardingWebViewRoute>(path: '/onboarding/web-view')
-class OnboardingWebViewRoute extends GoRouteData with $OnboardingWebViewRoute {
+class OnboardingWebViewRoute extends GoRouteData
+    with $OnboardingWebViewRoute, MaterialPageMixin {
   const OnboardingWebViewRoute({required this.title, required this.url});
 
   final String title;
@@ -193,7 +196,7 @@ class OnboardingWebViewRoute extends GoRouteData with $OnboardingWebViewRoute {
 
 @TypedGoRoute<BetaTestingWarningRoute>(path: '/beta-warning')
 class BetaTestingWarningRoute extends GoRouteData
-    with $BetaTestingWarningRoute {
+    with $BetaTestingWarningRoute, MaterialPageMixin {
   const BetaTestingWarningRoute();
 
   @override
@@ -202,7 +205,8 @@ class BetaTestingWarningRoute extends GoRouteData
 }
 
 @TypedGoRoute<EarthquakeHistoryRoute>(path: '/earthquake-history')
-class EarthquakeHistoryRoute extends GoRouteData with $EarthquakeHistoryRoute {
+class EarthquakeHistoryRoute extends GoRouteData
+    with $EarthquakeHistoryRoute, MaterialPageMixin {
   const EarthquakeHistoryRoute({this.$extra});
 
   final EarthquakeHistoryParameter? $extra;
@@ -213,7 +217,8 @@ class EarthquakeHistoryRoute extends GoRouteData with $EarthquakeHistoryRoute {
 }
 
 @TypedGoRoute<EewHistoryRoute>(path: '/eew-history')
-class EewHistoryRoute extends GoRouteData with $EewHistoryRoute {
+class EewHistoryRoute extends GoRouteData
+    with $EewHistoryRoute, MaterialPageMixin {
   const EewHistoryRoute();
 
   @override
@@ -222,7 +227,8 @@ class EewHistoryRoute extends GoRouteData with $EewHistoryRoute {
 }
 
 @TypedGoRoute<SeismicityRoute>(path: '/seismicity')
-class SeismicityRoute extends GoRouteData with $SeismicityRoute {
+class SeismicityRoute extends GoRouteData
+    with $SeismicityRoute, MaterialPageMixin {
   const SeismicityRoute();
 
   @override
@@ -231,7 +237,8 @@ class SeismicityRoute extends GoRouteData with $SeismicityRoute {
 }
 
 @TypedGoRoute<IntensityHistoryRoute>(path: '/intensity-history')
-class IntensityHistoryRoute extends GoRouteData with $IntensityHistoryRoute {
+class IntensityHistoryRoute extends GoRouteData
+    with $IntensityHistoryRoute, MaterialPageMixin {
   const IntensityHistoryRoute({this.prefectureCode, this.cityCode});
 
   final String? prefectureCode;
@@ -249,7 +256,7 @@ class IntensityHistoryRoute extends GoRouteData with $IntensityHistoryRoute {
   path: '/earthquake-history-details/:eventId',
 )
 class EarthquakeHistoryDetailsRoute extends GoRouteData
-    with $EarthquakeHistoryDetailsRoute {
+    with $EarthquakeHistoryDetailsRoute, MaterialPageMixin {
   const EarthquakeHistoryDetailsRoute({required this.eventId});
 
   final String eventId;
@@ -262,7 +269,7 @@ class EarthquakeHistoryDetailsRoute extends GoRouteData
 
 @TypedGoRoute<EarthquakeActivityRoute>(path: '/earthquake-activity')
 class EarthquakeActivityRoute extends GoRouteData
-    with $EarthquakeActivityRoute {
+    with $EarthquakeActivityRoute, MaterialPageMixin {
   const EarthquakeActivityRoute({required this.$extra});
 
   final EarthquakeActivityQuery $extra;
@@ -273,7 +280,8 @@ class EarthquakeActivityRoute extends GoRouteData
 }
 
 @TypedGoRoute<LiveMonitorRoute>(path: '/live-monitor')
-class LiveMonitorRoute extends GoRouteData with $LiveMonitorRoute {
+class LiveMonitorRoute extends GoRouteData
+    with $LiveMonitorRoute, MaterialPageMixin {
   const LiveMonitorRoute();
 
   @override
@@ -283,7 +291,7 @@ class LiveMonitorRoute extends GoRouteData with $LiveMonitorRoute {
 
 @TypedGoRoute<TelegramListByEventIdRoute>(path: '/telegram-list/:eventId')
 class TelegramListByEventIdRoute extends GoRouteData
-    with $TelegramListByEventIdRoute {
+    with $TelegramListByEventIdRoute, MaterialPageMixin {
   const TelegramListByEventIdRoute({required this.eventId});
 
   final String eventId;
@@ -306,12 +314,20 @@ class TelegramListByEventIdRoute extends GoRouteData
 class HomeRoute extends GoRouteData with $HomeRoute {
   const HomeRoute();
 
+  /// `sheet` パッケージのシートと secondary transition を連携させるため、
+  /// [MaterialPageMixin] ではなく [MaterialExtendedPage] を使う。
   @override
   Page<void> buildPage(BuildContext context, GoRouterState state) =>
-      const MaterialExtendedPage<void>(child: HomePage());
+      MaterialExtendedPage<void>(
+        key: state.pageKey,
+        name: state.name ?? state.path,
+        restorationId: state.pageKey.value,
+        child: const HomePage(),
+      );
 }
 
-class HomeMapLayerRoute extends GoRouteData with $HomeMapLayerRoute {
+class HomeMapLayerRoute extends GoRouteData
+    with $HomeMapLayerRoute, MaterialPageMixin {
   const HomeMapLayerRoute();
 
   @override
@@ -320,7 +336,7 @@ class HomeMapLayerRoute extends GoRouteData with $HomeMapLayerRoute {
 }
 
 @TypedGoRoute<TalkerRoute>(path: '/talker')
-class TalkerRoute extends GoRouteData with $TalkerRoute {
+class TalkerRoute extends GoRouteData with $TalkerRoute, MaterialPageMixin {
   const TalkerRoute();
 
   @override
@@ -433,7 +449,7 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
     ),
   ],
 )
-class SettingsRoute extends GoRouteData with $SettingsRoute {
+class SettingsRoute extends GoRouteData with $SettingsRoute, MaterialPageMixin {
   const SettingsRoute();
 
   @override
@@ -441,7 +457,7 @@ class SettingsRoute extends GoRouteData with $SettingsRoute {
       const SettingsPage();
 }
 
-class DisplayRoute extends GoRouteData with $DisplayRoute {
+class DisplayRoute extends GoRouteData with $DisplayRoute, MaterialPageMixin {
   const DisplayRoute();
 
   @override
@@ -449,7 +465,8 @@ class DisplayRoute extends GoRouteData with $DisplayRoute {
       const DisplaySettingsPage();
 }
 
-class ThemeSettingsRoute extends GoRouteData with $ThemeSettingsRoute {
+class ThemeSettingsRoute extends GoRouteData
+    with $ThemeSettingsRoute, MaterialPageMixin {
   const ThemeSettingsRoute();
 
   @override
@@ -457,7 +474,8 @@ class ThemeSettingsRoute extends GoRouteData with $ThemeSettingsRoute {
       const ThemeSettingsPage();
 }
 
-class ThemeEditorRoute extends GoRouteData with $ThemeEditorRoute {
+class ThemeEditorRoute extends GoRouteData
+    with $ThemeEditorRoute, MaterialPageMixin {
   const ThemeEditorRoute({required this.mode});
 
   final String mode;
@@ -473,7 +491,7 @@ class ThemeEditorRoute extends GoRouteData with $ThemeEditorRoute {
 }
 
 class NotificationSettingsRoute extends GoRouteData
-    with $NotificationSettingsRoute {
+    with $NotificationSettingsRoute, MaterialPageMixin {
   const NotificationSettingsRoute();
 
   @override
@@ -482,7 +500,7 @@ class NotificationSettingsRoute extends GoRouteData
 }
 
 class HomeWidgetSettingsRoute extends GoRouteData
-    with $HomeWidgetSettingsRoute {
+    with $HomeWidgetSettingsRoute, MaterialPageMixin {
   const HomeWidgetSettingsRoute();
 
   @override
@@ -491,7 +509,7 @@ class HomeWidgetSettingsRoute extends GoRouteData
 }
 
 class ShakeDetectionSettingsRoute extends GoRouteData
-    with $ShakeDetectionSettingsRoute {
+    with $ShakeDetectionSettingsRoute, MaterialPageMixin {
   const ShakeDetectionSettingsRoute();
 
   @override
@@ -500,7 +518,7 @@ class ShakeDetectionSettingsRoute extends GoRouteData
 }
 
 class NotificationHistoryRoute extends GoRouteData
-    with $NotificationHistoryRoute {
+    with $NotificationHistoryRoute, MaterialPageMixin {
   const NotificationHistoryRoute();
 
   @override
@@ -508,7 +526,7 @@ class NotificationHistoryRoute extends GoRouteData
       const DebugNotificationDeliveryLogPage();
 }
 
-class DebugRoute extends GoRouteData with $DebugRoute {
+class DebugRoute extends GoRouteData with $DebugRoute, MaterialPageMixin {
   const DebugRoute();
 
   @override
@@ -516,7 +534,7 @@ class DebugRoute extends GoRouteData with $DebugRoute {
 }
 
 class HttpApiEndpointSelectorRoute extends GoRouteData
-    with $HttpApiEndpointSelectorRoute {
+    with $HttpApiEndpointSelectorRoute, MaterialPageMixin {
   const HttpApiEndpointSelectorRoute();
 
   @override
@@ -525,7 +543,7 @@ class HttpApiEndpointSelectorRoute extends GoRouteData
 }
 
 class EarthquakeHistoryConfigRoute extends GoRouteData
-    with $EarthquakeHistoryConfigRoute {
+    with $EarthquakeHistoryConfigRoute, MaterialPageMixin {
   const EarthquakeHistoryConfigRoute();
 
   @override
@@ -533,7 +551,8 @@ class EarthquakeHistoryConfigRoute extends GoRouteData
       const EarthquakeHistoryConfigPage();
 }
 
-class TermOfServiceRoute extends GoRouteData with $TermOfServiceRoute {
+class TermOfServiceRoute extends GoRouteData
+    with $TermOfServiceRoute, MaterialPageMixin {
   const TermOfServiceRoute({
     required this.$extra,
     this.showAcceptButton = false,
@@ -547,7 +566,8 @@ class TermOfServiceRoute extends GoRouteData with $TermOfServiceRoute {
       TermOfServicePage(onResult: $extra, showAcceptButton: showAcceptButton);
 }
 
-class PrivacyPolicyRoute extends GoRouteData with $PrivacyPolicyRoute {
+class PrivacyPolicyRoute extends GoRouteData
+    with $PrivacyPolicyRoute, MaterialPageMixin {
   const PrivacyPolicyRoute({
     required this.$extra,
     this.showAcceptButton = false,
@@ -561,7 +581,7 @@ class PrivacyPolicyRoute extends GoRouteData with $PrivacyPolicyRoute {
       PrivacyPolicyPage(onResult: $extra, showAcceptButton: showAcceptButton);
 }
 
-class LicenseRoute extends GoRouteData with $LicenseRoute {
+class LicenseRoute extends GoRouteData with $LicenseRoute, MaterialPageMixin {
   const LicenseRoute();
 
   @override
@@ -569,7 +589,8 @@ class LicenseRoute extends GoRouteData with $LicenseRoute {
       const LicensePage();
 }
 
-class AboutThisAppRoute extends GoRouteData with $AboutThisAppRoute {
+class AboutThisAppRoute extends GoRouteData
+    with $AboutThisAppRoute, MaterialPageMixin {
   const AboutThisAppRoute();
 
   @override
@@ -578,7 +599,7 @@ class AboutThisAppRoute extends GoRouteData with $AboutThisAppRoute {
 }
 
 class EewDetailsByEventIdRoute extends GoRouteData
-    with $EewDetailsByEventIdRoute {
+    with $EewDetailsByEventIdRoute, MaterialPageMixin {
   const EewDetailsByEventIdRoute({required this.eventId});
 
   final String eventId;
@@ -590,7 +611,7 @@ class EewDetailsByEventIdRoute extends GoRouteData
 }
 
 class KyoshinMonitorAboutObservationNetworkRoute extends GoRouteData
-    with $KyoshinMonitorAboutObservationNetworkRoute {
+    with $KyoshinMonitorAboutObservationNetworkRoute, MaterialPageMixin {
   const KyoshinMonitorAboutObservationNetworkRoute();
 
   @override
@@ -599,7 +620,8 @@ class KyoshinMonitorAboutObservationNetworkRoute extends GoRouteData
   }
 }
 
-class DebugEewCardRoute extends GoRouteData with $DebugEewCardRoute {
+class DebugEewCardRoute extends GoRouteData
+    with $DebugEewCardRoute, MaterialPageMixin {
   const DebugEewCardRoute();
 
   @override
@@ -609,7 +631,7 @@ class DebugEewCardRoute extends GoRouteData with $DebugEewCardRoute {
 }
 
 class DebugEarthquakeHistoryCardRoute extends GoRouteData
-    with $DebugEarthquakeHistoryCardRoute {
+    with $DebugEarthquakeHistoryCardRoute, MaterialPageMixin {
   const DebugEarthquakeHistoryCardRoute();
 
   @override
@@ -619,7 +641,7 @@ class DebugEarthquakeHistoryCardRoute extends GoRouteData
 }
 
 class DebugEarthquakeHistoryListTileRoute extends GoRouteData
-    with $DebugEarthquakeHistoryListTileRoute {
+    with $DebugEarthquakeHistoryListTileRoute, MaterialPageMixin {
   const DebugEarthquakeHistoryListTileRoute();
 
   @override
@@ -629,7 +651,7 @@ class DebugEarthquakeHistoryListTileRoute extends GoRouteData
 }
 
 class DebugShakeDetectionCardRoute extends GoRouteData
-    with $DebugShakeDetectionCardRoute {
+    with $DebugShakeDetectionCardRoute, MaterialPageMixin {
   const DebugShakeDetectionCardRoute();
 
   @override
@@ -639,7 +661,7 @@ class DebugShakeDetectionCardRoute extends GoRouteData
 }
 
 class DebugShakeDetectionInsertRoute extends GoRouteData
-    with $DebugShakeDetectionInsertRoute {
+    with $DebugShakeDetectionInsertRoute, MaterialPageMixin {
   const DebugShakeDetectionInsertRoute();
 
   @override
@@ -648,7 +670,8 @@ class DebugShakeDetectionInsertRoute extends GoRouteData
   }
 }
 
-class DebugJmaMapRoute extends GoRouteData with $DebugJmaMapRoute {
+class DebugJmaMapRoute extends GoRouteData
+    with $DebugJmaMapRoute, MaterialPageMixin {
   const DebugJmaMapRoute();
 
   @override
@@ -657,7 +680,8 @@ class DebugJmaMapRoute extends GoRouteData with $DebugJmaMapRoute {
   }
 }
 
-class EqmonitorMapDebugRoute extends GoRouteData with $EqmonitorMapDebugRoute {
+class EqmonitorMapDebugRoute extends GoRouteData
+    with $EqmonitorMapDebugRoute, MaterialPageMixin {
   const EqmonitorMapDebugRoute();
 
   @override
@@ -667,7 +691,7 @@ class EqmonitorMapDebugRoute extends GoRouteData with $EqmonitorMapDebugRoute {
 }
 
 class DebugKyoshinMonitorRoute extends GoRouteData
-    with $DebugKyoshinMonitorRoute {
+    with $DebugKyoshinMonitorRoute, MaterialPageMixin {
   const DebugKyoshinMonitorRoute();
 
   @override
@@ -676,7 +700,8 @@ class DebugKyoshinMonitorRoute extends GoRouteData
   }
 }
 
-class PlaygroundRoute extends GoRouteData with $PlaygroundRoute {
+class PlaygroundRoute extends GoRouteData
+    with $PlaygroundRoute, MaterialPageMixin {
   const PlaygroundRoute();
 
   @override
@@ -685,7 +710,8 @@ class PlaygroundRoute extends GoRouteData with $PlaygroundRoute {
   }
 }
 
-class DebugWebSocketRoute extends GoRouteData with $DebugWebSocketRoute {
+class DebugWebSocketRoute extends GoRouteData
+    with $DebugWebSocketRoute, MaterialPageMixin {
   const DebugWebSocketRoute();
 
   @override
@@ -695,7 +721,7 @@ class DebugWebSocketRoute extends GoRouteData with $DebugWebSocketRoute {
 }
 
 class DebugNotificationDeliveryLogRoute extends GoRouteData
-    with $DebugNotificationDeliveryLogRoute {
+    with $DebugNotificationDeliveryLogRoute, MaterialPageMixin {
   const DebugNotificationDeliveryLogRoute();
 
   @override
@@ -704,7 +730,8 @@ class DebugNotificationDeliveryLogRoute extends GoRouteData
   }
 }
 
-class DebugDeviceAdminRoute extends GoRouteData with $DebugDeviceAdminRoute {
+class DebugDeviceAdminRoute extends GoRouteData
+    with $DebugDeviceAdminRoute, MaterialPageMixin {
   const DebugDeviceAdminRoute();
 
   @override
@@ -714,7 +741,7 @@ class DebugDeviceAdminRoute extends GoRouteData with $DebugDeviceAdminRoute {
 }
 
 class DebugDeviceSettingsRoute extends GoRouteData
-    with $DebugDeviceSettingsRoute {
+    with $DebugDeviceSettingsRoute, MaterialPageMixin {
   const DebugDeviceSettingsRoute();
 
   @override
@@ -723,7 +750,8 @@ class DebugDeviceSettingsRoute extends GoRouteData
   }
 }
 
-class DebugNavigationRoute extends GoRouteData with $DebugNavigationRoute {
+class DebugNavigationRoute extends GoRouteData
+    with $DebugNavigationRoute, MaterialPageMixin {
   const DebugNavigationRoute();
 
   @override
@@ -732,7 +760,8 @@ class DebugNavigationRoute extends GoRouteData with $DebugNavigationRoute {
   }
 }
 
-class DebugAppGroupRoute extends GoRouteData with $DebugAppGroupRoute {
+class DebugAppGroupRoute extends GoRouteData
+    with $DebugAppGroupRoute, MaterialPageMixin {
   const DebugAppGroupRoute();
 
   @override
@@ -741,7 +770,8 @@ class DebugAppGroupRoute extends GoRouteData with $DebugAppGroupRoute {
   }
 }
 
-class AssetPackDebugRoute extends GoRouteData with $AssetPackDebugRoute {
+class AssetPackDebugRoute extends GoRouteData
+    with $AssetPackDebugRoute, MaterialPageMixin {
   const AssetPackDebugRoute();
 
   @override
@@ -751,7 +781,7 @@ class AssetPackDebugRoute extends GoRouteData with $AssetPackDebugRoute {
 }
 
 class DebugSharedPreferencesRoute extends GoRouteData
-    with $DebugSharedPreferencesRoute {
+    with $DebugSharedPreferencesRoute, MaterialPageMixin {
   const DebugSharedPreferencesRoute();
 
   @override
@@ -761,7 +791,7 @@ class DebugSharedPreferencesRoute extends GoRouteData
 }
 
 class DebugSecureStorageRoute extends GoRouteData
-    with $DebugSecureStorageRoute {
+    with $DebugSecureStorageRoute, MaterialPageMixin {
   const DebugSecureStorageRoute();
 
   @override
@@ -770,7 +800,8 @@ class DebugSecureStorageRoute extends GoRouteData
   }
 }
 
-class DebugHttpCacheRoute extends GoRouteData with $DebugHttpCacheRoute {
+class DebugHttpCacheRoute extends GoRouteData
+    with $DebugHttpCacheRoute, MaterialPageMixin {
   const DebugHttpCacheRoute();
 
   @override
@@ -780,7 +811,7 @@ class DebugHttpCacheRoute extends GoRouteData with $DebugHttpCacheRoute {
 }
 
 class DebugIntensityIconRoute extends GoRouteData
-    with $DebugIntensityIconRoute {
+    with $DebugIntensityIconRoute, MaterialPageMixin {
   const DebugIntensityIconRoute();
 
   @override
@@ -789,7 +820,8 @@ class DebugIntensityIconRoute extends GoRouteData
   }
 }
 
-class DebugTelemetryRoute extends GoRouteData with $DebugTelemetryRoute {
+class DebugTelemetryRoute extends GoRouteData
+    with $DebugTelemetryRoute, MaterialPageMixin {
   const DebugTelemetryRoute();
 
   @override
@@ -799,7 +831,7 @@ class DebugTelemetryRoute extends GoRouteData with $DebugTelemetryRoute {
 }
 
 class DebugTsunamiDetailsRoute extends GoRouteData
-    with $DebugTsunamiDetailsRoute {
+    with $DebugTsunamiDetailsRoute, MaterialPageMixin {
   const DebugTsunamiDetailsRoute();
 
   @override
@@ -809,7 +841,7 @@ class DebugTsunamiDetailsRoute extends GoRouteData
 }
 
 class DebugTsunamiTimelineRoute extends GoRouteData
-    with $DebugTsunamiTimelineRoute {
+    with $DebugTsunamiTimelineRoute, MaterialPageMixin {
   const DebugTsunamiTimelineRoute({required this.tsunamiId});
 
   final String tsunamiId;
@@ -820,7 +852,7 @@ class DebugTsunamiTimelineRoute extends GoRouteData
   }
 }
 
-class NiedRoute extends GoRouteData with $NiedRoute {
+class NiedRoute extends GoRouteData with $NiedRoute, MaterialPageMixin {
   const NiedRoute();
 
   @override
@@ -829,7 +861,7 @@ class NiedRoute extends GoRouteData with $NiedRoute {
   }
 }
 
-class AquaRoute extends GoRouteData with $AquaRoute {
+class AquaRoute extends GoRouteData with $AquaRoute, MaterialPageMixin {
   const AquaRoute();
 
   @override
@@ -838,7 +870,8 @@ class AquaRoute extends GoRouteData with $AquaRoute {
   }
 }
 
-class AquaCatalogRoute extends GoRouteData with $AquaCatalogRoute {
+class AquaCatalogRoute extends GoRouteData
+    with $AquaCatalogRoute, MaterialPageMixin {
   const AquaCatalogRoute();
 
   @override
@@ -847,7 +880,7 @@ class AquaCatalogRoute extends GoRouteData with $AquaCatalogRoute {
   }
 }
 
-class FnetRoute extends GoRouteData with $FnetRoute {
+class FnetRoute extends GoRouteData with $FnetRoute, MaterialPageMixin {
   const FnetRoute();
 
   @override
@@ -856,7 +889,8 @@ class FnetRoute extends GoRouteData with $FnetRoute {
   }
 }
 
-class FnetCatalogRoute extends GoRouteData with $FnetCatalogRoute {
+class FnetCatalogRoute extends GoRouteData
+    with $FnetCatalogRoute, MaterialPageMixin {
   const FnetCatalogRoute();
 
   @override
@@ -865,7 +899,8 @@ class FnetCatalogRoute extends GoRouteData with $FnetCatalogRoute {
   }
 }
 
-class KnetWaveformRoute extends GoRouteData with $KnetWaveformRoute {
+class KnetWaveformRoute extends GoRouteData
+    with $KnetWaveformRoute, MaterialPageMixin {
   const KnetWaveformRoute();
 
   @override
@@ -874,7 +909,7 @@ class KnetWaveformRoute extends GoRouteData with $KnetWaveformRoute {
 }
 
 class KnetCredentialsSettingsRoute extends GoRouteData
-    with $KnetCredentialsSettingsRoute {
+    with $KnetCredentialsSettingsRoute, MaterialPageMixin {
   const KnetCredentialsSettingsRoute();
 
   @override
@@ -882,7 +917,8 @@ class KnetCredentialsSettingsRoute extends GoRouteData
       const KnetCredentialsSettingsPage();
 }
 
-class KnetMediaRoute extends GoRouteData with $KnetMediaRoute {
+class KnetMediaRoute extends GoRouteData
+    with $KnetMediaRoute, MaterialPageMixin {
   const KnetMediaRoute({required this.$extra});
 
   /// 地震発生時刻（JST）
@@ -893,7 +929,8 @@ class KnetMediaRoute extends GoRouteData with $KnetMediaRoute {
       KnetMediaPage(eventTime: $extra);
 }
 
-class KnetRecordListRoute extends GoRouteData with $KnetRecordListRoute {
+class KnetRecordListRoute extends GoRouteData
+    with $KnetRecordListRoute, MaterialPageMixin {
   const KnetRecordListRoute({required this.$extra});
 
   /// 地震発生時刻（JST）
@@ -905,7 +942,7 @@ class KnetRecordListRoute extends GoRouteData with $KnetRecordListRoute {
 }
 
 class KnetStationWaveformRoute extends GoRouteData
-    with $KnetStationWaveformRoute {
+    with $KnetStationWaveformRoute, MaterialPageMixin {
   const KnetStationWaveformRoute({required this.$extra});
 
   final KnetStationResult $extra;
@@ -915,7 +952,8 @@ class KnetStationWaveformRoute extends GoRouteData
       KnetStationWaveformPage(result: $extra);
 }
 
-class HinetSeismicityRoute extends GoRouteData with $HinetSeismicityRoute {
+class HinetSeismicityRoute extends GoRouteData
+    with $HinetSeismicityRoute, MaterialPageMixin {
   const HinetSeismicityRoute();
 
   @override
@@ -925,7 +963,7 @@ class HinetSeismicityRoute extends GoRouteData with $HinetSeismicityRoute {
 }
 
 class KyoshinMonitorAboutRoute extends GoRouteData
-    with $KyoshinMonitorAboutRoute {
+    with $KyoshinMonitorAboutRoute, MaterialPageMixin {
   const KyoshinMonitorAboutRoute();
 
   @override
@@ -934,7 +972,8 @@ class KyoshinMonitorAboutRoute extends GoRouteData
   }
 }
 
-class ChangelogRoute extends GoRouteData with $ChangelogRoute {
+class ChangelogRoute extends GoRouteData
+    with $ChangelogRoute, MaterialPageMixin {
   const ChangelogRoute();
 
   @override
@@ -943,7 +982,7 @@ class ChangelogRoute extends GoRouteData with $ChangelogRoute {
 }
 
 @TypedGoRoute<FeedRoute>(path: '/feed')
-class FeedRoute extends GoRouteData with $FeedRoute {
+class FeedRoute extends GoRouteData with $FeedRoute, MaterialPageMixin {
   const FeedRoute();
 
   @override
@@ -951,7 +990,8 @@ class FeedRoute extends GoRouteData with $FeedRoute {
 }
 
 @TypedGoRoute<FeedDetailsRoute>(path: '/feed/source/:telegramHash')
-class FeedDetailsRoute extends GoRouteData with $FeedDetailsRoute {
+class FeedDetailsRoute extends GoRouteData
+    with $FeedDetailsRoute, MaterialPageMixin {
   const FeedDetailsRoute({required this.telegramHash});
 
   final String telegramHash;
@@ -962,7 +1002,8 @@ class FeedDetailsRoute extends GoRouteData with $FeedDetailsRoute {
 }
 
 @TypedGoRoute<FeedItemDetailsRoute>(path: '/feed/detail/:id')
-class FeedItemDetailsRoute extends GoRouteData with $FeedItemDetailsRoute {
+class FeedItemDetailsRoute extends GoRouteData
+    with $FeedItemDetailsRoute, MaterialPageMixin {
   const FeedItemDetailsRoute({required this.id, this.$extra});
 
   final String id;
@@ -974,7 +1015,8 @@ class FeedItemDetailsRoute extends GoRouteData with $FeedItemDetailsRoute {
 }
 
 @TypedGoRoute<TsunamiDetailsRoute>(path: '/tsunami/:tsunamiId')
-class TsunamiDetailsRoute extends GoRouteData with $TsunamiDetailsRoute {
+class TsunamiDetailsRoute extends GoRouteData
+    with $TsunamiDetailsRoute, MaterialPageMixin {
   const TsunamiDetailsRoute({required this.tsunamiId});
 
   final String tsunamiId;
@@ -986,7 +1028,7 @@ class TsunamiDetailsRoute extends GoRouteData with $TsunamiDetailsRoute {
 }
 
 @TypedGoRoute<PaywallRoute>(path: '/subscription/paywall')
-class PaywallRoute extends GoRouteData with $PaywallRoute {
+class PaywallRoute extends GoRouteData with $PaywallRoute, MaterialPageMixin {
   const PaywallRoute();
 
   @override
@@ -996,7 +1038,7 @@ class PaywallRoute extends GoRouteData with $PaywallRoute {
 
 @TypedGoRoute<SubscriptionSettingsRoute>(path: '/subscription/settings')
 class SubscriptionSettingsRoute extends GoRouteData
-    with $SubscriptionSettingsRoute {
+    with $SubscriptionSettingsRoute, MaterialPageMixin {
   const SubscriptionSettingsRoute();
 
   @override

--- a/app/test/core/router/material_page_mixin_test.dart
+++ b/app/test/core/router/material_page_mixin_test.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:cupertino_ui/cupertino_ui.dart' show CupertinoPageTransition;
 import 'package:eqmonitor/core/router/material_page_mixin.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:material_ui/material_ui.dart';

--- a/app/test/core/router/material_page_mixin_test.dart
+++ b/app/test/core/router/material_page_mixin_test.dart
@@ -1,0 +1,147 @@
+import 'dart:io';
+
+import 'package:cupertino_ui/cupertino_ui.dart' show CupertinoPageTransition;
+import 'package:eqmonitor/core/router/material_page_mixin.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:material_ui/material_ui.dart';
+
+class _PlainRoute extends GoRouteData {
+  const _PlainRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const Scaffold(body: Text('detail'));
+}
+
+class _MaterialPageRoute extends GoRouteData with MaterialPageMixin {
+  const _MaterialPageRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const Scaffold(body: Text('detail'));
+}
+
+/// go_router_builder が生成する `GoRouteData.$route` と同じ形で
+/// `builder` / `pageBuilder` の双方を [GoRouteData] に委譲する。
+List<RouteBase> _routes(GoRouteData detail) => [
+  GoRoute(
+    path: '/',
+    builder: (_, _) => const Scaffold(body: Text('home')),
+  ),
+  GoRoute(
+    path: '/detail',
+    builder: detail.build,
+    pageBuilder: detail.buildPage,
+  ),
+];
+
+Future<ModalRoute<void>?> _pushDetail(
+  WidgetTester tester,
+  GoRouteData detail,
+) async {
+  final router = GoRouter(initialLocation: '/', routes: _routes(detail));
+  addTearDown(router.dispose);
+  await tester.pumpWidget(
+    MaterialApp.router(
+      theme: ThemeData(platform: TargetPlatform.iOS),
+      routerConfig: router,
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  router.push<void>('/detail').ignore();
+  await tester.pumpAndSettle();
+
+  return ModalRoute.of(tester.element(find.text('detail')));
+}
+
+void main() {
+  group('MaterialPageMixin', () {
+    testWidgets('mixin なしでは遷移アニメーションを持たないページになる', (tester) async {
+      // go_router は Flutter SDK の `MaterialApp` を祖先から探して既定の Page を
+      // 決めるため、`material_ui` の `MaterialApp` では検出できず
+      // `NoTransitionPage` にフォールバックする。この mixin が必要な理由。
+      final route = await _pushDetail(tester, const _PlainRoute());
+
+      expect(route?.transitionDuration, Duration.zero);
+      expect(find.byType(CupertinoPageTransition), findsNothing);
+    });
+
+    testWidgets('mixin ありでは iOS の遷移アニメーションを持つ', (tester) async {
+      final route = await _pushDetail(tester, const _MaterialPageRoute());
+
+      expect(route?.settings, isA<MaterialPage<void>>());
+      expect(route?.transitionDuration, greaterThan(Duration.zero));
+      expect(find.byType(CupertinoPageTransition), findsWidgets);
+    });
+
+    testWidgets('mixin ありでは左端スワイプで前の画面に戻れる', (tester) async {
+      await _pushDetail(tester, const _MaterialPageRoute());
+
+      await tester.dragFrom(const Offset(2, 300), const Offset(600, 0));
+      await tester.pumpAndSettle();
+
+      expect(find.text('detail'), findsNothing);
+      expect(find.text('home'), findsOneWidget);
+    });
+
+    testWidgets('mixin なしでは左端スワイプでは戻れない', (tester) async {
+      await _pushDetail(tester, const _PlainRoute());
+
+      await tester.dragFrom(const Offset(2, 300), const Offset(600, 0));
+      await tester.pumpAndSettle();
+
+      expect(find.text('detail'), findsOneWidget);
+    });
+
+    testWidgets('遷移ログ・状態復元に使うページ情報を引き継ぐ', (tester) async {
+      final route = await _pushDetail(tester, const _MaterialPageRoute());
+
+      // `_NavigatorObserver` / Firebase Analytics が画面名として参照する。
+      expect(route?.settings.name, '/detail');
+      expect(
+        route?.settings,
+        isA<MaterialPage<void>>().having(
+          (page) => page.restorationId,
+          'restorationId',
+          isNotNull,
+        ),
+      );
+    });
+  });
+
+  // go_router の Page 生成はルートごとの opt-in であり、mixin を付け忘れても
+  // コンパイルエラーにならず遷移アニメーションだけが静かに失われる。
+  // ルート定義の追加時に取りこぼしを検知するため、宣言を静的に検査する。
+  test('router.dart の全ルートが Page の生成方法を明示している', () {
+    /// 独自に [Page] を組み立てるため [MaterialPageMixin] を適用しないルート。
+    const routesWithOwnPage = {'HomeRoute'};
+
+    final source = File('lib/core/router/router.dart').readAsStringSync();
+    final declarations = RegExp(
+      r'class (\w+) extends GoRouteData\s+with ([^{]+)\{',
+    ).allMatches(source).toList();
+
+    // 正規表現の取りこぼしがないことを確認する。
+    expect(
+      declarations.length,
+      RegExp('extends GoRouteData').allMatches(source).length,
+    );
+
+    for (final declaration in declarations) {
+      final name = declaration.group(1);
+      if (routesWithOwnPage.contains(name)) {
+        continue;
+      }
+      expect(
+        declaration.group(2),
+        contains('MaterialPageMixin'),
+        reason:
+            '$name に MaterialPageMixin が適用されていません。'
+            'go_router の既定では遷移アニメーションと iOS のスワイプバックが失われます。',
+      );
+    }
+  });
+}

--- a/docs/knowledge/20260815_go_router_material_ui_page_transition.md
+++ b/docs/knowledge/20260815_go_router_material_ui_page_transition.md
@@ -1,0 +1,69 @@
+# go_router は material_ui の MaterialApp を検出できない（遷移アニメーション消失）
+
+## 事象
+
+iOS で go_router のページ遷移アニメーションが一切再生されず、左端からのスワイプバック
+（back gesture）も効かない。Android でも遷移アニメーションがない。
+
+`Navigator.push(MaterialPageRoute(...))` を直接呼んでいる画面（通知設定の子画面や
+地図ピッカーなど）だけは正常にアニメーションする、という切り分けになる。
+
+## 原因
+
+go_router は `GoRouteData.build()`（= `GoRoute.builder`）だけを実装したルートに対して、
+**祖先ウィジェットの型を見て** 既定の `Page` 実装を決めている。
+
+```dart
+// go_router/lib/src/pages/material.dart
+bool isMaterialApp(BuildContext context) =>
+    context.findAncestorWidgetOfExactType<MaterialApp>() != null;
+```
+
+ここで参照される `MaterialApp` は `package:flutter/material.dart`（Flutter SDK 本体）の
+クラスである。本アプリは `package:material_ui/material_ui.dart` へ移行済みで、
+`material_ui` は SDK とは**別の `MaterialApp` クラス**を定義している
+（`docs/todo/800_material_ui_migration_residuals.md` 参照）。
+
+そのため `findAncestorWidgetOfExactType<MaterialApp>()` は必ず null になり、
+go_router は「`WidgetsApp` 構成」と判定して全ルートを `NoTransitionPage` で包む。
+`NoTransitionPage` は `transitionDuration` が `Duration.zero` で、
+iOS のスワイプバックを提供する `CupertinoPageTransition` も挿入されない。
+
+go_router 17.5.0（現時点の最新）に material_ui 対応はない。
+
+## 対処
+
+`app/lib/core/router/material_page_mixin.dart` の `MaterialPageMixin` を全ルートへ適用し、
+`material_ui` の `MaterialPage` を明示的に生成する。
+
+```dart
+class SplashRoute extends GoRouteData with $SplashRoute, MaterialPageMixin {
+  const SplashRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) => const SplashPage();
+}
+```
+
+`buildPage()` を自前で実装するルート（`HomeRoute` は `sheet` パッケージ連携のため
+`MaterialExtendedPage` を使う）は mixin の対象外。その場合も
+`key` / `name` / `restorationId` を `GoRouterState` から渡すこと。渡さないと
+Navigator のページ同一性判定・状態復元・`FirebaseAnalytics` の画面名が壊れる。
+
+## 注意点
+
+- **ルート追加時に mixin を付け忘れてもコンパイルエラーにならず、遷移アニメーションだけが
+  静かに失われる。** `app/test/core/router/material_page_mixin_test.dart` が
+  `router.dart` の宣言を静的に検査して取りこぼしを検知する。
+- 同じ検出ロジックは go_router の `HeroController` 選択（`createMaterialHeroController`）と
+  既定エラー画面にも使われている。前者は残課題として
+  `docs/todo/800_material_ui_migration_residuals.md` に記載済み。
+- 外部パッケージが `package:flutter/material.dart` の型で分岐している箇所は同種の
+  不具合を起こす。`Theme.of` / `findAncestorWidgetOfExactType` を使うパッケージは疑う。
+
+## 再現・検証コマンド
+
+```bash
+cd app
+mise exec --no-deps flutter -- flutter test test/core/router/material_page_mixin_test.dart
+```

--- a/docs/todo/400_ios_swipe_back_blocked_by_pop_scope.md
+++ b/docs/todo/400_ios_swipe_back_blocked_by_pop_scope.md
@@ -1,0 +1,31 @@
+# PopScope で戻る操作を再割り当てしている画面は iOS のスワイプバックが効かない
+
+## 背景
+
+go_router のページ遷移を `MaterialPage` へ修正し、iOS の左端スワイプバックが
+機能するようになった（`docs/knowledge/20260815_go_router_material_ui_page_transition.md`）。
+
+一方で Flutter の `ModalRoute.popGestureEnabled` は
+`popDisposition == RoutePopDisposition.doNotPop` のときスワイプジェスチャを無効化する。
+`PopScope(canPop: false)` で戻る操作を別の用途へ割り当てている画面では、
+**ジェスチャ自体が開始されず `onPopInvokedWithResult` も呼ばれない**。
+Android のシステムバックでは意図どおり動くが、iOS ではユーザーには
+「スワイプしても何も起きない」画面として見える。
+
+## 該当箇所
+
+- `app/lib/feature/earthquake_history/ui/earthquake_history_page.dart`
+  - `canPop: isDefaultSort` — 並び替え中はスワイプバック不可
+- `app/lib/feature/intensity_history/ui/intensity_history_page.dart`
+  - `canPop: !isFocused` — 市区町村フォーカス中はスワイプバック不可
+- `app/lib/feature/live_monitor/ui/page/live_monitor_page.dart`
+  - `canPop: allowExit.value` — 終了確認を通す前はスワイプバック不可（意図通りの可能性あり）
+
+## 検討事項
+
+- 「戻る操作でフィルタ／フォーカスを解除する」挙動は Android のシステムバック向けの設計。
+  iOS では画面内の明示的な UI（クリアボタン等）で代替し、`canPop` を true に保つほうが
+  プラットフォームの期待に沿う。
+- LiveMonitor の終了確認は誤操作防止が目的なので、現状維持が妥当か UX として要判断。
+- 現状は「以前はスワイプバックが全画面で効かなかった」ため機能後退ではないが、
+  画面によって効く・効かないが混在するのは分かりにくい。

--- a/docs/todo/800_material_ui_migration_residuals.md
+++ b/docs/todo/800_material_ui_migration_residuals.md
@@ -31,7 +31,26 @@ material_ui の `TabBar` / `TabBarView` に渡せない。
 他に material 型を返すフック（`useTabController` 以外）を使い始める場合は
 同じ問題が起きる。
 
-## 3. Localizations delegate の重複
+## 3. go_router の app 種別判定が material_ui を検出できない
+
+go_router は `findAncestorWidgetOfExactType<MaterialApp>()`（Flutter 本体の型）で
+app 種別を判定するため、material_ui の `MaterialApp` 配下では常に
+「`WidgetsApp` 構成」と判定される。
+
+- 対応済み: 既定 `Page` が `NoTransitionPage` になり遷移アニメーションと iOS の
+  スワイプバックが失われる問題。全ルートに `MaterialPageMixin` を適用して解消した
+  （`docs/knowledge/20260815_go_router_material_ui_page_transition.md`）。
+- 未対応: `HeroController` が `createMaterialHeroController()` ではなく素の
+  `HeroController()` になるため、Hero 飛行の軌跡が `MaterialRectArcTween` の
+  弧ではなく直線になる。影響箇所は `onboarding_hero.dart` / `welcome_step_page.dart` /
+  `complete_step_page.dart` / `paywall_page.dart`。
+  go_router は `HeroController` の差し替え口を公開していないため、
+  material_ui 対応が go_router 本体に入るのを待つか、
+  `MaterialApp.router` の `builder` で `HeroControllerScope` を挟めないか検討する。
+- 未対応（影響なし）: 既定エラー画面が go_router の素の `ErrorScreen` になる。
+  `goRouterProvider` が `errorBuilder` を渡しているため実際には使われない。
+
+## 4. Localizations delegate の重複
 
 `flutter_localizations` と `material_ui` / `cupertino_ui` が
 同名の `GlobalMaterialLocalizations` / `GlobalCupertinoLocalizations` を公開する。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 事象

iOS でページ遷移アニメーションが再生されず、左端からのスワイプバックも効かない。

## 原因

go_router は `GoRouteData.build()` だけを実装したルートについて、**祖先ウィジェットの型**を見て既定の `Page` を決めている。

```dart
// go_router/lib/src/pages/material.dart
bool isMaterialApp(BuildContext context) =>
    context.findAncestorWidgetOfExactType<MaterialApp>() != null;
```

ここで参照される `MaterialApp` は `package:flutter/material.dart`（Flutter SDK 本体）のクラス。本アプリは `package:material_ui/material_ui.dart` へ移行済みで、`material_ui` は SDK とは**別の `MaterialApp` クラス**を定義しているため、この判定は必ず false になる（SDK 側の `lib/src/material/app.dart` にも独立した `MaterialApp` が残っている）。

結果として go_router は「`WidgetsApp` 構成」と判定し、`HomeRoute` を除く全ルートを `NoTransitionPage` で包んでいた。`NoTransitionPage` は `transitionDuration` が `Duration.zero` で、iOS のスワイプバックを提供する `CupertinoPageTransition` も挿入されない。`Navigator.push(MaterialPageRoute(...))` を直接呼ぶ画面（通知設定の子画面・地図ピッカーなど）だけが正常に動いていたのはこのため。

go_router 17.5.0（現時点の最新）に material_ui 対応はない。

## 変更内容

- `MaterialPageMixin` を追加し、`material_ui` の `MaterialPage` を明示的に生成するようにした。`key` / `name` / `arguments` / `restorationId` は go_router 本体が既定ページを組み立てるときと同じ値を渡している。
- `router.dart` の全ルート（74 クラス）に mixin を適用した。
- `HomeRoute` は `sheet` パッケージ連携のため `MaterialExtendedPage` を維持。ただしこれまで `key` / `name` / `restorationId` を渡しておらず、ページ同一性判定・状態復元・`FirebaseAnalytics` の画面名（`route.settings.name` が null）が壊れていたので併せて修正した。

## テスト

`app/test/core/router/material_page_mixin_test.dart`

- mixin なしのルートが `Duration.zero` かつ `CupertinoPageTransition` なし・スワイプで戻れないこと（= 今回の原因そのもの）
- mixin ありのルートが `MaterialPage` になり、遷移時間を持ち、`CupertinoPageTransition` が挿入され、左端スワイプで実際に pop されること
- ページ名・`restorationId` が引き継がれること

加えて、**mixin の付け忘れはコンパイルエラーにならず遷移アニメーションだけが静かに失われる**ため、`router.dart` のルート宣言を静的に検査して取りこぼしを検知するテストを入れている（`HomeRoute` のみ許可リスト）。

## 確認結果

```
cd app
dart analyze                # No issues found!
dart format --set-exit-if-changed lib/core/router test/core/router  # 差分なし
flutter test                # 1656 passed / 6 failed
```

失敗 6 件は `docs/todo/770_existing_eqmonitor_flutter_test_failures.md` に記録済みの既存不良（`live_monitor_detected_event_notifier_test.dart` 2 件、`theme_editor_page_test.dart` 3 件、`override_edit_page_test.dart` 1 件）と完全一致で、新規の回帰はない。

実機 iOS での動作確認は未実施（この環境ではビルドできないため）。

## ドキュメント

- `docs/knowledge/20260815_go_router_material_ui_page_transition.md` — 原因と対処、ルート追加時の注意
- `docs/todo/800_material_ui_migration_residuals.md` — 同じ判定ロジックに起因する残課題として、`HeroController` が `createMaterialHeroController()` にならず Hero 飛行が直線になる点を追記
- `docs/todo/400_ios_swipe_back_blocked_by_pop_scope.md` — スワイプバックが機能するようになったことで、`PopScope(canPop: false)` で戻る操作を再割り当てしている 3 画面では iOS のスワイプが無効になる点を要検討事項として記録

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00322-33e3-7696-b783-0170a4aada8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00322-33e3-7696-b783-0170a4aada8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

