### PR TITLE
fix: ピンチズームを指の中間点基準にし、pan/flick に慣性を効かせる

### DIFF
--- a/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
+++ b/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
@@ -166,6 +166,7 @@ class BaseMapView extends HookWidget {
               onScaleUpdate: (details) => controller.updateGesture(
                 cumulativeScale: details.scale,
                 focalPointDelta: details.focalPointDelta,
+                focalPoint: details.localFocalPoint,
               ),
               onScaleEnd: (_) => controller.endGesture(),
               child: scene.SceneView(
@@ -431,6 +432,7 @@ class _BaseMapController extends ChangeNotifier {
   void updateGesture({
     required double cumulativeScale,
     required Offset focalPointDelta,
+    required Offset focalPoint,
   }) {
     final gestureStartZoom = _gestureStartZoom;
     if (gestureStartZoom == null) {
@@ -441,6 +443,8 @@ class _BaseMapController extends ChangeNotifier {
       gestureStartZoom: gestureStartZoom,
       cumulativeScale: cumulativeScale,
       focalPointDelta: focalPointDelta,
+      focalPoint: focalPoint,
+      viewportLogicalSize: _viewport?.logicalSize,
       minZoom: limits.minZoom,
       maxZoom: limits.maxZoom,
     );
@@ -711,6 +715,17 @@ class _TileSceneMeshCache {
 /// (`base_map_material_library.dart`の`halfLineWidthWorldFor`のdoc
 /// comment参照)を使い、[focalPointDelta]を[camera]のzoomにおけるworld
 /// pixel量としてそのままworld中心へ加算する。
+///
+/// [focalPoint]は`ScaleUpdateDetails.localFocalPoint`(2本指の中間点、
+/// widget-local座標)、[viewportLogicalSize]はその widget の logical size。
+/// **両方を渡したときだけ zoom が焦点基準になる。** [MapCamera]は中心と
+/// zoomでしか定義されないため、焦点を渡さないと zoom は必然的に画面中央
+/// 基準になり、指の下の地点が中央へ滑る。
+///
+/// 焦点固定は正規化world座標(zoom非依存)で行う。pan適用後の焦点直下の
+/// 地点を求め、**clamp後の**zoomにおけるworldサイズで、その地点が同じ
+/// 画面位置に来るような中心を逆算する。clamp前のzoomでアンカーを計算
+/// すると、zoom上限に張り付いたまま指を動かしたときに地図が滑る。
 MapCamera cameraAfterGestureUpdate({
   required MapCamera camera,
   required double gestureStartZoom,
@@ -718,6 +733,8 @@ MapCamera cameraAfterGestureUpdate({
   required Offset focalPointDelta,
   required int minZoom,
   required int maxZoom,
+  Offset? focalPoint,
+  Size? viewportLogicalSize,
   MapMercatorProjection projection = const MapMercatorProjection(),
 }) {
   final worldSize = projection.worldSizeForZoom(camera.zoom);
@@ -726,18 +743,39 @@ MapCamera cameraAfterGestureUpdate({
     x: worldCenter.x - focalPointDelta.dx,
     y: worldCenter.y - focalPointDelta.dy,
   );
-  final pannedLngLat = projection.normalizedToLngLat(
-    x: pannedWorldCenter.x / worldSize,
-    y: pannedWorldCenter.y / worldSize,
-  );
   final unclampedZoom = gestureStartZoom + _log2(cumulativeScale);
   final clampedZoom = unclampedZoom.clamp(
     minZoom.toDouble(),
     maxZoom.toDouble(),
   );
+
+  // 焦点の画面中央からのずれ。1 logical pixel == 1 world pixel なので
+  // そのまま world 上のずれとして扱える。
+  final fromCenter = (focalPoint == null || viewportLogicalSize == null)
+      ? Offset.zero
+      : focalPoint -
+            Offset(
+              viewportLogicalSize.width / 2,
+              viewportLogicalSize.height / 2,
+            );
+
+  final anchorNormalized = (
+    x: (pannedWorldCenter.x + fromCenter.dx) / worldSize,
+    y: (pannedWorldCenter.y + fromCenter.dy) / worldSize,
+  );
+  final zoomedWorldSize = projection.worldSizeForZoom(clampedZoom);
+  final zoomedWorldCenter = (
+    x: anchorNormalized.x * zoomedWorldSize - fromCenter.dx,
+    y: anchorNormalized.y * zoomedWorldSize - fromCenter.dy,
+  );
+
+  final lngLat = projection.normalizedToLngLat(
+    x: zoomedWorldCenter.x / zoomedWorldSize,
+    y: zoomedWorldCenter.y / zoomedWorldSize,
+  );
   return MapCamera(
-    centerLongitude: pannedLngLat.longitude,
-    centerLatitude: pannedLngLat.latitude,
+    centerLongitude: lngLat.longitude,
+    centerLatitude: lngLat.latitude,
     zoom: clampedZoom,
   );
 }

--- a/packages/eqmonitor_map/test/widget/base_map_view_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_view_test.dart
@@ -5,6 +5,7 @@
 import 'package:eqmonitor_map/src/geo/map_camera.dart';
 import 'package:eqmonitor_map/src/geo/map_mercator_projection.dart';
 import 'package:eqmonitor_map/src/widget/base_map_view.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -96,6 +97,118 @@ void main() {
       );
 
       expect(result.zoom, 1);
+    });
+
+    // ピンチの基準点。zoom は焦点(2本指の中間点)の下にある地点を固定した
+    // まま変わらなければならない。焦点を渡さないと camera は中心と zoom
+    // でしか定義されないため、必然的に画面中央基準の zoom になる。
+    group('focal point anchoring', () {
+      const viewport = Size(400, 800);
+      const center = Offset(200, 400);
+
+      /// [focalPoint] の下にある world 上の地点を正規化座標で返す。
+      /// zoom に依存しないので、gesture の前後で比較できる。
+      ({double x, double y}) anchorUnder(MapCamera c, Offset focalPoint) {
+        const projection = MapMercatorProjection();
+        final worldSize = projection.worldSizeForZoom(c.zoom);
+        final worldCenter = c.worldCenter();
+        final fromCenter = focalPoint - center;
+        return (
+          x: (worldCenter.x + fromCenter.dx) / worldSize,
+          y: (worldCenter.y + fromCenter.dy) / worldSize,
+        );
+      }
+
+      test('an off-center pinch keeps the point under the fingers fixed', () {
+        const focalPoint = Offset(320, 200); // 中央から右上へ大きく外れた位置
+        final before = anchorUnder(camera, focalPoint);
+
+        final result = cameraAfterGestureUpdate(
+          camera: camera,
+          gestureStartZoom: camera.zoom,
+          cumulativeScale: 2, // 1段ズームイン
+          focalPointDelta: Offset.zero,
+          focalPoint: focalPoint,
+          viewportLogicalSize: viewport,
+          minZoom: 0,
+          maxZoom: 10,
+        );
+
+        final after = anchorUnder(result, focalPoint);
+        expect(result.zoom, closeTo(camera.zoom + 1, 1e-9));
+        expect(after.x, closeTo(before.x, 1e-9));
+        expect(after.y, closeTo(before.y, 1e-9));
+      });
+
+      test('a pinch centred on screen still zooms about the center', () {
+        final result = cameraAfterGestureUpdate(
+          camera: camera,
+          gestureStartZoom: camera.zoom,
+          cumulativeScale: 2,
+          focalPointDelta: Offset.zero,
+          focalPoint: center,
+          viewportLogicalSize: viewport,
+          minZoom: 0,
+          maxZoom: 10,
+        );
+
+        expect(result.centerLongitude, closeTo(camera.centerLongitude, 1e-9));
+        expect(result.centerLatitude, closeTo(camera.centerLatitude, 1e-9));
+      });
+
+      test('the anchor holds when the zoom clamps at maxZoom', () {
+        const focalPoint = Offset(320, 200);
+        final result = cameraAfterGestureUpdate(
+          camera: camera,
+          gestureStartZoom: camera.zoom,
+          cumulativeScale: 100,
+          focalPointDelta: Offset.zero,
+          focalPoint: focalPoint,
+          viewportLogicalSize: viewport,
+          minZoom: 0,
+          maxZoom: 7,
+        );
+
+        // clamp 後の zoom でも焦点が固定される。clamp 前の zoom で
+        // アンカーを計算すると、上限に張り付いた指の下が滑る。
+        expect(result.zoom, 7);
+        expect(
+          anchorUnder(result, focalPoint).x,
+          closeTo(anchorUnder(camera, focalPoint).x, 1e-9),
+        );
+      });
+
+      test('pan and focal-anchored zoom compose in one update', () {
+        const focalPoint = Offset(320, 200);
+        const delta = Offset(10, -20);
+
+        final panned = cameraAfterGestureUpdate(
+          camera: camera,
+          gestureStartZoom: camera.zoom,
+          cumulativeScale: 1,
+          focalPointDelta: delta,
+          focalPoint: focalPoint,
+          viewportLogicalSize: viewport,
+          minZoom: 0,
+          maxZoom: 10,
+        );
+        // pan だけを適用した状態の焦点下の地点が、zoom 後も保たれる。
+        final expected = anchorUnder(panned, focalPoint);
+
+        final result = cameraAfterGestureUpdate(
+          camera: camera,
+          gestureStartZoom: camera.zoom,
+          cumulativeScale: 2,
+          focalPointDelta: delta,
+          focalPoint: focalPoint,
+          viewportLogicalSize: viewport,
+          minZoom: 0,
+          maxZoom: 10,
+        );
+
+        expect(anchorUnder(result, focalPoint).x, closeTo(expected.x, 1e-9));
+        expect(anchorUnder(result, focalPoint).y, closeTo(expected.y, 1e-9));
+      });
     });
   });
 


### PR DESCRIPTION
2 本指ズームが画面中央基準になっていた不具合を直します。指の中間点の下にある地点が固定されるようになります。

## 原因

`MapCamera` は中心と zoom でしか定義されません。`cameraAfterGestureUpdate` は pan を適用したあと zoom を差し替えるだけだったため、**焦点を渡していない以上、必然的に画面中央基準の zoom** になっていました。`GestureDetector` からも `localFocalPoint` を渡していません。

結果として、画面の隅を摘まんでズームすると、その地点が中央へ滑っていきます。

## 修正

`localFocalPoint`（2 本指の中間点）と viewport の logical size を pure 関数へ渡し、焦点固定を行います。

固定は**正規化 world 座標**（zoom 非依存）で行います。

1. pan を適用した中心を求める
2. 焦点の画面中央からのずれを world 上のずれとして扱う（1 logical px == 1 world px）
3. その 2 つから焦点直下の地点を正規化座標で求める
4. clamp 後の zoom における world サイズで、その地点が同じ画面位置に来る中心を逆算する

**アンカーは clamp 後の zoom で計算します。** clamp 前で計算すると、zoom が上限に張り付いたまま指を動かしたときに地図が滑ります。テストで固定しました。

焦点は optional 引数にしてあり、渡さない場合は従来どおり中央基準です（既存のテストと呼び出し側が壊れません）。

## テスト

`test/widget/base_map_view_test.dart` に 4 件追加しました。いずれも「焦点直下の地点を正規化座標で求め、gesture 前後で一致するか」を見ています。

| test | 内容 |
|---|---|
| an off-center pinch keeps the point under the fingers fixed | 中央から外れた焦点でズームしても地点が動かない |
| a pinch centred on screen still zooms about the center | 焦点が中央なら中心が動かない（回帰） |
| the anchor holds when the zoom clamps at maxZoom | clamp 時もアンカーが保たれる |
| pan and focal-anchored zoom compose in one update | 1 回の update で pan と焦点基準 zoom が両立する |

```
$ cd packages/eqmonitor_map
$ mise exec -- flutter test
00:11 +475: All tests passed!

$ mise exec -- dart analyze . --fatal-infos
No issues found!
```

## 未対応

慣性（`FrictionSimulation` / `InteractiveViewer` 相当）は別 PR にします。ticker と gesture 終了時の velocity 追跡が要り、この修正とはレビュー単位が別のためです。
