### PR TITLE
Fix: assets_utilをAGP 9 DSLへ移行

### DIFF
--- a/docs/knowledge/20260816_assets_util_agp9_gradle_dsl.md
+++ b/docs/knowledge/20260816_assets_util_agp9_gradle_dsl.md
@@ -1,0 +1,57 @@
+# assets_util の AGP 9 Gradle DSL 移行
+
+## 症状
+
+Deploy App run `31967550259` の Android AAB build は、
+`packages/assets_util/android/build.gradle.kts` の script compilation error 4件で失敗した。
+
+- 旧 `android {}` accessor
+- `android.kotlinOptions`
+- 文字列 `jvmTarget`
+- `java.srcDirs(...)`
+
+CI の `warningsAsErrors=true` により、deprecated diagnostic も build failure になる。
+
+## 恒久対応
+
+Android library は AGP の公開 DSL interface を型付きで構成する。
+
+```kotlin
+import com.android.build.api.dsl.LibraryExtension
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+extensions.configure<LibraryExtension>("android") {
+    // Android library settings
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+    }
+}
+```
+
+`src/main/kotlin` は Kotlin Android plugin の既定値なので、SourceSet への再登録は不要。
+`android.newDsl=false` は AGP 10 で削除予定のため、恒久回避策に使わない。
+
+## 検証
+
+Android SDK がある環境では example build と package gate を実行する。
+
+```shell
+cd packages/assets_util/example
+mise exec -- flutter build apk --release
+
+cd ../
+mise exec -- flutter test
+
+cd ../../
+mise exec -- dart analyze packages/assets_util
+```
+
+AGP 9 の移行では、Dart tests だけでなく Gradle project evaluation または Android build を
+必ず含める。Kotlin/AGP の deprecated diagnostic は Dart analyzer では検出できない。
+
+参考:
+- https://developer.android.com/build/releases/agp-9-0-0-release-notes
+- https://kotlinlang.org/docs/gradle-compiler-options.html

--- a/docs/superpowers/plans/2026-08-16-assets-util-agp9-dsl.md
+++ b/docs/superpowers/plans/2026-08-16-assets-util-agp9-dsl.md
@@ -1,0 +1,71 @@
+# assets_util AGP 9 DSL Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy App の Android AAB build を止める assets_util の AGP 9 script compilation error 4件を解消する。
+
+**Architecture:** Android library 設定を AGP の公開 `LibraryExtension` で構成し、Kotlin compiler 設定を Kotlin extension へ分離する。既定の Kotlin source directory は上書きしない。
+
+**Tech Stack:** Gradle 9.3.1、AGP 9.1.1、Kotlin 2.4.0、Flutter、mise
+
+## Global Constraints
+
+- Flutter / Dart コマンドは必ず `mise exec --` 経由で実行する。
+- 固定値 fallback や互換フラグによる旧 DSL 延命を追加しない。
+- Android Gradle 設定以外の assets_util 挙動を変更しない。
+
+---
+
+### Task 1: assets_util Android build script
+
+**Files:**
+- Modify: `packages/assets_util/android/build.gradle.kts`
+- Create: `docs/knowledge/20260816_assets_util_agp9_gradle_dsl.md`
+
+**Interfaces:**
+- Consumes: AGP `com.android.build.api.dsl.LibraryExtension`、Kotlin `JvmTarget`
+- Produces: AGP 9.1.1 で deprecated diagnostic を出さず評価できる Android library configuration
+
+- [x] **Step 1: AGP 9.1.1 で失敗を再現する**
+
+`assets_util/example/android` の project graph を AGP 9.1.1 で評価する。
+
+Expected: `android`、`kotlinOptions`、文字列 `jvmTarget`、`srcDirs` の4件で script compilation error。
+
+- [x] **Step 2: 公開 DSL と compilerOptions へ移行する**
+
+```kotlin
+import com.android.build.api.dsl.LibraryExtension
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+extensions.configure<LibraryExtension>("android") {
+    // Existing Android library settings stay unchanged.
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+    }
+}
+```
+
+既定値と重複する `sourceSets` 上書きは削除する。
+
+- [x] **Step 3: Gradle と package gate を実行する**
+
+```shell
+mise exec -- flutter test packages/assets_util
+mise exec -- dart analyze packages/assets_util
+git --no-pager diff --check origin/develop...HEAD
+```
+
+Expected: tests/analyze/diff check が成功し、AGP 9 project graph から対象4 diagnostic が消える。
+
+- [ ] **Step 4: 実装と知見を分けてコミットする**
+
+```shell
+git add packages/assets_util/android/build.gradle.kts
+git commit -m "Fix: assets_utilをAGP 9 DSLへ移行"
+git add docs/knowledge/20260816_assets_util_agp9_gradle_dsl.md docs/superpowers
+git commit -m "Docs: assets_utilのAGP 9移行手順を記録"
+```

--- a/docs/superpowers/plans/2026-08-16-assets-util-agp9-dsl.md
+++ b/docs/superpowers/plans/2026-08-16-assets-util-agp9-dsl.md
@@ -61,7 +61,7 @@ git --no-pager diff --check origin/develop...HEAD
 
 Expected: tests/analyze/diff check が成功し、AGP 9 project graph から対象4 diagnostic が消える。
 
