### PR TITLE
Style: EEW Live Activity の取消表示・カウントダウン・Dynamic Island を整理

### DIFF
--- a/app/ios/Shared/EewDisplay.swift
+++ b/app/ios/Shared/EewDisplay.swift
@@ -11,6 +11,20 @@
 
 import Foundation
 
+/// Dynamic Island 展開時のレイアウト。
+///
+/// 展開領域は狭く、要素を並べるほど切り取られて読めなくなる。
+/// Apple のタイマー / アラームと同じく「主役を 1 つに絞る」方針で、
+/// 状況ごとにどの情報を主役にするかをここで決める。
+enum EewDynamicIslandLayout: Equatable {
+    /// 取消報。取消の事実だけを伝える。
+    case canceled
+    /// 主要動到達までのカウントダウンを主役にする（現在地の予想震度と対で見せる）。
+    case countdown
+    /// 到達予想が無い場合。予想最大震度と震源要素を見せる。
+    case summary
+}
+
 struct EewDisplay: Equatable {
     let isCanceled: Bool
     let isWarning: Bool
@@ -44,6 +58,14 @@ struct EewDisplay: Equatable {
         isCanceled ? nil : arrivalDate
     }
 
+    /// Dynamic Island 展開時に何を主役にするか
+    var dynamicIslandLayout: EewDynamicIslandLayout {
+        if isCanceled {
+            return .canceled
+        }
+        return countdownArrivalDate != nil ? .countdown : .summary
+    }
+
     // MARK: - 文言
 
     /// 「緊急地震速報(警報)」「緊急地震速報(予報)」「緊急地震速報(取消)」
@@ -66,9 +88,23 @@ struct EewDisplay: Equatable {
         return "\(typeLabel) \(serialLabel)"
     }
 
-    /// ヘッダーに出す headline。取消報では「地震発生」等が残るため出さない。
+    /// backend の headline をそのまま出してよいか判断する。
+    /// 取消報では「地震発生」等が残るため出さない。
     func headline(from raw: String?) -> String? {
         guard !isCanceled, let raw, !raw.isEmpty else { return nil }
         return raw
     }
+
+    /// ヘッダーの見出し行。取消報では backend の headline を捨て、取消の主文に差し替える。
+    func headerHeadline(from raw: String?) -> String? {
+        isCanceled ? Self.canceledTitle : headline(from: raw)
+    }
+
+    // MARK: - 取消報の文言
+
+    /// 取消報の主文。Lock Screen と Dynamic Island で文言を揃える。
+    static let canceledTitle = "緊急地震速報は取り消されました"
+
+    /// 取消報の補足。震度や到達予想を出していない理由を伝える。
+    static let canceledDescription = "予想震度・主要動到達の予想は無効です"
 }

--- a/app/ios/Widget/LiveActivity/Common/SharedComponents.swift
+++ b/app/ios/Widget/LiveActivity/Common/SharedComponents.swift
@@ -42,6 +42,38 @@ extension View {
     }
 }
 
+// MARK: - 主要動到達カウントダウン
+
+/// 主要動到達までの残り時間。桁が変わっても幅が揺れないよう等幅フォントで描く。
+/// Lock Screen のヘッダーと Dynamic Island で同じ見た目にするため共通化している。
+@available(iOS 16.1, *)
+struct ArrivalCountdownText: View {
+    let remaining: ClosedRange<Date>
+    let size: CGFloat
+    /// ヘッダーのように背景を自前で塗る場所では白を渡す
+    var color: Color = .primary
+
+    var body: some View {
+        // Workaround: timerInterval は横いっぱいに広がろうとするため、
+        // 同じフォントの placeholder で幅を確保して overlay で重ねる
+        // See: https://stackoverflow.com/questions/66210592/widgetkit-timer-text-style-expands-it-to-fill-the-width-instead-of-taking-spa
+        Text("00:00")
+            .font(font)
+            .hidden()
+            .overlay(alignment: .trailing) {
+                Text(timerInterval: remaining, countsDown: true)
+                    .font(font)
+                    .monospacedDigit()
+                    .foregroundColor(color)
+                    .contentTransition(.numericText(countsDown: true))
+            }
+    }
+
+    private var font: Font {
+        AppFonts.code(size: size, weight: .bold)
+    }
+}
+
 // MARK: - Stripe Pattern
 
 @available(iOS 16.1, *)

