### PR TITLE
feat: 火山噴火・遠地地震の震源カード表現を種別に合わせる

### DIFF
--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart
@@ -9,6 +9,7 @@ import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_histo
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_type.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/provider/region_name_resolver.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_type_icon.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/magnitude_text.dart';
 import 'package:extensions/extensions.dart';
 import 'package:material_ui/material_ui.dart';
@@ -89,11 +90,8 @@ class EarthquakeHistoryListTile extends StatelessWidget {
         ? intensityColors.fromJmaIntensity(maxIntensity).background
         : null;
 
-    final tileBaseColor = switch (earthquake.earthquakeType) {
-      EarthquakeType.distant => _distantColor,
-      EarthquakeType.volcano => _volcanoColor,
-      EarthquakeType.normal => maxIntensityColor,
-    };
+    final tileBaseColor =
+        earthquake.earthquakeType.baseColor ?? maxIntensityColor;
 
     final magnitude = hypocenter?.magnitude;
 
@@ -169,15 +167,9 @@ class EarthquakeHistoryListTile extends StatelessWidget {
         ],
       ),
       leading: switch (earthquake.earthquakeType) {
-        EarthquakeType.distant => _ForeignEarthquakeIcon(
+        EarthquakeType.distant || EarthquakeType.volcano => EarthquakeTypeIcon(
+          type: earthquake.earthquakeType,
           size: intensityIconSize,
-          color: _distantColor,
-          icon: Icons.public,
-        ),
-        EarthquakeType.volcano => _ForeignEarthquakeIcon(
-          size: intensityIconSize,
-          color: _volcanoColor,
-          icon: Icons.volcano,
         ),
         EarthquakeType.normal when maxIntensity != null => JmaIntensityIcon(
           intensity: maxIntensity,
@@ -221,44 +213,6 @@ class _AreaIntensityChip extends StatelessWidget {
           color: entry.resolvedForeground,
           fontWeight: FontWeight.bold,
           fontSize: 12,
-        ),
-      ),
-    );
-  }
-}
-
-/// 遠地地震 (海外地震情報) のベースカラー(青)。
-const _distantColor = Color(0xFF1976D2);
-
-/// 火山噴火 (海外の大規模な噴火) のベースカラー(赤)。
-const _volcanoColor = Color(0xFFD32F2F);
-
-/// 海外地震情報・火山噴火用のアイコン。
-/// 震度アイコン([JmaIntensityIcon]の`.filled`)と同じ角丸矩形の見た目に揃え、
-/// ベースカラーの中にアイコンを白で表示する。
-class _ForeignEarthquakeIcon extends StatelessWidget {
-  const _ForeignEarthquakeIcon({
-    required this.size,
-    required this.color,
-    required this.icon,
-  });
-
-  final double size;
-  final Color color;
-  final IconData icon;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      height: size,
-      width: size,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: color,
-          borderRadius: BorderRadius.circular(size / 5),
-        ),
-        child: Center(
-          child: Icon(icon, color: Colors.white, size: size * 0.7),
         ),
       ),
     );

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_summary_header.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_summary_header.dart
@@ -7,8 +7,10 @@ import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart'
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_depth.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_hypocenter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_magnitude.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_type.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/depth_text.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_info_text_style.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_type_icon.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/magnitude_text.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:intl/intl.dart';
@@ -26,20 +28,32 @@ class EarthquakeSummaryHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final maxIntensity = item.intensity?.maxIntensity;
+    final earthquakeType = item.earthquakeType ?? EarthquakeType.normal;
     final colorTheme = context.designSystem.colorTheme;
