### PR TITLE
Fix: 震度DB観測点アイコンの表示条件をXMLと統一

### DIFF
--- a/app/lib/feature/earthquake_history/ui/components/shindo_db_intensity_class_icon.dart
+++ b/app/lib/feature/earthquake_history/ui/components/shindo_db_intensity_class_icon.dart
@@ -18,6 +18,21 @@ extension ShindoDbIntensityClassMapIconId on ShindoDbIntensityClass {
         ? 'JmaIntensity.${IntensityIconType.small.name}.${exact.name}'
         : 'ShindoDbIntensityClass.${IntensityIconType.small.name}.$name';
   }
+
+  /// 地図スタイルに登録されたラベルなし観測点アイコン画像の ID
+  ///
+  /// 色だけでは分類できない歴史的階級は [mapIconId] のラベルを維持する。
+  String get plainMapIconId => switch (this) {
+    .five =>
+      'JmaIntensity.${IntensityIconType.smallWithoutText.name}.fiveUnknown',
+    .six =>
+      'JmaIntensity.${IntensityIconType.smallWithoutText.name}.sixUnknown',
+    _ => switch (exactJmaIntensity) {
+      final intensity? =>
+        'JmaIntensity.${IntensityIconType.smallWithoutText.name}.${intensity.name}',
+      null => mapIconId,
+    },
+  };
 }
 
 /// 震度データベースの震度階級の地図用円形アイコン

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart
@@ -4,11 +4,13 @@ import 'dart:convert';
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
 import 'package:eqmonitor/core/util/map/map_geo_json_source_updater.dart';
 import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_class.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_tree.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/provider/shindo_db_intensity_icon_provider.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/shindo_db_intensity_class_icon.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/layer/model/station_icon_image_expression.dart';
 import 'package:eqmonitor/feature/map/features/icon/data/provider/intensity_icon_provider.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -19,11 +21,13 @@ class EarthquakeHistoryShindoDbStationLayer extends HookConsumerWidget {
   const EarthquakeHistoryShindoDbStationLayer({
     required this.tree,
     required this.parameter,
+    this.stationDisplayMode = StationDisplayMode.auto,
     super.key,
   });
 
   final ShindoDbIntensityTree tree;
   final EarthquakeHistoryMapLayerParameter parameter;
+  final StationDisplayMode stationDisplayMode;
 
   static const sourceId = 'eq-history-shindo-db-station';
   static const iconLayerId = 'eq-history-shindo-db-station-icon';
@@ -112,13 +116,14 @@ class EarthquakeHistoryShindoDbStationLayer extends HookConsumerWidget {
           await styleController.addLayer(
             EarthquakeHistoryShindoDbStationLayerBuilder.build(
               parameter: parameter,
+              stationDisplayMode: stationDisplayMode,
             ),
           );
           isLayerInitialized.value = true;
         }),
       );
       return null;