-- [ ] **Step 4: 実装と知見を分けてコミットする**
+- [x] **Step 4: 実装と知見を分けてコミットする**
 
 ```shell
 git add packages/assets_util/android/build.gradle.kts

--- a/docs/superpowers/specs/2026-08-16-assets-util-agp9-dsl-design.md
+++ b/docs/superpowers/specs/2026-08-16-assets-util-agp9-dsl-design.md
@@ -1,0 +1,30 @@
+# assets_util AGP 9 DSL 移行設計
+
+## 目的
+
+Deploy App run 31967550259 の Android AAB build を停止させた
+`packages/assets_util/android/build.gradle.kts` の AGP 9 非互換を解消する。
+iOS build・配布経路や Dart/native 実装の挙動は変更しない。
+
+## 根因
+
+CI は AGP 9.1.1、Gradle 9.3.1、Kotlin 2.4.0 と
+`warningsAsErrors=true` を使用する。対象 script の旧 `android` accessor、
+`android.kotlinOptions`、文字列 `jvmTarget`、`java.srcDirs` が deprecated diagnostic
+を4件生成し、Kotlin script compilation error になっている。
+
+## 設計
+
+- Android library extension は `extensions.configure<LibraryExtension>("android")`
+  で新しい公開 DSL interface を明示する。
+- Kotlin JVM target は extension-level `kotlin.compilerOptions` と型付き
+  `JvmTarget.JVM_17` で指定する。
+- `src/main/kotlin` は Kotlin Android plugin の既定 source directory なので、
+  deprecated な SourceSet 上書きを削除する。
+- `android.newDsl=false` の延命や AGP downgrade は AGP 10 で行き止まりになるため
+  採用しない。
+
+## 検証
+
+AGP 9.1.1 で example project graph を評価し、対象4 diagnostic が消えることを確認する。
+加えて `assets_util` の Flutter tests、Dart analyze、diff check を実行する。

--- a/docs/todo/950_app_android_agp9_source_provider.md
+++ b/docs/todo/950_app_android_agp9_source_provider.md
@@ -1,0 +1,27 @@
+# app Android の generated assets を AGP 9 Sources API へ移行する
+
+## 症状
+
+`origin/develop` (`79c4a5e5a`) の `app/android` project evaluation が、
+`app/android/app/build.gradle.kts:54` で失敗する。
+
+```text
+You cannot add Provider instances to the Android SourceSet API.
+Use SourceDirectories.addGeneratedDirectory or addStaticDirectories.
+```
+
+`assets.srcDir(bundledAssetPackRoot)` が `Provider<Directory>` を旧 SourceSet API へ渡している。
+参照された Deploy App run `31967550259` の SHA `705694791` より後に、
+commit `682c6b929` で追加されたため、assets_util の4件とは別の blocker。
+
+## やること
+
+1. `stageBundledAssetPack` の出力を AGP 9 Variant `Sources` API の
+   `addGeneratedDirectory` で登録する。
+2. task dependency が自動配線されることを確認し、手動 `preBuild.dependsOn` を整理する。
+3. 実 Android SDK で release AAB を build し、AAB 内の `assets/platform` を検査する。
+4. app の旧 `android` accessor と `java.srcDirs` も公開 DSL へ移行する。
+5. app と自前 plugin を Built-in Kotlin へ移行し、`android.builtInKotlin=false` と
+   `android.newDsl=false` を削除する。どちらも AGP 10 で削除予定。
+
+`android.sourceset.disallowProvider=false` は task dependency を失う暫定回避なので使用しない。

--- a/packages/assets_util/android/build.gradle.kts
+++ b/packages/assets_util/android/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.android.build.api.dsl.LibraryExtension
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 group = "net.yumnumm.assets_util"
 version = "1.0"
 
@@ -6,7 +9,7 @@ plugins {
     id("kotlin-android")
 }
 
-android {
+extensions.configure<LibraryExtension>("android") {
     namespace = "net.yumnumm.assets_util"
     compileSdk = 36
 
@@ -19,12 +22,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+}
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
-    sourceSets {
-        getByName("main").java.srcDirs("src/main/kotlin")
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }


### PR DESCRIPTION
## 概要

Deploy App run [31967550259](https://github.com/YumNumm/EQMonitor/actions/runs/31967550259) の Android AAB build を止めた `packages/assets_util/android/build.gradle.kts` の AGP 9 非互換を修正します。

## Root cause

AGP 9.1.1 / Gradle 9.3.1 / Kotlin 2.4.0 と `warningsAsErrors=true` の組み合わせで、旧 `android` accessor、`android.kotlinOptions`、文字列 `jvmTarget`、`java.srcDirs` の deprecated diagnostic 4件が Kotlin script compilation error になっていました。

## 変更内容

- `LibraryExtension` を型付きで構成する公開 AGP DSL へ移行
- Kotlin JVM target を `kotlin.compilerOptions` + `JvmTarget.JVM_17` へ移行
- Kotlin Android plugin の既定値と重複する `src/main/kotlin` SourceSet 上書きを削除
- AGP 9 移行手順と設計・実装計画を記録
- 参照 run 後に develop へ入った別の app SourceSet Provider blockerを `docs/todo/950_app_android_agp9_source_provider.md` に記録

## 検証

- AGP 9.1.1 project evaluation: `BUILD SUCCESSFUL`（修正前は対象4件で失敗）
- `mise exec -- flutter test` in `packages/assets_util`: 13 passed
- `mise exec -- dart analyze packages/assets_util`: No issues found
- `git diff --check origin/develop...HEAD`: passed
- pre-commit: symlink / merge-conflict / private-key / gitleaks checks passed

## 補足

最新 develop の製品 app 構成は、参照 run の SHA より後に追加された `assets.srcDir(Provider<Directory>)` が AGP 9 で拒否される別問題を持ちます。本 PR は依頼対象の assets_util 4件を限定修正し、別問題は再現情報と恒久対応方針を高優先度 todo に残しています。