### PR TITLE
CI: Dart analyzerをproblem matcherへ移行

### DIFF
--- a/.github/problem-matchers/dart-analyzer.json
+++ b/.github/problem-matchers/dart-analyzer.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "dart-analyzer-machine",
+      "pattern": [
+        {
+          "regexp": "^(ERROR|WARNING|INFO)\\|[^|]*\\|([^|]*)\\|([^|]*)\\|(\\d+)\\|(\\d+)\\|\\d+\\|(.*)$",
+          "severity": 1,
+          "code": 2,
+          "file": 3,
+          "line": 4,
+          "column": 5,
+          "message": 6
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/wc-check-dart-analyze.yaml
+++ b/.github/workflows/wc-check-dart-analyze.yaml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   flutter-analyze:
@@ -14,7 +13,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -39,15 +37,14 @@ jobs:
       - name: Resolve dependencies
         run: mise exec -- dart pub get --enforce-lockfile
 
-      # https://github.com/invertase/github-action-dart-analyzer
-      - name: Report analyze
-        uses: invertase/github-action-dart-analyzer@e981b01a458d0bab71ee5da182e5b26687b7101b # v3.0.0
-        with:
-          fatal-infos: true
-          working-directory: app
+      - name: Register Dart analyzer problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/dart-analyzer.json"
+
+      - name: Analyze app
+        run: mise exec -- dart analyze app --fatal-infos --format machine
 
       # eqmonitor_custom_lints (avoid_direct_color_scheme 等) は
-      # analysis_options.yaml の `plugins:` 経由で上記 dart analyze から
+      # analysis_options.yaml の `plugins:` 経由で上記 Analyze app から
       # 既に実行されるため、ここではルール実装自体の回帰防止として
       # パッケージ単体のユニットテストのみ実行する。
       - name: Test eqmonitor_custom_lints

--- a/docs/knowledge/20260816_github_actions_dart_analyzer_annotations.md
+++ b/docs/knowledge/20260816_github_actions_dart_analyzer_annotations.md
@@ -1,0 +1,52 @@
+# GitHub Actions の Dart analyzer 注釈
+
+## 方針
+
+Flutter SDK を mise で固定している workflow では、analyzer 用 Action に解析を委譲しない。
+固定 SDK の `dart analyze` を直接実行し、GitHub problem matcher で注釈へ変換する。
+
+```yaml
+- name: Register Dart analyzer problem matcher
+  run: echo "::add-matcher::.github/problem-matchers/dart-analyzer.json"
+
+- name: Analyze app
+  run: mise exec -- dart analyze app --fatal-infos --format machine
+```
+
+matcher は `.github/problem-matchers/dart-analyzer.json` で管理する。
+追加の Dart SDK を導入すると Flutter 同梱 SDK と PATH が競合するため、
+matcher 登録だけを目的に `dart-lang/setup-dart` を追加しない。
+
+## machine 形式が必要な理由
+
+`dart analyze app` の通常出力は、実行位置にかかわらず解析対象からの相対パス
+（`lib/...`）を出力する。GitHub problem matcher は実在しないファイルや
+リポジトリ外のファイルを注釈対象から落とすため、root の `lib/...` と誤認される。
+
+`--format machine` はファイルを絶対パスで出力する。matcher は次の順序を扱う。
+
+```text
+SEVERITY|TYPE|CODE|FILE|LINE|COLUMN|LENGTH|MESSAGE
+```
+
+Dart 3.11 では `dart analyze --help` に表示されないが、machine 形式は利用できる。
+SDK 更新時は、実データのフィールド順と絶対パス出力を必ず再確認する。
+
+## 終了条件と権限
+
+`--fatal-infos` を維持し、info を含む diagnostics で job を失敗させる。
+problem matcher は runner の workflow command を使うため、`checks: write` は不要で、
+workflow の権限は `contents: read` のみにする。
+解析失敗を成功扱いにするフォールバックや Node 20 許可設定は追加しない。
+
+## ローカル検証
+
+```shell
+mise exec -- dart pub get --enforce-lockfile
+jq empty .github/problem-matchers/dart-analyzer.json
+mise exec -- actionlint .github/workflows/wc-check-dart-analyze.yaml
+mise exec -- dart analyze app --fatal-infos --format machine
+```
+
+既存 diagnostics で最後のコマンドが非ゼロ終了する場合は、matcher や workflow の
+構文不良と分けて扱う。先頭の machine 行で絶対パスとフィールド順を確認する。

--- a/docs/superpowers/plans/2026-08-16-replace-invertase-dart-analyzer.md
+++ b/docs/superpowers/plans/2026-08-16-replace-invertase-dart-analyzer.md
@@ -1,0 +1,100 @@
+# Invertase Dart Analyzer Action Replacement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** archived Invertase Action を、注釈対応の直接的な Dart analyzer 実行へ置換する。
+**Architecture:** リポジトリ管理の GitHub problem matcher が analyzer の標準出力をファイル注釈へ変換する。解析自体は mise で固定した Flutter 同梱 Dart SDK を使用し、既存の `app` スコープと blocking 条件を維持する。
+
+**Tech Stack:** GitHub Actions、Dart analyzer、mise、GitHub problem matcher、actionlint
+
+## Global Constraints
+
+- Flutter / Dart コマンドは必ず `mise exec --` 経由で実行する。
+- `app` の解析範囲、`--fatal-infos`、両 custom analyzer plugins を維持する。
+- Node 20 許可、成功扱いへのフォールバック、新しい analyzer Action を追加しない。
+
+### Task 1: Problem matcher と直接解析
+
+**Files:**
+- Create: `.github/problem-matchers/dart-analyzer.json`
+- Modify: `.github/workflows/wc-check-dart-analyze.yaml`
+
+**Interfaces:**
+- Consumes: `dart analyze` のハイフン区切りまたは中黒区切り diagnostics
+- Produces: GitHub の error、warning、info ファイル注釈と analyzer の終了コード
+
+- [ ] **Step 1: 置換前の検査が失敗することを確認する**
+
+```shell
+! test -f .github/problem-matchers/dart-analyzer.json
+rg -n "invertase/github-action-dart-analyzer|checks: write" .github/workflows/wc-check-dart-analyze.yaml
+```
+
+Expected: matcher は未作成で、workflow から Invertase Action と `checks: write` が検出される。
+
+- [ ] **Step 2: Dart analyzer problem matcher を追加する**
+
+`problemMatcher` 配列に severity、位置、メッセージ、診断コードを抽出する
+`dart-analyzer-bullet` と `dart-analyzer-dash` を定義する。
+
+- [ ] **Step 3: workflow を直接解析へ置換する**
+
+`checks: write` を workflow と job から削除し、`Report analyze` を次の2ステップへ置換する。
+
+```yaml
+      - name: Register Dart analyzer problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/dart-analyzer.json"
+
+      - name: Analyze app
+        run: mise exec -- dart analyze app --fatal-infos
+```
+
+- [ ] **Step 4: matcher と workflow を検証する**
+
+```shell
+jq -e '.problemMatcher | length == 2' .github/problem-matchers/dart-analyzer.json
+mise exec -- actionlint .github/workflows/wc-check-dart-analyze.yaml
+mise exec -- dart analyze app --fatal-infos
+! rg -n "invertase/github-action-dart-analyzer|ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION|checks: write" .github/workflows/wc-check-dart-analyze.yaml
+```
+
+Expected: JSON と workflow は有効で、archived Action、Node 20 許可、不要権限は存在しない。既存 diagnostics がある場合、analyzer はそれを報告して非ゼロ終了する。
+
+- [ ] **Step 5: 実装をコミットする**
+
+```shell
+git add .github/problem-matchers/dart-analyzer.json .github/workflows/wc-check-dart-analyze.yaml
+git commit -m "CI: Dart解析をproblem matcherへ移行"
+```
+
+### Task 2: CI 運用知見と最終検証
+
+**Files:**
+- Create: `docs/knowledge/20260816_github_actions_dart_analyzer_annotations.md`
+
+**Interfaces:**
+- Consumes: Task 1 の matcher 登録方式と解析コマンド
+- Produces: 今後の Flutter/Dart CI 更新時に参照する運用ルール
+
+- [ ] **Step 1: 運用知見を記録する**
+
+matcher 登録、mise SDK、root からの解析、fatal 条件、権限、検証コマンドを記録する。
+
+- [ ] **Step 2: 全差分を検証する**
+
+```shell
+mise exec -- actionlint .github/workflows/wc-check-dart-analyze.yaml
+jq empty .github/problem-matchers/dart-analyzer.json
+git --no-pager diff --check origin/ci/replace-invertase-dart-analyzer...HEAD
+git --no-pager status --short
+```
+
+Expected: 構文エラーと whitespace error がなく、意図した3ファイルと文書だけが変更されている。
+
+- [ ] **Step 3: 知見をコミットして push する**
+
+```shell
+git add docs/knowledge/20260816_github_actions_dart_analyzer_annotations.md
+git commit -m "Docs: Dart解析注釈のCI運用を記録"
+git push
+```

--- a/docs/superpowers/plans/2026-08-16-replace-invertase-dart-analyzer.md
+++ b/docs/superpowers/plans/2026-08-16-replace-invertase-dart-analyzer.md
@@ -20,7 +20,7 @@
 - Modify: `.github/workflows/wc-check-dart-analyze.yaml`
 
 **Interfaces:**
-- Consumes: `dart analyze` のハイフン区切りまたは中黒区切り diagnostics
+- Consumes: `dart analyze --format machine` の絶対パス付き diagnostics
 - Produces: GitHub の error、warning、info ファイル注釈と analyzer の終了コード
 
 - [ ] **Step 1: 置換前の検査が失敗することを確認する**
@@ -35,7 +35,7 @@ Expected: matcher は未作成で、workflow から Invertase Action と `checks
 - [ ] **Step 2: Dart analyzer problem matcher を追加する**
 
 `problemMatcher` 配列に severity、位置、メッセージ、診断コードを抽出する
-`dart-analyzer-bullet` と `dart-analyzer-dash` を定義する。
+`dart-analyzer-machine` を定義する。
 
 - [ ] **Step 3: workflow を直接解析へ置換する**
 
@@ -46,15 +46,15 @@ Expected: matcher は未作成で、workflow から Invertase Action と `checks
         run: echo "::add-matcher::.github/problem-matchers/dart-analyzer.json"
 
       - name: Analyze app
-        run: mise exec -- dart analyze app --fatal-infos
+        run: mise exec -- dart analyze app --fatal-infos --format machine
 ```
 
 - [ ] **Step 4: matcher と workflow を検証する**
 
 ```shell
-jq -e '.problemMatcher | length == 2' .github/problem-matchers/dart-analyzer.json
+jq -e '.problemMatcher | length == 1' .github/problem-matchers/dart-analyzer.json
 mise exec -- actionlint .github/workflows/wc-check-dart-analyze.yaml
-mise exec -- dart analyze app --fatal-infos
+mise exec -- dart analyze app --fatal-infos --format machine
 ! rg -n "invertase/github-action-dart-analyzer|ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION|checks: write" .github/workflows/wc-check-dart-analyze.yaml
 ```
 

--- a/docs/superpowers/specs/2026-08-16-replace-invertase-dart-analyzer-design.md
+++ b/docs/superpowers/specs/2026-08-16-replace-invertase-dart-analyzer-design.md
@@ -1,0 +1,53 @@
+# Invertase Dart Analyzer Action 置換設計
+
+## 背景
+
+`wc-check-dart-analyze.yaml` は、解析と GitHub 上の注釈に
+`invertase/github-action-dart-analyzer` を使用している。
+この Action は archive 済みで、実行ランタイムも Node 20 のままである。
+一時的に Node 20 を許可する環境変数は使用せず、保守されない Action を除去する。
+
+## 目的
+
+- mise で固定した Flutter 同梱の Dart SDK を使用する。
+- `app` の解析と `--fatal-infos` による blocking 動作を維持する。
+- analyzer diagnostics を GitHub Actions のファイル注釈として表示する。
+- `eqmonitor_lints_plugin` と `eqmonitor_custom_lints` を引き続き実行する。
+- analyzer の実行にサードパーティー Action を使用しない。
+
+## 採用する構成
+
+リポジトリ内に Dart analyzer 出力用の GitHub problem matcher を置く。
+workflow で matcher を登録した後、次のコマンドをリポジトリルートから実行する。
+
+```shell
+mise exec -- dart analyze app --fatal-infos
+```
+
+matcher は Dart 公式 `dart-lang/setup-dart` の matcher と同様に、
+現在使用されるハイフン区切りと従来の中黒区切りの両形式を扱う。
+診断の severity、ファイル、行、列、メッセージ、診断コードを抽出する。
+
+## Workflow の権限
+
+problem matcher の注釈は runner の workflow command で生成する。
+Checks API を直接呼ばないため、workflow と job の `checks: write` を削除し、
+`contents: read` のみを残す。
+
+## エラー時の動作
+
+matcher の登録は解析より前に行う。解析が error、warning、または info を検出した場合、
+`--fatal-infos` によってステップと job を失敗させる。
+SDK の導入、依存解決、plugin の起動に失敗した場合も、その終了コードをそのまま伝播する。
+固定値や解析成功扱いへのフォールバックは設けない。
+
+## 検証
+
+- problem matcher JSON が有効な JSON であることを確認する。
+- analyzer の代表的な両出力形式が matcher の正規表現に一致することを確認する。
+- `actionlint` で変更後の workflow を検証する。
+- mise 経由で実際の `dart analyze app --fatal-infos` を実行し、解析経路を確認する。
+- workflow から Invertase Action と Node 20 一時許可設定が消えていることを検索する。
+
+既存の analyzer debt によって解析が失敗する場合は、置換とは分離して結果を報告する。
+この変更では既存 diagnostics の修正や解析対象の拡大は行わない。

--- a/docs/superpowers/specs/2026-08-16-replace-invertase-dart-analyzer-design.md
+++ b/docs/superpowers/specs/2026-08-16-replace-invertase-dart-analyzer-design.md
@@ -21,12 +21,12 @@
 workflow で matcher を登録した後、次のコマンドをリポジトリルートから実行する。
 
 ```shell
-mise exec -- dart analyze app --fatal-infos
+mise exec -- dart analyze app --fatal-infos --format machine
 ```
 
-matcher は Dart 公式 `dart-lang/setup-dart` の matcher と同様に、
-現在使用されるハイフン区切りと従来の中黒区切りの両形式を扱う。
-診断の severity、ファイル、行、列、メッセージ、診断コードを抽出する。
+machine 形式は診断ファイルを絶対パスで出力するため、`app` 配下のファイルを
+GitHub が確実に解決できる。matcher は severity、ファイル、行、列、
+メッセージ、診断コードを抽出する。
 
 ## Workflow の権限
 
@@ -44,9 +44,9 @@ SDK の導入、依存解決、plugin の起動に失敗した場合も、その
 ## 検証
 
 - problem matcher JSON が有効な JSON であることを確認する。
-- analyzer の代表的な両出力形式が matcher の正規表現に一致することを確認する。
+- analyzer の machine 形式が matcher の正規表現に一致することを確認する。
 - `actionlint` で変更後の workflow を検証する。
-- mise 経由で実際の `dart analyze app --fatal-infos` を実行し、解析経路を確認する。
+- mise 経由で実際の machine 形式の解析を実行し、解析経路を確認する。
 - workflow から Invertase Action と Node 20 一時許可設定が消えていることを検索する。
 
 既存の analyzer debt によって解析が失敗する場合は、置換とは分離して結果を報告する。


### PR DESCRIPTION
## 概要

archive 済みの `invertase/github-action-dart-analyzer` を削除し、mise で固定した Dart analyzer とリポジトリ管理の GitHub problem matcher に置き換えます。

## 変更内容

- Dart machine diagnostics 用の problem matcher を追加
- `mise exec -- dart analyze app --fatal-infos --format machine` を直接実行
- 不要になった `checks: write` 権限を削除
- Node 20 に依存しない analyzer 注釈の運用手順を文書化

## 背景と影響

Invertase Action は archive 済みで、Node 20 ランタイムを使用していました。この変更後は analyzer 専用 JavaScript Action を実行せず、既存の固定 Flutter/Dart SDK、解析対象、`--fatal-infos`、custom analyzer plugins、GitHub ファイル注釈を維持します。

通常の analyzer 出力は `lib/...` の相対パスになり、リポジトリルート基準では注釈先を解決できません。machine 形式の絶対パスを matcher に渡すことで、`app` 配下の診断位置を正しく解決します。

## 検証

- `mise exec -- actionlint .github/workflows/wc-check-dart-analyze.yaml`
- matcher JSON の構文・owner・ECMAScript正規表現・全キャプチャ項目を検証
- archived Action、Node 20 一時許可、`checks: write` がないことを確認
- `mise exec -- dart analyze app --fatal-infos --format machine`
  - custom plugins を含む1,418件の既存 diagnostics を絶対パス付きで出力し、終了コード2となることを確認
  - 既存 debt は `docs/todo/760_existing_eqmonitor_custom_lint_debt.md` の追跡対象であり、このPRでは変更しません
- pre-commit の zizmor、pinact、gitleaks、merge-conflict、private-key、symlink checks
