### PR TITLE
fix(ci): ベータリリースの mise exec を python に限定

### DIFF
--- a/.github/workflows/create-beta-release.yaml
+++ b/.github/workflows/create-beta-release.yaml
@@ -56,12 +56,6 @@ jobs:
           cache: false
           install_args: "python"
 
-      - name: Configure git for tagging
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
-
       - name: Determine next beta version
         id: version
         env:
@@ -98,20 +92,16 @@ jobs:
 
           echo "version=v${BASE_VERSION}-beta.${NEXT}" >> "$GITHUB_OUTPUT"
 
-      - name: Create beta tag
-        if: ${{ !inputs.repair_existing_release }}
-        env:
-          BETA_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          git tag "$BETA_VERSION"
-          git push origin "$BETA_VERSION"
-
+      # タグは gh release create に作らせる。事前に push すると、後続が失敗したとき
+      # release の無いタグだけが残り、次回のベータ番号が無駄に進んでしまう。
       - name: Create GitHub pre-release
         if: ${{ !inputs.repair_existing_release }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BETA_VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
+
           gh api \
             --method POST \
             "repos/${{ github.repository }}/releases/generate-notes" \
@@ -119,7 +109,7 @@ jobs:
             -f target_commitish=develop \
             --jq .body \
             > release-notes.raw.md
-          mise exec -- python3 scripts/release/sanitize_release_notes.py \
+          mise exec python -- python3 scripts/release/sanitize_release_notes.py \
             < release-notes.raw.md \
             > release-notes.md
           gh release create "$BETA_VERSION" \
@@ -137,7 +127,7 @@ jobs:
             --json body \
             --jq .body \
             > release-notes.raw.md
-          mise exec -- python3 scripts/release/sanitize_release_notes.py \
+          mise exec python -- python3 scripts/release/sanitize_release_notes.py \
             < release-notes.raw.md \
             > release-notes.md
           gh release edit "$BETA_VERSION" --notes-file release-notes.md

--- a/docs/knowledge/20260816_mise_exec_tool_scope_in_ci.md
+++ b/docs/knowledge/20260816_mise_exec_tool_scope_in_ci.md
@@ -1,0 +1,24 @@
+# CI で `mise exec` を使うときはツールを必ず絞る
+
+`mise exec -- <cmd>` は `mise.toml` の**全ツール**を解決・インストールしようとする。
+CI ではこれが次の 2 つの問題を起こす。
+
+- `ubuntu-slim` ランナーには `libncurses.so.6` 等が無く、`core:swift` のインストールが
+  `exit code 127` で失敗する → コマンド本体に到達せずステップが落ちる
+- 不要な Flutter（約 1GB / 数分）まで clone してしまう
+
+`mise exec <tool> -- <cmd>` のようにツールを明示すれば、そのツールだけが解決される。
+
+```yaml
+# ❌ 悪い例: mise.toml の全ツール（swift 含む）を入れようとする
+- run: mise exec -- python3 scripts/release/sanitize_release_notes.py
+
+# ✅ 良い例
+- run: mise exec python -- python3 scripts/release/sanitize_release_notes.py
+```
+
+`ubuntu-24.04` などのフルイメージでは swift のインストールが成功するため、
+この問題は `ubuntu-slim` を使うジョブでのみ顕在化する。ランナーを絞ったジョブを
+追加するときは特に注意する。
+
+参考: [Create Beta Release #60](https://github.com/YumNumm/EQMonitor/actions/runs/31946789655/job/95163970760)


### PR DESCRIPTION
## 概要

[Create Beta Release #60](https://github.com/YumNumm/EQMonitor/actions/runs/31946789655/job/95163970760) が失敗していた問題の修正。

`mise exec -- python3 ...` は `mise.toml` の全ツールを解決しようとするため、Flutter を丸ごと clone した挙句 `core:swift` のインストールに失敗して落ちていた（`exit code 127`）。このジョブだけ `ubuntu-slim` で動いており、slim イメージには swift の実行に必要な共有ライブラリが無いことが原因。

- `mise exec python -- python3 ...` にツールを絞った（pre-release 作成 / repair の2箇所）
- 事前の `git tag` + `git push` を廃止し、タグ作成を `gh release create --target develop` に任せた。従来は後続が失敗すると release の無いタグだけが残り、次回のベータ番号が無駄に進んでいた（実際 `v3.0.0-beta.2` / `v3.0.0-beta.3` が孤立していた）
- 併せて不要になった `Configure git for tagging` ステップを削除
- 知見を `docs/knowledge/20260816_mise_exec_tool_scope_in_ci.md` に記録

## テスト

- [x] `actionlint` / `zizmor` / `pinact` が通ること
- [ ] マージ後に Release PR で `/beta` を実行し、pre-release が作成されること

Made with [Cursor](https://cursor.com)