+
+    // 火山噴火は震度が観測されないため常に種別アイコンを表示する。
+    // 遠地地震は国内で震度を観測した場合のみ最大震度を表示する。
+    final leading = switch ((earthquakeType, maxIntensity)) {
+      (EarthquakeType.volcano, _) || (EarthquakeType.distant, null) =>
+        EarthquakeTypeIcon(type: earthquakeType, size: _leadingIconSize),
+      (_, final JmaIntensity intensity) => _MaxIntensityWidget(
+        intensity: intensity,
+      ),
+      _ => null,
+    };
 
     return Stack(
       alignment: Alignment.center,
       children: [
         Row(
           children: [
-            if (maxIntensity != null)
-              _MaxIntensityWidget(intensity: maxIntensity),
+            if (leading != null) leading,
             const SizedBox(width: 4),
             Expanded(
               child: _EarthquakeInformationBody(
                 item: item,
                 hypocenter: item.hypocenter,
+                earthquakeType: earthquakeType,
                 hasIntensityDetails:
                     item.intensity?.intensityTree.isNotEmpty ?? false,
               ),
@@ -70,6 +84,9 @@ class EarthquakeSummaryHeader extends StatelessWidget {
   }
 }
 
+/// 最大震度アイコン・地震種別アイコンの表示サイズ。
+const _leadingIconSize = 60.0;
+
 class _MaxIntensityWidget extends StatelessWidget {
   const _MaxIntensityWidget({required this.intensity});
 
@@ -82,7 +99,11 @@ class _MaxIntensityWidget extends StatelessWidget {
       children: [
         const Text('最大震度', style: TextStyle(fontWeight: FontWeight.bold)),
         const SizedBox(height: 4),
-        JmaIntensityIcon(type: .filled, size: 60, intensity: intensity),
+        JmaIntensityIcon(
+          type: .filled,
+          size: _leadingIconSize,
+          intensity: intensity,
+        ),
       ],
     );
   }
@@ -92,11 +113,13 @@ class _EarthquakeInformationBody extends StatelessWidget {
   const _EarthquakeInformationBody({
     required this.item,
     required this.hypocenter,
+    required this.earthquakeType,
     required this.hasIntensityDetails,
   });
 
   final Earthquake item;
   final EarthquakeHypocenter? hypocenter;
+  final EarthquakeType earthquakeType;
   final bool hasIntensityDetails;
 
   @override
@@ -110,6 +133,11 @@ class _EarthquakeInformationBody extends StatelessWidget {
     final isDepthUnknown = depth == null || depth is EarthquakeDepthUnknown;
     final isMagnitudeAndDepthUnknown = isMagnitudeUnknown && isDepthUnknown;
     final isEarthquakeNull = isMagnitudeAndDepthUnknown && hypocenter == null;
+    // 遠地地震・火山噴火は震源要素の一部が発表されないため、
+    // 「調査中」ではなく判明している要素だけを表示する。
+    final isOverseasEvent =
+        earthquakeType == EarthquakeType.distant ||
+        earthquakeType == EarthquakeType.volcano;
     final dateFormat = DateFormat('yyyy/MM/dd HH:mm頃');
     final timeText = switch ((item.originTime, item.arrivalTime)) {
       (final DateTime originTime, _) =>
@@ -118,6 +146,15 @@ class _EarthquakeInformationBody extends StatelessWidget {
         '検知時刻: ${dateFormat.format(arrivalTime.toLocal())}',
       _ => null,
     };
+    final hypocenterWidget = _HypocenterWidget(
+      // 火山噴火は地震ではないため「震源地」とは表現しない。
+      label: switch (earthquakeType) {
+        EarthquakeType.volcano => '発生場所',
+        EarthquakeType.distant || EarthquakeType.normal => '震源地',
+      },
+      epicenterName: epicenterName,
+      epicenterDetailName: epicenterDetailName,
+    );
 
     return Wrap(
       spacing: 8,
@@ -125,27 +162,26 @@ class _EarthquakeInformationBody extends StatelessWidget {
       alignment: WrapAlignment.center,
       children: [
         const Row(),
-        if (isEarthquakeNull)
+        if (isOverseasEvent) ...[
+          if (!isMagnitudeUnknown)
+            MagnitudeText(magnitude: magnitude, variant: .display)
+          else if (earthquakeType == EarthquakeType.volcano)
+            const _VolcanoEruptionWidget(),
+          if (!isDepthUnknown) DepthText(depth: depth),
+          const SizedBox(width: double.infinity),
+          hypocenterWidget,
+        ] else if (isEarthquakeNull)
           _EarthquakeNullWidget(hasIntensityDetails: hasIntensityDetails)
         else if (isMagnitudeAndDepthUnknown) ...[
           _MagnitudeDepthUnknownWidget(
             hasIntensityDetails: hasIntensityDetails,
           ),
-          _HypocenterWidget(
-            epicenterName: epicenterName,
-            epicenterDetailName: epicenterDetailName,
-          ),
+          hypocenterWidget,
         ] else ...[
-          MagnitudeText(
-            magnitude: hypocenter?.magnitude,
-            variant: MagnitudeTextVariant.display,
-          ),
-          DepthText(depth: hypocenter?.depth),
+          MagnitudeText(magnitude: magnitude, variant: .display),
+          DepthText(depth: depth),
           const SizedBox(width: double.infinity),
-          _HypocenterWidget(
-            epicenterName: epicenterName,
-            epicenterDetailName: epicenterDetailName,
-          ),
+          hypocenterWidget,
         ],
         const Row(),
         if (timeText != null) Wrap(children: [Text(timeText)]),
@@ -156,10 +192,12 @@ class _EarthquakeInformationBody extends StatelessWidget {
 
 class _HypocenterWidget extends StatelessWidget {
   const _HypocenterWidget({
+    required this.label,
     required this.epicenterName,
     required this.epicenterDetailName,
   });
 
+  final String label;
   final String? epicenterName;
   final String? epicenterDetailName;
 
@@ -175,7 +213,7 @@ class _HypocenterWidget extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.baseline,
       children: [
-        Text('震源地', style: textTheme.labelStyle(bodySmall)),
+        Text(label, style: textTheme.labelStyle(bodySmall)),
         const SizedBox(width: 4),
         Flexible(
           child: Text.rich(
@@ -198,6 +236,19 @@ class _HypocenterWidget extends StatelessWidget {
         ),
       ],
     );
+  }
+}
+
+/// 火山噴火でマグニチュードが発表されない場合に、
+/// 「M不明」の代わりに事象そのものを示す表示。
+class _VolcanoEruptionWidget extends StatelessWidget {
+  const _VolcanoEruptionWidget();
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Text('火山の噴火', style: textTheme.valueStyle(textTheme.headlineMedium));
   }
 }
 

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_type_icon.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_type_icon.dart
@@ -1,0 +1,57 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_type.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// 遠地地震 (海外地震情報) のベースカラー(青)。
+const earthquakeDistantColor = Color(0xFF1976D2);
+
+/// 火山噴火 (海外の大規模な噴火) のベースカラー(赤)。
+const earthquakeVolcanoColor = Color(0xFFD32F2F);
+
+extension EarthquakeTypeAppearance on EarthquakeType {
+  /// 地震種別を表すベースカラー。
+  /// 通常の地震は最大震度の色を用いるため `null`。
+  Color? get baseColor => switch (this) {
+    .normal => null,
+    .distant => earthquakeDistantColor,
+    .volcano => earthquakeVolcanoColor,
+  };
+
+  /// 地震種別を表すアイコン。
+  /// 通常の地震は震度アイコンを用いるため `null`。
+  IconData? get iconData => switch (this) {
+    .normal => null,
+    .distant => Icons.public,
+    .volcano => Icons.volcano,
+  };
+}
+
+/// 海外地震情報・火山噴火用のアイコン。
+///
+/// 震度アイコン(`JmaIntensityIcon`の`.filled`)と同じ角丸矩形の見た目に揃え、
+/// ベースカラーの中にアイコンを白で表示する。
+/// [EarthquakeType.normal] は専用アイコンを持たないため何も表示しない。
+class EarthquakeTypeIcon extends StatelessWidget {
+  const EarthquakeTypeIcon({required this.type, required this.size, super.key});
+
+  final EarthquakeType type;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch ((type.baseColor, type.iconData)) {
+      (final Color color, final IconData icon) => SizedBox.square(
+        dimension: size,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(size / 5),
+          ),
+          child: Center(
+            child: Icon(icon, color: Colors.white, size: size * 0.7),
+          ),
+        ),
+      ),
+      _ => const SizedBox.shrink(),
+    };
+  }
+}

--- a/app/test/feature/earthquake_history/ui/components/earthquake_summary_header_test.dart
+++ b/app/test/feature/earthquake_history/ui/components/earthquake_summary_header_test.dart
@@ -1,0 +1,244 @@
+import 'package:eqmonitor/core/component/intenisty/jma_intensity_icon.dart';
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_depth.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_hypocenter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_magnitude.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_type.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/depth_text.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_summary_header.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_type_icon.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/magnitude_text.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
+void main() {
+  Earthquake buildEarthquake({
+    required EarthquakeType? earthquakeType,
+    required EarthquakeMagnitude magnitude,
+    required EarthquakeDepth depth,
+    JmaIntensity? maxIntensity,
+  }) => Earthquake(
+    eventId: 'test-event',
+    status: TelegramStatus.normal,
+    originTime: DateTime.utc(2026, 8, 15, 6, 58),
+    originTimePrecision: OriginTimePrecision.second,
+    arrivalTime: null,
+    dataSources: const [EarthquakeDataSource.jmaDisasterInformationXml],
+    telegramTypes: const [],
+    hypocenter: EarthquakeHypocenter(
+      code: '955',
+      name: 'インドネシア付近',
+      coordinates: const Coordinate.latLng(latitude: -8.5, longitude: 122.5),
+      magnitude: magnitude,
+      depth: depth,
+      detailedCode: null,
+      detailedName: 'インドネシア フローレス',
+    ),
+    intensity: maxIntensity == null
+        ? null
+        : EarthquakeIntensity(
+            maxIntensity: maxIntensity,
+            maxLpgmIntensity: null,
+            regions: const {},
+            intensityTree: const {},
+            lpgmIntensityTree: const {},
+          ),
+    earthquakeType: earthquakeType,
+    estimatedIntensityTileUrl: null,
+  );
+
+  Future<void> pumpHeader(WidgetTester tester, Earthquake item) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.light().copyWith(
+          extensions: [DesignSystemThemeExtension.light()],
+        ),
+        home: Scaffold(body: EarthquakeSummaryHeader(item: item)),
+      ),
+    );
+  }
+
+  EarthquakeTypeIcon typeIcon(WidgetTester tester) =>
+      tester.widget<EarthquakeTypeIcon>(find.byType(EarthquakeTypeIcon));
+
+  group('火山噴火', () {
+    testWidgets('最大震度の位置に火山アイコンを表示する', (tester) async {
+      await pumpHeader(
+        tester,
+        buildEarthquake(
+          earthquakeType: EarthquakeType.volcano,
+          magnitude: const EarthquakeMagnitude.unknown(),
+          depth: const EarthquakeDepth.unknown(),
+        ),
+      );
+
+      expect(typeIcon(tester).type, EarthquakeType.volcano);
+      expect(find.byType(JmaIntensityIcon), findsNothing);
+      expect(find.text('最大震度'), findsNothing);
+    });
+
+    testWidgets('マグニチュード不明時は"火山の噴火"を表示する', (tester) async {
+      await pumpHeader(
+        tester,
+        buildEarthquake(
+          earthquakeType: EarthquakeType.volcano,
+          magnitude: const EarthquakeMagnitude.unknown(),
+          depth: const EarthquakeDepth.unknown(),
+        ),
+      );
+
+      expect(find.text('火山の噴火'), findsOneWidget);
+      expect(find.text('不明'), findsNothing);
+      expect(find.text('調査中'), findsNothing);
+    });
+
+    testWidgets('震源地ではなく発生場所として震源要素名を表示する', (tester) async {
+      await pumpHeader(
+        tester,
+        buildEarthquake(
+          earthquakeType: EarthquakeType.volcano,
+          magnitude: const EarthquakeMagnitude.unknown(),
+          depth: const EarthquakeDepth.unknown(),
+        ),
+      );
+
+      expect(find.text('発生場所'), findsOneWidget);
+      expect(find.text('震源地'), findsNothing);
+    });
+
+    testWidgets('深さが判明している場合は深さのみ表示する', (tester) async {
+      await pumpHeader(
+        tester,
+        buildEarthquake(
+          earthquakeType: EarthquakeType.volcano,
+          magnitude: const EarthquakeMagnitude.unknown(),
+          depth: const EarthquakeDepth.shallow(),
+        ),
+      );
+
+      expect(find.text('火山の噴火'), findsOneWidget);
+      expect(find.byType(DepthText), findsOneWidget);
+      expect(find.text('深さごく浅い', findRichText: true), findsOneWidget);
+    });
+  });
+
+  group('遠地地震', () {
+    testWidgets('震度がない場合は最大震度の位置に種別アイコンを表示する', (tester) async {
+      await pumpHeader(
+        tester,
+        buildEarthquake(
+          earthquakeType: EarthquakeType.distant,
+          magnitude: const EarthquakeMagnitude.value(value: 7.7),
+          depth: const EarthquakeDepth.unknown(),
+        ),
+      );
+
+      expect(typeIcon(tester).type, EarthquakeType.distant);
+      expect(find.byType(JmaIntensityIcon), findsNothing);
+    });
+
+    testWidgets('震度がある場合は最大震度を表示する', (tester) async {
+      await pumpHeader(
+        tester,
+        buildEarthquake(
+          earthquakeType: EarthquakeType.distant,
+          magnitude: const EarthquakeMagnitude.value(value: 7.7),
+          depth: const EarthquakeDepth.value(value: 30),
+          maxIntensity: JmaIntensity.one,
+        ),
+      );
+
+      expect(find.byType(EarthquakeTypeIcon), findsNothing);
+      expect(find.text('最大震度'), findsOneWidget);
+      expect(find.byType(JmaIntensityIcon), findsOneWidget);
+    });
+
+    testWidgets('深さが不明ならマグニチュードのみ表示する', (tester) async {
+      await pumpHeader(
+        tester,
+        buildEarthquake(
+          earthquakeType: EarthquakeType.distant,
+          magnitude: const EarthquakeMagnitude.value(value: 7.7),
+          depth: const EarthquakeDepth.unknown(),
+        ),
+      );
+
+      expect(find.text('7.7'), findsOneWidget);
+      expect(find.byType(DepthText), findsNothing);
+      expect(find.text('調査中'), findsNothing);
+      expect(find.text('火山の噴火'), findsNothing);
+    });
+
+    testWidgets('マグニチュードが不明なら深さのみ表示する', (tester) async {
+      await pumpHeader(
+        tester,
+        buildEarthquake(
+          earthquakeType: EarthquakeType.distant,
+          magnitude: const EarthquakeMagnitude.unknown(),
+          depth: const EarthquakeDepth.value(value: 30),
+        ),
+      );
+
+      expect(find.text('深さ30km', findRichText: true), findsOneWidget);
+      expect(find.byType(MagnitudeText), findsNothing);
+      expect(find.text('不明'), findsNothing);
+      expect(find.text('火山の噴火'), findsNothing);
+    });
+
+    testWidgets('震源地の接頭辞は震源地のままとする', (tester) async {
+      await pumpHeader(
+        tester,
+        buildEarthquake(
+          earthquakeType: EarthquakeType.distant,
+          magnitude: const EarthquakeMagnitude.value(value: 7.7),
+          depth: const EarthquakeDepth.unknown(),
+        ),
+      );
+
+      expect(find.text('震源地'), findsOneWidget);
+      expect(find.text('発生場所'), findsNothing);
+    });
+  });
+
+  group('通常の地震', () {
+    testWidgets('M・深さが不明なら従来通り調査中を表示する', (tester) async {
+      await pumpHeader(
+        tester,
+        buildEarthquake(
+          earthquakeType: EarthquakeType.normal,
+          magnitude: const EarthquakeMagnitude.unknown(),
+          depth: const EarthquakeDepth.unknown(),
+        ),
+      );
+
+      expect(find.text('M・深さ'), findsOneWidget);
+      expect(find.text('調査中'), findsOneWidget);
+      expect(find.text('震源地'), findsOneWidget);
+      expect(find.byType(EarthquakeTypeIcon), findsNothing);
+    });
+
+    testWidgets('種別がnullでも通常の地震として扱う', (tester) async {
+      await pumpHeader(
+        tester,
+        buildEarthquake(
+          earthquakeType: null,
+          magnitude: const EarthquakeMagnitude.value(value: 5.5),
+          depth: const EarthquakeDepth.value(value: 10),
+          maxIntensity: JmaIntensity.four,
+        ),
+      );
+
+      expect(find.byType(EarthquakeTypeIcon), findsNothing);
+      expect(find.text('最大震度'), findsOneWidget);
+      expect(find.text('5.5'), findsOneWidget);
+      expect(find.text('震源地'), findsOneWidget);
+    });
+  });
+}

--- a/docs/knowledge/20260815_widget_test_golden_preview.md
+++ b/docs/knowledge/20260815_widget_test_golden_preview.md
@@ -1,0 +1,48 @@
+# Widget の見た目を golden で目視確認する（日本語フォント読み込み）
+
+UI 変更のレビュー時、`flutter test --update-goldens` で PNG を書き出すと
+実機を起動せずにレイアウトを目視確認できる。日本語を含む Widget では
+フォント読み込みの手順を誤ると必ずハマるため、以下を守る。
+
+## フォント読み込みは `setUpAll` で行う
+
+`testWidgets` のボディは fake async ゾーンで実行されるため、
+`File.readAsBytes()` のような実 I/O の `Future` は完了せず、
+`await FontLoader.load()` がテストタイムアウト（既定 10 分）まで停止する。
+
+```dart
+Future<void> loadFonts() async {
+  final loader = FontLoader('NotoSansJP')
+    ..addFont(
+      File('assets/fonts/NotoSansJP/NotoSansJP-Bold.ttf')
+          .readAsBytes()
+          .then((b) => b.buffer.asByteData()),
+    );
+  await loader.load();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(loadFonts); // ✅ testWidgets の中で await しない
+  ...
+}
+```
+
+パスは package ルート（`app/`）からの相対パスで解決される。
+
+## テーマの fontFamilyFallback も再現する
+
+アプリ本体は `NotoSansJP` を fallback に持つテーマを使っている。
+テストで `ThemeData.dark()` を素で使うと、`GoogleSansCode` / `GoogleSansFlex`
+（いずれも欧文フォント）が当たった日本語が豆腐（□）で描画される。
+豆腐が出ても実機の不具合とは限らないため、確認したい文字列に対して
+適切な fontFamilyFallback を設定したテーマを組むこと。
+
+## 確認コマンド
+
+```bash
+cd app
+flutter test --update-goldens test/tmp_visual_preview_test.dart
+```
+
+確認用のプレビューテストと生成された PNG はコミットしない。

--- a/docs/todo/450_volcano_list_tile_magnitude_unknown.md
+++ b/docs/todo/450_volcano_list_tile_magnitude_unknown.md
@@ -1,0 +1,23 @@
+# 火山噴火の ListTile 末尾に「M不明」が表示される
+
+## 現状
+
+震源カード（`EarthquakeSummaryHeader`）は地震種別に応じた表現へ変更済み。
+
+- 火山噴火: マグニチュード不明時は「M不明」ではなく「火山の噴火」を表示
+- 遠地地震: 判明している要素（M / 深さ）だけを表示
+
+一方 `EarthquakeHistoryListTile` の `trailing` は種別を考慮しておらず、
+火山噴火でも `MagnitudeText` が「M不明」を描画する。
+地震履歴一覧・近傍地震カードの両方で、噴火なのにマグニチュードを
+探しているような表示になっている。
+
+## 対応候補
+
+- 火山噴火では `trailing` を出さない
+- もしくは種別に応じた短いラベル（例: 「噴火」）を出す
+
+`trailing` は幅が限られるため、文言を決めてから実装する。
+`app/lib/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart`
+の `trailing` と、`app/test/feature/earthquake_history/ui/components/` 配下の
+テスト追加が必要。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

火山噴火・遠地地震のときに、震源カード（`EarthquakeSummaryHeader` / `EarthquakeHypocenterInformationCard`）が通常の地震と同じ表現になっており、「M・深さ 調査中」「震源地」といった実態に合わない文言が出ていた。地震種別に応じた表現へ変更する。

## 変更内容

### 火山噴火

- 最大震度の位置に火山アイコン（ListTile と同じ赤の角丸アイコン）を表示する
- マグニチュードが発表されない場合は「M不明」「M・深さ 調査中」ではなく **「火山の噴火」** を表示する
- 震源要素名の接頭辞を「震源地」から **「発生場所」** に変更する（噴火は地震ではないため）

### 遠地地震

- 国内で震度を観測していない場合は、最大震度の位置に ListTile と同じ種別アイコン（青の地球アイコン）を表示する
- 震度を観測している場合は従来通り最大震度アイコンを表示する
- マグニチュード・深さは **判明しているものだけ** を表示する（不明な要素は「調査中」を出さずに省略）

### 通常の地震

表示は変更していない（M・深さが不明なときの「調査中」表示も従来通り）。

### リファクタ

`EarthquakeHistoryListTile` が持っていた種別アイコンとベースカラーを `earthquake_type_icon.dart` へ切り出し、ListTile と震源カードで共有するようにした。

## テスト

- `app/test/feature/earthquake_history/ui/components/earthquake_summary_header_test.dart` を新規追加（11 ケース / 火山噴火・遠地地震・通常の地震）
- `flutter test test/feature/earthquake_history test/feature/live_monitor test/core/component` を実行し、本変更に関する失敗なし
  - `live_monitor_detected_event_notifier_test.dart` の 2 件は develop でも同様に失敗する既存の不具合
- `dart analyze app` : No issues found

## 補足

`EarthquakeHistoryListTile` の `trailing` は種別非対応のままで、火山噴火でも「M不明」が出る。文言を決めてから別途対応するため `docs/todo/450_volcano_list_tile_magnitude_unknown.md` に記載した。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0032d-b8e0-713b-82d1-e854a1949572?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0032d-b8e0-713b-82d1-e854a1949572&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