--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -246,8 +246,9 @@ struct EewExpandedCenterView: View {
            let regionName = state.location?.regionName,
            !regionName.isEmpty {
             HStack(spacing: 2) {
+                // SF Symbol はカスタムフォントのメトリクスに引っ張られるためシステムフォントで描く
                 Image(systemName: "location.fill")
-                    .font(AppFonts.flex(size: 9, weight: .semibold))
+                    .font(.system(size: 9, weight: .semibold))
                 Text(regionName)
                     .font(AppFonts.flex(size: 11, weight: .semibold))
                     .lineLimit(1)

--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -94,7 +94,9 @@ struct EewCompactLeadingView: View {
     let state: EewContentState
 
     var body: some View {
-        if let intensity = state.display.intensity {
+        if state.display.isCanceled {
+            EewCanceledSymbol(size: 20)
+        } else if let intensity = state.display.intensity {
             DynamicIslandIntensityBadge(intensity: intensity, size: 24)
         } else {
             Image("AppIconForeground")
@@ -106,16 +108,24 @@ struct EewCompactLeadingView: View {
     }
 }
 
+/// compact では主要動到達までの残り時間を最優先で出す。
+/// Apple のタイマーと同じく、畳んだ状態で知りたいのは「あと何秒か」だけ。
 @available(iOS 16.1, *)
 struct EewCompactTrailingView: View {
     let state: EewContentState
 
     var body: some View {
-        EewStatusPill(
-            isWarning: state.display.isWarning,
-            isCanceled: state.display.isCanceled,
-            compact: true
-        )
+        if let remaining = ArrivalCountdown.remaining(
+            until: state.display.countdownArrivalDate
+        ) {
+            ArrivalCountdownText(remaining: remaining, size: 14)
+        } else {
+            EewStatusPill(
+                isWarning: state.display.isWarning,
+                isCanceled: state.display.isCanceled,
+                compact: true
+            )
+        }
     }
 }
 
@@ -124,7 +134,9 @@ struct EewMinimalView: View {
     let state: EewContentState
 
     var body: some View {
-        if let intensity = state.display.intensity {
+        if state.display.isCanceled {
+            EewCanceledSymbol(size: 18)
+        } else if let intensity = state.display.intensity {
             DynamicIslandIntensityBadge(intensity: intensity, size: 22)
         } else {
             Image("AppIconForeground")
@@ -136,18 +148,18 @@ struct EewMinimalView: View {
     }
 }
 
+/// 展開時の leading。細い L 字領域では要素を積むと角で切り取られるため、
+/// ラベルは center 行へ回して常に 1 要素だけ置く。
 @available(iOS 16.1, *)
 struct EewExpandedLeadingView: View {
     let state: EewContentState
 
     var body: some View {
-        if let intensity = state.display.intensity {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(state.display.intensityLabel)
-                    .font(AppFonts.flex(size: 9, weight: .medium))
-                    .foregroundStyle(Color.eqTextSecondary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
+        switch state.display.dynamicIslandLayout {
+        case .canceled:
+            EewCanceledSymbol(size: DynamicIslandMetrics.expandedBadgeSize * 0.75)
+        case .countdown, .summary:
+            if let intensity = state.display.intensity {
                 DynamicIslandIntensityBadge(
                     intensity: intensity,
                     size: DynamicIslandMetrics.expandedBadgeSize
@@ -162,13 +174,9 @@ struct EewExpandedTrailingView: View {
     let state: EewContentState
 
     var body: some View {
-        VStack(alignment: .trailing, spacing: 6) {
-            EewStatusPill(
-                isWarning: state.display.isWarning,
-                isCanceled: state.display.isCanceled
-            )
-            // 「最終 第32報」を 4 つの Text に分けると細い trailing 領域で
-            // 折り返し・切り取りが起きるため、1 つの Text にまとめて縮小させる
+        switch state.display.dynamicIslandLayout {
+        case .canceled:
+            // center の主文と重ならないよう、取消バッジではなく報番号だけを添える
             if let serialLabel = state.display.serialLabel {
                 Text(serialLabel)
                     .font(AppFonts.code(size: 11, weight: .bold))
@@ -177,33 +185,86 @@ struct EewExpandedTrailingView: View {
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
             }
+        case .countdown:
+            if let remaining = ArrivalCountdown.remaining(
+                until: state.display.countdownArrivalDate
+            ) {
+                ArrivalCountdownText(remaining: remaining, size: 26)
+            } else {
+                Text("到達済み")
+                    .font(AppFonts.flex(size: 14, weight: .bold))
+                    .foregroundStyle(Color.eqTextPrimary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+        case .summary:
+            EewStatusPill(
+                isWarning: state.display.isWarning,
+                isCanceled: state.display.isCanceled
+            )
         }
     }
 }
 
+/// leading / trailing の値に対する説明ラベル行。
+/// カメラ下の全幅領域なので、左右端に寄せれば上の値の真下に並ぶ。
 @available(iOS 16.1, *)
 struct EewExpandedCenterView: View {
     let state: EewContentState
 
     var body: some View {
-        if state.display.isCanceled {
-            Text("緊急地震速報は取り消されました")
-                .font(AppFonts.flex(size: 13, weight: .bold))
+        switch state.display.dynamicIslandLayout {
+        case .canceled:
+            Text(EewDisplay.canceledTitle)
+                .font(AppFonts.flex(size: 14, weight: .bold))
                 .foregroundStyle(Color.eqTextPrimary)
-                .lineLimit(2)
-                .minimumScaleFactor(0.75)
-        } else if let hypocenterName = state.hypocenterName {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(state.isPlum == true || state.isLevel == true ? "検知観測点" : "震源地")
-                    .font(AppFonts.flex(size: 9, weight: .medium))
-                    .foregroundStyle(Color.eqTextSecondary)
-                Text(hypocenterName)
-                    .font(AppFonts.flex(size: 16, weight: .bold))
-                    .foregroundStyle(Color.eqTextPrimary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.75)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        case .countdown:
+            HStack(spacing: 6) {
+                intensityCaption
+                Spacer(minLength: 4)
+                captionText("主要動到達まで")
+            }
+        case .summary:
+            HStack(spacing: 6) {
+                intensityCaption
+                Spacer(minLength: 4)
+                if let serialLabel = state.display.serialLabel {
+                    captionText(serialLabel)
+                }
             }
         }
+    }
+
+    /// leading のバッジがどの震度かを示すラベル。
+    /// 現在地の予想震度を出しているときだけ地名を添える。全国の最大震度に
+    /// フォールバックしている場合に地名を出すと誤読を招く。
+    @ViewBuilder
+    private var intensityCaption: some View {
+        if state.display.forecastIntensity != nil,
+           let regionName = state.location?.regionName,
+           !regionName.isEmpty {
+            HStack(spacing: 2) {
+                Image(systemName: "location.fill")
+                    .font(AppFonts.flex(size: 9, weight: .semibold))
+                Text(regionName)
+                    .font(AppFonts.flex(size: 11, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+            .foregroundStyle(Color.eqTextSecondary)
+        } else if state.display.intensity != nil {
+            captionText(state.display.intensityLabel)
+        }
+    }
+
+    private func captionText(_ text: String) -> some View {
+        Text(text)
+            .font(AppFonts.flex(size: 11, weight: .medium))
+            .foregroundStyle(Color.eqTextSecondary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
     }
 }
 
@@ -212,59 +273,120 @@ struct EewExpandedBottomView: View {
     let state: EewContentState
 
     var body: some View {
-        // 取消報では震源・規模・到達予想がすべて無効なため、trailing の取消バッジに任せる
-        if state.display.isCanceled {
-            EmptyView()
-        } else {
+        switch state.display.dynamicIslandLayout {
+        case .canceled:
+            Text(EewDisplay.canceledDescription)
+                .font(AppFonts.flex(size: 12, weight: .medium))
+                .foregroundStyle(Color.eqTextSecondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        case .countdown:
+            // カウントダウンを主役にするため、震源要素は 1 行に抑える
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                EewStatusPill(
+                    isWarning: state.display.isWarning,
+                    isCanceled: state.display.isCanceled,
+                    compact: true
+                )
+                EewHypocenterSummaryView(state: state, size: 13)
+                Spacer(minLength: 4)
+                EewHypocenterDetailView(state: state, size: 14)
+            }
+        case .summary:
             HStack(alignment: .firstTextBaseline, spacing: 8) {
-                if state.isPlum == true {
-                    detectionMethodLabel("PLUM法による検知")
-                } else if state.isLevel == true {
-                    detectionMethodLabel("レベル法による検知")
-                } else if state.isOnePoint == true {
-                    detectionMethodLabel("低精度の緊急地震速報")
-                } else {
-                    HStack(spacing: 12) {
-                        if let magnitude = state.magnitude {
-                            HStack(alignment: .firstTextBaseline, spacing: 1) {
-                                Text("M")
-                                    .font(AppFonts.flex(size: 11, weight: .semibold))
-                                    .foregroundStyle(Color.eqTextSecondary)
-                                Text(String(format: "%.1f", magnitude))
-                                    .font(AppFonts.code(size: 16, weight: .bold))
-                                    .monospacedDigit()
-                                    .tracking(-1)
-                            }
-                        }
-                        if let depth = state.depth {
-                            HStack(alignment: .firstTextBaseline, spacing: 1) {
-                                Text("深さ")
-                                    .font(AppFonts.flex(size: 11, weight: .medium))
-                                    .foregroundStyle(Color.eqTextSecondary)
-                                Text("\(Int(depth))")
-                                    .font(AppFonts.code(size: 16, weight: .bold))
-                                    .monospacedDigit()
-                                Text("km")
-                                    .font(AppFonts.flex(size: 11, weight: .medium))
-                                    .foregroundStyle(Color.eqTextSecondary)
-                            }
-                        }
+                EewHypocenterSummaryView(state: state, size: 15)
+                Spacer(minLength: 4)
+                EewHypocenterDetailView(state: state, size: 16)
+            }
+        }
+    }
+}
+
+/// 震源地（PLUM法・レベル法では検知観測点）を 1 行で示す。
+/// 細い領域で Text を分割すると折り返し・切り取りが起きるため 1 つにまとめる。
+@available(iOS 16.1, *)
+struct EewHypocenterSummaryView: View {
+    let state: EewContentState
+    let size: CGFloat
+
+    var body: some View {
+        if let text = text {
+            Text(text)
+                .font(AppFonts.flex(size: size, weight: .bold))
+                .foregroundStyle(Color.eqTextPrimary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+    }
+
+    private var text: String? {
+        guard let hypocenterName = state.hypocenterName, !hypocenterName.isEmpty else {
+            return nil
+        }
+        // 仮定震源要素を使う検知では震源地ではなく検知観測点。混同させない
+        if state.isPlum == true || state.isLevel == true {
+            return "検知観測点 \(hypocenterName)"
+        }
+        return hypocenterName
+    }
+}
+
+/// M・深さ。精度の低い検知（PLUM法・レベル法・1点検知）では
+/// 数値を出さず検知方法を示す（Lock Screen と同じ判断）。
+@available(iOS 16.1, *)
+struct EewHypocenterDetailView: View {
+    let state: EewContentState
+    let size: CGFloat
+
+    var body: some View {
+        if let detectionMethod = detectionMethod {
+            Text(detectionMethod)
+                .font(AppFonts.flex(size: size * 0.8, weight: .semibold))
+                .foregroundStyle(Color.eqTextSecondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        } else {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                if let magnitude = state.magnitude {
+                    HStack(alignment: .firstTextBaseline, spacing: 1) {
+                        Text("M")
+                            .font(AppFonts.flex(size: size * 0.7, weight: .semibold))
+                            .foregroundStyle(Color.eqTextSecondary)
+                        Text(String(format: "%.1f", magnitude))
+                            .font(AppFonts.code(size: size, weight: .bold))
+                            .monospacedDigit()
+                            .foregroundStyle(Color.eqTextPrimary)
                     }
                 }
-                Spacer(minLength: 4)
-                if let location = state.location {
-                    ArrivalInfoView(location: location)
+                if let depth = state.depth {
+                    HStack(alignment: .firstTextBaseline, spacing: 1) {
+                        Text("深さ")
+                            .font(AppFonts.flex(size: size * 0.7, weight: .medium))
+                            .foregroundStyle(Color.eqTextSecondary)
+                        Text("\(Int(depth))")
+                            .font(AppFonts.code(size: size, weight: .bold))
+                            .monospacedDigit()
+                            .foregroundStyle(Color.eqTextPrimary)
+                        Text("km")
+                            .font(AppFonts.flex(size: size * 0.7, weight: .medium))
+                            .foregroundStyle(Color.eqTextSecondary)
+                    }
                 }
             }
         }
     }
 
-    private func detectionMethodLabel(_ text: String) -> some View {
-        Text(text)
-            .font(AppFonts.flex(size: 13, weight: .bold))
-            .foregroundStyle(Color.eqTextPrimary)
-            .lineLimit(1)
-            .minimumScaleFactor(0.75)
+    private var detectionMethod: String? {
+        if state.isPlum == true {
+            return "PLUM法"
+        }
+        if state.isLevel == true {
+            return "レベル法"
+        }
+        if state.isOnePoint == true {
+            return "1点検知(低精度)"
+        }
+        return nil
     }
 }
 
@@ -478,37 +600,14 @@ struct EewStatusPill: View {
     }
 }
 
+/// 取消報を一目で伝えるシンボル。震度バッジの代わりに置く。
 @available(iOS 16.1, *)
-struct ArrivalInfoView: View {
-    let location: LocationInfo
+struct EewCanceledSymbol: View {
+    let size: CGFloat
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 4) {
-            Text(location.regionName)
-                .font(AppFonts.flex(size: 11, weight: .medium))
-                .foregroundStyle(Color.eqTextSecondary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.75)
-
-            if let remaining = ArrivalCountdown.remaining(until: location.arrivalDate) {
-                // Workaround: timerInterval が横方向に広がるのを防ぐ
-                Text("00:00")
-                    .font(AppFonts.code(size: 12, weight: .bold))
-                    .hidden()
-                    .overlay(alignment: .trailing) {
-                        Text(timerInterval: remaining, countsDown: true)
-                            .font(AppFonts.code(size: 12, weight: .bold))
-                            .monospacedDigit()
-                            .foregroundStyle(Color.eqTextPrimary)
-                            .contentTransition(.numericText(countsDown: true))
-                    }
-            } else if location.arrivalDate != nil {
-                Text("主要動到達済み")
-                    .font(AppFonts.flex(size: 12, weight: .bold))
-                    .foregroundStyle(Color.eqTextPrimary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.75)
-            }
-        }
+        Image(systemName: "slash.circle.fill")
+            .font(.system(size: size, weight: .semibold))
+            .foregroundStyle(Color.eqTextSecondary)
     }
 }

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
@@ -240,6 +240,39 @@ extension EewContentState {
         )
     )
 
+    /// 主要動到達カウントダウンを主役にするレイアウトのプレビュー。
+    /// 固定日時では常に「到達済み」になってしまうため、実行時刻から到達予想を作る。
+    static func countingDown(secondsUntilArrival: TimeInterval = 30) -> EewContentState {
+        let formatter = ISO8601DateFormatter()
+        return EewContentState(
+            eventId: "20240101123456",
+            type: "eew",
+            hypocenterName: "石川県能登地方",
+            magnitude: 7.6,
+            depth: 10,
+            time: formatter.string(from: Date()),
+            isOriginTime: true,
+            maxIntensity: "6+",
+            serialNo: 32,
+            isFinal: false,
+            isWarning: true,
+            isCanceled: false,
+            headline: "石川県で地震 北陸で強い揺れ",
+            isPlum: false,
+            isLevel: false,
+            isOnePoint: false,
+            location: LocationInfo(
+                regionName: "東京都23区",
+                forecastIntensity: "5-",
+                forecastLpgmIntensity: "2",
+                arrivalTime: formatter.string(
+                    from: Date().addingTimeInterval(secondsUntilArrival)
+                ),
+                intensity: nil
+            )
+        )
+    }
+
     static let onePoint = EewContentState(
         eventId: "20240105123456",
         type: "eew",

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
@@ -51,8 +51,8 @@ struct HeaderContainer: View {
                         .lineLimit(1)
                         .minimumScaleFactor(0.7)
 
-                    // headline: "XXXで地震" または警報時 "XX YYで強い揺れ"
-                    if let headline = display.headline(from: headline) {
+                    // headline: "XXXで地震" / 警報時 "XX YYで強い揺れ" / 取消時 "取り消されました"
+                    if let headline = display.headerHeadline(from: headline) {
                         Text(headline)
                             .font(.system(size: 15, weight: .heavy))
                             .foregroundColor(.primary)
@@ -67,26 +67,11 @@ struct HeaderContainer: View {
                     VStack(alignment: .trailing, spacing: 0) {
                         Text("主要動到達まで")
                             .eewLabelStyle(.header)
-                        // Workaround: countsDownの時に、横いっぱいに広がろうとするのを防ぐ
-                        // See: https://stackoverflow.com/questions/66210592/widgetkit-timer-text-style-expands-it-to-fill-the-width-instead-of-taking-spa
-                        Text("00:00")
-                            .font(
-                                .system(
-                                    size: 18,
-                                    weight: .black,
-                                    design: .monospaced
-                                )
-                            )
-                            .tracking(-0.5)
-                            .hidden()
-                            .overlay(alignment: .trailing) {
-                                Text(timerInterval: remaining, countsDown: true)
-                                    .contentTransition(.numericText(countsDown: true))
-                                    .font(.system(size: 18, weight: .black))
-                                    .foregroundColor(.white)
-                                    .monospacedDigit()
-                                    .tracking(-0.5)
-                            }
+                        ArrivalCountdownText(
+                            remaining: remaining,
+                            size: 20,
+                            color: .white
+                        )
                     }
                 } else if display.countdownArrivalDate != nil {
                     Text("主要動到達済み")
@@ -135,53 +120,66 @@ struct EewLockScreenView: View {
             HeaderContainer(display: display, headline: state.headline)
                 .padding(.horizontal, standardMargin)
                 .padding(.top, standardMargin)
-                .padding(.bottom, 4)
+                .padding(.bottom, display.isCanceled ? 8 : 4)
 
-            // メインコンテンツ
-            HStack(alignment: .bottom, spacing: 10) {
-                // 左側: 最大震度（正方形）。取消報では予想震度自体が無効
-                if display.showsEarthquakeDetails, let intensity = display.maxIntensity {
-                    VStack(spacing: 2) {
-                        Text("最大震度")
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundColor(eewSecondaryTextColor)
-                        SquareIntensityBadge(
-                            intensity: intensity,
-                            size: .normal
-                        )
-                    }
-                }
-
-                detailsView
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                if display.showsEarthquakeDetails,
-                   let intensity = display.forecastIntensity,
-                   let regionName = state.location?.regionName,
-                   !regionName.isEmpty {
-                    forecastIntensityView(
-                        regionName: regionName,
-                        intensity: intensity
-                    )
-                }
-            }
-            .padding(.horizontal, standardMargin)
-            .padding(.bottom, standardMargin)
+            contentView
+                .padding(.horizontal, standardMargin)
+                .padding(.bottom, standardMargin)
         }
     }
 
-    // MARK: - Details (震源地, M, 深さ, 発生時刻)
-
     @ViewBuilder
-    private var detailsView: some View {
+    private var contentView: some View {
         if state.display.isCanceled {
-            Text("緊急地震速報は取り消されました")
-                .font(.system(size: 14, weight: .bold))
-                .foregroundColor(.primary)
-                .lineLimit(2)
-                .minimumScaleFactor(0.75)
+            canceledContentView
         } else {
+            earthquakeContentView
+        }
+    }
+
+    // MARK: - 取消報
+
+    /// 取消報では震源・予想震度・到達予想がすべて無効。
+    /// 主文はヘッダーの見出し行に出しているため、ここは値を出していない理由だけを添える。
+    private var canceledContentView: some View {
+        HStack(alignment: .center, spacing: 8) {
+            EewCanceledSymbol(size: 24)
+            Text(EewDisplay.canceledDescription)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(eewSecondaryTextColor)
+                .lineLimit(2)
+                .minimumScaleFactor(0.8)
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - 通常報
+
+    private var earthquakeContentView: some View {
+        HStack(alignment: .bottom, spacing: 10) {
+            if let intensity = state.display.maxIntensity {
+                VStack(spacing: 2) {
+                    Text("最大震度")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(eewSecondaryTextColor)
+                    SquareIntensityBadge(
+                        intensity: intensity,
+                        size: .normal
+                    )
+                }
+            }
+
             uncanceledDetailsView
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let intensity = state.display.forecastIntensity,
+               let regionName = state.location?.regionName,
+               !regionName.isEmpty {
+                forecastIntensityView(
+                    regionName: regionName,
+                    intensity: intensity
+                )
+            }
         }
     }
 
@@ -433,7 +431,15 @@ struct EewLiveActivityWidget_Previews: PreviewProvider {
             .previewContext(.canceledWithStaleValues, viewKind: .dynamicIsland(.expanded))
             .previewDisplayName("Expanded - 取消(値が残存)")
 
+        attributes
+            .previewContext(.countingDown(), viewKind: .content)
+            .previewDisplayName("Lock Screen - 到達カウントダウン")
+
         // Dynamic Island - Compact
+        attributes
+            .previewContext(.countingDown(), viewKind: .dynamicIsland(.compact))
+            .previewDisplayName("Compact - 到達カウントダウン")
+
         attributes
             .previewContext(.noto32, viewKind: .dynamicIsland(.compact))
             .previewDisplayName("Compact - 警報")
@@ -442,7 +448,15 @@ struct EewLiveActivityWidget_Previews: PreviewProvider {
             .previewContext(.ibarakiForecast, viewKind: .dynamicIsland(.compact))
             .previewDisplayName("Compact - 予報")
 
+        attributes
+            .previewContext(.canceled, viewKind: .dynamicIsland(.compact))
+            .previewDisplayName("Compact - 取消")
+
         // Dynamic Island - Expanded
+        attributes
+            .previewContext(.countingDown(), viewKind: .dynamicIsland(.expanded))
+            .previewDisplayName("Expanded - 到達カウントダウン")
+
         attributes
             .previewContext(.noto32, viewKind: .dynamicIsland(.expanded))
             .previewDisplayName("Expanded - 警報")
@@ -450,6 +464,18 @@ struct EewLiveActivityWidget_Previews: PreviewProvider {
         attributes
             .previewContext(.ibarakiForecast, viewKind: .dynamicIsland(.expanded))
             .previewDisplayName("Expanded - 予報")
+
+        attributes
+            .previewContext(.notoFinal, viewKind: .dynamicIsland(.expanded))
+            .previewDisplayName("Expanded - 最終報(到達予想なし)")
+
+        attributes
+            .previewContext(.plum, viewKind: .dynamicIsland(.expanded))
+            .previewDisplayName("Expanded - PLUM法")
+
+        attributes
+            .previewContext(.canceled, viewKind: .dynamicIsland(.expanded))
+            .previewDisplayName("Expanded - 取消")
 
         // Dynamic Island - Minimal
         attributes

--- a/app/ios/WidgetModelsTests/EewDisplayTests.swift
+++ b/app/ios/WidgetModelsTests/EewDisplayTests.swift
@@ -106,4 +106,38 @@ struct EewDisplayTests {
         #expect(display().headline(from: nil) == nil)
         #expect(display().headline(from: "") == nil)
     }
+
+    /// 取消報ではヘッダーの見出し行を取消の主文に差し替える
+    @Test func headerHeadlineReplacesStaleHeadlineOnCanceledReport() {
+        #expect(display(isCanceled: true).headerHeadline(from: "地震発生")
+                == EewDisplay.canceledTitle)
+        #expect(display().headerHeadline(from: "石川県で地震") == "石川県で地震")
+        #expect(display().headerHeadline(from: nil) == nil)
+    }
+
+    // MARK: - Dynamic Island のレイアウト選択
+
+    /// 到達予想があるときは主要動到達カウントダウンを主役にする
+    @Test func dynamicIslandEmphasizesCountdownWhenArrivalIsKnown() {
+        #expect(display().dynamicIslandLayout == .countdown)
+    }
+
+    /// 到達予想が無いときは予想最大震度と震源要素の要約にする
+    @Test func dynamicIslandFallsBackToSummaryWithoutArrival() {
+        let withoutArrival = EewDisplay(
+            isCanceled: false,
+            isWarning: true,
+            isFinal: false,
+            serialNo: 3,
+            maxIntensity: .sixUpper,
+            forecastIntensity: nil,
+            arrivalDate: nil
+        )
+        #expect(withoutArrival.dynamicIslandLayout == .summary)
+    }
+
+    /// 取消報では到達予想が残っていてもカウントダウンを主役にしない
+    @Test func dynamicIslandUsesCanceledLayoutEvenWithStaleArrival() {
+        #expect(display(isCanceled: true).dynamicIslandLayout == .canceled)
+    }
 }

--- a/docs/knowledge/20260815_dynamic_island_eew_layout.md
+++ b/docs/knowledge/20260815_dynamic_island_eew_layout.md
@@ -1,0 +1,72 @@
+---
+alwaysApply: false
+globs: app/ios/Widget/LiveActivity/**,app/ios/Shared/EewDisplay.swift
+---
+
+# EEW Live Activity / Dynamic Island のレイアウト方針
+
+Dynamic Island は展開しても表示面積が小さく、要素を並べるほど「角で切り取られる」
+「文字が縮んで読めない」の両方が起きる。Apple のタイマー / アラームと同じく
+**主役を 1 つに絞る**方針で組む。
+
+## 1. 状況ごとに主役を決める（判定は `EewDisplay` に置く）
+
+`EewDisplay.dynamicIslandLayout`（`app/ios/Shared/EewDisplay.swift`）で 3 通りに分岐する。
+Foundation のみに依存させ、`WidgetModelsTests` で固定する。
+
+| レイアウト | 条件 | leading | trailing | center（説明ラベル） | bottom |
+|---|---|---|---|---|---|
+| `.countdown` | 到達予想あり | 現在地の予想震度バッジ | 残り時間（等幅・大） | 地名 / 「主要動到達まで」 | 警報バッジ + 震源地 + M・深さ |
+| `.summary` | 到達予想なし | 予想最大震度バッジ | 警報 / 予報バッジ | 震度の種別 / 報番号 | 震源地 + M・深さ |
+| `.canceled` | 取消報 | 取消シンボル | 報番号 | 「緊急地震速報は取り消されました」 | 「予想震度・主要動到達の予想は無効です」 |
+
+取消報の文言は `EewDisplay.canceledTitle` / `canceledDescription` に集約し、
+Lock Screen と Dynamic Island でズレないようにする。
+
+## 2. leading / trailing には要素を 1 つだけ置く
+
+`.leading` / `.trailing` は TrueDepth カメラ脇の細い L 字領域。ここに
+`VStack { ラベル; バッジ }` のように積むと、上端が島の角で切り取られる（実機で発生）。
+
+```swift
+// ❌ 悪い例: ラベルを積んで角で切れる
+DynamicIslandExpandedRegion(.leading) {
+    VStack { Text("予想震度"); IntensityBadge(...) }
+}
+
+// ✅ 良い例: 値だけ置き、ラベルは全幅の center 行へ回す
+DynamicIslandExpandedRegion(.leading) { IntensityBadge(...) }
+DynamicIslandExpandedRegion(.center) {
+    HStack { Text("予想震度"); Spacer(); Text("主要動到達まで") }
+}
+```
+
+`.center` はカメラ下の全幅領域なので、左右端に寄せれば leading / trailing の値の
+真下にラベルが並び、キャプションとして読める。余白（`padding`）は足さない。
+
+## 3. カウントダウンは等幅フォント + 同じフォントの placeholder
+
+`Text(timerInterval:)` は横幅いっぱいに広がろうとするため、`Text("00:00").hidden()` で
+幅を確保して `overlay` で重ねる。**placeholder と本文のフォントは必ず一致させる**
+（片方だけ `design: .monospaced` にすると確保した幅と実際の幅がずれる）。
+
+数字は `AppFonts.code`（GoogleSansCode = アプリの Mono フォント）で描く。
+実装は `ArrivalCountdownText`（`Widget/LiveActivity/Common/SharedComponents.swift`）に
+共通化してあり、Lock Screen ヘッダー（`color: .white`）と Dynamic Island で共用する。
+
+## 4. 精度の低い検知では M・深さを出さない
+
+PLUM法 / レベル法 / 1点検知は震源要素の精度が低い。Lock Screen と同じく、
+Dynamic Island でも M・深さの代わりに検知方法（`PLUM法` / `レベル法` / `1点検知(低精度)`）を出す。
+仮定震源要素の検知では「震源地」ではなく「検知観測点」と明示する。
+
+## 5. 検証手段
+
+- 判定ロジック（`EewDisplay`）は Linux でも検証できる。SwiftPM の一時パッケージへ
+  `EewDisplay.swift` と `IntensityValue` のスタブをコピーし `swift test`
+  （手順は `docs/knowledge/20260815_live_activity_content_state_robustness.md`）。
+- 見た目は Xcode Preview（`EewLiveActivityWidget_Previews`）と実機で確認する。
+  到達カウントダウンのプレビューは固定日時だと常に「到達済み」になるため、
+  実行時刻から生成する `EewContentState.countingDown()` を使う。
+- 実機は `設定 > デバッグ > Live Activity テスト` からローカル開始できる
+  （`docs/knowledge/20260815_live_activity_local_debug.md`）。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

EEW Live Activity について、以下 3 点を整えた。

1. **取消報のデザイン整理**（Lock Screen / Dynamic Island）
2. **主要動到達カウントダウンを Mono フォント（GoogleSansCode）に統一**
3. **Dynamic Island 展開表示の見切れ対策と情報の整理**（Apple のタイマー / アラーム風）

## 1. 取消報

- 主文「緊急地震速報は取り消されました」をヘッダーの見出し行（`headline` の位置）へ移し、
  本文はシンボル + 「予想震度・主要動到達の予想は無効です」だけに絞った。
  従来は本文の左下に太字 1 行が浮いていて、右半分が空いていた。
- 文言は `EewDisplay.canceledTitle` / `canceledDescription` に集約し、
  Lock Screen と Dynamic Island でズレないようにした。
- compact / minimal の取消報はアプリアイコンではなく取消シンボル（`slash.circle.fill`）にした。

## 2. カウントダウンの Mono フォント化

ヘッダーのカウントダウンは、幅確保用の hidden placeholder だけが `design: .monospaced` で、
実際に表示される `Text(timerInterval:)` はプロポーショナルなシステムフォントだった
（= 幅の見積もりもずれていた）。

`ArrivalCountdownText`（`SharedComponents.swift`）へ共通化し、placeholder と本文の両方を
`AppFonts.code`（アプリの Mono = GoogleSansCode）で描くようにした。Lock Screen ヘッダーと
Dynamic Island で同じコンポーネントを使う。

## 3. Dynamic Island

`EewDisplay.dynamicIslandLayout` で 3 通りに分岐し、状況ごとに主役を 1 つへ絞った。

| レイアウト | 条件 | leading | trailing | center（ラベル行） | bottom |
|---|---|---|---|---|---|
| `.countdown` | 到達予想あり | 現在地の予想震度 | 残り時間（等幅・26pt） | 地名 / 「主要動到達まで」 | 警報バッジ + 震源地 + M・深さ |
| `.summary` | 到達予想なし | 予想最大震度 | 警報 / 予報バッジ | 震度の種別 / 報番号 | 震源地 + M・深さ |
| `.canceled` | 取消報 | 取消シンボル | 報番号 | 取消の主文 | 補足 |

見切れ対策として、**leading / trailing には要素を 1 つだけ置く**方針に変更した。
従来は leading が `VStack { Text("予想震度"); バッジ }`、trailing が `VStack { 警報バッジ; 第32報 }`
で、細い L 字領域の上端が島の角で切り取られていた。ラベル類はカメラ下の全幅領域（`.center`）へ
移し、左右端に寄せることで leading / trailing の値の真下に並ぶキャプションにした。

compact も畳んだ状態で知りたい情報に寄せ、到達予想があるときは警報バッジではなく残り時間を出す。

精度の低い検知（PLUM法 / レベル法 / 1点検知）では、Lock Screen と同様に M・深さの代わりに
検知方法を出す。仮定震源要素の検知は「検知観測点」と明示する。

## テスト

`EewDisplay` に追加した判定（`dynamicIslandLayout` / `headerHeadline`）のテストを
`WidgetModelsTests/EewDisplayTests.swift` に追加。Linux では SwiftPM の一時パッケージへ
`EewDisplay.swift` + `IntensityValue` スタブをコピーして `swift test` を実行し、17 件パスを確認した。

**未検証（macOS 必須）**: Swift のコンパイル・iOS ビルド・実機での表示。
特に見切れの解消はレイアウト構造で対策しているため、Xcode Preview（プレビューを
到達カウントダウン / 最終報 / PLUM法 / 取消の分だけ追加済み）と実機での確認が必要。
実機確認は `設定 > デバッグ > Live Activity テスト` からローカル開始できる。

## ドキュメント

`docs/knowledge/20260815_dynamic_island_eew_layout.md` にレイアウト方針、
leading / trailing に要素を積まない理由、カウントダウンの placeholder とフォントを
一致させる注意点を記録した。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a003fa-9118-7353-8fbd-a76a396288be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a003fa-9118-7353-8fbd-a76a396288be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

