### PR TITLE
Fix: 地震履歴一覧の表示設定を反映

### DIFF
--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.dart
@@ -23,6 +23,9 @@ abstract class EarthquakeHistoryListConfig with _$EarthquakeHistoryListConfig {
     /// 背景塗りつぶしの有無
     @Default(true) bool isFillBackground,
 
+    /// 発生時刻ソート時に日付区切りを表示するか
+    @Default(true) bool showDateSeparator,
+
     /// ホーム「指定地域」用。将来の地域選択UIから設定
     RegionSearchType? designatedRegionSearchType,
     String? designatedRegionCode,
@@ -47,12 +50,7 @@ abstract class EarthquakeHistoryDetailsConfig
 }
 
 /// 地震履歴詳細画面における塗りつぶし表示モード
-enum EarthquakeHistoryFillMode {
-  none,
-  auto,
-  region,
-  city,
-}
+enum EarthquakeHistoryFillMode { none, auto, region, city }
 
 /// 観測点の表示方法
 enum StationDisplayMode {
@@ -64,8 +62,4 @@ enum StationDisplayMode {
 }
 
 /// 震央マーカーの表示方法
-enum HypocenterDisplayMode {
-  zoomFade,
-  alwaysOpaque,
-  belowStations,
-}
+enum HypocenterDisplayMode { zoomFade, alwaysOpaque, belowStations }

--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.freezed.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.freezed.dart
@@ -318,7 +318,8 @@ $EarthquakeHistoryDetailsConfigCopyWith<$Res> get details {
 mixin _$EarthquakeHistoryListConfig {
 
 /// 背景塗りつぶしの有無
- bool get isFillBackground;/// ホーム「指定地域」用。将来の地域選択UIから設定
+ bool get isFillBackground;/// 発生時刻ソート時に日付区切りを表示するか
+ bool get showDateSeparator;/// ホーム「指定地域」用。将来の地域選択UIから設定
  RegionSearchType? get designatedRegionSearchType; String? get designatedRegionCode; String? get designatedRegionName;
 /// Create a copy of EarthquakeHistoryListConfig
 /// with the given fields replaced by the non-null parameter values.
@@ -332,16 +333,16 @@ $EarthquakeHistoryListConfigCopyWith<EarthquakeHistoryListConfig> get copyWith =
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EarthquakeHistoryListConfig&&(identical(other.isFillBackground, isFillBackground) || other.isFillBackground == isFillBackground)&&(identical(other.designatedRegionSearchType, designatedRegionSearchType) || other.designatedRegionSearchType == designatedRegionSearchType)&&(identical(other.designatedRegionCode, designatedRegionCode) || other.designatedRegionCode == designatedRegionCode)&&(identical(other.designatedRegionName, designatedRegionName) || other.designatedRegionName == designatedRegionName));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EarthquakeHistoryListConfig&&(identical(other.isFillBackground, isFillBackground) || other.isFillBackground == isFillBackground)&&(identical(other.showDateSeparator, showDateSeparator) || other.showDateSeparator == showDateSeparator)&&(identical(other.designatedRegionSearchType, designatedRegionSearchType) || other.designatedRegionSearchType == designatedRegionSearchType)&&(identical(other.designatedRegionCode, designatedRegionCode) || other.designatedRegionCode == designatedRegionCode)&&(identical(other.designatedRegionName, designatedRegionName) || other.designatedRegionName == designatedRegionName));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,isFillBackground,designatedRegionSearchType,designatedRegionCode,designatedRegionName);
+int get hashCode => Object.hash(runtimeType,isFillBackground,showDateSeparator,designatedRegionSearchType,designatedRegionCode,designatedRegionName);
 
 @override
 String toString() {
-  return 'EarthquakeHistoryListConfig(isFillBackground: $isFillBackground, designatedRegionSearchType: $designatedRegionSearchType, designatedRegionCode: $designatedRegionCode, designatedRegionName: $designatedRegionName)';
+  return 'EarthquakeHistoryListConfig(isFillBackground: $isFillBackground, showDateSeparator: $showDateSeparator, designatedRegionSearchType: $designatedRegionSearchType, designatedRegionCode: $designatedRegionCode, designatedRegionName: $designatedRegionName)';
 }
 
 
@@ -352,7 +353,7 @@ abstract mixin class $EarthquakeHistoryListConfigCopyWith<$Res>  {
   factory $EarthquakeHistoryListConfigCopyWith(EarthquakeHistoryListConfig value, $Res Function(EarthquakeHistoryListConfig) _then) = _$EarthquakeHistoryListConfigCopyWithImpl;
 @useResult
 $Res call({
- bool isFillBackground, RegionSearchType? designatedRegionSearchType, String? designatedRegionCode, String? designatedRegionName
+ bool isFillBackground, bool showDateSeparator, RegionSearchType? designatedRegionSearchType, String? designatedRegionCode, String? designatedRegionName
 });
 
 
@@ -369,9 +370,10 @@ class _$EarthquakeHistoryListConfigCopyWithImpl<$Res>
 
 /// Create a copy of EarthquakeHistoryListConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? isFillBackground = null,Object? designatedRegionSearchType = freezed,Object? designatedRegionCode = freezed,Object? designatedRegionName = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? isFillBackground = null,Object? showDateSeparator = null,Object? designatedRegionSearchType = freezed,Object? designatedRegionCode = freezed,Object? designatedRegionName = freezed,}) {
   return _then(_self.copyWith(
 isFillBackground: null == isFillBackground ? _self.isFillBackground : isFillBackground // ignore: cast_nullable_to_non_nullable
+as bool,showDateSeparator: null == showDateSeparator ? _self.showDateSeparator : showDateSeparator // ignore: cast_nullable_to_non_nullable
 as bool,designatedRegionSearchType: freezed == designatedRegionSearchType ? _self.designatedRegionSearchType : designatedRegionSearchType // ignore: cast_nullable_to_non_nullable
 as RegionSearchType?,designatedRegionCode: freezed == designatedRegionCode ? _self.designatedRegionCode : designatedRegionCode // ignore: cast_nullable_to_non_nullable
 as String?,designatedRegionName: freezed == designatedRegionName ? _self.designatedRegionName : designatedRegionName // ignore: cast_nullable_to_non_nullable
@@ -460,10 +462,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool isFillBackground,  RegionSearchType? designatedRegionSearchType,  String? designatedRegionCode,  String? designatedRegionName)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool isFillBackground,  bool showDateSeparator,  RegionSearchType? designatedRegionSearchType,  String? designatedRegionCode,  String? designatedRegionName)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EarthquakeHistoryListConfig() when $default != null:
-return $default(_that.isFillBackground,_that.designatedRegionSearchType,_that.designatedRegionCode,_that.designatedRegionName);case _:
+return $default(_that.isFillBackground,_that.showDateSeparator,_that.designatedRegionSearchType,_that.designatedRegionCode,_that.designatedRegionName);case _:
   return orElse();
 
 }