-    }, [styleController, parameter, iconData, dbIconData]);
+    }, [styleController, parameter, stationDisplayMode, iconData, dbIconData]);
 
     useEffect(() {
       final token = lifecycleToken.value;
@@ -148,12 +153,16 @@ class EarthquakeHistoryShindoDbStationLayerBuilder {
 
   static SymbolStyleLayer build({
     required EarthquakeHistoryMapLayerParameter parameter,
+    required StationDisplayMode stationDisplayMode,
   }) => SymbolStyleLayer(
     id: EarthquakeHistoryShindoDbStationLayer.iconLayerId,
     sourceId: EarthquakeHistoryShindoDbStationLayer.sourceId,
     minZoom: parameter.stationMinZoom,
     layout: {
-      'icon-image': ['get', 'iconId'],
+      'icon-image': const StationIconImageExpressionBuilder().build(
+        stationDisplayMode: stationDisplayMode,
+        stationTextZoom: parameter.stationTextZoom,
+      ),
       'icon-allow-overlap': true,
       'icon-ignore-placement': true,
       'symbol-sort-key': ['get', 'sortKey'],
@@ -177,6 +186,11 @@ class EarthquakeHistoryShindoDbStationGeoJsonBuilder {
 
   String build({required ShindoDbIntensityTree tree}) {
     final features = <Map<String, dynamic>>[];
+    final sortedClasses = {
+      ...tree.tree.keys,
+      ...tree.unresolvedStations.keys,
+    }.toList()..sort((a, b) => b.orderIndex.compareTo(a.orderIndex));
+    final maxClass = sortedClasses.firstOrNull;
 
     void addStation(ShindoDbStationNode station, ShindoDbIntensityClass cls) {
       final loc = station.location;
@@ -191,7 +205,9 @@ class EarthquakeHistoryShindoDbStationGeoJsonBuilder {
         },
         'properties': {
           'name': station.name,
-          'iconId': cls.mapIconId,
+          'iconIdFull': cls.mapIconId,
+          'iconIdPlain': cls.plainMapIconId,
+          'isMax': cls == maxClass,
           // 高震度が上に描画されるようソートキーに使用
           'sortKey': cls.orderIndex,
         },

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_lifecycle_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_lifecycle_test.dart
@@ -1,8 +1,30 @@
 import 'dart:convert';
 
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_catalog.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_class.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_tree.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lat_lng/lat_lng.dart';
+
+ShindoDbStationNode makeStation({
+  required String code,
+  required String name,
+  required ShindoDbIntensityClass intensityClass,
+}) => ShindoDbStationNode(
+  record: EarthquakeCatalogStationRecord(
+    stationCode: code,
+    intensityClass: intensityClass,
+    instrumentalIntensity: null,
+    observedAt: null,
+    maxAcceleration: null,
+    maxAccelTime: null,
+    periods: null,
+    observationCount: null,
+  ),
+  name: name,
+  location: const LatLng(35, 139),
+);
 
 void main() {
   test('tree が空でも固定 source ID 向けの空 GeoJSON を生成する', () {
@@ -19,5 +41,59 @@ void main() {
     expect(decoded['features'], isEmpty);
     expect(EarthquakeHistoryShindoDbStationLayer.sourceId, isNotEmpty);
     expect(EarthquakeHistoryShindoDbStationLayer.iconLayerId, isNotEmpty);
+  });
+
+  test('観測階級から full/plain アイコンと最大階級フラグを生成する', () {
+    final tree = ShindoDbIntensityTree(
+      tree: const {},
+      unresolvedStations: {
+        ShindoDbIntensityClass.three: [
+          makeStation(
+            code: 'ST3',
+            name: '震度3',
+            intensityClass: ShindoDbIntensityClass.three,
+          ),
+        ],
+        ShindoDbIntensityClass.five: [
+          makeStation(
+            code: 'ST5',
+            name: '旧震度5',
+            intensityClass: ShindoDbIntensityClass.five,
+          ),
+        ],
+      },
+      totalStationCount: 2,
+    );
+
+    final decoded = jsonDecode(
+      const EarthquakeHistoryShindoDbStationGeoJsonBuilder().build(
+        tree: tree,
+      ),
+    ) as Map<String, dynamic>;
+    final features = (decoded['features'] as List<dynamic>)
+        .cast<Map<String, dynamic>>();
+    final propertiesByName = <String, Map<String, dynamic>>{
+      for (final feature in features)
+        if (feature['properties'] case final Map<String, dynamic> properties)
+          properties['name'] as String: properties,
+    };
+
+    expect(
+      propertiesByName['震度3'],
+      containsPair('iconIdFull', 'JmaIntensity.small.three'),
+    );
+    expect(
+      propertiesByName['震度3'],
+      containsPair('iconIdPlain', 'JmaIntensity.smallWithoutText.three'),
+    );
+    expect(propertiesByName['震度3'], containsPair('isMax', false));
+    expect(propertiesByName['旧震度5'], containsPair('isMax', true));
+    expect(
+      propertiesByName['旧震度5'],
+      containsPair(
+        'iconIdPlain',
+        'JmaIntensity.smallWithoutText.fiveUnknown',
+      ),
+    );
   });
 }

--- a/app/test/feature/earthquake_history/ui/shindo_db_intensity_class_map_icon_test.dart
+++ b/app/test/feature/earthquake_history/ui/shindo_db_intensity_class_map_icon_test.dart
@@ -92,5 +92,24 @@ void main() {
         'ShindoDbIntensityClass.small.unknownFelt',
       );
     });
+
+    test('ラベルなしアイコンIDは数値階級だけ文字なし画像を返すこと', () {
+      expect(
+        ShindoDbIntensityClass.four.plainMapIconId,
+        'JmaIntensity.smallWithoutText.four',
+      );
+      expect(
+        ShindoDbIntensityClass.five.plainMapIconId,
+        'JmaIntensity.smallWithoutText.fiveUnknown',
+      );
+      expect(
+        ShindoDbIntensityClass.six.plainMapIconId,
+        'JmaIntensity.smallWithoutText.sixUnknown',
+      );
+      expect(
+        ShindoDbIntensityClass.local.plainMapIconId,
+        'ShindoDbIntensityClass.small.local',
+      );
+    });
   });
 }

--- a/docs/superpowers/plans/2026-08-16-shindo-db-station-icon-display.md
+++ b/docs/superpowers/plans/2026-08-16-shindo-db-station-icon-display.md
@@ -4,7 +4,7 @@
 
 **Goal:** 震度DB観測点へXML観測点と同じfull/plain/最大震度のアイコン表示要件を適用する。
 
-**Architecture:** 震度階級からラベルなしアイコンIDを解決する責務を既存のアイコンID extensionへ追加する。震度DB GeoJSONを表示モード非依存のfull/plain/isMax契約に変更し、MapLibreレイヤーではXMLと同じ `stationIconImageExpression` を利用する。
+**Architecture:** 震度階級からラベルなしアイコンIDを解決する責務を既存のアイコンID extensionへ追加する。震度DB GeoJSONを表示モード非依存のfull/plain/isMax契約に変更し、MapLibreレイヤーではXMLと同じ `StationIconImageExpressionBuilder` を利用する。
 
 **Tech Stack:** Flutter、Dart、MapLibre style expressions、flutter_test
 
@@ -66,7 +66,7 @@ Commit: `Fix: 震度DB階級にラベルなしアイコンIDを追加`
 - Test: `app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_lifecycle_test.dart`
 
 **Interfaces:**
-- Consumes: `mapIconId`、`plainMapIconId`、`stationIconImageExpression`
+- Consumes: `mapIconId`、`plainMapIconId`、`StationIconImageExpressionBuilder`
 - Produces: GeoJSON properties `iconIdFull`、`iconIdPlain`、`isMax`、`sortKey`
 
 - [ ] **Step 1: GeoJSON契約の失敗テストを書く**
@@ -92,7 +92,7 @@ Expected: `iconIdFull` / `iconIdPlain` / `isMax` が無くFAIL。
 全観測階級から `orderIndex` 最大の階級を導出し、各featureへfull/plain/isMaxを格納する。`EarthquakeHistoryShindoDbStationLayer` とBuilderへ既定値 `.auto` の `StationDisplayMode` を渡し、`icon-image` を次へ変更する。
 
 ```dart
-'icon-image': stationIconImageExpression(
+'icon-image': const StationIconImageExpressionBuilder().build(
   stationDisplayMode: stationDisplayMode,
   stationTextZoom: parameter.stationTextZoom,
 ),

--- a/docs/superpowers/plans/2026-08-16-shindo-db-station-icon-display.md
+++ b/docs/superpowers/plans/2026-08-16-shindo-db-station-icon-display.md
@@ -1,0 +1,110 @@
+# 震度DB観測点アイコン表示統一 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 震度DB観測点へXML観測点と同じfull/plain/最大震度のアイコン表示要件を適用する。
+
+**Architecture:** 震度階級からラベルなしアイコンIDを解決する責務を既存のアイコンID extensionへ追加する。震度DB GeoJSONを表示モード非依存のfull/plain/isMax契約に変更し、MapLibreレイヤーではXMLと同じ `stationIconImageExpression` を利用する。
+
+**Tech Stack:** Flutter、Dart、MapLibre style expressions、flutter_test
+
+## Global Constraints
+
+- Flutter/Dartコマンドは `mise exec --` 経由で実行する。
+- 歴史的分類はラベルなしでは意味を区別できないため、plainでもラベルを維持する。
+- 最大震度階級は実データの階級から導出し、固定値へフォールバックしない。
+- ユーザーの無関係な作業ツリー変更には触れない。
+
+---
+
+### Task 1: full/plainアイコンID契約
+
+**Files:**
+- Modify: `app/lib/feature/earthquake_history/ui/components/shindo_db_intensity_class_icon.dart`
+- Test: `app/test/feature/earthquake_history/ui/shindo_db_intensity_class_map_icon_test.dart`
+
+**Interfaces:**
+- Produces: `ShindoDbIntensityClass.mapIconId`（ラベル入り）と `ShindoDbIntensityClass.plainMapIconId`（ラベルなし）
+
+- [ ] **Step 1: ラベルなしIDの失敗テストを書く**
+
+```dart
+expect(ShindoDbIntensityClass.four.plainMapIconId,
+    'JmaIntensity.smallWithoutText.four');
+expect(ShindoDbIntensityClass.five.plainMapIconId,
+    'JmaIntensity.smallWithoutText.fiveUnknown');
+expect(ShindoDbIntensityClass.local.plainMapIconId,
+    'ShindoDbIntensityClass.small.local');
+```
+
+- [ ] **Step 2: REDを確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/ui/shindo_db_intensity_class_map_icon_test.dart`
+Expected: `plainMapIconId` が未定義でFAIL。
+
+- [ ] **Step 3: 最小実装を追加する**
+
+```dart
+String get plainMapIconId => switch (this) {
+  .five => 'JmaIntensity.${IntensityIconType.smallWithoutText.name}.fiveUnknown',
+  .six => 'JmaIntensity.${IntensityIconType.smallWithoutText.name}.sixUnknown',
+  _ when exactJmaIntensity case final exact? =>
+    'JmaIntensity.${IntensityIconType.smallWithoutText.name}.${exact.name}',
+  _ => mapIconId,
+};
+```
+
+- [ ] **Step 4: GREENを確認してコミットする**
+
+Run: Step 2と同じ。Expected: PASS。
+Commit: `Fix: 震度DB階級にラベルなしアイコンIDを追加`
+
+### Task 2: 震度DBレイヤーの共通表示式移行
+
+**Files:**
+- Modify: `app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart`
+- Test: `app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_lifecycle_test.dart`
+
+**Interfaces:**
+- Consumes: `mapIconId`、`plainMapIconId`、`stationIconImageExpression`
+- Produces: GeoJSON properties `iconIdFull`、`iconIdPlain`、`isMax`、`sortKey`
+
+- [ ] **Step 1: GeoJSON契約の失敗テストを書く**
+
+震度3、旧震度5、歴史的分類localの実 `ShindoDbStationNode` を `unresolvedStations` に入れ、literal値で次を検証する。
+
+```dart
+expect(propertiesByName['震度3'], containsPair('isMax', false));
+expect(propertiesByName['旧震度5'], containsPair('isMax', true));
+expect(propertiesByName['旧震度5'], containsPair(
+  'iconIdPlain', 'JmaIntensity.smallWithoutText.fiveUnknown'));
+expect(propertiesByName['局発'], containsPair(
+  'iconIdPlain', 'ShindoDbIntensityClass.small.local'));
+```
+
+- [ ] **Step 2: REDを確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_lifecycle_test.dart`
+Expected: `iconIdFull` / `iconIdPlain` / `isMax` が無くFAIL。
+
+- [ ] **Step 3: GeoJSONとレイヤーを最小修正する**
+
+全観測階級から `orderIndex` 最大の階級を導出し、各featureへfull/plain/isMaxを格納する。`EarthquakeHistoryShindoDbStationLayer` とBuilderへ既定値 `.auto` の `StationDisplayMode` を渡し、`icon-image` を次へ変更する。
+
+```dart
+'icon-image': stationIconImageExpression(
+  stationDisplayMode: stationDisplayMode,
+  stationTextZoom: parameter.stationTextZoom,
+),
+```
+
+- [ ] **Step 4: GREENと関連テストを確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_lifecycle_test.dart test/feature/earthquake_history/ui/layer/station_icon_image_expression_test.dart test/feature/earthquake_history/ui/shindo_db_intensity_class_map_icon_test.dart`
+Expected: 全件PASS。
+
+- [ ] **Step 5: format/analyze後にコミットする**
+
+Run: `mise exec -- dart format app/lib/feature/earthquake_history/ui/components/shindo_db_intensity_class_icon.dart app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart app/test/feature/earthquake_history/ui/shindo_db_intensity_class_map_icon_test.dart app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_lifecycle_test.dart`
+Run: `cd app && mise exec -- flutter analyze lib/feature/earthquake_history/ui/components/shindo_db_intensity_class_icon.dart lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart`
+Commit: `Fix: 震度DB観測点をXMLと同じ表示条件に統一`

--- a/docs/superpowers/specs/2026-08-16-shindo-db-station-icon-display-design.md
+++ b/docs/superpowers/specs/2026-08-16-shindo-db-station-icon-display-design.md
@@ -1,0 +1,40 @@
+# 震度DB観測点アイコン表示統一 設計
+
+## 背景
+
+地震履歴詳細マップでは、防災情報XML由来の観測点が `StationDisplayMode.auto` に従い、ズーム閾値未満では最大震度の観測点だけに震度ラベルを表示し、閾値以上では全観測点に表示する。
+
+震度データベース由来の観測点は単一の `iconId` を常に参照しており、この表示要件が適用されていない。XML観測点を `iconIdFull`、`iconIdPlain`、`isMax` と共通の `stationIconImageExpression` へ移行した際、震度DBレイヤーが移行対象から漏れたことが原因である。
+
+## 方針
+
+震度DB観測点にもXML観測点と同じ `stationIconImageExpression` を適用する。震度DB用GeoJSONは各観測点に次のプロパティを持たせる。
+
+- `iconIdFull`: 震度階級ラベル入りアイコン
+- `iconIdPlain`: ラベルなしアイコン
+- `isMax`: 当該カタログ内で最上位の震度階級か
+- `sortKey`: 既存の震度階級表示順
+
+最大階級は、実際に観測点を持つ `tree` と `unresolvedStations` のキーを集約し、`ShindoDbIntensityClass.orderIndex` が最大の階級として求める。固定値や震源レコードへの推測によるフォールバックは行わない。
+
+## アイコンの扱い
+
+現行JMA震度と一致する階級では、既存の `JmaIntensity.small` と `JmaIntensity.smallWithoutText` を再利用する。
+
+旧階級の震度5・6は、ラベル入りでは既存の震度DB専用アイコンを使い、ラベルなしでは対応する `JmaIntensity.fiveUnknown` / `sixUnknown` の `smallWithoutText` を利用する。
+
+震度不明・顕著地震などの歴史的分類は色だけでは分類を区別できない。そのため `iconIdPlain` にもラベル入り専用アイコンを指定し、低ズームでも意味を失わないようにする。
+
+## 表示動作
+
+既定の `StationDisplayMode.auto` では次の表示になる。
+
+- `stationTextZoom` 未満: 最大震度階級だけラベル入り。その他の数値階級はラベルなし
+- `stationTextZoom` 以上: 全数値階級をラベル入り
+- 歴史的分類: ズームにかかわらず分類ラベルを維持
+
+将来、他の `StationDisplayMode` を呼び出し側から渡す場合も、XMLと震度DBで同じ共通式が適用される。
+
+## 検証
+
+震度DB用GeoJSONビルダーの小さな回帰テストを追加し、最大階級判定とfull/plainアイコンIDの出力を確認する。既存の共通表示式テストとあわせて、XML・震度DBの表示条件が同じ契約に従うことを保証する。

--- a/docs/superpowers/specs/2026-08-16-shindo-db-station-icon-display-design.md
+++ b/docs/superpowers/specs/2026-08-16-shindo-db-station-icon-display-design.md
@@ -4,11 +4,11 @@
 
 地震履歴詳細マップでは、防災情報XML由来の観測点が `StationDisplayMode.auto` に従い、ズーム閾値未満では最大震度の観測点だけに震度ラベルを表示し、閾値以上では全観測点に表示する。
 
-震度データベース由来の観測点は単一の `iconId` を常に参照しており、この表示要件が適用されていない。XML観測点を `iconIdFull`、`iconIdPlain`、`isMax` と共通の `stationIconImageExpression` へ移行した際、震度DBレイヤーが移行対象から漏れたことが原因である。
+震度データベース由来の観測点は単一の `iconId` を常に参照しており、この表示要件が適用されていない。XML観測点を `iconIdFull`、`iconIdPlain`、`isMax` と共通の `StationIconImageExpressionBuilder` へ移行した際、震度DBレイヤーが移行対象から漏れたことが原因である。
 
 ## 方針
 
-震度DB観測点にもXML観測点と同じ `stationIconImageExpression` を適用する。震度DB用GeoJSONは各観測点に次のプロパティを持たせる。
+震度DB観測点にもXML観測点と同じ `StationIconImageExpressionBuilder` を適用する。震度DB用GeoJSONは各観測点に次のプロパティを持たせる。
 
 - `iconIdFull`: 震度階級ラベル入りアイコン
 - `iconIdPlain`: ラベルなしアイコン


### PR DESCRIPTION
## 概要

震度データベース由来の観測点アイコンを、防災情報XML由来の観測点と同じ表示条件へ統一します。

## 原因

XML観測点を `iconIdFull` / `iconIdPlain` / `isMax` と共通の `StationIconImageExpressionBuilder` へ移行した際、震度DBレイヤーが単一の `iconId` を常時表示する旧実装のまま残っていました。

## 変更内容

- 震度DB GeoJSONへ `iconIdFull`、`iconIdPlain`、`isMax` を追加
- 実際の観測階級から最大階級を算出し、固定値へのフォールバックは不使用
- XMLと同じ `StationDisplayMode.auto` を適用
  - `stationTextZoom` 未満は最大震度のみラベル入り
  - 閾値以上は全観測点をラベル入り
- 旧震度5・6には対応する文字なしアイコンを使用
- 色だけで区別できない歴史的階級は低ズームでもラベルを維持

## 確認

- [x] 対象・関連テスト 13件成功
- [x] 変更4ファイルの `flutter analyze --no-fatal-infos` が終了コード0（既存info lint 5件のみ）
- [x] `git diff --check` 成功
- [ ] app全体テスト: 1689件中1676件成功、13件失敗
  - 失敗はホーム、設定、オンボーディング等の既存Widgetテストで、今回変更した震度DB領域とは非重複
