### PR TITLE
Fix: 長周期地震動モニターの配信経路を修正

### DIFF
--- a/.cursor/rules/map-renderer-references.mdc
+++ b/.cursor/rules/map-renderer-references.mdc
@@ -1,0 +1,46 @@
+---
+description: eqmonitor_map の地図レンダラ参照実装ルール
+globs: packages/eqmonitor_map/**/*.dart,packages/eqmonitor_map/**/*.fmat,docs/superpowers/specs/*eqmonitor-map*
+alwaysApply: false
+---
+
+# Map Renderer Reference Rules
+
+`packages/eqmonitor_map` のマップレンダラを実装・デバッグするときは、独自判断で方式を作る前に、必ず以下3つの参照実装と既存の `docs/knowledge/` を確認する。
+
+## 参照先の使い分け
+
+| 問題領域 | 参照先 |
+| --- | --- |
+| Web Mercator / tile cover / overzoom / world wrap / MVT edge handling | MapLibre Native |
+| fill / line vertex generation / joins / caps / line extrusion shader | MapLibre Native |
+| frame snapshot / ordered layers / observation points / intensity display | KEVi |
+| label placement / zoom-vs-stroke-width / integer-zoom geometry cache | KEVi |
+| Flutter Scene mechanics / `.fmat` / material parameters | dashmap |
+| worker isolate mesh building / GPU upload frame budgeting / floating origin | dashmap |
+
+## 固定参照
+
+- MapLibre Native: https://github.com/maplibre/maplibre-native/tree/f1905c521577f009c70179fac53e3f4f67a3fa53
+  - Repository: `maplibre/maplibre-native`
+  - License: BSD-2-Clause
+  - Commit: `f1905c521577f009c70179fac53e3f4f67a3fa53`
+  - 知見: `docs/knowledge/20260805_maplibre_native_renderer_reference.md`
+- KEVi: https://github.com/ingen084/KyoshinEewViewerIngen/tree/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f
+  - Repository: `ingen084/KyoshinEewViewerIngen`
+  - License: MIT
+  - Commit: `5a2bf513b6b9c93ee06473f70b6d27ee96070b3f`
+  - Geometry cache section: `cc5ce50b19e0a68b18bcc3a7caa0df413bd8ed05`
+  - 知見: `docs/knowledge/20260802_kevi_map_renderer_reference.md`
+- dashmap: https://github.com/bdero/dashmap/tree/a6ff92edd999e922f81d26d209d8f589faee3fd0
+  - Repository: `bdero/dashmap`
+  - License: MIT
+  - Commit: `a6ff92edd999e922f81d26d209d8f589faee3fd0`
+  - 知見: `docs/knowledge/20260807_dashmap_flutter_scene_reference.md`
+
+## 運用ルール
+
+- 新しい参照知見を追加するときは、必ず対象repository・license・commit SHAを固定して記録する。
+- 参照repositoryは `/tmp/refs` 配下へcloneし、EQMonitor workspace内へ置かない。
+- 新しい発見・運用上の注意点は `knowledge-management.mdc` に従い、`docs/knowledge/` に簡潔に残す。
+- dashmapはPMTiles / MVT / vector line stroking / label実装を持たないため、これらの正本として引用しない。

--- a/app/lib/feature/home/ui/page/home_map_layer_page.dart
+++ b/app/lib/feature/home/ui/page/home_map_layer_page.dart
@@ -829,7 +829,7 @@ class _KyoshinRealtimeLayerTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final setting = ref.watch(kyoshinMonitorSettingsProvider).requireValue;
-    if (!setting.useKmoni) {
+    if (!setting.canSelectRealtimeLayer) {
       return const SizedBox.shrink();
     }
     return _SettingDropdownField<RealtimeLayer>(

--- a/app/lib/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.dart
+++ b/app/lib/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.dart
@@ -40,6 +40,13 @@ abstract class KyoshinMonitorSettingsModel with _$KyoshinMonitorSettingsModel {
       _$KyoshinMonitorSettingsModelFromJson(json);
 }
 
+extension KyoshinMonitorSettingsModelX on KyoshinMonitorSettingsModel {
+  RealtimeLayer get effectiveRealtimeLayer =>
+      realtimeDataType.isLpgm ? RealtimeLayer.surface : realtimeLayer;
+
+  bool get canSelectRealtimeLayer => useKmoni && !realtimeDataType.isLpgm;
+}
+
 @freezed
 abstract class KyoshinMonitorSettingsApiModel
     with _$KyoshinMonitorSettingsApiModel {

--- a/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart
+++ b/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart
@@ -90,7 +90,7 @@ class KyoshinMonitorNotifier extends _$KyoshinMonitorNotifier {
     state = await AsyncValue.guard(() async {
       final settings = ref.read(kyoshinMonitorSettingsProvider).requireValue;
       final realtimeDataType = settings.realtimeDataType;
-      final realtimeLayer = settings.realtimeLayer;
+      final realtimeLayer = settings.effectiveRealtimeLayer;
       final monitorSource = settings.monitorSource;
 
       final analyzer = await ref.read(
@@ -111,9 +111,9 @@ class KyoshinMonitorNotifier extends _$KyoshinMonitorNotifier {
         image = await Timeline.timeSync(
           'lmoni.fetchImage',
           () async => lpgmDataSource.getRealtimeImageData(
-            realtimeDataType,
-            realtimeLayer,
-            targetTime,
+            type: realtimeDataType,
+            layer: realtimeLayer,
+            dateTime: targetTime,
           ),
         );
       } else {

--- a/app/test/feature/kyoshin_monitor/kyoshin_monitor_settings_model_test.dart
+++ b/app/test/feature/kyoshin_monitor/kyoshin_monitor_settings_model_test.dart
@@ -1,0 +1,31 @@
+import 'package:eqmonitor/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kyoshin_monitor_api/kyoshin_monitor_api.dart';
+
+void main() {
+  test('長周期データでは保存値が地下でも実効レイヤーは地表になる', () {
+    const settings = KyoshinMonitorSettingsModel(
+      realtimeDataType: RealtimeDataType.abrspmx,
+      realtimeLayer: RealtimeLayer.underground,
+    );
+
+    expect(settings.effectiveRealtimeLayer, RealtimeLayer.surface);
+    expect(settings.canSelectRealtimeLayer, isFalse);
+  });
+
+  test('通常データでは保存済みレイヤーを維持する', () {
+    const settings = KyoshinMonitorSettingsModel(
+      realtimeDataType: RealtimeDataType.shindo,
+      realtimeLayer: RealtimeLayer.underground,
+    );
+
+    expect(settings.effectiveRealtimeLayer, RealtimeLayer.underground);
+    expect(settings.canSelectRealtimeLayer, isTrue);
+  });
+
+  test('モニター無効時はレイヤーを選択できない', () {
+    const settings = KyoshinMonitorSettingsModel(useKmoni: false);
+
+    expect(settings.canSelectRealtimeLayer, isFalse);
+  });
+}

--- a/docs/knowledge/20260807_dashmap_flutter_scene_reference.md
+++ b/docs/knowledge/20260807_dashmap_flutter_scene_reference.md
@@ -1,0 +1,61 @@
+# dashmap Flutter Scene実装から参照する設計知見
+
+## 調査対象
+
+- Repository: `bdero/dashmap`
+- Commit: `a6ff92edd999e922f81d26d209d8f589faee3fd0` (2026-08-06)
+- License: MIT
+- 固定参照: https://github.com/bdero/dashmap/tree/a6ff92edd999e922f81d26d209d8f589faee3fd0
+- `flutter_scene`: `pubspec.yaml`では`../../flutter_scene/packages/flutter_scene`へのpath依存、`pubspec.lock`上は`0.18.1`
+
+dashmapは`flutter_scene`上で動く、raster terrain + satellite imagery + Overpass building extrusionの3Dデモである。PMTiles engineでもMVT rendererでもない。
+PMTiles、MVT、vector line stroking、tile extent handling、map label描画は確認した範囲では存在しない。したがってEQMonitorの2D base map rendererの正本にはせず、Flutter Sceneを実運用する際の局所的な設計知見として参照する。
+
+## 採用するパターン
+
+- `lib/map/terrain/terrain_streamer.dart` / `lib/map/terrain/tile_mesh_worker.dart`:
+  tile scaleはmesh jobへ明示的に渡す。入力データのscaleを隠れた定数にしない点を、`packages/eqmonitor_map/lib/src/widget/base_map_view.dart`の`mvtDefaultExtent`=4096固定除去へ適用する。`packages/eqmonitor_map/lib/src/tile/mvt/mvt_decoder.dart`はlayerの`extent`を読んでいるため、`BaseMapTileGeometry`またはlayer geometry metadataへ伝搬する。
+- `assets/globe_terrain.fmat` / `assets/globe_solid.fmat`:
+  shader座標空間はmaterial parameterとセットで検証する。dashmapは`curve_center` / `focus_merc_yn`を渡し、vertex stageで相対Mercator座標を扱う。EQMonitorでは`packages/eqmonitor_map/assets/base_map_line.fmat`と`packages/eqmonitor_map/lib/src/flutter_scene/base_map_geometry_factory.dart`の`half_width_ndc` / `texCoords` extrude修正を、座標空間のregression test対象として固定する。
+- `lib/map/terrain/heightfield_mesh.dart` / `lib/map/terrain/terrain_streamer.dart`:
+  tile境界の見た目はデータ任せにせずrenderer policyとして持つ。dashmapはskirt geometryで隙間を隠し、imagery textureに`clampToEdge`を使う。EQMonitorのMVT buffer clip問題は同じ実装では解けないが、line/fillのtile visible rectに対するclip/scissor/discard方針を明文化する根拠になる。
+- `lib/map/terrain/terrain_streamer.dart` / `lib/map/buildings/building_streamer.dart` / `lib/map/buildings/building_mesh.dart`:
+  GPU uploadをframe budget化する。dashmapはterrainを3 tiles/frame、buildingを1 chunk/frameで適用し、building chunkは`kBuildingChunkVertexBudget = 24000`に分割する。EQMonitorの`packages/eqmonitor_map/lib/src/widget/base_map_view.dart`は`_rebuildSceneNodes`で`sceneGraph.removeAll()`→`addAll(nodes)`を行うため、将来はmesh upload、visibility/transform更新、scene graph差分適用を分離する。
+- `lib/map/terrain/tile_mesh_worker.dart` / `lib/map/buildings/building_worker.dart` / `lib/map/terrain/tile_selector.dart`:
+  mesh構築はworker isolateへ逃がし、in-flight cap、exponential backoff、coarse-to-fine ancestor stand-inを組み合わせる。dashmapのrender setは重複なし、load setはancestor pyramidを含む。EQMonitorの`BaseMapTileCache.lookupWithFallback`周辺も、親子tileを同じscreen areaへ重複描画しない不変条件をtest化する。
+- `lib/map/geo/floating_origin.dart` / `lib/map/map_camera.dart` / `lib/map/map_screen.dart`:
+  Web Mercator meter + floating originでfloat32精度を保つ。現行2D rendererへ混ぜないが、`docs/todo/650_eqmonitor_map_3d_camera.md`の将来3D camera、地下震源、断層面、terrain表現では、地理座標、Mercator meter、altitude meter、render-local floatの境界設計に使える。
+
+## 参考にしないもの
+
+- live第三者データをrender pathへ入れる構造。dashmapはAWS Open Data Terrarium、Esri World Imagery、Overpass API、Photon APIへlive HTTPする。EQMonitorのbase mapはAsset Pack attestationとPMTiles digest/sidecar検証が前提であり、未検証network tileをrendererが直接読む構造は採用しない。
+- OSM default heightと`(building.id % 7)`のheight jitter。dashmapは見た目のためにdefault heightや決定的jitterを使うが、EQMonitorは生命に関わる情報を扱うため、震源・断層・hazard表現で推測値を事実のように描かない。
+- JSONをhot render pathへ置く設計。dashmapのbuilding cacheはgzipped JSONで、Overpass parseは`Map<String, dynamic>`を通る。EQMonitorの描画経路ではGeoJSON/JSON serializationを使わない。
+- StatefulWidget中心の大きなscreen controller。dashmapの`MapScreen`はdemoとして妥当だが、EQMonitorではHookWidget/HookConsumerWidget、repository/provider、Action/Flow分離に合わせる。
+- hole未対応のear clipping。dashmapの`lib/map/buildings/building_mesh.dart`はbuilding roof専用で、multipolygon holesはTODOである。EQMonitorのMVT polygon fillでは`dart_earcut`とring winding/holes対応済みの方針を維持する。
+- `frustumCulled = false`の無条件コピー。dashmapはglobe wrapで通常boundsが壊れるためmanual horizon cullingとセットで無効化している。EQMonitorの2D tileで同じことをすると描画負荷だけが増える可能性がある。
+- unbounded disk cache。dashmapの`TileByteCache`には`TODO(cache-eviction)`があり、長時間roamingで蓄積する可能性がある。EQMonitorのAsset Pack / PMTiles cacheはmanifest policyとsize limitを持つべきである。
+
+## EQMonitorでの適用境界
+
+dashmapはMVT fill/line、PMTiles range fetch、vector tile extent、tile buffer clipping、label placement、glyph atlasの参考実装ではない。これらはMapLibre NativeやEQMonitor独自実装を正本にする。
+
+一方で、Flutter Scene上でmesh生成とGPU uploadを分割する方法、`.fmat` material parameterの座標空間検証、tile境界をrenderer policyとして扱う姿勢、worker isolateとframe budget、floating originは再利用価値が高い。既知のocean flood / line-width / tile-clip問題に対しては、dashmapのvector実装ではなく「scaleを固定値に隠さない」「shader座標空間をmaterial設定と一緒に確認する」「tile境界処理をrenderer policyとして持つ」の3点だけを持ち込む。
+
+## 再取得方法
+
+参照実装はrepository外の`/tmp/refs`へcloneする。workspaceを汚さないため、EQMonitor配下には置かない。
+
+```bash
+mkdir -p /tmp/refs
+git clone --depth 50 https://github.com/bdero/dashmap.git /tmp/refs/dashmap
+cd /tmp/refs/dashmap
+git rev-parse HEAD
+git log -1 --format='%H %cI'
+```
+
+必要に応じて固定commitへ移動する。
+
+```bash
+git -C /tmp/refs/dashmap checkout a6ff92edd999e922f81d26d209d8f589faee3fd0
+```

--- a/docs/knowledge/20260816_lpgm_monitor_endpoints.md
+++ b/docs/knowledge/20260816_lpgm_monitor_endpoints.md
@@ -1,0 +1,39 @@
+# LMoni リアルタイム画像の配信経路
+
+## 結論
+
+LMoni のリアルタイム画像は、通常の強震モニタ互換データと長周期地震動データで配信経路が異なる。
+単一のベースパスに統合せず、データ種別で明示的に振り分ける。
+
+- 通常データ: `/img_svr/data/map_img/RealTimeImg/{type}_{layer}/...`
+- 長周期データ: `/monitor/data/data/map_img/RealTimeImg/{type}_s/...`
+
+長周期データには地中画像がなく、レイヤーは常に地表を表す `_s` とする。
+保存済み設定が地中でも `_b` を組み立ててはならない。
+
+## 確認方法
+
+日時部分は LMoni が公開済みの日本標準時に置き換える。
+
+```bash
+curl --fail --head \
+  'https://www.lmoni.bosai.go.jp/img_svr/data/map_img/RealTimeImg/jma_s/YYYYMMDD/YYYYMMDDHHMMSS.jma_s.gif'
+
+curl --fail --head \
+  'https://www.lmoni.bosai.go.jp/monitor/data/data/map_img/RealTimeImg/abrspmx_s/YYYYMMDD/YYYYMMDDHHMMSS.abrspmx_s.gif'
+```
+
+公式モニターの JavaScript も両者を別の URL として組み立てているため、配信形式の変更を疑う場合は最初に公式画面の通信とスクリプトを確認する。
+
+- 公式モニター: <https://www.lmoni.bosai.go.jp/monitor/>
+- 防災科研の利用上の注意: <https://www.kyoshin.bosai.go.jp/ja/about_lmoni/>
+
+防災科研は配信形態を予告なく変更する場合があるとしている。取得失敗時に別レイヤーや固定値へフォールバックせず、エラーとして扱って経路を再確認する。
+
+## 参考実装
+
+`ingen084/KyoshinMonitorLib` の `LpgmWebApiUrlGenerator` は、通常画像と長周期画像の URL 生成を別メソッドに分け、長周期画像を地表固定としている。この責務分離を参考にする。
+
+ただし、同ライブラリが通常画像用に使用する `smi.lmoniexp.bosai.go.jp` は現行の公式画面の経路ではない。ホストとパスは公式画面の現在の通信を優先する。
+
+- 参考: <https://github.com/ingen084/KyoshinMonitorLib>

--- a/docs/superpowers/plans/2026-08-16-lpgm-monitor-routing-fix.md
+++ b/docs/superpowers/plans/2026-08-16-lpgm-monitor-routing-fix.md
@@ -1,0 +1,350 @@
+# LPGM Monitor Routing Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** LMoni の通常データと長周期データを現行の正しい配信経路から取得し、長周期データで無効な地下レイヤーを要求しない。
+
+**Architecture:** Retrofit クライアントで通常データと長周期データのエンドポイントを別メソッドにし、DataSource が `RealtimeDataType.isLpgm` で選択する。アプリ設定モデルが保存値と実効レイヤーを分離し、Notifier と設定 UI が同じ制約を利用する。
+
+**Tech Stack:** Dart 3.11、Flutter 3.44、Dio、Retrofit、Freezed、Riverpod、flutter_test / test
+
+## Global Constraints
+
+- Flutter / Dart コマンドは必ず `mise exec --` 経由で実行する。
+- 外部配信エラー時に別ソース、固定値、古い画像へフォールバックしない。
+- 通常データは `/img_svr/data/map_img/RealTimeImg/`、長周期データは `/monitor/data/data/map_img/RealTimeImg/` を使う。
+- 長周期データの URL と実効レイヤーは地表 (`s`) 固定とする。
+- 保存済みの地下設定は破棄せず、通常データへ戻したときに再利用する。
+- ユーザーの既存未コミット変更には触れない。
+
+---
+
+### Task 1: LMoni 配信経路をデータ種別ごとに分離する
+
+**Files:**
+- Create: `packages/kyoshin_monitor_api/test/src/api/lpgm_kyoshin_monitor_web_api_client_test.dart`
+- Modify: `packages/kyoshin_monitor_api/lib/src/api/lpgm_kyoshin_monitor_web_api_client.dart`
+- Modify: `packages/kyoshin_monitor_api/lib/src/api/lpgm_kyoshin_monitor_web_api_client.g.dart`
+- Modify: `packages/kyoshin_monitor_api/lib/src/data_source/lpgm_kyoshin_monitor_web_api_data_source.dart`
+
+**Interfaces:**
+- Consumes: `RealtimeDataType.isLpgm`、`RealtimeLayer.urlString`、指定時刻。
+- Produces: `getKyoshinRealtimeImageData(...)` と `getLpgmRealtimeImageData(...)`、および種別を判定する `LpgmKyoshinMonitorWebApiDataSource.getRealtimeImageData({required type, required layer, required dateTime})`。
+
+- [ ] **Step 1: 現在の誤った URL を捕捉する回帰テストを書く**
+
+```dart
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:kyoshin_monitor_api/kyoshin_monitor_api.dart';
+import 'package:test/test.dart';
+
+final class _RecordingBytesAdapter implements HttpClientAdapter {
+  RequestOptions? request;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    request = options;
+    return ResponseBody.fromBytes(const [1, 2, 3], 200);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+void main() {
+  late _RecordingBytesAdapter adapter;
+  late LpgmKyoshinMonitorWebApiDataSource dataSource;
+
+  setUp(() {
+    adapter = _RecordingBytesAdapter();
+    final dio = Dio()..httpClientAdapter = adapter;
+    dataSource = LpgmKyoshinMonitorWebApiDataSource(
+      client: LpgmKyoshinMonitorWebApiClient(dio),
+    );
+  });
+
+  test('通常震度の地表は img_svr の jma_s を取得する', () async {
+    await dataSource.getRealtimeImageData(
+      RealtimeDataType.shindo,
+      RealtimeLayer.surface,
+      DateTime(2026, 8, 16, 22, 58, 3),
+    );
+    expect(
+      adapter.request?.path,
+      'https://www.lmoni.bosai.go.jp/img_svr/data/map_img/'
+      'RealTimeImg/jma_s/20260816/20260816225803.jma_s.gif',
+    );
+  });
+
+  test('通常震度の地下は img_svr の jma_b を取得する', () async {
+    await dataSource.getRealtimeImageData(
+      RealtimeDataType.shindo,
+      RealtimeLayer.underground,
+      DateTime(2026, 8, 16, 22, 58, 3),
+    );
+    expect(adapter.request?.path, endsWith('20260816225803.jma_b.gif'));
+  });
+
+  test('長周期データは地下設定でも monitor 配下の abrspmx_s を取得する', () async {
+    await dataSource.getRealtimeImageData(
+      RealtimeDataType.abrspmx,
+      RealtimeLayer.underground,
+      DateTime(2026, 8, 16, 22, 58, 3),
+    );
+    expect(
+      adapter.request?.path,
+      'https://www.lmoni.bosai.go.jp/monitor/data/data/map_img/'
+      'RealTimeImg/abrspmx_s/20260816/20260816225803.abrspmx_s.gif',
+    );
+  });
+}
+```
+
+- [ ] **Step 2: 回帰テストが期待した理由で失敗することを確認する**
+
+Run: `mise exec -- dart test packages/kyoshin_monitor_api/test/src/api/lpgm_kyoshin_monitor_web_api_client_test.dart`
+
+Expected: 通常震度は `/monitor/data/data/` のため失敗し、長周期地下は `abrspmx_b` のため失敗する。
+
+- [ ] **Step 3: 失敗する回帰テストだけをコミットする**
+
+```bash
+git add packages/kyoshin_monitor_api/test/src/api/lpgm_kyoshin_monitor_web_api_client_test.dart
+git commit -m "Test: LMoni配信経路の回帰テストを追加"
+```
+
+- [ ] **Step 4: API クライアントと DataSource を最小修正する**
+
+```dart
+@GET(
+  '/img_svr/data/map_img/RealTimeImg/'
+  '{type}_{layer}/{date}/{dateTime}.{type}_{layer}.gif',
+)
+@DioResponseType(ResponseType.bytes)
+Future<List<int>> getKyoshinRealtimeImageData({
+  @Path('type') required String type,
+  @Path('layer') required String layer,
+  @Path('date') required String date,
+  @Path('dateTime') required String dateTime,
+});
+
+@GET(
+  '/monitor/data/data/map_img/RealTimeImg/'
+  '{type}_s/{date}/{dateTime}.{type}_s.gif',
+)
+@DioResponseType(ResponseType.bytes)
+Future<List<int>> getLpgmRealtimeImageData({
+  @Path('type') required String type,
+  @Path('date') required String date,
+  @Path('dateTime') required String dateTime,
+});
+```
+
+```dart
+Future<List<int>> getRealtimeImageData({
+  required RealtimeDataType type,
+  required RealtimeLayer layer,
+  required DateTime dateTime,
+}) {
+  final date = dateFormat.format(dateTime);
+  final formattedDateTime = dateTimeFormat.format(dateTime);
+  if (type.isLpgm) {
+    return _client.getLpgmRealtimeImageData(
+      type: type.urlString,
+      date: date,
+      dateTime: formattedDateTime,
+    );
+  }
+  return _client.getKyoshinRealtimeImageData(
+    type: type.urlString,
+    layer: layer.urlString,
+    date: date,
+    dateTime: formattedDateTime,
+  );
+}
+```
+
+この名前付き引数への変更時に、Step 1 の3つのテスト呼び出しも
+`type:`、`layer:`、`dateTime:` を使う形へ機械的に更新し、期待 URL は変更しない。
+
+- [ ] **Step 5: Retrofit コードを再生成する**
+
+Workdir: `packages/kyoshin_monitor_api`
+
+Run: `mise exec -- dart run build_runner build --delete-conflicting-outputs`
+
+- [ ] **Step 6: 回帰テストとパッケージ全テストを通す**
+
+Run: `mise exec -- dart test packages/kyoshin_monitor_api/test/src/api/lpgm_kyoshin_monitor_web_api_client_test.dart`
+
+Run: `mise exec -- dart test packages/kyoshin_monitor_api/test`
+
+Expected: すべて PASS。
+
+- [ ] **Step 7: 配信経路修正をコミットする**
+
+```bash
+git add packages/kyoshin_monitor_api/lib/src/api/lpgm_kyoshin_monitor_web_api_client.dart packages/kyoshin_monitor_api/lib/src/api/lpgm_kyoshin_monitor_web_api_client.g.dart packages/kyoshin_monitor_api/lib/src/data_source/lpgm_kyoshin_monitor_web_api_data_source.dart
+git commit -m "Fix: LMoni画像の配信経路をデータ種別で分離"
+```
+
+### Task 2: 長周期データの実効レイヤーと設定 UI を地表に制限する
+
+**Files:**
+- Modify: `app/lib/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.dart`
+- Modify: `app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart`
+- Modify: `app/lib/feature/home/ui/page/home_map_layer_page.dart`
+- Create: `app/test/feature/kyoshin_monitor/kyoshin_monitor_settings_model_test.dart`
+
+**Interfaces:**
+- Consumes: 保存済み `KyoshinMonitorSettingsModel.realtimeLayer` と `realtimeDataType`。
+- Produces: `effectiveRealtimeLayer` と `canSelectRealtimeLayer`。前者は取得と状態記録、後者は設定 UI の表示判定に使う。
+
+- [ ] **Step 1: 実効レイヤーと UI 可視性の失敗テストを書く**
+
+```dart
+import 'package:eqmonitor/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kyoshin_monitor_api/kyoshin_monitor_api.dart';
+
+void main() {
+  test('長周期データでは保存値が地下でも実効レイヤーは地表になる', () {
+    const settings = KyoshinMonitorSettingsModel(
+      realtimeDataType: RealtimeDataType.abrspmx,
+      realtimeLayer: RealtimeLayer.underground,
+    );
+    expect(settings.effectiveRealtimeLayer, RealtimeLayer.surface);
+    expect(settings.canSelectRealtimeLayer, isFalse);
+  );
+
+  test('通常データでは保存済みレイヤーを維持する', () {
+    const settings = KyoshinMonitorSettingsModel(
+      realtimeDataType: RealtimeDataType.shindo,
+      realtimeLayer: RealtimeLayer.underground,
+    );
+    expect(settings.effectiveRealtimeLayer, RealtimeLayer.underground);
+    expect(settings.canSelectRealtimeLayer, isTrue);
+  );
+
+  test('モニター無効時はレイヤーを選択できない', () {
+    const settings = KyoshinMonitorSettingsModel(useKmoni: false);
+    expect(settings.canSelectRealtimeLayer, isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: 新しい契約が未実装のため失敗することを確認する**
+
+Run: `mise exec -- flutter test app/test/feature/kyoshin_monitor/kyoshin_monitor_settings_model_test.dart`
+
+Expected: `effectiveRealtimeLayer` / `canSelectRealtimeLayer` が未定義で FAIL。
+
+- [ ] **Step 3: 設定モデルの派生値を最小実装する**
+
+```dart
+extension KyoshinMonitorSettingsModelX on KyoshinMonitorSettingsModel {
+  RealtimeLayer get effectiveRealtimeLayer =>
+      realtimeDataType.isLpgm ? RealtimeLayer.surface : realtimeLayer;
+
+  bool get canSelectRealtimeLayer => useKmoni && !realtimeDataType.isLpgm;
+}
+```
+
+- [ ] **Step 4: Notifier と UI を同じ派生値へ接続する**
+
+`KyoshinMonitorNotifier` は `settings.effectiveRealtimeLayer` を DataSource と
+`KyoshinMonitorState.currentRealtimeLayer` の両方へ渡す。LMoni DataSource 呼び出しは
+Task 1 の名前付き引数へ更新する。
+
+`_KyoshinRealtimeLayerTile` は次のガードを使う。
+
+```dart
+if (!setting.canSelectRealtimeLayer) {
+  return const SizedBox.shrink();
+}
+```
+
+- [ ] **Step 5: モデルテストと既存の強震モニタテストを通す**
+
+Run: `mise exec -- flutter test app/test/feature/kyoshin_monitor/kyoshin_monitor_settings_model_test.dart app/test/feature/kyoshin_monitor/kyoshin_monitor_delay_test.dart`
+
+Expected: すべて PASS。
+
+- [ ] **Step 6: アプリ側修正をコミットする**
+
+```bash
+git add app/lib/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.dart app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart app/lib/feature/home/ui/page/home_map_layer_page.dart app/test/feature/kyoshin_monitor/kyoshin_monitor_settings_model_test.dart
+git commit -m "Fix: 長周期データの取得レイヤーを地表に制限"
+```
+
+### Task 3: 運用知見を記録して全体を検証する
+
+**Files:**
+- Create: `docs/knowledge/20260816_lpgm_monitor_endpoints.md`
+
+**Interfaces:**
+- Consumes: 公式サイト JavaScript、HTTP 200/404 の実測、`ingen084/KyoshinMonitorLib` の責務分離。
+- Produces: 配信経路変更時に再確認すべき URL、レイヤー制約、確認コマンドをまとめた運用知識。
+
+- [ ] **Step 1: 配信仕様と確認手順を記録する**
+
+```markdown
+# 長周期地震動モニターの配信経路
+
+- 通常データ: `/img_svr/data/map_img/RealTimeImg/{type}_{layer}/...`
+- 長周期データ: `/monitor/data/data/map_img/RealTimeImg/{type}_s/...`
+- 長周期データは地表 (`s`) のみで、地下 (`b`) を要求すると 404 になる。
+- 配信形態は変更され得るため、公式サイト JavaScript と同時刻の HTTP 応答を確認する。
+```
+
+確認コマンドには `latest.json` の取得と、同一時刻の `jma_s`、`jma_b`、
+`abrspmx_s`、`abrspmx_b` の HTTP ステータス比較を記載する。
+
+- [ ] **Step 2: フォーマットと対象範囲の解析を実行する**
+
+Run: `mise exec -- dart format packages/kyoshin_monitor_api/lib packages/kyoshin_monitor_api/test/src/api/lpgm_kyoshin_monitor_web_api_client_test.dart app/lib/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.dart app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart app/lib/feature/home/ui/page/home_map_layer_page.dart app/test/feature/kyoshin_monitor/kyoshin_monitor_settings_model_test.dart`
+
+Run: `mise exec -- dart analyze packages/kyoshin_monitor_api --fatal-infos`
+
+Run: `mise exec -- flutter analyze app`
+
+Expected: 変更に起因する error / warning / info がない。
+
+- [ ] **Step 3: 回帰テストを新鮮な状態で再実行する**
+
+Run: `mise exec -- dart test packages/kyoshin_monitor_api/test`
+
+Run: `mise exec -- flutter test app/test/feature/kyoshin_monitor`
+
+Expected: すべて PASS。
+
+- [ ] **Step 4: 差分と禁止事項を確認する**
+
+Run: `git --no-pager diff --check`
+
+Run: `git --no-pager diff HEAD~3 -- packages/kyoshin_monitor_api app/lib/feature/kyoshin_monitor app/lib/feature/home/ui/page/home_map_layer_page.dart app/test/feature/kyoshin_monitor docs/knowledge`
+
+Expected: 固定値フォールバック、ランダム値、`print()`、`dynamic`、`Object`、`!` の新規使用がない。
+
+- [ ] **Step 5: 知識ドキュメントをコミットする**
+
+```bash
+git add docs/knowledge/20260816_lpgm_monitor_endpoints.md
+git commit -m "Docs: LMoni配信経路の運用知識を記録"
+```
+
+- [ ] **Step 6: ブランチを push して修正 PR を作成する**
+
+ブランチ名: `codex/fix-lpgm-monitor-routing`
+
+PR タイトル: `Fix: 長周期地震動モニターの配信経路を修正`
+
+PR 本文には根本原因、通常/LPGMの経路分離、地表制約、実行したテスト、
+既存の未コミット変更を含めていないことを記載する。

--- a/docs/superpowers/specs/2026-08-16-lpgm-monitor-routing-fix-design.md
+++ b/docs/superpowers/specs/2026-08-16-lpgm-monitor-routing-fix-design.md
@@ -1,0 +1,98 @@
+# 長周期地震動モニター配信経路修正設計
+
+## 背景
+
+長周期地震動モニターを選択したとき、設定の組み合わせによってリアルタイム画像取得が
+HTTP 404 になり、観測点レイヤーが更新されない。
+
+2026-08-16 時点の公式サイトと実際の配信応答を確認すると、リアルタイム画像には
+次の2系統がある。
+
+- 長周期地震動データは
+  `/monitor/data/data/map_img/RealTimeImg/{type}_s/...` から配信される。
+- 通常の強震モニタデータは
+  `/img_svr/data/map_img/RealTimeImg/{type}_{layer}/...` から配信される。
+
+長周期地震動データに地下 (`_b`) はなく、地表 (`_s`) のみが配信される。
+
+## 根本原因
+
+`KyoshinMonitorNotifier` は、次のいずれかを満たすと
+`LpgmKyoshinMonitorWebApiDataSource` を選ぶ。
+
+- `monitorSource == KyoshinMonitorSource.lmoni`
+- `realtimeDataType.isLpgm`
+
+しかし現在の LMoni クライアントは、すべてのリアルタイムデータを長周期側の
+`/monitor/data/data/` へ送る。このため、LMoni ソースで通常震度などを選ぶと
+存在しない URL になり 404 が返る。
+
+また、画面では長周期データ選択中も地下レイヤーを選択できる。地下設定が残った状態で
+長周期データを取得すると `{type}_b` を要求し、これも 404 になる。
+
+## 参考実装
+
+`ingen084/KyoshinMonitorLib` の `LpgmWebApiUrlGenerator` は、通常データの
+`RealtimeImg` と長周期データの `LpgmRealtimeImg` を別の URL として定義している。
+長周期側はレイヤー引数を持たず、URLを常に `{type}_s` として生成する。
+
+この責務分離と地表固定を採用する。ただし参考実装の通常データ用ホスト
+`smi.lmoniexp.bosai.go.jp` は現行公式サイトの実装と異なるためコピーしない。
+現行公式サイトが使い、HTTP 200 を実測した `/img_svr/data/` を正とする。
+
+## 採用する設計
+
+### API クライアント
+
+`LpgmKyoshinMonitorWebApiClient` にリアルタイム画像取得メソッドを2つ定義する。
+
+- 通常データ用メソッドは `/img_svr/data/map_img/RealTimeImg/` を使い、
+  地表・地下の指定を受け取る。
+- 長周期データ用メソッドは `/monitor/data/data/map_img/RealTimeImg/` を使い、
+  URL のレイヤーを常に `s` とする。
+
+既存の曖昧な `getRealtimeImageData` は、呼び分け漏れを防ぐため置き換える。
+
+### Data 層
+
+`LpgmKyoshinMonitorWebApiDataSource.getRealtimeImageData` は
+`RealtimeDataType.isLpgm` によって2つのクライアントメソッドを選ぶ。
+
+- 通常データでは呼び出し元の `RealtimeLayer` を保持する。
+- 長周期データでは `RealtimeLayer` を URL 生成へ渡さず、地表を取得する。
+
+固定値へのフォールバックではなく、公式配信仕様として型ごとの有効な経路を選択する。
+
+### Presentation 層
+
+長周期データの選択中は「リアルタイムデータのレイヤー」を表示しない。
+保存済み設定が地下でも、通常データへ戻したときのユーザー設定として保持する。
+取得状態の `currentRealtimeLayer` には、実際に取得した地表を記録する。
+
+通常データを選択している場合は、LMoni ソースでも従来どおり地表・地下を選択できる。
+
+## エラー処理
+
+通信失敗は現在の `AsyncValue.guard` によるエラー状態を維持する。
+別ソースへの自動フォールバックや古い画像の流用は行わない。生命に関わる情報で
+配信元・対象時刻を曖昧にしないためである。
+
+## テスト
+
+外部サーバーへ依存しない記録用 `HttpClientAdapter` を使い、次を回帰テストする。
+
+- LMoni の通常震度・地表が `/img_svr/data/.../jma_s/...` を要求する。
+- LMoni の通常震度・地下が `/img_svr/data/.../jma_b/...` を要求する。
+- 長周期地震動階級は地下設定を渡しても
+  `/monitor/data/data/.../abrspmx_s/...` を要求する。
+- 長周期データでは実効レイヤーが地表になる。
+- 長周期データ選択中はレイヤー選択 UI を表示しない。
+
+修正前に各回帰テストが誤った URL または表示状態によって失敗することを確認し、
+修正後に関連パッケージテストと Flutter analyze を実行する。
+
+## 運用上の記録
+
+公式配信の URL 体系、長周期データが地表限定であること、配信形態が変更され得ることを
+`docs/knowledge/` に記録する。将来の変更では参考ライブラリの定数ではなく、
+公式サイトの現行 JavaScript と実際の HTTP 応答を再確認する。

--- a/docs/todo/700_eqmonitor_map_line_extrude_projection.md
+++ b/docs/todo/700_eqmonitor_map_line_extrude_projection.md
@@ -1,0 +1,19 @@
+# eqmonitor_map line extrude projection
+
+## 現在の契約
+
+`LineMeshBuilder`はMVT入力と同じtile-local Y-down座標系で線分法線を生成する。
+`BaseMapGeometryFactory`はFlutter Sceneへ渡す境界でY成分を反転し、`base_map_line.fmat`が
+`vertex.world_position`へ直接加算できるclip/NDC Y-up座標系の押し出し方向として
+`texCoords`へ積む。
+
+この契約は、現在の`viewProjectionMatrixFor`が正射影・north-lockedで、回転やpitchを持たず、
+screen logical pixelとworld pixelの対応が等方であることを前提にしている。
+
+## Deferred work
+
+pitch、bearing、perspectiveを導入する前に、MapLibre-styleの押し出し設計へ移行する。
+具体的には、中心線と同じ行列の線形部で押し出しベクトルを変換してからprojection後の位置へ
+加算する必要がある。現在のY反転だけの最小修正は、正射影かつnorth-lockedの間だけ正しい。
+
+参照: `docs/knowledge/20260805_maplibre_native_renderer_reference.md`

--- a/packages/eqmonitor_map/assets/base_map_line.fmat
+++ b/packages/eqmonitor_map/assets/base_map_line.fmat
@@ -1,10 +1,12 @@
 // Lineレイヤーの押し出し描画material。
 //
-// `extrude`はLineMeshBuilderが頂点ごとに詰める押し出し法線(tile-localの
-// 座標系とは独立な、方向のみを持つ単位ベクトル。直線部分・capでは長さ1、
-// miter joinでは`joinNormal * miterLength`。lib/src/mesh/line_mesh.dartの
-// doc comment参照)。`half_width_ndc`はCPU側で毎frame確定するNDC単位の
-// 半線幅(`vec2`。x/yで異なる値を持つ)で、shader内でzoomから再計算しない
+// `extrude`はLineMeshBuilderが頂点ごとに詰めるtile-local Y-down座標系の
+// 押し出し法線を、BaseMapGeometryFactoryがclip/NDC Y-up座標系へ変換した
+// 方向ベクトルである。直線部分・capでは長さ1、miter joinでは
+// `joinNormal * miterLength`になる(lib/src/mesh/line_mesh_builder.dartと
+// lib/src/flutter_scene/base_map_geometry_factory.dartのdoc comment参照)。
+// `half_width_ndc`はCPU側で毎frame確定するNDC単位の半線幅(`vec2`。x/yで
+// 異なる値を持つ)で、shader内でzoomから再計算しない
 // (lib/src/flutter_scene/base_map_material_library.dartのdoc comment参照)。
 //
 // # なぜworld単位ではなくNDC単位のvec2か(訂正の経緯)
@@ -70,8 +72,8 @@ material {
 
 vertex {
   void Vertex(inout VertexInputs vertex) {
-    // vertex.uvはUV座標ではなく押し出し法線(vec2)を運ぶ
-    // (このファイル冒頭のdoc comment参照)。
+    // vertex.uvはUV座標ではなく、clip/NDC Y-up座標系へ変換済みの
+    // 押し出し法線(vec2)を運ぶ(このファイル冒頭のdoc comment参照)。
     // half_width_ndcはx/y成分ごとに独立な係数を持つNDC単位の半線幅
     // (base_map_material_library.dartのhalfLineWidthNdcFor doc comment
     // 参照)。vertex.world_positionはこの時点で実質NDC相当の空間にいる

--- a/packages/eqmonitor_map/lib/src/flutter_scene/base_map_geometry_factory.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/base_map_geometry_factory.dart
@@ -37,9 +37,11 @@ class BaseMapGeometryFactory {
 
   /// [mesh]から線描画用の`scene.Geometry`を作る。
   ///
-  /// [LineMesh.extrudes]は`MeshGeometry.fromArrays`の組み込み`texCoords`
-  /// 引数(`vec2`)へ渡す。以前は`setCustomAttribute('extrude', ...)`で
-  /// custom vertex attributeとして渡していたが、この環境ではGPUへ値が
+  /// [LineMesh.extrudes]はtile-local Y-down座標系の法線なので、
+  /// [buildLineGeometryArgs]でY成分を反転してclip/NDC Y-up座標系の
+  /// 押し出し方向へ変換してから、`MeshGeometry.fromArrays`の組み込み
+  /// `texCoords`引数(`vec2`)へ渡す。以前は`setCustomAttribute('extrude', ...)`
+  /// でcustom vertex attributeとして渡していたが、この環境ではGPUへ値が
   /// 届かず、代わりに同じ頂点の`position`(origin rebasing後の座標)が
   /// shaderで読まれてしまうバグがあることをGPUレベルの実験で確認した
   /// (`.superpowers/sdd/2026-08-05-eqmonitor-map-base-layer-pmtiles/
@@ -92,12 +94,14 @@ class LineGeometryArgs {
   /// [LineMesh.indices]をそのまま渡す。
   final Uint16List indices;
 
-  /// [LineMesh.extrudes]をそのまま渡す(2成分、z拡張は不要。押し出し方向は
-  /// 座標ではなく`vec2`の方向ベクトルであり、`MeshGeometry.fromArrays`の
-  /// `positions`のような3成分要求を持たない)。`lineGeometry`が
-  /// `MeshGeometry.fromArrays`の`texCoords:`引数へそのまま渡す
-  /// (`lineGeometry`のdoc comment参照。custom attributeの不具合を避ける
-  /// ため、組み込みのtexCoordsへ押し出し法線を積んでいる)。
+  /// [LineMesh.extrudes]のY成分を反転したclip/NDC Y-up座標系の押し出し方向
+  /// (2成分、z拡張は不要)。`LineMeshBuilder`の出力はtile-local Y-down座標系の
+  /// 法線だが、`base_map_line.fmat`は`vertex.world_position`が既に実質NDCの
+  /// 空間にある時点でこの値を加算するため、このFlutter Scene adapter境界で
+  /// 座標系を合わせる。`lineGeometry`が`MeshGeometry.fromArrays`の
+  /// `texCoords:`引数へ渡す(`lineGeometry`のdoc comment参照。custom
+  /// attributeの不具合を避けるため、組み込みのtexCoordsへ押し出し法線を
+  /// 積んでいる)。
   final Float32List extrudes;
 }
 
@@ -111,10 +115,14 @@ FillGeometryArgs buildFillGeometryArgs(FillMesh mesh) {
 
 /// [mesh]から[BaseMapGeometryFactory.lineGeometry]の引数を組み立てる。
 LineGeometryArgs buildLineGeometryArgs(LineMesh mesh) {
+  final extrudes = Float32List.fromList(mesh.extrudes);
+  for (var i = 1; i < extrudes.length; i += 2) {
+    extrudes[i] = -extrudes[i];
+  }
   return LineGeometryArgs(
     positions: _expandTo3D(mesh.positions),
     indices: mesh.indices,
-    extrudes: mesh.extrudes,
+    extrudes: extrudes,
   );
 }
 

--- a/packages/eqmonitor_map/lib/src/mesh/line_mesh_builder.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/line_mesh_builder.dart
@@ -256,9 +256,9 @@ _buildRing(Int32List ring, {required double miterLimit}) {
     final x = xs[i];
     final y = ys[i];
     // 中心線の同じ座標を2頂点分格納し、押し出し法線を+/-反転させることで
-    // 線の両側(plus側/minus側)を表す。押し出し自体はshader側が
-    // `position + extrude * halfWidth`として行う想定であり、ここでは
-    // 中心線座標と押し出し法線だけを持つ。
+    // 線の両側(plus側/minus側)を表す。ここで生成する法線はMVT入力と同じ
+    // tile-local Y-down座標系の方向ベクトルであり、Flutter Scene/shaderへ
+    // 渡す直前に`BaseMapGeometryFactory`がclip/NDC Y-up座標系へ変換する。
     positions[i * 4] = x;
     positions[i * 4 + 1] = y;
     positions[i * 4 + 2] = x;

--- a/packages/eqmonitor_map/test/flutter_scene/base_map_geometry_factory_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/base_map_geometry_factory_test.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui';
 
@@ -6,8 +7,73 @@ import 'package:eqmonitor_map/src/flutter_scene/base_map_material_library.dart';
 import 'package:eqmonitor_map/src/geo/map_viewport.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh.dart';
 import 'package:eqmonitor_map/src/mesh/line_mesh.dart';
+import 'package:eqmonitor_map/src/mesh/line_mesh_builder.dart';
+import 'package:eqmonitor_map/src/mesh/line_mesh_builder_limits.dart';
+import 'package:eqmonitor_map/src/tile/mvt/mvt_tile.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math.dart' show Vector2;
+
+final class LineExtrudeProjectionCase {
+  const LineExtrudeProjectionCase({
+    required this.name,
+    required this.dx,
+    required this.dy,
+  });
+
+  final String name;
+  final int dx;
+  final int dy;
+
+  MvtFeature feature() {
+    return MvtFeature(
+      type: MvtGeometryType.lineString,
+      rings: [
+        Int32List.fromList([0, 0, dx, dy]),
+      ],
+    );
+  }
+
+  Vector2 screenDirection() {
+    final length = math.sqrt(dx * dx + dy * dy);
+    return Vector2(dx / length, dy / length);
+  }
+}
+
+final class LineExtrudeProjectionHarness {
+  const LineExtrudeProjectionHarness({
+    required this.viewport,
+    required this.halfWidthLogicalPixels,
+  });
+
+  final MapViewport viewport;
+  final double halfWidthLogicalPixels;
+
+  Vector2 projectedScreenOffsetFor({
+    required LineExtrudeProjectionCase testCase,
+  }) {
+    final builder = LineMeshBuilder(
+      limits: const LineMeshBuilderLimits(maxVerticesPerSegment: 64),
+      miterLimit: 2,
+    );
+    final meshes = builder.build([testCase.feature()]);
+    expect(meshes, hasLength(1));
+
+    final args = buildLineGeometryArgs(meshes.single);
+    final halfWidthNdc = halfLineWidthNdcFor(
+      halfWidthLogicalPixels: halfWidthLogicalPixels,
+      viewport: viewport,
+    );
+    final shaderNdcOffset = Vector2(
+      args.extrudes[0] * halfWidthNdc.x,
+      args.extrudes[1] * halfWidthNdc.y,
+    );
+
+    return Vector2(
+      shaderNdcOffset.x * viewport.logicalSize.width / 2,
+      -shaderNdcOffset.y * viewport.logicalSize.height / 2,
+    );
+  }
+}
 
 // このtestはGPU初期化を必要としない範囲だけを検証する。
 // `BaseMapGeometryFactory.fillGeometry`/`lineGeometry`自体は
@@ -88,7 +154,7 @@ void main() {
       );
     });
 
-    test('extrudesは2成分のまま変更せず渡す', () {
+    test('extrudesは2成分のままYをclip/NDC向けに反転して渡す', () {
       final extrudes = Float32List.fromList(const [0.6, 0.8, -0.6, -0.8]);
       final mesh = LineMesh(
         positions: Float32List.fromList(const [0, 0, 1, 1]),
@@ -99,12 +165,13 @@ void main() {
 
       final args = buildLineGeometryArgs(mesh);
 
-      expect(args.extrudes, Float32List.fromList(const [0.6, 0.8, -0.6, -0.8]));
+      expect(args.extrudes, Float32List.fromList(const [0.6, -0.8, -0.6, 0.8]));
       // zパディングは`positions`だけの事情(`MeshGeometry.fromArrays`が
       // 3成分を要求する)であり、`extrudes`は`MeshGeometry.fromArrays`の
-      // `texCoords:`引数へ渡すvec2属性なので触ってはいけない。触っていない
-      // ことを同一インスタンスであることで確認する。
-      expect(identical(args.extrudes, extrudes), isTrue);
+      // `texCoords:`引数へ渡すvec2属性なので2成分のままにする。一方、
+      // `LineMeshBuilder`のtile-local Y-down法線をshaderが加算する
+      // clip/NDC Y-up空間へ合わせるため、Y成分だけは反転する。
+      expect(identical(args.extrudes, extrudes), isFalse);
     });
 
     test('indicesをUint16Listのまま(コピーせず)渡す', () {
@@ -120,6 +187,40 @@ void main() {
 
       expect(args.indices, isA<Uint16List>());
       expect(identical(args.indices, indices), isTrue);
+    });
+
+    test('line extrudeがscreen logical pxで線分に直交し半幅を保つ', () {
+      const halfWidthLogicalPixels = 7.0;
+      final harness = LineExtrudeProjectionHarness(
+        viewport: MapViewport(
+          logicalSize: const Size(400, 800),
+          devicePixelRatio: 1,
+        ),
+        halfWidthLogicalPixels: halfWidthLogicalPixels,
+      );
+      const cases = [
+        LineExtrudeProjectionCase(name: 'horizontal', dx: 100, dy: 0),
+        LineExtrudeProjectionCase(name: 'vertical', dx: 0, dy: 100),
+        LineExtrudeProjectionCase(name: '45deg', dx: 100, dy: 100),
+        LineExtrudeProjectionCase(name: '30deg', dx: 100, dy: 58),
+        LineExtrudeProjectionCase(name: '135deg', dx: -100, dy: 100),
+      ];
+
+      for (final testCase in cases) {
+        final offset = harness.projectedScreenOffsetFor(testCase: testCase);
+        final direction = testCase.screenDirection();
+
+        expect(
+          direction.dot(offset),
+          closeTo(0, 1e-6),
+          reason: '${testCase.name} offset must be perpendicular',
+        );
+        expect(
+          offset.length,
+          closeTo(halfWidthLogicalPixels, 1e-6),
+          reason: '${testCase.name} offset must keep half width',
+        );
+      }
     });
   });
 

--- a/packages/kyoshin_monitor_api/bin/kyoshin_monitor_api.dart
+++ b/packages/kyoshin_monitor_api/bin/kyoshin_monitor_api.dart
@@ -67,9 +67,9 @@ class DownloadCommand extends Command<void> {
     try {
       final data = type.isLpgm
           ? await lpgmKyoshinMonitorWebApiDataSource.getRealtimeImageData(
-              type,
-              layer,
-              datetime,
+              type: type,
+              layer: layer,
+              dateTime: datetime,
             )
           : await kyoshinMonitorWebApiDataSource.getRealtimeImageData(
               type: type,

--- a/packages/kyoshin_monitor_api/lib/src/api/lpgm_kyoshin_monitor_web_api_client.dart
+++ b/packages/kyoshin_monitor_api/lib/src/api/lpgm_kyoshin_monitor_web_api_client.dart
@@ -48,19 +48,36 @@ abstract class LpgmKyoshinMonitorWebApiClient {
     @Path('dateTime') required String dateTime,
   });
 
-  /// RealtimeImg
+  /// 強震モニタ RealtimeImg
   ///
   /// [type] データ種別
   /// [layer] 地上(s), 地下(b)
   /// [date] 日付(yyyyMMdd)
   /// [dateTime] 日付(yyyyMMddHHmmss)
   @GET(
-    '/monitor/data/data/map_img/RealTimeImg/{type}_{layer}/{date}/{dateTime}.{type}_{layer}.gif',
+    '/img_svr/data/map_img/RealTimeImg/'
+    '{type}_{layer}/{date}/{dateTime}.{type}_{layer}.gif',
   )
   @DioResponseType(ResponseType.bytes)
-  Future<List<int>> getRealtimeImageData({
+  Future<List<int>> getKyoshinRealtimeImageData({
     @Path('type') required String type,
     @Path('layer') required String layer,
+    @Path('date') required String date,
+    @Path('dateTime') required String dateTime,
+  });
+
+  /// 長周期地震動モニタ RealtimeImg
+  ///
+  /// [type] データ種別
+  /// [date] 日付(yyyyMMdd)
+  /// [dateTime] 日付(yyyyMMddHHmmss)
+  @GET(
+    '/monitor/data/data/map_img/RealTimeImg/'
+    '{type}_s/{date}/{dateTime}.{type}_s.gif',
+  )
+  @DioResponseType(ResponseType.bytes)
+  Future<List<int>> getLpgmRealtimeImageData({
+    @Path('type') required String type,
     @Path('date') required String date,
     @Path('dateTime') required String dateTime,
   });

--- a/packages/kyoshin_monitor_api/lib/src/api/lpgm_kyoshin_monitor_web_api_client.g.dart
+++ b/packages/kyoshin_monitor_api/lib/src/api/lpgm_kyoshin_monitor_web_api_client.g.dart
@@ -155,7 +155,7 @@ class _LpgmKyoshinMonitorWebApiClient
   }
 
   @override
-  Future<List<int>> getRealtimeImageData({
+  Future<List<int>> getKyoshinRealtimeImageData({
     required String type,
     required String layer,
     required String date,
@@ -174,7 +174,43 @@ class _LpgmKyoshinMonitorWebApiClient
           )
           .compose(
             _dio.options,
-            '/monitor/data/data/map_img/RealTimeImg/${type}_${layer}/${date}/${dateTime}.${type}_${layer}.gif',
+            '/img_svr/data/map_img/RealTimeImg/${type}_${layer}/${date}/${dateTime}.${type}_${layer}.gif',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<int> _value;
+    try {
+      _value = _result.data!.cast<int>();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<List<int>> getLpgmRealtimeImageData({
+    required String type,
+    required String date,
+    required String dateTime,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<List<int>>(
+      Options(
+            method: 'GET',
+            headers: _headers,
+            extra: _extra,
+            responseType: ResponseType.bytes,
+          )
+          .compose(
+            _dio.options,
+            '/monitor/data/data/map_img/RealTimeImg/${type}_s/${date}/${dateTime}.${type}_s.gif',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/packages/kyoshin_monitor_api/lib/src/data_source/lpgm_kyoshin_monitor_web_api_data_source.dart
+++ b/packages/kyoshin_monitor_api/lib/src/data_source/lpgm_kyoshin_monitor_web_api_data_source.dart
@@ -32,16 +32,27 @@ class LpgmKyoshinMonitorWebApiDataSource {
       );
 
   /// RealtimeImg
-  Future<List<int>> getRealtimeImageData(
-    RealtimeDataType type,
-    RealtimeLayer layer,
-    DateTime dateTime,
-  ) => _client.getRealtimeImageData(
-    type: type.urlString,
-    layer: layer.urlString,
-    date: dateFormat.format(dateTime),
-    dateTime: dateTimeFormat.format(dateTime),
-  );
+  Future<List<int>> getRealtimeImageData({
+    required RealtimeDataType type,
+    required RealtimeLayer layer,
+    required DateTime dateTime,
+  }) {
+    final date = dateFormat.format(dateTime);
+    final formattedDateTime = dateTimeFormat.format(dateTime);
+    if (type.isLpgm) {
+      return _client.getLpgmRealtimeImageData(
+        type: type.urlString,
+        date: date,
+        dateTime: formattedDateTime,
+      );
+    }
+    return _client.getKyoshinRealtimeImageData(
+      type: type.urlString,
+      layer: layer.urlString,
+      date: date,
+      dateTime: formattedDateTime,
+    );
+  }
 
   static DateFormat get dateFormat => DateFormat('yyyyMMdd');
   static DateFormat get dateTimeFormat => DateFormat('yyyyMMddHHmmss');

--- a/packages/kyoshin_monitor_api/test/src/api/lpgm_kyoshin_monitor_web_api_client_test.dart
+++ b/packages/kyoshin_monitor_api/test/src/api/lpgm_kyoshin_monitor_web_api_client_test.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:kyoshin_monitor_api/kyoshin_monitor_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late _RecordingBytesAdapter adapter;
+  late LpgmKyoshinMonitorWebApiDataSource dataSource;
+
+  setUp(() {
+    adapter = _RecordingBytesAdapter();
+    final dio = Dio()..httpClientAdapter = adapter;
+    dataSource = LpgmKyoshinMonitorWebApiDataSource(
+      client: LpgmKyoshinMonitorWebApiClient(dio),
+    );
+  });
+
+  test('通常震度の地表は img_svr の jma_s を取得する', () async {
+    await dataSource.getRealtimeImageData(
+      RealtimeDataType.shindo,
+      RealtimeLayer.surface,
+      DateTime(2026, 8, 16, 22, 58, 3),
+    );
+
+    expect(
+      adapter.request?.uri.toString(),
+      'https://www.lmoni.bosai.go.jp/img_svr/data/map_img/'
+      'RealTimeImg/jma_s/20260816/20260816225803.jma_s.gif',
+    );
+  });
+
+  test('通常震度の地下は img_svr の jma_b を取得する', () async {
+    await dataSource.getRealtimeImageData(
+      RealtimeDataType.shindo,
+      RealtimeLayer.underground,
+      DateTime(2026, 8, 16, 22, 58, 3),
+    );
+
+    expect(
+      adapter.request?.uri.toString(),
+      'https://www.lmoni.bosai.go.jp/img_svr/data/map_img/'
+      'RealTimeImg/jma_b/20260816/20260816225803.jma_b.gif',
+    );
+  });
+
+  test('長周期データは地下設定でも monitor 配下の abrspmx_s を取得する', () async {
+    await dataSource.getRealtimeImageData(
+      RealtimeDataType.abrspmx,
+      RealtimeLayer.underground,
+      DateTime(2026, 8, 16, 22, 58, 3),
+    );
+
+    expect(
+      adapter.request?.uri.toString(),
+      'https://www.lmoni.bosai.go.jp/monitor/data/data/map_img/'
+      'RealTimeImg/abrspmx_s/20260816/20260816225803.abrspmx_s.gif',
+    );
+  });
+}
+
+final class _RecordingBytesAdapter implements HttpClientAdapter {
+  RequestOptions? request;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    request = options;
+    return ResponseBody.fromBytes(const [1, 2, 3], 200);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/packages/kyoshin_monitor_api/test/src/api/lpgm_kyoshin_monitor_web_api_client_test.dart
+++ b/packages/kyoshin_monitor_api/test/src/api/lpgm_kyoshin_monitor_web_api_client_test.dart
@@ -19,9 +19,9 @@ void main() {
 
   test('通常震度の地表は img_svr の jma_s を取得する', () async {
     await dataSource.getRealtimeImageData(
-      RealtimeDataType.shindo,
-      RealtimeLayer.surface,
-      DateTime(2026, 8, 16, 22, 58, 3),
+      type: RealtimeDataType.shindo,
+      layer: RealtimeLayer.surface,
+      dateTime: DateTime(2026, 8, 16, 22, 58, 3),
     );
 
     expect(
@@ -33,9 +33,9 @@ void main() {
 
   test('通常震度の地下は img_svr の jma_b を取得する', () async {
     await dataSource.getRealtimeImageData(
-      RealtimeDataType.shindo,
-      RealtimeLayer.underground,
-      DateTime(2026, 8, 16, 22, 58, 3),
+      type: RealtimeDataType.shindo,
+      layer: RealtimeLayer.underground,
+      dateTime: DateTime(2026, 8, 16, 22, 58, 3),
     );
 
     expect(
@@ -47,9 +47,9 @@ void main() {
 
   test('長周期データは地下設定でも monitor 配下の abrspmx_s を取得する', () async {
     await dataSource.getRealtimeImageData(
-      RealtimeDataType.abrspmx,
-      RealtimeLayer.underground,
-      DateTime(2026, 8, 16, 22, 58, 3),
+      type: RealtimeDataType.abrspmx,
+      layer: RealtimeLayer.underground,
+      dateTime: DateTime(2026, 8, 16, 22, 58, 3),
     );
 
     expect(


### PR DESCRIPTION
## 概要

長周期地震動モニター（LMoni）の画像取得経路を、現在の公式モニターの配信構成に合わせて修正します。

## 原因

通常の強震モニタ互換画像と長周期地震動画像を同じベースパスで取得していました。また、長周期地震動画像に地中レイヤー（`_b`）を指定できたため、存在しないURLへアクセスしていました。

## 変更内容

- 通常画像を `/img_svr/data/map_img/RealTimeImg/{type}_{layer}/...` から取得
- 長周期画像を `/monitor/data/data/map_img/RealTimeImg/{type}_s/...` から取得
- 長周期データの実効レイヤーを常に地表へ制限
- 長周期データ選択時はレイヤー選択UIを非表示
- URL全体を検証する回帰テストと設定モデルのテストを追加
- 配信経路と確認方法を `docs/knowledge` に記録

参考: https://github.com/ingen084/KyoshinMonitorLib

## 確認

- `mise exec -- dart analyze packages/kyoshin_monitor_api --fatal-infos`
- `mise exec -- flutter analyze <変更したFlutter 4ファイル>`
- `mise exec -- dart test packages/kyoshin_monitor_api/test --reporter expanded`（26件）
- `mise exec -- flutter test app/test/feature/kyoshin_monitor --reporter expanded`（7件）

## 補足

`mise exec -- flutter analyze app` は今回の差分外を含む既存警告1,058件で非ゼロ終了します。変更したFlutterファイル単位の解析では問題ありません。