@@ -481,10 +483,10 @@ return $default(_that.isFillBackground,_that.designatedRegionSearchType,_that.de
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool isFillBackground,  RegionSearchType? designatedRegionSearchType,  String? designatedRegionCode,  String? designatedRegionName)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool isFillBackground,  bool showDateSeparator,  RegionSearchType? designatedRegionSearchType,  String? designatedRegionCode,  String? designatedRegionName)  $default,) {final _that = this;
 switch (_that) {
 case _EarthquakeHistoryListConfig():
-return $default(_that.isFillBackground,_that.designatedRegionSearchType,_that.designatedRegionCode,_that.designatedRegionName);case _:
+return $default(_that.isFillBackground,_that.showDateSeparator,_that.designatedRegionSearchType,_that.designatedRegionCode,_that.designatedRegionName);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -501,10 +503,10 @@ return $default(_that.isFillBackground,_that.designatedRegionSearchType,_that.de
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool isFillBackground,  RegionSearchType? designatedRegionSearchType,  String? designatedRegionCode,  String? designatedRegionName)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool isFillBackground,  bool showDateSeparator,  RegionSearchType? designatedRegionSearchType,  String? designatedRegionCode,  String? designatedRegionName)?  $default,) {final _that = this;
 switch (_that) {
 case _EarthquakeHistoryListConfig() when $default != null:
-return $default(_that.isFillBackground,_that.designatedRegionSearchType,_that.designatedRegionCode,_that.designatedRegionName);case _:
+return $default(_that.isFillBackground,_that.showDateSeparator,_that.designatedRegionSearchType,_that.designatedRegionCode,_that.designatedRegionName);case _:
   return null;
 
 }
@@ -516,11 +518,13 @@ return $default(_that.isFillBackground,_that.designatedRegionSearchType,_that.de
 @JsonSerializable()
 
 class _EarthquakeHistoryListConfig implements EarthquakeHistoryListConfig {
-  const _EarthquakeHistoryListConfig({this.isFillBackground = true, this.designatedRegionSearchType, this.designatedRegionCode, this.designatedRegionName});
+  const _EarthquakeHistoryListConfig({this.isFillBackground = true, this.showDateSeparator = true, this.designatedRegionSearchType, this.designatedRegionCode, this.designatedRegionName});
   factory _EarthquakeHistoryListConfig.fromJson(Map<String, dynamic> json) => _$EarthquakeHistoryListConfigFromJson(json);
 
 /// 背景塗りつぶしの有無
 @override@JsonKey() final  bool isFillBackground;
+/// 発生時刻ソート時に日付区切りを表示するか
+@override@JsonKey() final  bool showDateSeparator;
 /// ホーム「指定地域」用。将来の地域選択UIから設定
 @override final  RegionSearchType? designatedRegionSearchType;
 @override final  String? designatedRegionCode;
@@ -539,16 +543,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EarthquakeHistoryListConfig&&(identical(other.isFillBackground, isFillBackground) || other.isFillBackground == isFillBackground)&&(identical(other.designatedRegionSearchType, designatedRegionSearchType) || other.designatedRegionSearchType == designatedRegionSearchType)&&(identical(other.designatedRegionCode, designatedRegionCode) || other.designatedRegionCode == designatedRegionCode)&&(identical(other.designatedRegionName, designatedRegionName) || other.designatedRegionName == designatedRegionName));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EarthquakeHistoryListConfig&&(identical(other.isFillBackground, isFillBackground) || other.isFillBackground == isFillBackground)&&(identical(other.showDateSeparator, showDateSeparator) || other.showDateSeparator == showDateSeparator)&&(identical(other.designatedRegionSearchType, designatedRegionSearchType) || other.designatedRegionSearchType == designatedRegionSearchType)&&(identical(other.designatedRegionCode, designatedRegionCode) || other.designatedRegionCode == designatedRegionCode)&&(identical(other.designatedRegionName, designatedRegionName) || other.designatedRegionName == designatedRegionName));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,isFillBackground,designatedRegionSearchType,designatedRegionCode,designatedRegionName);
+int get hashCode => Object.hash(runtimeType,isFillBackground,showDateSeparator,designatedRegionSearchType,designatedRegionCode,designatedRegionName);
 
 @override
 String toString() {
-  return 'EarthquakeHistoryListConfig(isFillBackground: $isFillBackground, designatedRegionSearchType: $designatedRegionSearchType, designatedRegionCode: $designatedRegionCode, designatedRegionName: $designatedRegionName)';
+  return 'EarthquakeHistoryListConfig(isFillBackground: $isFillBackground, showDateSeparator: $showDateSeparator, designatedRegionSearchType: $designatedRegionSearchType, designatedRegionCode: $designatedRegionCode, designatedRegionName: $designatedRegionName)';
 }
 
 
@@ -559,7 +563,7 @@ abstract mixin class _$EarthquakeHistoryListConfigCopyWith<$Res> implements $Ear
   factory _$EarthquakeHistoryListConfigCopyWith(_EarthquakeHistoryListConfig value, $Res Function(_EarthquakeHistoryListConfig) _then) = __$EarthquakeHistoryListConfigCopyWithImpl;
 @override @useResult
 $Res call({
- bool isFillBackground, RegionSearchType? designatedRegionSearchType, String? designatedRegionCode, String? designatedRegionName
+ bool isFillBackground, bool showDateSeparator, RegionSearchType? designatedRegionSearchType, String? designatedRegionCode, String? designatedRegionName
 });
 
 
@@ -576,9 +580,10 @@ class __$EarthquakeHistoryListConfigCopyWithImpl<$Res>
 
 /// Create a copy of EarthquakeHistoryListConfig
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? isFillBackground = null,Object? designatedRegionSearchType = freezed,Object? designatedRegionCode = freezed,Object? designatedRegionName = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? isFillBackground = null,Object? showDateSeparator = null,Object? designatedRegionSearchType = freezed,Object? designatedRegionCode = freezed,Object? designatedRegionName = freezed,}) {
   return _then(_EarthquakeHistoryListConfig(
 isFillBackground: null == isFillBackground ? _self.isFillBackground : isFillBackground // ignore: cast_nullable_to_non_nullable
+as bool,showDateSeparator: null == showDateSeparator ? _self.showDateSeparator : showDateSeparator // ignore: cast_nullable_to_non_nullable
 as bool,designatedRegionSearchType: freezed == designatedRegionSearchType ? _self.designatedRegionSearchType : designatedRegionSearchType // ignore: cast_nullable_to_non_nullable
 as RegionSearchType?,designatedRegionCode: freezed == designatedRegionCode ? _self.designatedRegionCode : designatedRegionCode // ignore: cast_nullable_to_non_nullable
 as String?,designatedRegionName: freezed == designatedRegionName ? _self.designatedRegionName : designatedRegionName // ignore: cast_nullable_to_non_nullable

--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.g.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.g.dart
@@ -44,6 +44,10 @@ _EarthquakeHistoryListConfig _$EarthquakeHistoryListConfigFromJson(
         'is_fill_background',
         (v) => v as bool? ?? true,
       ),
+      showDateSeparator: $checkedConvert(
+        'show_date_separator',
+        (v) => v as bool? ?? true,
+      ),
       designatedRegionSearchType: $checkedConvert(
         'designated_region_search_type',
         (v) => $enumDecodeNullable(_$RegionSearchTypeEnumMap, v),
@@ -61,6 +65,7 @@ _EarthquakeHistoryListConfig _$EarthquakeHistoryListConfigFromJson(
   },
   fieldKeyMap: const {
     'isFillBackground': 'is_fill_background',
+    'showDateSeparator': 'show_date_separator',
     'designatedRegionSearchType': 'designated_region_search_type',
     'designatedRegionCode': 'designated_region_code',
     'designatedRegionName': 'designated_region_name',
@@ -71,6 +76,7 @@ Map<String, dynamic> _$EarthquakeHistoryListConfigToJson(
   _EarthquakeHistoryListConfig instance,
 ) => <String, dynamic>{
   'is_fill_background': instance.isFillBackground,
+  'show_date_separator': instance.showDateSeparator,
   'designated_region_search_type':
       _$RegionSearchTypeEnumMap[instance.designatedRegionSearchType],
   'designated_region_code': instance.designatedRegionCode,

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
@@ -3,14 +3,17 @@ import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/ads/ui/component/ad_banner.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_not_found.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_parameter_persistent_delegate.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/model/earthquake_history_list_display.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
@@ -46,6 +49,11 @@ class _SliverListBody extends HookConsumerWidget {
     final dataSourceAsync = ref.watch(
       earthquakeHistoryDataSourceProvider(parameter.value),
     );
+    final listConfig = ref.watch(
+      earthquakeHistoryConfigProvider.select(
+        (value) => value.requireValue.list,
+      ),
+    );
 
     // デフォルト(発生時刻↓)以外のソート中は、戻る操作でページを閉じずに
     // ソートをデフォルトへ戻す
@@ -72,6 +80,7 @@ class _SliverListBody extends HookConsumerWidget {
         ),
         data: (dataSource) => _PagingBody(
           dataSource: dataSource,
+          listConfig: listConfig,
           parameter: parameter,
           onParameterChanged: (result) => parameter.value = result,
           onRefresh: () => dataSource.refresh(),
@@ -84,18 +93,24 @@ class _SliverListBody extends HookConsumerWidget {
 class _PagingBody extends StatelessWidget {
   const _PagingBody({
     required this.dataSource,
+    required this.listConfig,
     required this.parameter,
     required this.onParameterChanged,
     required this.onRefresh,
   });
 
   final EarthquakeHistoryDataSource dataSource;
+  final EarthquakeHistoryListConfig listConfig;
   final ValueNotifier<EarthquakeHistoryParameter> parameter;
   final ValueChanged<EarthquakeHistoryParameter> onParameterChanged;
   final Future<void> Function() onRefresh;
 
   @override
   Widget build(BuildContext context) {
+    final display = EarthquakeHistoryListDisplay.resolve(
+      config: listConfig,
+      sortBy: parameter.value.sortBy,
+    );
     return RefreshIndicator(
       onRefresh: onRefresh,
       edgeOffset:
@@ -128,14 +143,17 @@ class _PagingBody extends StatelessWidget {
           ),
           SliverGroupedPagingList<String?, String, EarthquakePartial>(
             dataSource: dataSource,
-            stickyHeader: true,
-            headerBuilder: (_, date, _) => _DateHeader(date: date),
+            stickyHeader: display.showDateSeparator,
+            headerBuilder: (_, date, _) => display.showDateSeparator
+                ? _DateHeader(date: date)
+                : const SizedBox.shrink(),
             itemBuilder: (context, item, globalIndex, localIndex) => Column(
               mainAxisSize: MainAxisSize.min,
               children: [
                 EarthquakeHistoryListTile(
                   item: item,
                   searchParameter: parameter.value,
+                  showBackgroundColor: display.showBackgroundColor,
                   onTap: () async => EarthquakeHistoryDetailsRoute(
                     eventId: item.earthquake.eventId,
                   ).push<void>(context),

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
@@ -49,9 +49,9 @@ class _SliverListBody extends HookConsumerWidget {
     final dataSourceAsync = ref.watch(
       earthquakeHistoryDataSourceProvider(parameter.value),
     );
-    final listConfig = ref.watch(
+    final listConfigAsync = ref.watch(
       earthquakeHistoryConfigProvider.select(
-        (value) => value.requireValue.list,
+        (value) => value.whenData((config) => config.list),
       ),
     );
 
@@ -71,19 +71,30 @@ class _SliverListBody extends HookConsumerWidget {
           );
         }
       },
-      child: dataSourceAsync.when(
+      child: listConfigAsync.when(
         loading: () => const _EarthquakeHistorySkeleton(),
         error: (error, _) => ErrorCard(
           error: error,
-          onReload: () async =>
-              ref.refresh(earthquakeHistoryDataSourceProvider(parameter.value)),
+          onReload: () async {
+            ref.invalidate(earthquakeHistoryConfigProvider);
+            await ref.read(earthquakeHistoryConfigProvider.future);
+          },
         ),
-        data: (dataSource) => _PagingBody(
-          dataSource: dataSource,
-          listConfig: listConfig,
-          parameter: parameter,
-          onParameterChanged: (result) => parameter.value = result,
-          onRefresh: () => dataSource.refresh(),
+        data: (listConfig) => dataSourceAsync.when(
+          loading: () => const _EarthquakeHistorySkeleton(),
+          error: (error, _) => ErrorCard(
+            error: error,
+            onReload: () async => ref.refresh(
+              earthquakeHistoryDataSourceProvider(parameter.value),
+            ),
+          ),
+          data: (dataSource) => _PagingBody(
+            dataSource: dataSource,
+            listConfig: listConfig,
+            parameter: parameter,
+            onParameterChanged: (result) => parameter.value = result,
+            onRefresh: () => dataSource.refresh(),
+          ),
         ),
       ),
     );

--- a/app/lib/feature/earthquake_history/ui/model/earthquake_history_list_display.dart
+++ b/app/lib/feature/earthquake_history/ui/model/earthquake_history_list_display.dart
@@ -1,0 +1,21 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+
+class EarthquakeHistoryListDisplay {
+  const EarthquakeHistoryListDisplay({
+    required this.showBackgroundColor,
+    required this.showDateSeparator,
+  });
+
+  factory EarthquakeHistoryListDisplay.resolve({
+    required EarthquakeHistoryListConfig config,
+    required EarthquakeSortBy sortBy,
+  }) => EarthquakeHistoryListDisplay(
+    showBackgroundColor: config.isFillBackground,
+    showDateSeparator:
+        config.showDateSeparator && sortBy == EarthquakeSortBy.eventId,
+  );
+
+  final bool showBackgroundColor;
+  final bool showDateSeparator;
+}

--- a/app/lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart
+++ b/app/lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart
@@ -113,6 +113,30 @@ class _EarthquakeHistoryListConfigWidget extends ConsumerWidget {
                 );
           },
         ),
+        ListTile(
+          title: const Text('発生時刻ソート時の日付区切り'),
+          trailing: AppSwitch(
+            value: state.showDateSeparator,
+            onChanged: (value) async {
+              final full = ref
+                  .read(earthquakeHistoryConfigProvider)
+                  .requireValue;
+              await ref
+                  .read(earthquakeHistoryConfigProvider.notifier)
+                  .save(full.copyWith.list(showDateSeparator: value));
+            },
+          ),
+          onTap: () async {
+            final full = ref.read(earthquakeHistoryConfigProvider).requireValue;
+            await ref
+                .read(earthquakeHistoryConfigProvider.notifier)
+                .save(
+                  full.copyWith.list(
+                    showDateSeparator: !state.showDateSeparator,
+                  ),
+                );
+          },
+        ),
       ],
     );
   }

--- a/app/test/feature/earthquake_history/data/earthquake_history_config_test.dart
+++ b/app/test/feature/earthquake_history/data/earthquake_history_config_test.dart
@@ -11,6 +11,7 @@ void main() {
         list: EarthquakeHistoryListConfig(),
       );
       expect(config.list.isFillBackground, isTrue);
+      expect(config.list.showDateSeparator, isTrue);
       expect(config.list.designatedRegionSearchType, isNull);
     });
   });
@@ -33,6 +34,7 @@ void main() {
       const original = EarthquakeHistoryConfig(
         list: EarthquakeHistoryListConfig(
           isFillBackground: false,
+          showDateSeparator: false,
           designatedRegionSearchType: RegionSearchType.city,
           designatedRegionCode: '13101',
           designatedRegionName: '千代田区',

--- a/app/test/feature/earthquake_history/data/model/earthquake_history_config_model_test.dart
+++ b/app/test/feature/earthquake_history/data/model/earthquake_history_config_model_test.dart
@@ -8,6 +8,17 @@ void main() {
     });
 
     expect(config.details.stationDisplayMode, StationDisplayMode.auto);
+    expect(config.list.showDateSeparator, isTrue);
+  });
+
+  test('showDateSeparator を JSON ラウンドトリップできる', () {
+    const config = EarthquakeHistoryConfig(
+      list: EarthquakeHistoryListConfig(showDateSeparator: false),
+    );
+
+    final restored = EarthquakeHistoryConfig.fromJson(config.toJson());
+
+    expect(restored.list.showDateSeparator, isFalse);
   });
 
   test('stationDisplayMode を JSON ラウンドトリップできる', () {

--- a/app/test/feature/earthquake_history/ui/earthquake_history_page_test.dart
+++ b/app/test/feature/earthquake_history/ui/earthquake_history_page_test.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/earthquake_history_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class _LoadingEarthquakeHistoryConfig extends EarthquakeHistoryConfigNotifier {
+  @override
+  Future<EarthquakeHistoryConfig> build() =>
+      Completer<EarthquakeHistoryConfig>().future;
+}
+
+void main() {
+  testWidgets('一覧設定の読み込み中はスケルトンを表示する', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          earthquakeHistoryConfigProvider.overrideWith(
+            _LoadingEarthquakeHistoryConfig.new,
+          ),
+          earthquakeHistoryDataSourceProvider.overrideWith(
+            (ref, parameter) => Completer<EarthquakeHistoryDataSource>().future,
+          ),
+        ],
+        child: const MaterialApp(home: EarthquakeHistoryPage()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('震源地 0'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/app/test/feature/earthquake_history/ui/model/earthquake_history_list_display_test.dart
+++ b/app/test/feature/earthquake_history/ui/model/earthquake_history_list_display_test.dart
@@ -1,11 +1,8 @@
-// ignore_for_file: avoid_top_level_functions
-
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/model/earthquake_history_list_display.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-// ignore: avoid_top_level_functions
 void main() {
   test('背景塗りつぶし設定を一覧表示へ反映する', () {
     final display = EarthquakeHistoryListDisplay.resolve(

--- a/app/test/feature/earthquake_history/ui/model/earthquake_history_list_display_test.dart
+++ b/app/test/feature/earthquake_history/ui/model/earthquake_history_list_display_test.dart
@@ -1,0 +1,49 @@
+// ignore_for_file: avoid_top_level_functions
+
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/model/earthquake_history_list_display.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ignore: avoid_top_level_functions
+void main() {
+  test('背景塗りつぶし設定を一覧表示へ反映する', () {
+    final display = EarthquakeHistoryListDisplay.resolve(
+      config: const EarthquakeHistoryListConfig(isFillBackground: false),
+      sortBy: EarthquakeSortBy.eventId,
+    );
+
+    expect(display.showBackgroundColor, isFalse);
+  });
+
+  test('設定が有効なら発生時刻ソートの昇順・降順で日付区切りを表示できる', () {
+    final display = EarthquakeHistoryListDisplay.resolve(
+      config: const EarthquakeHistoryListConfig(),
+      sortBy: EarthquakeSortBy.eventId,
+    );
+
+    expect(display.showDateSeparator, isTrue);
+  });
+
+  test('設定が無効なら発生時刻ソートでも日付区切りを表示しない', () {
+    final display = EarthquakeHistoryListDisplay.resolve(
+      config: const EarthquakeHistoryListConfig(showDateSeparator: false),
+      sortBy: EarthquakeSortBy.eventId,
+    );
+
+    expect(display.showDateSeparator, isFalse);
+  });
+
+  test('発生時刻以外のソートでは日付区切りを表示しない', () {
+    for (final sortBy in EarthquakeSortBy.values.where(
+      (value) => value != EarthquakeSortBy.eventId,
+    )) {
+      final display = EarthquakeHistoryListDisplay.resolve(
+        config: const EarthquakeHistoryListConfig(),
+        sortBy: sortBy,
+      );
+
+      expect(display.showDateSeparator, isFalse, reason: sortBy.name);
+    }
+  });
+}

--- a/app/test/feature/settings/children/config/earthquake_history/earthquake_history_config_page_test.dart
+++ b/app/test/feature/settings/children/config/earthquake_history/earthquake_history_config_page_test.dart
@@ -1,0 +1,65 @@
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart';
+import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
+import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
+import 'package:eqmonitor/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class _StubEarthquakeHistoryConfig extends EarthquakeHistoryConfigNotifier {
+  EarthquakeHistoryConfig? savedValue;
+
+  @override
+  Future<EarthquakeHistoryConfig> build() async =>
+      const EarthquakeHistoryConfig(list: EarthquakeHistoryListConfig());
+
+  @override
+  Future<void> save(EarthquakeHistoryConfig value) async {
+    savedValue = value;
+    state = AsyncValue.data(value);
+  }
+}
+
+class _StubHomeConfiguration extends HomeConfigurationNotifier {
+  @override
+  Future<HomeConfigurationModel> build() async =>
+      const HomeConfigurationModel();
+}
+
+void main() {
+  testWidgets('日付区切りタイルをタップすると常時非表示設定を保存する', (tester) async {
+    final historyConfig = _StubEarthquakeHistoryConfig();
+    final container = ProviderContainer(
+      overrides: [
+        earthquakeHistoryConfigProvider.overrideWith(() => historyConfig),
+        homeConfigurationProvider.overrideWith(_StubHomeConfiguration.new),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(earthquakeHistoryConfigProvider.future);
+    await container.read(homeConfigurationProvider.future);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: ThemeData.light().copyWith(
+            extensions: [DesignSystemThemeExtension.light()],
+          ),
+          home: const EarthquakeHistoryConfigPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final tile = find.text('発生時刻ソート時の日付区切り');
+    expect(tile, findsOneWidget);
+
+    await tester.tap(tile);
+    await tester.pump();
+
+    expect(historyConfig.savedValue?.list.showDateSeparator, isFalse);
+  });
+}

--- a/docs/knowledge/20260816_eqmonitor_lint_test_main.md
+++ b/docs/knowledge/20260816_eqmonitor_lint_test_main.md
@@ -1,0 +1,34 @@
+# eqmonitor lintのテストmain警告
+
+## 現象
+
+`app/test` のファイルを対象へ明示して `dart analyze` を実行すると、
+Flutterテストに必須のトップレベル `main()` が
+`avoid_top_level_functions` として警告される。
+
+```sh
+cd app
+mise exec -- dart analyze test/feature/example_test.dart
+```
+
+`// ignore: avoid_top_level_functions` と
+`// ignore_for_file: avoid_top_level_functions` は、現行の
+`eqmonitor_lints_plugin` による診断を抑制しない。
+
+## 変更時の検証方法
+
+- productionコードは変更ファイルを指定して `dart analyze` する。
+- テストコードは `mise exec -- flutter test <test-path>` でコンパイルと挙動を検証する。
+- 効果のないignoreコメントを追加しない。
+- app全体のlint debtは `docs/todo/760_existing_eqmonitor_custom_lint_debt.md` で追跡する。
+
+例:
+
+```sh
+cd app
+mise exec -- dart analyze lib/feature/example/example_page.dart
+mise exec -- flutter test test/feature/example/example_page_test.dart
+```
+
+lintルール側を修正する場合は、テストファイルの `main()` を除外する契約と、
+ignore directiveを尊重する契約をplugin自身のテストで固定する。

--- a/docs/superpowers/plans/2026-08-16-earthquake-history-list-display-settings.md
+++ b/docs/superpowers/plans/2026-08-16-earthquake-history-list-display-settings.md
@@ -1,0 +1,249 @@
+# Earthquake History List Display Settings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 地震履歴一覧の背景塗りつぶし設定を反映し、日付区切りを発生時刻ソート時だけ表示するか常に非表示にするかを設定可能にする。
+
+**Architecture:** 一覧設定モデルへ後方互換なbooleanを追加し、表示条件は小さなpresentation modelへ集約する。地震履歴ページは設定Providerを購読してpresentation modelの値をListTileとgroup headerへ渡し、設定画面は既存Notifier経由で保存する。
+
+**Tech Stack:** Flutter 3.44、Dart 3.11、Riverpod 3、Freezed、paging_view、flutter_test
+
+## Global Constraints
+
+- Flutter / Dartコマンドは必ず `mise exec --` 経由で実行する。
+- `dynamic`、`Object`、null assertion (`!`) を新規コードで使わない。
+- 既存の地震履歴設定JSONに新キーがなくても既定値 `true` で復元する。
+- 日付区切りは `EarthquakeSortBy.eventId` の昇順・降順でだけ表示対象とする。
+- 「常に表示」モードは実装しない。
+- ユーザーの未コミット差分には触れない。
+
+---
+
+### Task 1: 設定モデルの後方互換な拡張
+
+**Files:**
+- Modify: `app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.dart`
+- Modify: `app/test/feature/earthquake_history/data/earthquake_history_config_test.dart`
+- Modify: `app/test/feature/earthquake_history/data/model/earthquake_history_config_model_test.dart`
+- Generate: `app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.freezed.dart`
+- Generate: `app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.g.dart`
+
+**Interfaces:**
+- Produces: `EarthquakeHistoryListConfig.showDateSeparator: bool`（既定値 `true`）
+
+- [ ] **Step 1: 失敗するモデルテストを書く**
+
+```dart
+expect(config.list.showDateSeparator, isTrue);
+
+final restored = EarthquakeHistoryConfig.fromJson({
+  'list': <String, dynamic>{'show_date_separator': false},
+});
+expect(restored.list.showDateSeparator, isFalse);
+```
+
+- [ ] **Step 2: REDを確認する**
+
+Run: `mise exec -- flutter test test/feature/earthquake_history/data/earthquake_history_config_test.dart test/feature/earthquake_history/data/model/earthquake_history_config_model_test.dart`
+
+Expected: `showDateSeparator` が未定義でコンパイル失敗。
+
+- [ ] **Step 3: 最小実装を追加して生成コードを更新する**
+
+```dart
+/// 発生時刻ソート時に日付区切りを表示するか
+@Default(true) bool showDateSeparator,
+```
+
+Run: `mise exec -- dart run build_runner build --delete-conflicting-outputs`
+
+- [ ] **Step 4: GREENを確認する**
+
+Run: `mise exec -- flutter test test/feature/earthquake_history/data/earthquake_history_config_test.dart test/feature/earthquake_history/data/model/earthquake_history_config_model_test.dart`
+
+Expected: PASS。
+
+- [ ] **Step 5: コミットする**
+
+```bash
+git add app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.dart app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.freezed.dart app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.g.dart app/test/feature/earthquake_history/data/earthquake_history_config_test.dart app/test/feature/earthquake_history/data/model/earthquake_history_config_model_test.dart
+git commit -m "Feat: 地震履歴の日付区切り設定を追加"
+```
+
+### Task 2: 一覧表示への設定反映
+
+**Files:**
+- Create: `app/lib/feature/earthquake_history/ui/model/earthquake_history_list_display.dart`
+- Create: `app/test/feature/earthquake_history/ui/model/earthquake_history_list_display_test.dart`
+- Modify: `app/lib/feature/earthquake_history/ui/earthquake_history_page.dart`
+
+**Interfaces:**
+- Consumes: `EarthquakeHistoryListConfig.showDateSeparator`, `EarthquakeHistoryListConfig.isFillBackground`, `EarthquakeSortBy`
+- Produces: `EarthquakeHistoryListDisplay.resolve({required EarthquakeHistoryListConfig config, required EarthquakeSortBy sortBy})`
+- Produces: `showBackgroundColor: bool`, `showDateSeparator: bool`
+
+- [ ] **Step 1: 失敗する表示ポリシーテストを書く**
+
+```dart
+final display = EarthquakeHistoryListDisplay.resolve(
+  config: const EarthquakeHistoryListConfig(
+    isFillBackground: false,
+    showDateSeparator: true,
+  ),
+  sortBy: EarthquakeSortBy.eventId,
+);
+expect(display.showBackgroundColor, isFalse);
+expect(display.showDateSeparator, isTrue);
+```
+
+`showDateSeparator: false` と `EarthquakeSortBy.magnitude` のケースでは `display.showDateSeparator` がfalseになることも別テストで確認する。
+
+- [ ] **Step 2: REDを確認する**
+
+Run: `mise exec -- flutter test test/feature/earthquake_history/ui/model/earthquake_history_list_display_test.dart`
+
+Expected: `EarthquakeHistoryListDisplay` が未定義でコンパイル失敗。
+
+- [ ] **Step 3: presentation modelを最小実装する**
+
+```dart
+class EarthquakeHistoryListDisplay {
+  const EarthquakeHistoryListDisplay({
+    required this.showBackgroundColor,
+    required this.showDateSeparator,
+  });
+
+  factory EarthquakeHistoryListDisplay.resolve({
+    required EarthquakeHistoryListConfig config,
+    required EarthquakeSortBy sortBy,
+  }) => EarthquakeHistoryListDisplay(
+    showBackgroundColor: config.isFillBackground,
+    showDateSeparator:
+        config.showDateSeparator && sortBy == EarthquakeSortBy.eventId,
+  );
+
+  final bool showBackgroundColor;
+  final bool showDateSeparator;
+}
+```
+
+- [ ] **Step 4: 地震履歴ページへ配線する**
+
+`_SliverListBody` で `earthquakeHistoryConfigProvider` の `.list` を購読し、`_PagingBody` へ渡す。`_PagingBody.build` でpresentation modelを解決し、次を設定する。
+
+```dart
+stickyHeader: display.showDateSeparator,
+headerBuilder: (_, date, _) => display.showDateSeparator
+    ? _DateHeader(date: date)
+    : const SizedBox.shrink(),
+```
+
+```dart
+EarthquakeHistoryListTile(
+  item: item,
+  searchParameter: parameter.value,
+  showBackgroundColor: display.showBackgroundColor,
+)
+```
+
+- [ ] **Step 5: GREENと静的解析を確認する**
+
+Run: `mise exec -- flutter test test/feature/earthquake_history/ui/model/earthquake_history_list_display_test.dart`
+
+Run: `mise exec -- dart analyze lib/feature/earthquake_history/ui/earthquake_history_page.dart lib/feature/earthquake_history/ui/model/earthquake_history_list_display.dart test/feature/earthquake_history/ui/model/earthquake_history_list_display_test.dart`
+
+Expected: PASS、対象ファイルにdiagnosticなし。
+
+- [ ] **Step 6: コミットする**
+
+```bash
+git add app/lib/feature/earthquake_history/ui/earthquake_history_page.dart app/lib/feature/earthquake_history/ui/model/earthquake_history_list_display.dart app/test/feature/earthquake_history/ui/model/earthquake_history_list_display_test.dart
+git commit -m "Fix: 地震履歴一覧へ表示設定を反映"
+```
+
+### Task 3: 設定画面のスイッチ
+
+**Files:**
+- Modify: `app/lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart`
+- Create: `app/test/feature/settings/children/config/earthquake_history/earthquake_history_config_page_test.dart`
+
+**Interfaces:**
+- Consumes: `EarthquakeHistoryListConfig.showDateSeparator`
+- Uses: `EarthquakeHistoryConfigNotifier.save(EarthquakeHistoryConfig value)`
+
+- [ ] **Step 1: 失敗するWidgetテストを書く**
+
+設定ProviderをテストNotifierで上書きし、ページ上の「発生時刻ソート時の日付区切り」をタップすると保存値の `showDateSeparator` が `true` から `false` になることを確認する。
+
+```dart
+expect(find.text('発生時刻ソート時の日付区切り'), findsOneWidget);
+await tester.tap(find.text('発生時刻ソート時の日付区切り'));
+await tester.pump();
+expect(notifier.savedValue?.list.showDateSeparator, isFalse);
+```
+
+- [ ] **Step 2: REDを確認する**
+
+Run: `mise exec -- flutter test test/feature/settings/children/config/earthquake_history/earthquake_history_config_page_test.dart`
+
+Expected: 対象の設定タイルが見つからずFAIL。
+
+- [ ] **Step 3: 既存スイッチと同じ保存経路で実装する**
+
+```dart
+ListTile(
+  title: const Text('発生時刻ソート時の日付区切り'),
+  trailing: AppSwitch(value: state.showDateSeparator, onChanged: saveValue),
+  onTap: () async => saveValue(!state.showDateSeparator),
+)
+```
+
+`saveValue` はWidgetメソッドにせず、各コールバック内で既存と同じ `full.copyWith.list(showDateSeparator: value)` を保存する。
+
+- [ ] **Step 4: GREENと対象解析を確認する**
+
+Run: `mise exec -- flutter test test/feature/settings/children/config/earthquake_history/earthquake_history_config_page_test.dart`
+
+Run: `mise exec -- dart analyze lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart test/feature/settings/children/config/earthquake_history/earthquake_history_config_page_test.dart`
+
+Expected: PASS、対象ファイルにdiagnosticなし。
+
+- [ ] **Step 5: コミットする**
+
+```bash
+git add app/lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart app/test/feature/settings/children/config/earthquake_history/earthquake_history_config_page_test.dart
+git commit -m "Feat: 地震履歴の日付区切り設定UIを追加"
+```
+
+### Task 4: 回帰検証とPR作成
+
+**Files:**
+- Verify only: all files changed by Tasks 1-3
+
+- [ ] **Step 1: フォーマットする**
+
+Run: `mise exec -- dart format app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.dart app/lib/feature/earthquake_history/ui/model/earthquake_history_list_display.dart app/lib/feature/earthquake_history/ui/earthquake_history_page.dart app/lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart app/test/feature/earthquake_history/data/earthquake_history_config_test.dart app/test/feature/earthquake_history/data/model/earthquake_history_config_model_test.dart app/test/feature/earthquake_history/ui/model/earthquake_history_list_display_test.dart app/test/feature/settings/children/config/earthquake_history/earthquake_history_config_page_test.dart`
+
+- [ ] **Step 2: 関連テストをまとめて実行する**
+
+Run: `mise exec -- flutter test test/feature/earthquake_history/data/earthquake_history_config_test.dart test/feature/earthquake_history/data/model/earthquake_history_config_model_test.dart test/feature/earthquake_history/ui/model/earthquake_history_list_display_test.dart test/feature/settings/children/config/earthquake_history/earthquake_history_config_page_test.dart`
+
+Expected: PASS。
+
+- [ ] **Step 3: 対象範囲を解析する**
+
+Run: `mise exec -- dart analyze app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.dart app/lib/feature/earthquake_history/ui/model/earthquake_history_list_display.dart app/lib/feature/earthquake_history/ui/earthquake_history_page.dart app/lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart app/test/feature/earthquake_history/data/earthquake_history_config_test.dart app/test/feature/earthquake_history/data/model/earthquake_history_config_model_test.dart app/test/feature/earthquake_history/ui/model/earthquake_history_list_display_test.dart app/test/feature/settings/children/config/earthquake_history/earthquake_history_config_page_test.dart`
+
+Expected: diagnosticsなし。
+
+- [ ] **Step 4: 差分を監査する**
+
+Run: `git --no-pager diff origin/develop...HEAD --check`
+
+Run: `git --no-pager diff origin/develop...HEAD --stat`
+
+ユーザー既存差分がコミットへ混入していないことを `git --no-pager status --short` でも確認する。
+
+- [ ] **Step 5: pushしてdraft PRを作成する**
+
+ブランチ `codex/fix-earthquake-history-display-settings` をpushし、base `develop` のdraft PRを作成する。本文には原因、修正内容、テスト結果を記載する。

--- a/docs/superpowers/specs/2026-08-16-earthquake-history-list-display-settings-design.md
+++ b/docs/superpowers/specs/2026-08-16-earthquake-history-list-display-settings-design.md
@@ -1,0 +1,54 @@
+# 地震履歴一覧の表示設定 設計
+
+## 目的
+
+地震履歴設定の「最大震度ごとの背景塗りつぶし」を一覧表示へ正しく反映する。
+また、日付区切りを発生時刻ソート時だけ表示するか、常に非表示にするかを利用者が選べるようにする。
+
+## 現状と原因
+
+- `EarthquakeHistoryListConfig.isFillBackground` は設定画面から保存できる。
+- `EarthquakeHistoryListTile` も `showBackgroundColor` で塗りつぶしを制御できる。
+- しかし地震履歴一覧は設定 Provider を購読せず、`showBackgroundColor` を渡していないため、既定値 `true` が常に使われている。
+- 日付区切りは現在、ソート種別にかかわらず sticky header として常に表示される。
+
+## 設定モデル
+
+`EarthquakeHistoryListConfig` に `showDateSeparator` を追加する。既定値は `true` とする。
+
+- `true`: `EarthquakeSortBy.eventId`（画面上の「発生時刻」）でソートしている時だけ日付区切りを表示する。昇順・降順の両方を対象とする。
+- `false`: ソート種別にかかわらず日付区切りを表示しない。
+
+保存済み JSON にキーがない場合は Freezed の既定値によって `true` に復元し、既存利用者の表示を維持する。
+
+## UI とデータフロー
+
+地震履歴設定画面には「発生時刻ソート時の日付区切り」のスイッチを追加する。スイッチ変更時は既存の `EarthquakeHistoryConfigNotifier.save` を通じて設定全体を保存する。
+
+地震履歴一覧は `earthquakeHistoryConfigProvider` から一覧設定だけを購読する。
+
+- `isFillBackground` を `EarthquakeHistoryListTile.showBackgroundColor` へ渡す。
+- 日付区切りの表示可否は、一覧設定と現在の `EarthquakeHistoryParameter.sortBy` から純粋関数で決定する。
+- 非表示時は `headerBuilder` が `SizedBox.shrink()` を返し、`stickyHeader` も無効にする。
+
+日付によるデータのグループ化は維持する。ページングデータソースやAPIリクエストには変更を加えない。
+
+## エラー処理
+
+設定の読み込み・保存エラー処理は既存の Provider に委ねる。新しい固定値フォールバックや例外の握り潰しは追加しない。
+
+## テスト
+
+- `EarthquakeHistoryListConfig` の既定値が `showDateSeparator == true` であること。
+- 新しいキーがない既存 JSON から `true` へ復元できること。
+- `showDateSeparator` の `false` を JSON ラウンドトリップできること。
+- 発生時刻ソートの昇順・降順では、設定が有効なら日付区切りを表示すること。
+- 発生時刻以外のソートと、設定が無効な場合は日付区切りを表示しないこと。
+- 地震履歴一覧が `isFillBackground` を各 ListTile に渡すこと。
+- 設定画面のスイッチ操作で `showDateSeparator` が保存されること。
+
+## 対象外
+
+- 日付区切りを常に表示するモード。
+- EEW履歴など、地震履歴以外の一覧の日付区切り設定。
+- ページングパッケージやAPIの変更。


### PR DESCRIPTION
## 概要

- 地震履歴一覧で「最大震度ごとの背景塗りつぶし」設定を実際のListTileへ反映
- 「発生時刻ソート時の日付区切り」設定を追加（デフォルトON）
- 設定OFF時、または発生時刻以外のソート時は日付区切りとsticky headerを非表示
- 設定読み込み中はスケルトン、読み込み失敗時は再試行UIを表示

## 原因

設定値は保存されていましたが、地震履歴一覧が設定Providerを購読しておらず、ListTileの既定値 `true` が常に使われていました。

## 互換性

既存の保存JSONに `show_date_separator` がない場合は `true` として復元します。

## テスト

- `mise exec -- flutter test --reporter silent`（アプリ全テスト成功）
- 今回のconfig/model/display/page/settings対象テスト14件成功