### PR TITLE
カスタム通知の地域選択を改善

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/data/action/notification_region_add_action.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/action/notification_region_add_action.dart
@@ -1,0 +1,34 @@
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_selection.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'notification_region_add_action.g.dart';
+
+@riverpod
+NotificationRegionAddAction notificationRegionAddAction(Ref ref) =>
+    const NotificationRegionAddAction();
+
+final class NotificationRegionAddAction {
+  const NotificationRegionAddAction();
+
+  Future<void> add({
+    required WidgetRef ref,
+    required NotificationRegionSelection selection,
+  }) async {
+    await NotificationSlotsNotifier.addRegionMutation.run(ref, (tsx) async {
+      final regionId = int.tryParse(selection.regionCode);
+      if (regionId == null) {
+        throw const FormatException('Invalid notification region code');
+      }
+      await tsx
+          .get(notificationSlotsProvider.notifier)
+          .addRegion(
+            regionId: regionId,
+            regionName: selection.regionName,
+            cityCode: selection.cityCode,
+            cityName: selection.cityName,
+          );
+    });
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/action/notification_region_add_action.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/action/notification_region_add_action.dart
@@ -10,7 +10,7 @@ NotificationRegionAddAction notificationRegionAddAction(Ref ref) =>
     const NotificationRegionAddAction();
 
 final class NotificationRegionAddAction {
-  const NotificationRegionAddAction();
+  const new();
 
   Future<void> add({
     required WidgetRef ref,

--- a/app/lib/feature/settings/features/notification_settings/data/action/notification_region_add_action.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/action/notification_region_add_action.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'notification_region_add_action.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(notificationRegionAddAction)
+final notificationRegionAddActionProvider =
+    NotificationRegionAddActionProvider._();
+
+final class NotificationRegionAddActionProvider
+    extends
+        $FunctionalProvider<
+          NotificationRegionAddAction,
+          NotificationRegionAddAction,
+          NotificationRegionAddAction
+        >
+    with $Provider<NotificationRegionAddAction> {
+  NotificationRegionAddActionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'notificationRegionAddActionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$notificationRegionAddActionHash();
+
+  @$internal
+  @override
+  $ProviderElement<NotificationRegionAddAction> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  NotificationRegionAddAction create(Ref ref) {
+    return notificationRegionAddAction(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(NotificationRegionAddAction value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<NotificationRegionAddAction>(value),
+    );
+  }
+}
+
+String _$notificationRegionAddActionHash() =>
+    r'35f32a035274dde2d47b560d2ea182bb37698f8c';

--- a/app/lib/feature/settings/features/notification_settings/data/logic/latest_map_operation_guard.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/logic/latest_map_operation_guard.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+final class LatestMapOperationGuard {
+  var _generation = 0;
+  var _disposed = false;
+  Future<void> _cameraTail = Future<void>.value();
+
+  int begin() {
+    if (_disposed) {
+      throw StateError('LatestMapOperationGuard is disposed');
+    }
+    _generation++;
+    return _generation;
+  }
+
+  bool isCurrent(int generation) => !_disposed && generation == _generation;
+
+  void invalidate() {
+    if (!_disposed) {
+      _generation++;
+    }
+  }
+
+  Future<void> runLatest({
+    required int generation,
+    required Future<void> Function() operation,
+  }) {
+    final completer = Completer<void>();
+    _cameraTail = _cameraTail.then((_) async {
+      if (!isCurrent(generation)) {
+        completer.complete();
+        return;
+      }
+      try {
+        await operation();
+        completer.complete();
+      } on Exception catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+      } on Error catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+      }
+    });
+    return completer.future;
+  }
+
+  void dispose() {
+    _disposed = true;
+    _generation++;
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_catalog_builder.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_catalog_builder.dart
@@ -1,0 +1,71 @@
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:eqmonitor/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'notification_region_catalog_builder.g.dart';
+
+@riverpod
+NotificationRegionCatalogBuilder notificationRegionCatalogBuilder(Ref ref) =>
+    const NotificationRegionCatalogBuilder();
+
+final class NotificationRegionCatalogBuilder {
+  const NotificationRegionCatalogBuilder();
+
+  NotificationRegionCatalog build({
+    required JmaCodeTableParameter codeTable,
+    required EarthquakeParameter earthquake,
+  }) {
+    final knownRegionCodes = codeTable.codeTables.areaForecastLocalEew
+        .map((region) => region.code)
+        .toSet();
+    final regionCodeByObservationCode = {
+      for (final item in codeTable.codeTables.areaInformationCity)
+        item.code: item.parentAreaForecastLocalEewCode,
+    };
+    final citiesByRegionCode = <String, Map<String, NotificationCityOption>>{};
+    final unmappedCityCodes = <String>[];
+
+    for (final prefecture in earthquake.prefectures) {
+      for (final earthquakeRegion in prefecture.regions) {
+        for (final city in earthquakeRegion.cities) {
+          final observationCodes = {
+            city.code,
+            ...city.stations.map((station) => station.code),
+          };
+          final regionCodes = observationCodes
+              .map((code) => regionCodeByObservationCode[code])
+              .whereType<String>()
+              .where(knownRegionCodes.contains)
+              .toSet();
+          if (regionCodes.isEmpty) {
+            unmappedCityCodes.add(city.code);
+            continue;
+          }
+          final option = NotificationCityOption(
+            code: city.code,
+            name: city.name.ja,
+            kana: city.kana,
+          );
+          for (final regionCode in regionCodes) {
+            (citiesByRegionCode[regionCode] ??= {})[city.code] = option;
+          }
+        }
+      }
+    }
+
+    return NotificationRegionCatalog(
+      regions: codeTable.codeTables.areaForecastLocalEew
+          .map(
+            (region) => NotificationRegionOption(
+              code: region.code,
+              name: region.name.ja,
+              kana: region.kana,
+              cities: citiesByRegionCode[region.code]?.values.toList() ?? [],
+            ),
+          )
+          .toList(),
+      unmappedCityCodes: unmappedCityCodes,
+    );
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_catalog_builder.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_catalog_builder.dart
@@ -10,7 +10,7 @@ NotificationRegionCatalogBuilder notificationRegionCatalogBuilder(Ref ref) =>
     const NotificationRegionCatalogBuilder();
 
 final class NotificationRegionCatalogBuilder {
-  const NotificationRegionCatalogBuilder();
+  const new();
 
   NotificationRegionCatalog build({
     required JmaCodeTableParameter codeTable,

--- a/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_catalog_builder.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_catalog_builder.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'notification_region_catalog_builder.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(notificationRegionCatalogBuilder)
+final notificationRegionCatalogBuilderProvider =
+    NotificationRegionCatalogBuilderProvider._();
+
+final class NotificationRegionCatalogBuilderProvider
+    extends
+        $FunctionalProvider<
+          NotificationRegionCatalogBuilder,
+          NotificationRegionCatalogBuilder,
+          NotificationRegionCatalogBuilder
+        >
+    with $Provider<NotificationRegionCatalogBuilder> {
+  NotificationRegionCatalogBuilderProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'notificationRegionCatalogBuilderProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$notificationRegionCatalogBuilderHash();
+
+  @$internal
+  @override
+  $ProviderElement<NotificationRegionCatalogBuilder> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  NotificationRegionCatalogBuilder create(Ref ref) {
+    return notificationRegionCatalogBuilder(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(NotificationRegionCatalogBuilder value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<NotificationRegionCatalogBuilder>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$notificationRegionCatalogBuilderHash() =>
+    r'b6395a89034d6df6c1d4a25c4d85488f91ea3fbf';

--- a/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_map_filter.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_map_filter.dart
@@ -1,0 +1,41 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'notification_region_map_filter.g.dart';
+
+@riverpod
+NotificationRegionMapFilter notificationRegionMapFilter(Ref ref) =>
+    const NotificationRegionMapFilter();
+
+final class NotificationRegionMapFilter {
+  const NotificationRegionMapFilter();
+
+  List<Object> buildRegion(String? regionCode) => regionCode == null
+      ? buildMatchNothing('code')
+      : <Object>[
+          '==',
+          <Object>['get', 'code'],
+          regionCode,
+        ];
+
+  List<Object> buildRegionCities(List<String> cityCodes) => cityCodes.isEmpty
+      ? buildMatchNothing('regioncode')
+      : <Object>[
+          'in',
+          <Object>['get', 'regioncode'],
+          <Object>['literal', cityCodes],
+        ];
+
+  List<Object> buildSelectedCity(String? cityCode) => cityCode == null
+      ? buildMatchNothing('regioncode')
+      : <Object>[
+          '==',
+          <Object>['get', 'regioncode'],
+          cityCode,
+        ];
+
+  List<Object> buildMatchNothing(String property) => <Object>[
+    '==',
+    <Object>['get', property],
+    '__eqmonitor_no_match__',
+  ];
+}

--- a/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_map_filter.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_map_filter.dart
@@ -7,7 +7,7 @@ NotificationRegionMapFilter notificationRegionMapFilter(Ref ref) =>
     const NotificationRegionMapFilter();
 
 final class NotificationRegionMapFilter {
-  const NotificationRegionMapFilter();
+  const new();
 
   List<Object> buildRegion(String? regionCode) => regionCode == null
       ? buildMatchNothing('code')

--- a/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_map_filter.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_map_filter.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'notification_region_map_filter.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(notificationRegionMapFilter)
+final notificationRegionMapFilterProvider =
+    NotificationRegionMapFilterProvider._();
+
+final class NotificationRegionMapFilterProvider
+    extends
+        $FunctionalProvider<
+          NotificationRegionMapFilter,
+          NotificationRegionMapFilter,
+          NotificationRegionMapFilter
+        >
+    with $Provider<NotificationRegionMapFilter> {
+  NotificationRegionMapFilterProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'notificationRegionMapFilterProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$notificationRegionMapFilterHash();
+
+  @$internal
+  @override
+  $ProviderElement<NotificationRegionMapFilter> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  NotificationRegionMapFilter create(Ref ref) {
+    return notificationRegionMapFilter(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(NotificationRegionMapFilter value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<NotificationRegionMapFilter>(value),
+    );
+  }
+}
+
+String _$notificationRegionMapFilterHash() =>
+    r'f05c0aaff2abbd1314b0da902815c470c4ae8879';

--- a/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_search.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_search.dart
@@ -8,7 +8,7 @@ NotificationRegionSearch notificationRegionSearch(Ref ref) =>
     const NotificationRegionSearch();
 
 final class NotificationRegionSearch {
-  const NotificationRegionSearch();
+  const new();
 
   List<T> filter<T>({
     required List<T> items,

--- a/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_search.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_search.dart
@@ -1,0 +1,43 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:unorm_dart/unorm_dart.dart' as unorm;
+
+part 'notification_region_search.g.dart';
+
+@riverpod
+NotificationRegionSearch notificationRegionSearch(Ref ref) =>
+    const NotificationRegionSearch();
+
+final class NotificationRegionSearch {
+  const NotificationRegionSearch();
+
+  List<T> filter<T>({
+    required List<T> items,
+    required String query,
+    required String Function(T item) name,
+    required String? Function(T item) kana,
+  }) {
+    final normalizedQuery = normalize(query);
+    if (normalizedQuery.isEmpty) {
+      return items;
+    }
+    return items.where((item) {
+      final itemKana = kana(item);
+      return normalize(name(item)).contains(normalizedQuery) ||
+          (itemKana != null && normalize(itemKana).contains(normalizedQuery));
+    }).toList();
+  }
+
+  String normalize(String value) {
+    final compact = unorm
+        .nfkc(value)
+        .toLowerCase()
+        .replaceAll(RegExp(r'\s+'), '');
+    return String.fromCharCodes(
+      compact.runes.map(
+        (codePoint) => codePoint >= 0x30A1 && codePoint <= 0x30F6
+            ? codePoint - 0x60
+            : codePoint,
+      ),
+    );
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_search.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/logic/notification_region_search.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'notification_region_search.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(notificationRegionSearch)
+final notificationRegionSearchProvider = NotificationRegionSearchProvider._();
+
+final class NotificationRegionSearchProvider
+    extends
+        $FunctionalProvider<
+          NotificationRegionSearch,
+          NotificationRegionSearch,
+          NotificationRegionSearch
+        >
+    with $Provider<NotificationRegionSearch> {
+  NotificationRegionSearchProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'notificationRegionSearchProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$notificationRegionSearchHash();
+
+  @$internal
+  @override
+  $ProviderElement<NotificationRegionSearch> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  NotificationRegionSearch create(Ref ref) {
+    return notificationRegionSearch(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(NotificationRegionSearch value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<NotificationRegionSearch>(value),
+    );
+  }
+}
+
+String _$notificationRegionSearchHash() =>
+    r'69671fb5a5e768f992d8bbc196c6c7db3b7ebfd9';

--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart
@@ -1,0 +1,56 @@
+import 'dart:collection';
+
+final class NotificationCityOption {
+  const NotificationCityOption({
+    required this.code,
+    required this.name,
+    required this.kana,
+  });
+
+  final String code;
+  final String name;
+  final String? kana;
+}
+
+final class NotificationRegionOption {
+  NotificationRegionOption({
+    required this.code,
+    required this.name,
+    required this.kana,
+    required List<NotificationCityOption> cities,
+  }) : cities = UnmodifiableListView(cities);
+
+  final String code;
+  final String name;
+  final String? kana;
+  final List<NotificationCityOption> cities;
+
+  NotificationCityOption? cityByCode(String code) {
+    for (final city in cities) {
+      if (city.code == code) {
+        return city;
+      }
+    }
+    return null;
+  }
+}
+
+final class NotificationRegionCatalog {
+  NotificationRegionCatalog({
+    required List<NotificationRegionOption> regions,
+    required List<String> unmappedCityCodes,
+  }) : regions = UnmodifiableListView(regions),
+       unmappedCityCodes = UnmodifiableListView(unmappedCityCodes);
+
+  final List<NotificationRegionOption> regions;
+  final List<String> unmappedCityCodes;
+
+  NotificationRegionOption? regionByCode(String code) {
+    for (final region in regions) {
+      if (region.code == code) {
+        return region;
+      }
+    }
+    return null;
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart
@@ -1,7 +1,7 @@
 import 'dart:collection';
 
 final class NotificationCityOption {
-  const NotificationCityOption({
+  const new({
     required this.code,
     required this.name,
     required this.kana,
@@ -13,7 +13,7 @@ final class NotificationCityOption {
 }
 
 final class NotificationRegionOption {
-  NotificationRegionOption({
+  new({
     required this.code,
     required this.name,
     required this.kana,
@@ -36,7 +36,7 @@ final class NotificationRegionOption {
 }
 
 final class NotificationRegionCatalog {
-  NotificationRegionCatalog({
+  new({
     required List<NotificationRegionOption> regions,
     required List<String> unmappedCityCodes,
   }) : regions = UnmodifiableListView(regions),

--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_region_map_selection.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_region_map_selection.dart
@@ -1,24 +1,24 @@
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
 
 sealed class NotificationRegionMapSelection {
-  const NotificationRegionMapSelection();
+  const new();
 }
 
 final class NotificationRegionMapNationwide
     extends NotificationRegionMapSelection {
-  const NotificationRegionMapNationwide();
+  const new();
 }
 
 final class NotificationRegionMapFocused
     extends NotificationRegionMapSelection {
-  const NotificationRegionMapFocused({required this.region});
+  const new({required this.region});
 
   final NotificationRegionOption region;
 }
 
 final class NotificationRegionMapCitySelected
     extends NotificationRegionMapSelection {
-  const NotificationRegionMapCitySelected({
+  const new({
     required this.region,
     required this.city,
   });

--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_region_map_selection.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_region_map_selection.dart
@@ -1,0 +1,28 @@
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
+
+sealed class NotificationRegionMapSelection {
+  const NotificationRegionMapSelection();
+}
+
+final class NotificationRegionMapNationwide
+    extends NotificationRegionMapSelection {
+  const NotificationRegionMapNationwide();
+}
+
+final class NotificationRegionMapFocused
+    extends NotificationRegionMapSelection {
+  const NotificationRegionMapFocused({required this.region});
+
+  final NotificationRegionOption region;
+}
+
+final class NotificationRegionMapCitySelected
+    extends NotificationRegionMapSelection {
+  const NotificationRegionMapCitySelected({
+    required this.region,
+    required this.city,
+  });
+
+  final NotificationRegionOption region;
+  final NotificationCityOption city;
+}

--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_region_selection.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_region_selection.dart
@@ -1,0 +1,13 @@
+final class NotificationRegionSelection {
+  const NotificationRegionSelection({
+    required this.regionCode,
+    required this.regionName,
+    this.cityCode,
+    this.cityName,
+  });
+
+  final String regionCode;
+  final String regionName;
+  final String? cityCode;
+  final String? cityName;
+}

--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_region_selection.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_region_selection.dart
@@ -1,5 +1,5 @@
 final class NotificationRegionSelection {
-  const NotificationRegionSelection({
+  const new({
     required this.regionCode,
     required this.regionName,
     this.cityCode,

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/notification_region_map_selection_notifier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/notification_region_map_selection_notifier.dart
@@ -1,0 +1,42 @@
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_map_selection.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'notification_region_map_selection_notifier.g.dart';
+
+@riverpod
+class NotificationRegionMapSelectionController
+    extends _$NotificationRegionMapSelectionController {
+  @override
+  NotificationRegionMapSelection build() =>
+      const NotificationRegionMapNationwide();
+
+  void focusRegion(NotificationRegionOption region) {
+    state = NotificationRegionMapFocused(region: region);
+  }
+
+  bool selectCity(NotificationCityOption city) {
+    final current = state;
+    final region = switch (current) {
+      NotificationRegionMapFocused(:final region) => region,
+      NotificationRegionMapCitySelected(:final region) => region,
+      NotificationRegionMapNationwide() => null,
+    };
+    if (region == null || region.cityByCode(city.code) == null) {
+      return false;
+    }
+    state = NotificationRegionMapCitySelected(region: region, city: city);
+    return true;
+  }
+
+  void deselectCity() {
+    final current = state;
+    if (current is NotificationRegionMapCitySelected) {
+      state = NotificationRegionMapFocused(region: current.region);
+    }
+  }
+
+  void reset() {
+    state = const NotificationRegionMapNationwide();
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/notification_region_map_selection_notifier.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/notification_region_map_selection_notifier.g.dart
@@ -1,0 +1,83 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'notification_region_map_selection_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(NotificationRegionMapSelectionController)
+final notificationRegionMapSelectionControllerProvider =
+    NotificationRegionMapSelectionControllerProvider._();
+
+final class NotificationRegionMapSelectionControllerProvider
+    extends
+        $NotifierProvider<
+          NotificationRegionMapSelectionController,
+          NotificationRegionMapSelection
+        > {
+  NotificationRegionMapSelectionControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'notificationRegionMapSelectionControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$notificationRegionMapSelectionControllerHash();
+
+  @$internal
+  @override
+  NotificationRegionMapSelectionController create() =>
+      NotificationRegionMapSelectionController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(NotificationRegionMapSelection value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<NotificationRegionMapSelection>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$notificationRegionMapSelectionControllerHash() =>
+    r'd6ee21cf1c47b2116caf02d4cfcdb91661c1b128';
+
+abstract class _$NotificationRegionMapSelectionController
+    extends $Notifier<NotificationRegionMapSelection> {
+  NotificationRegionMapSelection build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref =
+        this.ref
+            as $Ref<
+              NotificationRegionMapSelection,
+              NotificationRegionMapSelection
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                NotificationRegionMapSelection,
+                NotificationRegionMapSelection
+              >,
+              NotificationRegionMapSelection,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/provider/notification_region_catalog_provider.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/provider/notification_region_catalog_provider.dart
@@ -1,0 +1,24 @@
+import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/logic/notification_region_catalog_builder.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'notification_region_catalog_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+Future<NotificationRegionCatalog> notificationRegionCatalog(Ref ref) async {
+  final parameters = await ref.watch(parameterSetProvider.future);
+  final catalog = ref
+      .watch(notificationRegionCatalogBuilderProvider)
+      .build(
+        codeTable: parameters.jmaCodeTable,
+        earthquake: parameters.earthquake,
+      );
+  for (final cityCode in catalog.unmappedCityCodes) {
+    talker.warning(
+      'NotificationRegionCatalog: EEW regionを解決できない市区町村を除外しました: $cityCode',
+    );
+  }
+  return catalog;
+}

--- a/app/lib/feature/settings/features/notification_settings/data/provider/notification_region_catalog_provider.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/provider/notification_region_catalog_provider.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'notification_region_catalog_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(notificationRegionCatalog)
+final notificationRegionCatalogProvider = NotificationRegionCatalogProvider._();
+
+final class NotificationRegionCatalogProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<NotificationRegionCatalog>,
+          NotificationRegionCatalog,
+          FutureOr<NotificationRegionCatalog>
+        >
+    with
+        $FutureModifier<NotificationRegionCatalog>,
+        $FutureProvider<NotificationRegionCatalog> {
+  NotificationRegionCatalogProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'notificationRegionCatalogProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$notificationRegionCatalogHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<NotificationRegionCatalog> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<NotificationRegionCatalog> create(Ref ref) {
+    return notificationRegionCatalog(ref);
+  }
+}
+
+String _$notificationRegionCatalogHash() =>
+    r'1b198d32091fa414010f5ce7f3497571a4e62894';

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_layer.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_layer.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
+import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
+import 'package:eqmonitor/core/util/converter/color_converter.dart';
+import 'package:eqmonitor/core/util/map/replace_map_style_layers.dart';
+import 'package:eqmonitor/feature/map/data/provider/map_style_util.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/logic/notification_region_map_filter.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_map_selection.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_region_map_selection_notifier.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:maplibre/maplibre.dart';
+
+const notificationRegionFocusLayerId = 'notification-region-focus-line';
+const notificationRegionCityLayerId = 'notification-region-city-line';
+const notificationSelectedCityLayerId = 'notification-selected-city-line';
+
+class NotificationRegionMapLayer extends HookConsumerWidget {
+  const NotificationRegionMapLayer({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final style = MapController.maybeOf(context)?.style;
+    final enqueue = useMapOperationQueue();
+    final selection = ref.watch(
+      notificationRegionMapSelectionControllerProvider,
+    );
+    final filterBuilder = ref.watch(notificationRegionMapFilterProvider);
+    final colorSet = ref.watch(activeColorSetProvider);
+    final focusColor = colorSet.primary.toHexStringRGB();
+    final boundaryColor = colorSet.mapColors.japanLine.toHexStringRGB();
+    final region = switch (selection) {
+      NotificationRegionMapNationwide() => null,
+      NotificationRegionMapFocused(:final region) => region,
+      NotificationRegionMapCitySelected(:final region) => region,
+    };
+    final cityCode = switch (selection) {
+      NotificationRegionMapCitySelected(:final city) => city.code,
+      _ => null,
+    };
+    final regionCityCodes =
+        region?.cities.map((city) => city.code).toList() ?? const <String>[];
+
+    useEffect(() {
+      if (style == null) {
+        return null;
+      }
+      unawaited(
+        enqueue(() async {
+          try {
+            await style.updateFilter(
+              id: BaseLayer.areaInformationCityQuakeLine.name,
+              filter: filterBuilder.buildMatchNothing('regioncode'),
+            );
+            await replaceMapStyleLayers(
+              styleController: style,
+              layerIds: const [
+                notificationRegionFocusLayerId,
+                notificationRegionCityLayerId,
+                notificationSelectedCityLayerId,
+              ],
+              layers: [
+                (
+                  layer: LineStyleLayer(
+                    id: notificationRegionFocusLayerId,
+                    sourceId: 'eqmonitor_map',
+                    sourceLayerId: 'areaForecastLocalEew',
+                    filter: filterBuilder.buildRegion(region?.code),
+                    paint: {
+                      'line-color': focusColor,
+                      'line-width': 3,
+                      'line-opacity': 1,
+                    },
+                  ),
+                  belowLayerId: null,
+                  aboveLayerId: null,
+                  atIndex: null,
+                ),
+                (
+                  layer: LineStyleLayer(
+                    id: notificationRegionCityLayerId,
+                    sourceId: 'eqmonitor_map',
+                    sourceLayerId: 'areaInformationCityQuake',
+                    minZoom: 6,
+                    filter: filterBuilder.buildRegionCities(regionCityCodes),
+                    paint: {
+                      'line-color': boundaryColor,
+                      'line-width': 1.2,
+                      'line-opacity': 0.85,
+                    },
+                  ),
+                  belowLayerId: null,
+                  aboveLayerId: null,
+                  atIndex: null,
+                ),
+                (
+                  layer: LineStyleLayer(
+                    id: notificationSelectedCityLayerId,
+                    sourceId: 'eqmonitor_map',
+                    sourceLayerId: 'areaInformationCityQuake',
+                    minZoom: 6,
+                    filter: filterBuilder.buildSelectedCity(cityCode),
+                    paint: {
+                      'line-color': focusColor,
+                      'line-width': 4,
+                      'line-opacity': 1,
+                    },
+                  ),
+                  belowLayerId: null,
+                  aboveLayerId: null,
+                  atIndex: null,
+                ),
+              ],
+            );
+          } on Exception catch (error, stackTrace) {
+            talker.handle(error, stackTrace);
+          }
+        }),
+      );
+
+      return () {
+        unawaited(
+          enqueue(() async {
+            try {
+              await style.updateFilter(
+                id: BaseLayer.areaInformationCityQuakeLine.name,
+                filter: null,
+              );
+            } on Exception catch (error, stackTrace) {
+              talker.handle(error, stackTrace);
+            }
+            for (final id in const [
+              notificationSelectedCityLayerId,
+              notificationRegionCityLayerId,
+              notificationRegionFocusLayerId,
+            ]) {
+              try {
+                await style.removeLayer(id);
+              } on Exception catch (error, stackTrace) {
+                talker.handle(error, stackTrace);
+              }
+            }
+          }),
+        );
+      };
+    }, [style, enqueue, filterBuilder, focusColor, boundaryColor]);
+
+    useEffect(() {
+      if (style == null) {
+        return null;
+      }
+      unawaited(
+        enqueue(() async {
+          try {
+            await style.updateFilter(
+              id: notificationRegionFocusLayerId,
+              filter: filterBuilder.buildRegion(region?.code),
+            );
+            await style.updateFilter(
+              id: notificationRegionCityLayerId,
+              filter: filterBuilder.buildRegionCities(regionCityCodes),
+            );
+            await style.updateFilter(
+              id: notificationSelectedCityLayerId,
+              filter: filterBuilder.buildSelectedCity(cityCode),
+            );
+          } on Exception catch (error, stackTrace) {
+            talker.handle(error, stackTrace);
+          }
+        }),
+      );
+      return null;
+    }, [style, enqueue, filterBuilder, selection]);
+
+    return const SizedBox.shrink();
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_layer.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_layer.dart
@@ -55,7 +55,7 @@ class NotificationRegionMapLayer extends HookConsumerWidget {
               id: BaseLayer.areaInformationCityQuakeLine.name,
               filter: filterBuilder.buildMatchNothing('regioncode'),
             );
-            await replaceMapStyleLayers(
+            await MapStyleLayerReplacer.replace(
               styleController: style,
               layerIds: const [
                 notificationRegionFocusLayerId,

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_layer.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_layer.dart
@@ -19,7 +19,7 @@ const notificationRegionCityLayerId = 'notification-region-city-line';
 const notificationSelectedCityLayerId = 'notification-selected-city-line';
 
 class NotificationRegionMapLayer extends HookConsumerWidget {
-  const NotificationRegionMapLayer({super.key});
+  const new({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_selection_card.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_selection_card.dart
@@ -2,7 +2,7 @@ import 'package:eqmonitor/feature/settings/features/notification_settings/data/m
 import 'package:material_ui/material_ui.dart';
 
 class NotificationRegionMapSelectionCard extends StatelessWidget {
-  const NotificationRegionMapSelectionCard({
+  const new({
     required this.selection,
     required this.isResolving,
     required this.onDecideRegion,

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_selection_card.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_selection_card.dart
@@ -1,0 +1,72 @@
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_map_selection.dart';
+import 'package:flutter/material.dart';
+
+class NotificationRegionMapSelectionCard extends StatelessWidget {
+  const NotificationRegionMapSelectionCard({
+    required this.selection,
+    required this.isResolving,
+    required this.onDecideRegion,
+    required this.onDecideCity,
+    required this.onBackToRegion,
+    super.key,
+  });
+
+  final NotificationRegionMapSelection selection;
+  final bool isResolving;
+  final VoidCallback onDecideRegion;
+  final VoidCallback onDecideCity;
+  final VoidCallback onBackToRegion;
+
+  @override
+  Widget build(BuildContext context) => Card(
+    child: Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: switch (selection) {
+        NotificationRegionMapNationwide() => Row(
+          children: [
+            if (isResolving)
+              const SizedBox.square(
+                dimension: 24,
+                child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+              )
+            else
+              const Icon(Icons.touch_app_outlined),
+            const SizedBox(width: 12),
+            const Expanded(child: Text('地図をタップして地域を選択')),
+          ],
+        ),
+        NotificationRegionMapFocused(:final region) => Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(region.name, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 4),
+            const Text('市区町村を選ぶ場合は地図をタップしてください'),
+            const SizedBox(height: 8),
+            FilledButton(
+              onPressed: isResolving ? null : onDecideRegion,
+              child: const Text('この地域全域を選択'),
+            ),
+          ],
+        ),
+        NotificationRegionMapCitySelected(:final region, :final city) => Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(region.name, style: Theme.of(context).textTheme.bodySmall),
+            Text(city.name, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            FilledButton(
+              onPressed: isResolving ? null : onDecideCity,
+              child: const Text('この市区町村を選択'),
+            ),
+            TextButton(
+              onPressed: isResolving ? null : onBackToRegion,
+              child: const Text('地域全域の選択に戻る'),
+            ),
+          ],
+        ),
+      },
+    ),
+  );
+}

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_selection_card.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_selection_card.dart
@@ -1,5 +1,5 @@
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_map_selection.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class NotificationRegionMapSelectionCard extends StatelessWidget {
   const NotificationRegionMapSelectionCard({

--- a/app/lib/feature/settings/features/notification_settings/ui/page/city_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/city_picker_page.dart
@@ -1,9 +1,9 @@
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/logic/notification_region_search.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_selection.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 class CityPickerPage extends HookConsumerWidget {
   const CityPickerPage({required this.region, super.key});

--- a/app/lib/feature/settings/features/notification_settings/ui/page/city_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/city_picker_page.dart
@@ -6,7 +6,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:material_ui/material_ui.dart';
 
 class CityPickerPage extends HookConsumerWidget {
-  const CityPickerPage({required this.region, super.key});
+  const new({required this.region, super.key});
 
   final NotificationRegionOption region;
 
@@ -84,7 +84,7 @@ class CityPickerPage extends HookConsumerWidget {
 }
 
 class _WholeRegionTile extends StatelessWidget {
-  const _WholeRegionTile({required this.region});
+  const new({required this.region});
 
   final NotificationRegionOption region;
 
@@ -106,7 +106,7 @@ class _WholeRegionTile extends StatelessWidget {
 }
 
 class _CityListTile extends StatelessWidget {
-  const _CityListTile({required this.region, required this.city});
+  const new({required this.region, required this.city});
 
   final NotificationRegionOption region;
   final NotificationCityOption city;

--- a/app/lib/feature/settings/features/notification_settings/ui/page/city_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/city_picker_page.dart
@@ -1,218 +1,129 @@
-import 'dart:async';
-
-import 'package:dio/dio.dart';
-import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
-import 'package:eqmonitor/core/provider/jma_code_table_provider.dart';
-import 'package:eqmonitor/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.dart';
-import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
-import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/pro_upgrade_dialog.dart';
-import 'package:material_ui/material_ui.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/logic/notification_region_search.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_selection.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:riverpod/experimental/mutation.dart';
 
 class CityPickerPage extends HookConsumerWidget {
-  const CityPickerPage({
-    required this.regionCode,
-    required this.regionName,
-    super.key,
-  });
+  const CityPickerPage({required this.region, super.key});
 
-  final String regionCode;
-  final String regionName;
+  final NotificationRegionOption region;
+
+  static Future<NotificationRegionSelection?> show(
+    BuildContext context, {
+    required NotificationRegionOption region,
+  }) => Navigator.of(context).push<NotificationRegionSelection>(
+    MaterialPageRoute(builder: (_) => CityPickerPage(region: region)),
+  );
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final searchController = useTextEditingController();
     final searchText = useState('');
-
     useEffect(() {
       void listener() => searchText.value = searchController.text;
       searchController.addListener(listener);
       return () => searchController.removeListener(listener);
     }, [searchController]);
 
-    final jmaCodeTableAsync = ref.watch(jmaCodeTableProvider);
-    final cities = jmaCodeTableAsync.value?.codeTables.areaInformationCity;
-
-    final filteredCities = _filterCities(cities, regionCode, searchText.value);
-
-    ref.listen(NotificationSlotsNotifier.addRegionMutation, (_, next) {
-      if (next is MutationError) {
-        final error = next.error;
-        if (error is DioException && error.response?.statusCode == 402) {
-          unawaited(const ProUpgradeDialogAction().show(context));
-        } else {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text('地域の追加に失敗しました: $error'),
-              backgroundColor: context.designSystem.colorTheme.error,
-            ),
-          );
-        }
-      }
-      if (next is MutationSuccess) {
-        Navigator.of(context)
-          ..pop()
-          ..pop();
-      }
-    });
-
-    final isAdding = ref.watch(
-      NotificationSlotsNotifier.addRegionMutation,
-    ) is MutationPending;
+    final search = ref.watch(notificationRegionSearchProvider);
+    final filteredCities = search.filter(
+      items: region.cities,
+      query: searchText.value,
+      name: (city) => city.name,
+      kana: (city) => city.kana,
+    );
 
     return Scaffold(
-      appBar: AppBar(title: Text('$regionName - 市区町村を選択')),
+      appBar: AppBar(title: Text('${region.name} - 市区町村を選択')),
       body: Column(
         children: [
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
             child: SearchBar(
               controller: searchController,
-              hintText: '市区町村名で検索',
-              leading: const Padding(
-                padding: EdgeInsets.only(left: 8),
-                child: Icon(Icons.search),
-              ),
+              hintText: '市区町村名・ふりがなで検索',
+              leading: const Icon(Icons.search),
               trailing: [
                 if (searchText.value.isNotEmpty)
                   IconButton(
                     icon: const Icon(Icons.clear),
-                    onPressed: () {
-                      searchController.clear();
-                      searchText.value = '';
-                    },
+                    onPressed: searchController.clear,
                   ),
               ],
             ),
           ),
-          if (isAdding) const LinearProgressIndicator(),
           Expanded(
-            child: switch (jmaCodeTableAsync) {
-              AsyncLoading() => const Center(
-                child: CircularProgressIndicator.adaptive(),
-              ),
-              AsyncError(:final error) => Center(
-                child: Text('読み込みに失敗しました: $error'),
-              ),
-              _ when filteredCities != null => ListView.builder(
-                itemCount: filteredCities.length + 1,
-                itemBuilder: (context, index) {
-                  if (index == 0) {
-                    return _WholeRegionTile(
-                      regionCode: regionCode,
-                      regionName: regionName,
-                      enabled: !isAdding,
-                    );
-                  }
-                  final city = filteredCities[index - 1];
-                  return _CityListTile(
-                    city: city,
-                    regionCode: regionCode,
-                    enabled: !isAdding,
+            child: ListView.builder(
+              itemCount: filteredCities.isEmpty ? 2 : filteredCities.length + 1,
+              itemBuilder: (context, index) {
+                if (index == 0) {
+                  return _WholeRegionTile(region: region);
+                }
+                if (filteredCities.isEmpty) {
+                  final message = searchText.value.isEmpty
+                      ? '選択できる市区町村がありません'
+                      : '該当する市区町村がありません';
+                  return Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Center(child: Text(message)),
                   );
-                },
-              ),
-              _ => const SizedBox.shrink(),
-            },
+                }
+                return _CityListTile(
+                  region: region,
+                  city: filteredCities[index - 1],
+                );
+              },
+            ),
           ),
         ],
       ),
     );
   }
-
-  static List<JmaCodeTableCityItem>? _filterCities(
-    List<JmaCodeTableCityItem>? cities,
-    String regionCode,
-    String query,
-  ) {
-    if (cities == null) {
-      return null;
-    }
-    final regionCities = cities
-        .where((c) => c.parentAreaForecastLocalEewCode == regionCode)
-        .toList();
-    if (query.isEmpty) {
-      return regionCities;
-    }
-    final lowerQuery = query.toLowerCase();
-    return regionCities.where((item) {
-      return item.name.ja.toLowerCase().contains(lowerQuery);
-    }).toList();
-  }
 }
 
-class _WholeRegionTile extends ConsumerWidget {
-  const _WholeRegionTile({
-    required this.regionCode,
-    required this.regionName,
-    required this.enabled,
-  });
+class _WholeRegionTile extends StatelessWidget {
+  const _WholeRegionTile({required this.region});
 
-  final String regionCode;
-  final String regionName;
-  final bool enabled;
+  final NotificationRegionOption region;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return ListTile(
-      enabled: enabled,
-      leading: const Icon(Icons.select_all),
-      title: Text('$regionName 全域'),
-      subtitle: const Text('この地域全体の通知を受け取ります'),
-      trailing: const Icon(Icons.add),
-      onTap: enabled
-          ? () async {
-              await NotificationSlotsNotifier.addRegionMutation.run(ref, (
-                tsx,
-              ) async {
-                await tsx
-                    .get(notificationSlotsProvider.notifier)
-                    .addRegion(
-                      regionId: int.parse(regionCode),
-                      regionName: regionName,
-                    );
-              });
-            }
-          : null,
-    );
-  }
+  Widget build(BuildContext context) => ListTile(
+    minTileHeight: 48,
+    visualDensity: VisualDensity.compact,
+    leading: const Icon(Icons.select_all),
+    title: Text('${region.name} 全域'),
+    subtitle: const Text('この地域全体の通知を受け取ります'),
+    trailing: const Icon(Icons.add),
+    onTap: () => Navigator.of(context).pop(
+      NotificationRegionSelection(
+        regionCode: region.code,
+        regionName: region.name,
+      ),
+    ),
+  );
 }
 
-class _CityListTile extends ConsumerWidget {
-  const _CityListTile({
-    required this.city,
-    required this.regionCode,
-    required this.enabled,
-  });
+class _CityListTile extends StatelessWidget {
+  const _CityListTile({required this.region, required this.city});
 
-  final JmaCodeTableCityItem city;
-  final String regionCode;
-  final bool enabled;
+  final NotificationRegionOption region;
+  final NotificationCityOption city;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return ListTile(
-      enabled: enabled,
-      title: Text(city.name.ja),
-      subtitle: Text(city.code),
-      trailing: const Icon(Icons.add),
-      onTap: enabled
-          ? () async {
-              await NotificationSlotsNotifier.addRegionMutation.run(ref, (
-                tsx,
-              ) async {
-                await tsx
-                    .get(notificationSlotsProvider.notifier)
-                    .addRegion(
-                      regionId: int.parse(regionCode),
-                      cityCode: city.code,
-                      cityName: city.name.ja,
-                    );
-              });
-            }
-          : null,
-    );
-  }
+  Widget build(BuildContext context) => ListTile(
+    minTileHeight: 48,
+    visualDensity: VisualDensity.compact,
+    title: Text(city.name),
+    trailing: const Icon(Icons.add),
+    onTap: () => Navigator.of(context).pop(
+      NotificationRegionSelection(
+        regionCode: region.code,
+        regionName: region.name,
+        cityCode: city.code,
+        cityName: city.name,
+      ),
+    ),
+  );
 }

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_region_map_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_region_map_picker_page.dart
@@ -13,10 +13,10 @@ import 'package:eqmonitor/feature/settings/features/notification_settings/data/n
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/provider/notification_region_catalog_provider.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_region_map_layer.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_region_map_selection_card.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:maplibre/maplibre.dart';
+import 'package:material_ui/material_ui.dart';
 
 class NotificationRegionMapPickerPage extends HookConsumerWidget {
   const NotificationRegionMapPickerPage({super.key});
@@ -76,7 +76,7 @@ class NotificationRegionMapPickerPage extends HookConsumerWidget {
       );
     }
 
-    final mapOptions = calculateJapanViewMapOptions(
+    final mapOptions = const MapZoomCalculator().japanViewMapOptions(
       context: context,
       styleString: styleString,
     );
@@ -189,14 +189,17 @@ class NotificationRegionMapPickerPage extends HookConsumerWidget {
                       }
                       notifier.focusRegion(region);
                       final size = MediaQuery.sizeOf(context);
-                      final zoom = zoomLevelForBounds(
-                        minLat: bounds.southWest.lat,
-                        maxLat: bounds.northEast.lat,
-                        minLng: bounds.southWest.lng,
-                        maxLng: bounds.northEast.lng,
-                        screenWidth: size.width,
-                        screenHeight: size.height * 0.65,
-                      ).clamp(6, 9).toDouble();
+                      final zoom = const MapZoomCalculator()
+                          .calculate(
+                            minLat: bounds.southWest.lat,
+                            maxLat: bounds.northEast.lat,
+                            minLng: bounds.southWest.lng,
+                            maxLng: bounds.northEast.lng,
+                            screenWidth: size.width,
+                            screenHeight: size.height * 0.65,
+                          )
+                          .clamp(6, 9)
+                          .toDouble();
                       await operationGuard.runLatest(
                         generation: generation,
                         operation: () => mapController.animateCamera(

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_region_map_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_region_map_picker_page.dart
@@ -1,0 +1,319 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/core/provider/map/jma_map_provider.dart';
+import 'package:eqmonitor/feature/location/data/jma_map_isolate.dart';
+import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
+import 'package:eqmonitor/feature/map/ui/map_operation_queue_scope.dart';
+import 'package:eqmonitor/feature/map/utils/map_zoom_calculator.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/logic/latest_map_operation_guard.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_map_selection.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_selection.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_region_map_selection_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/provider/notification_region_catalog_provider.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_region_map_layer.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_region_map_selection_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:maplibre/maplibre.dart';
+
+class NotificationRegionMapPickerPage extends HookConsumerWidget {
+  const NotificationRegionMapPickerPage({super.key});
+
+  static Future<NotificationRegionSelection?> show(BuildContext context) =>
+      Navigator.of(context).push<NotificationRegionSelection>(
+        MaterialPageRoute(
+          fullscreenDialog: true,
+          builder: (_) => const NotificationRegionMapPickerPage(),
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mapConfigurationAsync = ref.watch(mapConfigurationProvider);
+    final catalogAsync = ref.watch(notificationRegionCatalogProvider);
+    final isolateAsync = ref.watch(jmaMapIsolateProvider);
+    final selection = ref.watch(
+      notificationRegionMapSelectionControllerProvider,
+    );
+    final controller = useRef<MapController?>(null);
+    final isStyleLoaded = useState(false);
+    final isResolving = useState(false);
+    final operationGuard = useMemoized(LatestMapOperationGuard.new);
+    useEffect(() {
+      return () {
+        operationGuard.dispose();
+        controller.value = null;
+      };
+    }, [operationGuard]);
+
+    final styleString = mapConfigurationAsync.value?.styleString;
+    final catalog = catalogAsync.value;
+    final isolate = isolateAsync.value;
+    final hasError =
+        mapConfigurationAsync.hasError ||
+        catalogAsync.hasError ||
+        isolateAsync.hasError;
+
+    if (hasError) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('地図から地域を選択')),
+        body: _NotificationRegionMapError(
+          onRetry: () {
+            ref
+              ..invalidate(mapConfigurationProvider)
+              ..invalidate(notificationRegionCatalogProvider)
+              ..invalidate(jmaMapIsolateProvider);
+          },
+        ),
+      );
+    }
+    if (styleString == null || catalog == null || isolate == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('地図から地域を選択')),
+        body: const Center(child: CircularProgressIndicator.adaptive()),
+      );
+    }
+
+    final mapOptions = calculateJapanViewMapOptions(
+      context: context,
+      styleString: styleString,
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('地図から地域を選択'),
+        actions: [
+          if (selection is! NotificationRegionMapNationwide)
+            IconButton(
+              tooltip: '全国表示に戻す',
+              icon: const Icon(Icons.public),
+              onPressed: isResolving.value
+                  ? null
+                  : () async {
+                      final generation = operationGuard.begin();
+                      ref
+                          .read(
+                            notificationRegionMapSelectionControllerProvider
+                                .notifier,
+                          )
+                          .reset();
+                      final mapController = controller.value;
+                      if (mapController == null) {
+                        return;
+                      }
+                      try {
+                        await operationGuard.runLatest(
+                          generation: generation,
+                          operation: () => mapController.animateCamera(
+                            center: JapanBounds.center,
+                            zoom: mapOptions.initZoom,
+                          ),
+                        );
+                      } on Exception catch (error, stackTrace) {
+                        talker.handle(error, stackTrace);
+                      }
+                    },
+            ),
+        ],
+      ),
+      body: Stack(
+        children: [
+          MapOperationQueueScope(
+            child: MapLibreMap(
+              options: mapOptions,
+              onMapCreated: (mapController) {
+                controller.value = mapController;
+              },
+              onStyleLoaded: (_) {
+                isStyleLoaded.value = true;
+              },
+              onEvent: (event) {
+                if (event is! MapEventClick && event is! MapEventLongClick) {
+                  return;
+                }
+                if (!context.mounted) {
+                  return;
+                }
+                if (isResolving.value) {
+                  return;
+                }
+                final point = switch (event) {
+                  MapEventClick(:final point) => point,
+                  MapEventLongClick(:final point) => point,
+                  _ => throw UnimplementedError(),
+                };
+                unawaited(() async {
+                  final generation = operationGuard.begin();
+                  isResolving.value = true;
+                  final state = ref.read(
+                    notificationRegionMapSelectionControllerProvider,
+                  );
+                  final type = switch (state) {
+                    NotificationRegionMapNationwide() =>
+                      JmaMapType.areaForecastLocalEew,
+                    _ => JmaMapType.areaInformationCity,
+                  };
+                  try {
+                    final item = await isolate.calculateNearestElement(
+                      latitude: point.lat,
+                      longitude: point.lon,
+                      type: type,
+                    );
+                    if (!operationGuard.isCurrent(generation) ||
+                        !context.mounted) {
+                      return;
+                    }
+                    final property = item?.property;
+                    if (property == null) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('この場所は選択できません')),
+                      );
+                      return;
+                    }
+                    final notifier = ref.read(
+                      notificationRegionMapSelectionControllerProvider.notifier,
+                    );
+                    if (state is NotificationRegionMapNationwide) {
+                      final region = catalog.regionByCode(property.code);
+                      final bounds = item?.bounds;
+                      final mapController = controller.value;
+                      if (region == null ||
+                          bounds == null ||
+                          mapController == null) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('地域情報を特定できませんでした')),
+                        );
+                        return;
+                      }
+                      notifier.focusRegion(region);
+                      final size = MediaQuery.sizeOf(context);
+                      final zoom = zoomLevelForBounds(
+                        minLat: bounds.southWest.lat,
+                        maxLat: bounds.northEast.lat,
+                        minLng: bounds.southWest.lng,
+                        maxLng: bounds.northEast.lng,
+                        screenWidth: size.width,
+                        screenHeight: size.height * 0.65,
+                      ).clamp(6, 9).toDouble();
+                      await operationGuard.runLatest(
+                        generation: generation,
+                        operation: () => mapController.animateCamera(
+                          center: Geographic(
+                            lon:
+                                (bounds.southWest.lng + bounds.northEast.lng) /
+                                2,
+                            lat:
+                                (bounds.southWest.lat + bounds.northEast.lat) /
+                                2,
+                          ),
+                          zoom: zoom,
+                        ),
+                      );
+                    } else {
+                      final region = switch (state) {
+                        NotificationRegionMapFocused(:final region) => region,
+                        NotificationRegionMapCitySelected(:final region) =>
+                          region,
+                        NotificationRegionMapNationwide() => null,
+                      };
+                      final city = region?.cityByCode(property.code);
+                      if (city == null || !notifier.selectCity(city)) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('フォーカス中の地域内を選択してください')),
+                        );
+                      }
+                    }
+                  } on Exception catch (error, stackTrace) {
+                    talker.handle(error, stackTrace);
+                    if (operationGuard.isCurrent(generation) &&
+                        context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('地図から地域を選択できませんでした')),
+                      );
+                    }
+                  } finally {
+                    if (operationGuard.isCurrent(generation) &&
+                        context.mounted) {
+                      isResolving.value = false;
+                    }
+                  }
+                }());
+              },
+              children: [
+                if (isStyleLoaded.value) const NotificationRegionMapLayer(),
+              ],
+            ),
+          ),
+          Positioned(
+            left: 12,
+            right: 12,
+            bottom: 12,
+            child: SafeArea(
+              top: false,
+              child: NotificationRegionMapSelectionCard(
+                selection: selection,
+                isResolving: isResolving.value,
+                onDecideRegion: () {
+                  final region = switch (selection) {
+                    NotificationRegionMapFocused(:final region) => region,
+                    NotificationRegionMapCitySelected(:final region) => region,
+                    NotificationRegionMapNationwide() => null,
+                  };
+                  if (region == null) {
+                    return;
+                  }
+                  Navigator.of(context).pop(
+                    NotificationRegionSelection(
+                      regionCode: region.code,
+                      regionName: region.name,
+                    ),
+                  );
+                },
+                onDecideCity: () {
+                  if (selection case NotificationRegionMapCitySelected(
+                    :final region,
+                    :final city,
+                  )) {
+                    Navigator.of(context).pop(
+                      NotificationRegionSelection(
+                        regionCode: region.code,
+                        regionName: region.name,
+                        cityCode: city.code,
+                        cityName: city.name,
+                      ),
+                    );
+                  }
+                },
+                onBackToRegion: () => ref
+                    .read(
+                      notificationRegionMapSelectionControllerProvider.notifier,
+                    )
+                    .deselectCity(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NotificationRegionMapError extends StatelessWidget {
+  const _NotificationRegionMapError({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) => Center(
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Text('地図情報を読み込めませんでした'),
+        const SizedBox(height: 8),
+        FilledButton.tonal(onPressed: onRetry, child: const Text('再試行')),
+      ],
+    ),
+  );
+}

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_region_map_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_region_map_picker_page.dart
@@ -19,7 +19,7 @@ import 'package:maplibre/maplibre.dart';
 import 'package:material_ui/material_ui.dart';
 
 class NotificationRegionMapPickerPage extends HookConsumerWidget {
-  const NotificationRegionMapPickerPage({super.key});
+  const new({super.key});
 
   static Future<NotificationRegionSelection?> show(BuildContext context) =>
       Navigator.of(context).push<NotificationRegionSelection>(
@@ -304,7 +304,7 @@ class NotificationRegionMapPickerPage extends HookConsumerWidget {
 }
 
 class _NotificationRegionMapError extends StatelessWidget {
-  const _NotificationRegionMapError({required this.onRetry});
+  const new({required this.onRetry});
 
   final VoidCallback onRetry;
 

--- a/app/lib/feature/settings/features/notification_settings/ui/page/region_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/region_picker_page.dart
@@ -1,9 +1,18 @@
-import 'package:eqmonitor/core/provider/jma_code_table_provider.dart';
-import 'package:eqmonitor/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.dart';
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/action/notification_region_add_action.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/logic/notification_region_search.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/provider/notification_region_catalog_provider.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/pro_upgrade_dialog.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/city_picker_page.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod/experimental/mutation.dart';
 
 class RegionPickerPage extends HookConsumerWidget {
   const RegionPickerPage({super.key});
@@ -12,69 +21,94 @@ class RegionPickerPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final searchController = useTextEditingController();
     final searchText = useState('');
+    useEffect(() {
+      void listener() => searchText.value = searchController.text;
+      searchController.addListener(listener);
+      return () => searchController.removeListener(listener);
+    }, [searchController]);
 
-    useEffect(
-      () {
-        void listener() => searchText.value = searchController.text;
-        searchController.addListener(listener);
-        return () => searchController.removeListener(listener);
-      },
-      [searchController],
-    );
+    ref.listen(NotificationSlotsNotifier.addRegionMutation, (_, next) {
+      if (next is MutationError) {
+        final error = next.error;
+        if (error is DioException && error.response?.statusCode == 402) {
+          unawaited(showProUpgradeDialog(context));
+          return;
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('地域を追加できませんでした'),
+            backgroundColor: context.designSystem.colorTheme.error,
+          ),
+        );
+      } else if (next is MutationSuccess && context.mounted) {
+        Navigator.of(context).pop();
+      }
+    });
 
-    final jmaCodeTableAsync = ref.watch(jmaCodeTableProvider);
-    final regions = jmaCodeTableAsync.value?.codeTables.areaForecastLocalEew;
-
-    final filteredRegions = _filterRegions(regions, searchText.value);
+    final catalogAsync = ref.watch(notificationRegionCatalogProvider);
+    final search = ref.watch(notificationRegionSearchProvider);
+    final regions = catalogAsync.value;
+    final filteredRegions = regions == null
+        ? null
+        : search.filter(
+            items: regions.regions,
+            query: searchText.value,
+            name: (region) => region.name,
+            kana: (region) => region.kana,
+          );
+    final isAdding =
+        ref.watch(NotificationSlotsNotifier.addRegionMutation)
+            is MutationPending;
 
     return Scaffold(
       appBar: AppBar(title: const Text('地域を選択')),
       body: Column(
         children: [
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
             child: SearchBar(
               controller: searchController,
-              hintText: '地域名で検索',
-              leading: const Padding(
-                padding: EdgeInsets.only(left: 8),
-                child: Icon(Icons.search),
-              ),
+              hintText: '地域名・ふりがなで検索',
+              leading: const Icon(Icons.search),
               trailing: [
                 if (searchText.value.isNotEmpty)
                   IconButton(
                     icon: const Icon(Icons.clear),
-                    onPressed: () {
-                      searchController.clear();
-                      searchText.value = '';
-                    },
+                    onPressed: searchController.clear,
                   ),
               ],
             ),
           ),
+          if (isAdding) const LinearProgressIndicator(),
           Expanded(
-            child: switch (jmaCodeTableAsync) {
+            child: switch (catalogAsync) {
               AsyncLoading() => const Center(
                 child: CircularProgressIndicator.adaptive(),
               ),
-              AsyncError(:final error) => Center(
-                child: Text('読み込みに失敗しました: $error'),
+              AsyncError() => _RegionCatalogError(
+                onRetry: () =>
+                    ref.invalidate(notificationRegionCatalogProvider),
               ),
+              _ when filteredRegions != null && filteredRegions.isEmpty =>
+                const Center(child: Text('該当する地域がありません')),
               _ when filteredRegions != null => ListView.builder(
                 itemCount: filteredRegions.length,
                 itemBuilder: (context, index) {
                   final region = filteredRegions[index];
                   return _RegionListTile(
                     region: region,
+                    enabled: !isAdding,
                     onTap: () async {
-                      await Navigator.of(context).push(
-                        MaterialPageRoute<void>(
-                          builder: (_) => CityPickerPage(
-                            regionCode: region.code,
-                            regionName: region.name.ja,
-                          ),
-                        ),
+                      final selection = await CityPickerPage.show(
+                        context,
+                        region: region,
                       );
+                      if (selection == null || !context.mounted) {
+                        return;
+                      }
+                      await ref
+                          .read(notificationRegionAddActionProvider)
+                          .add(ref: ref, selection: selection);
                     },
                   );
                 },
@@ -86,42 +120,44 @@ class RegionPickerPage extends HookConsumerWidget {
       ),
     );
   }
-
-  static List<JmaCodeTableItem>? _filterRegions(
-    List<JmaCodeTableItem>? regions,
-    String query,
-  ) {
-    if (regions == null) {
-      return null;
-    }
-    if (query.isEmpty) {
-      return regions;
-    }
-    final lowerQuery = query.toLowerCase();
-    return regions.where((item) {
-      final nameMatch = item.name.ja.toLowerCase().contains(lowerQuery);
-      final kanaMatch = item.kana?.toLowerCase().contains(lowerQuery) ?? false;
-      return nameMatch || kanaMatch;
-    }).toList();
-  }
 }
 
 class _RegionListTile extends StatelessWidget {
   const _RegionListTile({
     required this.region,
+    required this.enabled,
     required this.onTap,
   });
 
-  final JmaCodeTableItem region;
+  final NotificationRegionOption region;
+  final bool enabled;
   final VoidCallback onTap;
 
   @override
-  Widget build(BuildContext context) {
-    return ListTile(
-      title: Text(region.name.ja),
-      subtitle: Text(region.code),
-      trailing: const Icon(Icons.chevron_right),
-      onTap: onTap,
-    );
-  }
+  Widget build(BuildContext context) => ListTile(
+    enabled: enabled,
+    minTileHeight: 48,
+    visualDensity: VisualDensity.compact,
+    title: Text(region.name),
+    trailing: const Icon(Icons.chevron_right),
+    onTap: onTap,
+  );
+}
+
+class _RegionCatalogError extends StatelessWidget {
+  const _RegionCatalogError({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) => Center(
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Text('地域情報を読み込めませんでした'),
+        const SizedBox(height: 8),
+        FilledButton.tonal(onPressed: onRetry, child: const Text('再試行')),
+      ],
+    ),
+  );
 }

--- a/app/lib/feature/settings/features/notification_settings/ui/page/region_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/region_picker_page.dart
@@ -9,9 +9,10 @@ import 'package:eqmonitor/feature/settings/features/notification_settings/data/n
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/provider/notification_region_catalog_provider.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/pro_upgrade_dialog.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/city_picker_page.dart';
-import 'package:material_ui/material_ui.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/notification_region_map_picker_page.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:riverpod/experimental/mutation.dart';
 
 class RegionPickerPage extends HookConsumerWidget {
@@ -61,7 +62,27 @@ class RegionPickerPage extends HookConsumerWidget {
             is MutationPending;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('地域を選択')),
+      appBar: AppBar(
+        title: const Text('地域を選択'),
+        actions: [
+          IconButton(
+            tooltip: '地図から選択',
+            icon: const Icon(Icons.map_outlined),
+            onPressed: isAdding
+                ? null
+                : () async {
+                    final selection =
+                        await NotificationRegionMapPickerPage.show(context);
+                    if (selection == null || !context.mounted) {
+                      return;
+                    }
+                    await ref
+                        .read(notificationRegionAddActionProvider)
+                        .add(ref: ref, selection: selection);
+                  },
+          ),
+        ],
+      ),
       body: Column(
         children: [
           Padding(

--- a/app/lib/feature/settings/features/notification_settings/ui/page/region_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/region_picker_page.dart
@@ -32,7 +32,7 @@ class RegionPickerPage extends HookConsumerWidget {
       if (next is MutationError) {
         final error = next.error;
         if (error is DioException && error.response?.statusCode == 402) {
-          unawaited(showProUpgradeDialog(context));
+          unawaited(const ProUpgradeDialogAction().show(context));
           return;
         }
         ScaffoldMessenger.of(context).showSnackBar(
@@ -57,9 +57,9 @@ class RegionPickerPage extends HookConsumerWidget {
             name: (region) => region.name,
             kana: (region) => region.kana,
           );
-    final isAdding =
-        ref.watch(NotificationSlotsNotifier.addRegionMutation)
-            is MutationPending;
+    final isAdding = ref.watch(
+      NotificationSlotsNotifier.addRegionMutation,
+    ) is MutationPending;
 
     return Scaffold(
       appBar: AppBar(

--- a/app/lib/feature/settings/features/notification_settings/ui/page/region_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/region_picker_page.dart
@@ -16,7 +16,7 @@ import 'package:material_ui/material_ui.dart';
 import 'package:riverpod/experimental/mutation.dart';
 
 class RegionPickerPage extends HookConsumerWidget {
-  const RegionPickerPage({super.key});
+  const new({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -144,7 +144,7 @@ class RegionPickerPage extends HookConsumerWidget {
 }
 
 class _RegionListTile extends StatelessWidget {
-  const _RegionListTile({
+  const new({
     required this.region,
     required this.enabled,
     required this.onTap,
@@ -166,7 +166,7 @@ class _RegionListTile extends StatelessWidget {
 }
 
 class _RegionCatalogError extends StatelessWidget {
-  const _RegionCatalogError({required this.onRetry});
+  const new({required this.onRetry});
 
   final VoidCallback onRetry;
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -191,6 +191,7 @@ dependencies:
   cryptography: ^2.9.0
   material_ui: ^1.0.0
   cupertino_ui: ^1.0.0
+  unorm_dart: ^0.3.2
 
 dev_dependencies:
   build_runner: ^2.11.1

--- a/app/test/feature/settings/features/notification_settings/city_picker_page_test.dart
+++ b/app/test/feature/settings/features/notification_settings/city_picker_page_test.dart
@@ -1,8 +1,8 @@
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/city_picker_page.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   final region = NotificationRegionOption(

--- a/app/test/feature/settings/features/notification_settings/city_picker_page_test.dart
+++ b/app/test/feature/settings/features/notification_settings/city_picker_page_test.dart
@@ -1,0 +1,53 @@
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/city_picker_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  final region = NotificationRegionOption(
+    code: '9011',
+    name: '北海道道央',
+    kana: 'ほっかいどうどうおう',
+    cities: const [
+      NotificationCityOption(code: '0110100', name: '札幌市', kana: 'さっぽろし'),
+      NotificationCityOption(code: '0120200', name: '函館市', kana: 'はこだてし'),
+    ],
+  );
+
+  Widget app() => ProviderScope(
+    child: MaterialApp(home: CityPickerPage(region: region)),
+  );
+
+  testWidgets('観測点名やIDではなく正しい市区町村名を表示する', (tester) async {
+    await tester.pumpWidget(app());
+
+    expect(find.text('札幌市'), findsOneWidget);
+    expect(find.text('0110100'), findsNothing);
+    expect(find.text('札幌市中央区北2条'), findsNothing);
+    final tile = tester.widget<ListTile>(
+      find.ancestor(of: find.text('札幌市'), matching: find.byType(ListTile)),
+    );
+    expect(tile.minTileHeight, 48);
+  });
+
+  testWidgets('半角カナのふりがな検索で市区町村を絞り込む', (tester) async {
+    await tester.pumpWidget(app());
+
+    await tester.enterText(find.byType(SearchBar), 'ﾊｺﾀﾞﾃ');
+    await tester.pump();
+
+    expect(find.text('札幌市'), findsNothing);
+    expect(find.text('函館市'), findsOneWidget);
+  });
+
+  testWidgets('検索結果がなくても地域全域を選択できる', (tester) async {
+    await tester.pumpWidget(app());
+
+    await tester.enterText(find.byType(SearchBar), '該当なし');
+    await tester.pump();
+
+    expect(find.text('北海道道央 全域'), findsOneWidget);
+    expect(find.text('該当する市区町村がありません'), findsOneWidget);
+  });
+}

--- a/app/test/feature/settings/features/notification_settings/latest_map_operation_guard_test.dart
+++ b/app/test/feature/settings/features/notification_settings/latest_map_operation_guard_test.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/logic/latest_map_operation_guard.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('新しい世代が始まると古い世代を無効化する', () {
+    final guard = LatestMapOperationGuard();
+    final first = guard.begin();
+    final second = guard.begin();
+
+    expect(guard.isCurrent(first), isFalse);
+    expect(guard.isCurrent(second), isTrue);
+    guard.dispose();
+    expect(guard.isCurrent(second), isFalse);
+  });
+
+  test('cameraキューは実行開始時点で最新の世代だけを実行する', () async {
+    final guard = LatestMapOperationGuard();
+    final releaseFirst = Completer<void>();
+    final firstStarted = Completer<void>();
+    final executed = <String>[];
+    final first = guard.begin();
+    final firstFuture = guard.runLatest(
+      generation: first,
+      operation: () async {
+        executed.add('first');
+        firstStarted.complete();
+        await releaseFirst.future;
+      },
+    );
+    await firstStarted.future;
+
+    final second = guard.begin();
+    final secondFuture = guard.runLatest(
+      generation: second,
+      operation: () async => executed.add('second'),
+    );
+    final third = guard.begin();
+    final thirdFuture = guard.runLatest(
+      generation: third,
+      operation: () async => executed.add('third'),
+    );
+    releaseFirst.complete();
+
+    await Future.wait([firstFuture, secondFuture, thirdFuture]);
+    expect(executed, ['first', 'third']);
+  });
+
+  test('dispose後は待機中のcamera処理を実行しない', () async {
+    final guard = LatestMapOperationGuard();
+    final releaseFirst = Completer<void>();
+    final firstStarted = Completer<void>();
+    var queuedDidRun = false;
+    final first = guard.begin();
+    final firstFuture = guard.runLatest(
+      generation: first,
+      operation: () async {
+        firstStarted.complete();
+        await releaseFirst.future;
+      },
+    );
+    await firstStarted.future;
+    final queued = guard.begin();
+    final queuedFuture = guard.runLatest(
+      generation: queued,
+      operation: () async => queuedDidRun = true,
+    );
+
+    guard.dispose();
+    releaseFirst.complete();
+    await Future.wait([firstFuture, queuedFuture]);
+
+    expect(queuedDidRun, isFalse);
+  });
+}

--- a/app/test/feature/settings/features/notification_settings/notification_region_catalog_builder_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_region_catalog_builder_test.dart
@@ -1,0 +1,141 @@
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_common.dart';
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_metadata.dart';
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_type.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:eqmonitor/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/logic/notification_region_catalog_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lat_lng/lat_lng.dart';
+
+const metadata = ParameterMetadata(
+  type: ParameterType.jmaCodeTable,
+  schemaVersion: 1,
+  sourceVersion: 'test',
+  sourceUpdatedAt: null,
+  sourceUrls: [],
+  sha256: 'test',
+);
+
+LocalizedName name(String value) => LocalizedName(ja: value);
+
+EarthquakeParameterStationItem station(String code) =>
+    EarthquakeParameterStationItem(
+      code: code,
+      noCode: code,
+      name: name('観測点$code'),
+      kana: null,
+      status: EarthquakeStationStatus.operating,
+      sourceStatus: 'OPERATING',
+      owner: 'test',
+      location: const LatLng(35, 135),
+    );
+
+EarthquakeParameterCityItem city({
+  required String code,
+  required String cityName,
+  required List<String> stationCodes,
+}) => EarthquakeParameterCityItem(
+  code: code,
+  name: name(cityName),
+  kana: '$cityName-kana',
+  stations: stationCodes.map(station).toList(),
+);
+
+void main() {
+  test('観測点の親EEW regionへ正しい市区町村を重複なく結合する', () {
+    final codeTable = JmaCodeTableParameter(
+      metadata: metadata,
+      codeTables: JmaCodeTableCodeTables(
+        areaForecastLocalEew: [
+          JmaCodeTableItem(
+            code: '100',
+            name: name('地域A'),
+            kana: 'ちいきえー',
+            description: null,
+          ),
+          JmaCodeTableItem(
+            code: '200',
+            name: name('地域B'),
+            kana: 'ちいきびー',
+            description: null,
+          ),
+        ],
+        areaInformationPrefectureEarthquake: const [],
+        areaInformationCity: [
+          JmaCodeTableCityItem(
+            code: 'station-a',
+            name: name('観測点A'),
+            parentAreaForecastLocalEewCode: '100',
+            parentAreaInformationPrefectureEarthquakeCode: '01',
+          ),
+          JmaCodeTableCityItem(
+            code: 'station-b',
+            name: name('観測点B'),
+            parentAreaForecastLocalEewCode: '100',
+            parentAreaInformationPrefectureEarthquakeCode: '01',
+          ),
+          JmaCodeTableCityItem(
+            code: 'station-c',
+            name: name('観測点C'),
+            parentAreaForecastLocalEewCode: '200',
+            parentAreaInformationPrefectureEarthquakeCode: '01',
+          ),
+        ],
+        areaEpicenter: const [],
+        areaEpicenterAbbreviation: const [],
+        areaEpicenterDetail: const [],
+      ),
+    );
+    final earthquake = EarthquakeParameter(
+      metadata: metadata,
+      prefectures: [
+        EarthquakeParameterPrefectureItem(
+          code: '01',
+          name: name('県'),
+          regions: [
+            EarthquakeParameterRegionItem(
+              code: '10',
+              name: name('一次細分区域'),
+              kana: null,
+              cities: [
+                city(
+                  code: 'city-1',
+                  cityName: '正しい市名',
+                  stationCodes: ['station-a', 'station-b'],
+                ),
+                city(
+                  code: 'city-2',
+                  cityName: '複数地域市',
+                  stationCodes: ['station-a', 'station-c'],
+                ),
+                city(
+                  code: 'city-unmapped',
+                  cityName: '未対応市',
+                  stationCodes: ['station-unknown'],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    final catalog = const NotificationRegionCatalogBuilder().build(
+      codeTable: codeTable,
+      earthquake: earthquake,
+    );
+
+    expect(catalog.regionByCode('100')?.cities.map((item) => item.name), [
+      '正しい市名',
+      '複数地域市',
+    ]);
+    expect(catalog.regionByCode('200')?.cities.map((item) => item.name), [
+      '複数地域市',
+    ]);
+    expect(
+      catalog.regionByCode('100')?.cityByCode('city-1')?.kana,
+      '正しい市名-kana',
+    );
+    expect(catalog.unmappedCityCodes, ['city-unmapped']);
+  });
+}

--- a/app/test/feature/settings/features/notification_settings/notification_region_map_filter_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_region_map_filter_test.dart
@@ -23,6 +23,14 @@ void main() {
     ]);
   });
 
+  test('市区町村がないregionはどの境界にも一致しない', () {
+    expect(filter.buildRegionCities(const []), [
+      '==',
+      ['get', 'regioncode'],
+      '__eqmonitor_no_match__',
+    ]);
+  });
+
   test('選択中の市区町村だけに一致する', () {
     expect(filter.buildSelectedCity('0110100'), [
       '==',

--- a/app/test/feature/settings/features/notification_settings/notification_region_map_filter_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_region_map_filter_test.dart
@@ -1,0 +1,33 @@
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/logic/notification_region_map_filter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const filter = NotificationRegionMapFilter();
+
+  test('未選択regionは一致しないfilterを返す', () {
+    expect(filter.buildRegion(null), [
+      '==',
+      ['get', 'code'],
+      '__eqmonitor_no_match__',
+    ]);
+  });
+
+  test('フォーカスregion配下の市区町村だけに一致する', () {
+    expect(filter.buildRegionCities(['0110100', '0120200']), [
+      'in',
+      ['get', 'regioncode'],
+      [
+        'literal',
+        ['0110100', '0120200'],
+      ],
+    ]);
+  });
+
+  test('選択中の市区町村だけに一致する', () {
+    expect(filter.buildSelectedCity('0110100'), [
+      '==',
+      ['get', 'regioncode'],
+      '0110100',
+    ]);
+  });
+}

--- a/app/test/feature/settings/features/notification_settings/notification_region_map_selection_card_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_region_map_selection_card_test.dart
@@ -1,0 +1,87 @@
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_map_selection.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_region_map_selection_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const city = NotificationCityOption(
+    code: '0720100',
+    name: '福島市',
+    kana: 'ふくしまし',
+  );
+  final region = NotificationRegionOption(
+    code: '250',
+    name: '福島県中通り',
+    kana: 'ふくしまけんなかどおり',
+    cities: const [city],
+  );
+
+  testWidgets('全国では地図タップの案内だけを表示する', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: NotificationRegionMapSelectionCard(
+            selection: const NotificationRegionMapNationwide(),
+            isResolving: false,
+            onDecideRegion: () {},
+            onDecideCity: () {},
+            onBackToRegion: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('地図をタップして地域を選択'), findsOneWidget);
+    expect(find.textContaining('250'), findsNothing);
+  });
+
+  testWidgets('regionでは地域全域を決定できる', (tester) async {
+    var decided = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: NotificationRegionMapSelectionCard(
+            selection: NotificationRegionMapFocused(region: region),
+            isResolving: false,
+            onDecideRegion: () => decided = true,
+            onDecideCity: () {},
+            onBackToRegion: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('福島県中通り'), findsOneWidget);
+    await tester.tap(find.text('この地域全域を選択'));
+    expect(decided, isTrue);
+  });
+
+  testWidgets('市区町村では市区町村決定とregionへ戻る操作を提供する', (tester) async {
+    var cityDecided = false;
+    var wentBack = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: NotificationRegionMapSelectionCard(
+            selection: NotificationRegionMapCitySelected(
+              region: region,
+              city: city,
+            ),
+            isResolving: false,
+            onDecideRegion: () {},
+            onDecideCity: () => cityDecided = true,
+            onBackToRegion: () => wentBack = true,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('福島市'), findsOneWidget);
+    expect(find.textContaining('0720100'), findsNothing);
+    await tester.tap(find.text('この市区町村を選択'));
+    await tester.tap(find.text('地域全域の選択に戻る'));
+    expect(cityDecided, isTrue);
+    expect(wentBack, isTrue);
+  });
+}

--- a/app/test/feature/settings/features/notification_settings/notification_region_map_selection_card_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_region_map_selection_card_test.dart
@@ -1,8 +1,8 @@
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_map_selection.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_region_map_selection_card.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   const city = NotificationCityOption(

--- a/app/test/feature/settings/features/notification_settings/notification_region_map_selection_notifier_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_region_map_selection_notifier_test.dart
@@ -1,0 +1,67 @@
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_map_selection.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_region_map_selection_notifier.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  const city = NotificationCityOption(
+    code: '0110100',
+    name: '札幌市',
+    kana: 'さっぽろし',
+  );
+  final region = NotificationRegionOption(
+    code: '9011',
+    name: '北海道道央',
+    kana: 'ほっかいどうどうおう',
+    cities: const [city],
+  );
+
+  test('全国からregion、市区町村を選択し全国へ戻る', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(
+      notificationRegionMapSelectionControllerProvider.notifier,
+    );
+
+    expect(
+      container.read(notificationRegionMapSelectionControllerProvider),
+      isA<NotificationRegionMapNationwide>(),
+    );
+    notifier.focusRegion(region);
+    expect(notifier.selectCity(city), isTrue);
+    final selected = container.read(
+      notificationRegionMapSelectionControllerProvider,
+    );
+    expect(selected, isA<NotificationRegionMapCitySelected>());
+    notifier.deselectCity();
+    expect(
+      container.read(notificationRegionMapSelectionControllerProvider),
+      isA<NotificationRegionMapFocused>(),
+    );
+    notifier.reset();
+    expect(
+      container.read(notificationRegionMapSelectionControllerProvider),
+      isA<NotificationRegionMapNationwide>(),
+    );
+  });
+
+  test('フォーカス外の市区町村は選択しない', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(
+      notificationRegionMapSelectionControllerProvider.notifier,
+    )..focusRegion(region);
+
+    expect(
+      notifier.selectCity(
+        const NotificationCityOption(code: '9999999', name: '地域外', kana: null),
+      ),
+      isFalse,
+    );
+    expect(
+      container.read(notificationRegionMapSelectionControllerProvider),
+      isA<NotificationRegionMapFocused>(),
+    );
+  });
+}

--- a/app/test/feature/settings/features/notification_settings/notification_region_search_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_region_search_test.dart
@@ -1,0 +1,32 @@
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/logic/notification_region_search.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const search = NotificationRegionSearch();
+  const items = [
+    NotificationCityOption(code: '1', name: '札幌市', kana: 'さっぽろし'),
+    NotificationCityOption(code: '2', name: 'Region 1', kana: null),
+  ];
+
+  List<NotificationCityOption> filter(String query) => search.filter(
+    items: items,
+    query: query,
+    name: (item) => item.name,
+    kana: (item) => item.kana,
+  );
+
+  test('漢字とふりがなのひらがな・カタカナ・半角カナで一致する', () {
+    expect(filter('札幌').single.code, '1');
+    expect(filter('サッポロ').single.code, '1');
+    expect(filter('ｻｯﾎﾟﾛ').single.code, '1');
+  });
+
+  test('全角英数と空白を正規化して一致する', () {
+    expect(filter('ＲＥＧＩＯＮ　１').single.code, '2');
+  });
+
+  test('空文字は元の順序を保つ', () {
+    expect(filter('').map((item) => item.code), ['1', '2']);
+  });
+}

--- a/app/test/feature/settings/features/notification_settings/region_picker_page_test.dart
+++ b/app/test/feature/settings/features/notification_settings/region_picker_page_test.dart
@@ -1,9 +1,9 @@
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/provider/notification_region_catalog_provider.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/region_picker_page.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   final catalog = NotificationRegionCatalog(

--- a/app/test/feature/settings/features/notification_settings/region_picker_page_test.dart
+++ b/app/test/feature/settings/features/notification_settings/region_picker_page_test.dart
@@ -1,0 +1,57 @@
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/provider/notification_region_catalog_provider.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/region_picker_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  final catalog = NotificationRegionCatalog(
+    regions: [
+      NotificationRegionOption(
+        code: '9011',
+        name: '北海道道央',
+        kana: 'ほっかいどうどうおう',
+        cities: const [],
+      ),
+      NotificationRegionOption(
+        code: '9012',
+        name: '北海道道南',
+        kana: 'ほっかいどうどうなん',
+        cities: const [],
+      ),
+    ],
+    unmappedCityCodes: const [],
+  );
+
+  Widget app() => ProviderScope(
+    overrides: [
+      notificationRegionCatalogProvider.overrideWith((ref) async => catalog),
+    ],
+    child: const MaterialApp(home: RegionPickerPage()),
+  );
+
+  testWidgets('IDを表示せず48px以上のコンパクトな地域行を表示する', (tester) async {
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    expect(find.text('北海道道央'), findsOneWidget);
+    expect(find.text('9011'), findsNothing);
+    final tile = tester.widget<ListTile>(
+      find.ancestor(of: find.text('北海道道央'), matching: find.byType(ListTile)),
+    );
+    expect(tile.minTileHeight, 48);
+    expect(tile.visualDensity, VisualDensity.compact);
+  });
+
+  testWidgets('カタカナのふりがな検索で地域を絞り込む', (tester) async {
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(SearchBar), 'ドウナン');
+    await tester.pump();
+
+    expect(find.text('北海道道央'), findsNothing);
+    expect(find.text('北海道道南'), findsOneWidget);
+  });
+}

--- a/docs/knowledge/20260816_notification_region_map_lifecycle.md
+++ b/docs/knowledge/20260816_notification_region_map_lifecycle.md
@@ -1,0 +1,34 @@
+# 通知地域地図のデータとライフサイクル
+
+## 地域データの正本
+
+- 通知の `regionId` は `areaForecastLocalEew` のコードを使う。
+- 表示する市区町村名・ふりがなは `EarthquakeParameter` を正本とする。
+- `jma_code_table.areaInformationCity` は観測点名を含むため表示には使わない。
+  観測点コードから親 `areaForecastLocalEew` を結合する用途に限定する。
+- 結合できない市区町村を固定値や近隣地域へ補完しない。除外してログに残す。
+
+## MapLibre と非同期検索
+
+- JMAポリゴン検索はUI isolateで展開せず、常駐 `JmaMapIsolate` を事前読込して使う。
+- タップごとに世代番号を発行し、検索完了時に最新世代かつWidgetがmountedか確認する。
+- カメラ操作は直列キューへ積み、実行開始時にも世代を確認する。古い検索結果で新しい
+  フォーカスを上書きしない。
+- `dispose` では世代を無効化し、MapController参照を破棄する。待機中のカメラ操作は
+  実行しない。
+- style layerの追加・filter更新・削除は `MapOperationQueueScope` の共有キューで直列化する。
+  cleanupでは変更した既存filterを復元し、追加したlayerをIDごとに削除する。
+- 全国表示では市区町村境界を隠す。regionフォーカス後だけ配下の市区町村コードで
+  filterし、選択中の市区町村は別layerの太線で重ねる。
+- 市区町村タイルを表示できるよう、regionフォーカス時のzoomは6未満にしない。
+
+## 検証コマンド
+
+```bash
+cd app
+mise exec -- flutter test --no-pub test/feature/settings/features/notification_settings
+mise exec -- flutter analyze --no-pub
+cd ..
+git --no-pager diff --check
+git --no-pager diff origin/develop...HEAD -- app/lib/feature/intensity_history
+```

--- a/docs/superpowers/plans/2026-08-16-notification-region-picker.md
+++ b/docs/superpowers/plans/2026-08-16-notification-region-picker.md
@@ -1,0 +1,96 @@
+# Notification Region Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** カスタム通知で正しい地域をかな検索または地図から安全に選択できるようにする。
+
+**Architecture:** EEW region、地震観測パラメータの市区町村、観測点→EEW region対応を不変カタログへ結合し、一覧と地図で共有する。地図タップは既存JMA map isolate、style操作はマップ単位キュー、非同期結果とcameraは世代guardで競合を防ぐ。
+
+**Tech Stack:** Flutter、Riverpod 3、flutter_hooks、MapLibre、jma_map、unorm_dart、flutter_test
+
+## Global Constraints
+
+- 地域別最大震度は変更しない。欠損を固定値・ランダム値・別地域への推測で補わない。
+- Dart/Flutterコマンドは `mise exec --` 経由、依存追加は `flutter pub add` を使う。
+- UIはHook/Consumer Widget、ロジックは専用クラスとRiverpod DIへ分離し、`dynamic`、`Object`、`!`を追加しない。
+- 1コミット30〜100行程度、英語1語prefix＋日本語説明、完了後push・Draft PR作成。
+
+---
+
+### Task 1: 地域カタログとかな検索
+
+**Files:** Create `app/lib/feature/settings/features/notification_settings/data/model/notification_region_catalog.dart`, `data/logic/notification_region_catalog_builder.dart`, `data/logic/notification_region_search.dart`, `data/provider/notification_region_catalog_provider.dart`; Test `app/test/feature/settings/features/notification_settings/notification_region_catalog_builder_test.dart`, `notification_region_search_test.dart`; Modify `app/pubspec.yaml`, lockfiles.
+
+**Interfaces:** Produce `NotificationRegionCatalog.regions`, `NotificationRegionOption(code,name,kana,cities)`, `NotificationCityOption(code,name,kana)`, `NotificationRegionCatalogBuilder.build({required JmaCodeTableParameter codeTable, required EarthquakeParameter earthquake})`, `NotificationRegionSearch.filter({required List<T> items, required String query, required String Function(T) name, required String? Function(T) kana})`.
+
+```dart
+NotificationRegionCatalog build({required JmaCodeTableParameter codeTable, required EarthquakeParameter earthquake});
+List<T> filter<T>({required List<T> items, required String query, required String Function(T) name, required String? Function(T) kana});
+```
+
+- [ ] Add `unorm_dart` with `mise exec -- flutter pub add unorm_dart` from `app/`.
+- [ ] Test that station codes join correct city names/kana, duplicates collapse, multi-region cities remain in each actual region, and unmapped cities are omitted.
+- [ ] Implement catalog models/builder/provider; log unmapped data without fallback.
+- [ ] Test kanji, hiragana, katakana, half-width kana, full-width ASCII, and whitespace queries.
+- [ ] Implement NFKC→lowercase→whitespace removal→katakana-to-hiragana normalization and generic filtering.
+- [ ] Run both tests, format, and commit `Feat: 通知地域カタログとかな検索を追加`.
+
+### Task 2: 一覧選択UI
+
+**Files:** Create `app/lib/feature/settings/features/notification_settings/data/model/notification_region_selection.dart`; Modify `ui/page/region_picker_page.dart`, `ui/page/city_picker_page.dart`; Test `app/test/feature/settings/features/notification_settings/region_picker_page_test.dart`, `city_picker_page_test.dart`.
+
+**Interfaces:** Consume catalog/search. Produce `NotificationRegionSelection(regionCode,regionName,cityCode?,cityName?)`; city/map pages return this value, and `RegionPickerPage` alone runs `NotificationSlotsNotifier.addRegionMutation`.
+
+```dart
+final class NotificationRegionSelection {
+  const NotificationRegionSelection({required this.regionCode, required this.regionName, this.cityCode, this.cityName});
+}
+```
+
+- [ ] Write Widget tests for no IDs, compact 48px-min rows, correct city names, kana search, empty states, and disabled double submission.
+- [ ] Refactor region/city pages to watch catalog provider, use shared search, return a selection, and centralize mutation/error/navigation in the region page.
+- [ ] Run Widget tests and commit `Fix: 通知地域一覧の表示と検索を改善`.
+
+### Task 3: 地図状態・解決・競合guard
+
+**Files:** Create `data/model/notification_region_map_selection.dart`, `data/notifier/notification_region_map_selection_notifier.dart`, `data/logic/notification_region_map_filter.dart`, `data/logic/latest_map_operation_guard.dart`; Test matching files under `app/test/feature/settings/features/notification_settings/`.
+
+**Interfaces:** Produce `focusRegion`, `selectCity`, `reset`; `buildRegionCityFilter(List<String>)`, `buildSelectedCityFilter(String?)`; `LatestMapOperationGuard.begin/isCurrent/invalidate/dispose` and queued latest-wins camera execution.
+
+```dart
+int begin();
+bool isCurrent(int generation);
+Future<void> runLatest(Future<void> Function() operation);
+void invalidate();
+```
+
+- [ ] Test nationwide→region→city→region→nationwide transitions and rejection of cities outside the focused region.
+- [ ] Implement the auto-dispose notifier with immutable selection values.
+- [ ] Test empty/region/selected-city MapLibre filter expressions and stale/disposed operation rejection.
+- [ ] Implement filter builders and generation-based async/camera guard without storing MapController in provider state.
+- [ ] Run tests, generate Riverpod code, and commit `Feat: 通知地域地図の状態と競合制御を追加`.
+
+### Task 4: 地図ページとレイヤー
+
+**Files:** Create `ui/page/notification_region_map_picker_page.dart`, `ui/component/notification_region_map_layer.dart`, `ui/component/notification_region_map_selection_card.dart`; Modify `ui/page/region_picker_page.dart`; Test `app/test/feature/settings/features/notification_settings/notification_region_map_selection_card_test.dart`.
+
+**Interfaces:** Consume `mapConfigurationProvider`, `jmaMapIsolateProvider`, catalog, selection notifier, filters, guard. Return `NotificationRegionSelection?` to `RegionPickerPage`.
+
+```dart
+static Future<NotificationRegionSelection?> show(BuildContext context);
+```
+
+- [ ] Test bottom card content/actions for nationwide, region, and city states.
+- [ ] Build Japan-initialized MapLibre page; preload style/catalog/isolate, resolve EEW region then city by code, fit region bounds, reset to Japan, and ignore stale/unmounted results.
+- [ ] Add queued layers for selected region outline and selected-city thick line; update base city-line and custom filters so only focused-region cities appear; restore/remove individually on cleanup.
+- [ ] Wire region/city decision buttons and AppBar reset; surface short loading/error/outside-map messages.
+- [ ] Run map-related tests, format/analyze touched files, and commit `Feat: 通知地域を地図から選択可能にする`.
+
+### Task 5: 検証・知見・PR
+
+**Files:** Create `docs/knowledge/20260816_notification_region_map_lifecycle.md`; Modify generated files only as required.
+
+- [ ] Record catalog source-of-truth and MapLibre isolate/generation/queue lifecycle rules with exact verification commands.
+- [ ] Run targeted tests, `mise exec -- flutter analyze --no-pub`, `git diff --check`, and inspect that `app/lib/feature/intensity_history/` is unchanged.
+- [ ] Commit docs as `Docs: 通知地域地図のデータとライフサイクルを記録` and any isolated verification fixes separately.
+- [ ] Create `codex/notification-region-picker`, push all commits, and open a Draft PR summarizing behavior, tests, risks, and manual map checks.

--- a/docs/superpowers/specs/2026-08-16-notification-region-picker-design.md
+++ b/docs/superpowers/specs/2026-08-16-notification-region-picker-design.md
@@ -1,0 +1,95 @@
+# カスタム通知 地域選択改善 設計
+
+## 背景と目的
+
+現状はregion・市区町村コードが表示され、余白も大きい。市区町村一覧は `jma_code_table.areaInformationCity` を直接参照するため観測点名が混ざり、市区町村のかな検索と地図選択もない。
+
+コード表示と過剰な余白を除き、正しいregion・市区町村を漢字またはふりがなで検索できるようにする。さらに、日本全域からregion、市区町村へ段階的にフォーカスする地図選択を追加し、初期化・選択更新・レイヤー更新・disposeの競合で古い処理が反映されない構造にする。
+
+地域別最大震度マップは参考実装として調査したが、将来、市区町村表示をデフォルトにする予定があるため、今回は変更しない。通知API、backend、既存スロットの一括移行、現在地から選択する新導線も対象外とする。
+
+## 地域カタログ
+
+通知スロットの `regionId` は、現在地更新と同じ `areaForecastLocalEew` のコードを使う。region名・かなは `JmaCodeTableParameter.codeTables.areaForecastLocalEew` を正本とする。市区町村コード・正しい名前・かなは `EarthquakeParameter.prefectures[].regions[].cities[]` を正本とし、`jma_code_table.areaInformationCity` の名前は表示に使わない。
+
+通知用EEW regionと市区町村は次のように結合する。
+
+1. `jma_code_table.areaInformationCity` から観測点コード→親EEW regionコードをindex化する。
+2. `EarthquakeParameter` の各市区町村について、配下の観測点コードをindexへ照合する。
+3. 得られたEEW regionへ、正しい市区町村コード・名前・かなを登録する。
+4. regionと市区町村コードの組で重複排除する。複数regionが実データから得られた場合は各regionへ登録し、1件へ丸めない。
+5. 対応不能な市区町村は推測配置せず診断ログへ記録する。
+
+構築結果は一覧検索と地図filterが共有する不変カタログとし、UIごとの再計算を避ける。
+
+## 一覧と検索
+
+現在の「region一覧→region全域または市区町村一覧」という2段階導線を維持し、region一覧のAppBarに地図アイコンを追加する。
+
+- region・市区町村コードのsubtitleを削除する。
+- 検索欄の外側余白を上下4、左右12程度へ縮める。
+- 行の密度を上げつつ、48 logical pixel以上のタップ領域を維持する。
+- region行は名前と遷移アイコン、市区町村行は正しい名前と追加アイコンだけを表示する。
+- 市区町村画面先頭の「○○ 全域」と、追加中の二重送信防止・progressは維持する。
+
+検索はWidgetから分離した純粋ロジックを共有する。名前とかなをUnicode NFKCで正規化した後、小文字化、全空白除去、カタカナからひらがなへの変換を行い、部分一致させる。NFKC実装が未導入なら依存は `flutter pub add` で追加する。空文字は元の順序の全件、かな欠損時は名前だけを対象とし、読みを固定値で補わない。
+
+## 地図選択
+
+地図は独立した全画面ページとし、初期cameraで日本全域を表示する。
+
+### 全国
+
+- `areaForecastLocalEew` 境界を表示し、市区町村境界は表示しない。
+- 下部に「地図をタップして地域を選択」と表示する。
+- JMAポリゴンの内包判定でEEW regionを解決する。海上・データ外では選択を変えず短い案内を出す。
+
+### regionフォーカス
+
+- 選択regionのboundsへpadding付きで `fitBounds` し、輪郭を強調する。
+- カタログから当該regionの市区町村コードだけを抽出し、その境界だけ表示する。base mapの全市区町村境界もページ内filterで抑止する。
+- 下部にregion名、「この地域全域を選択」、市区町村タップの案内を表示する。
+
+### 市区町村選択
+
+- `areaInformationCity` のタップ結果をコードでカタログへ照合し、フォーカス中regionに属する場合だけ選択する。
+- 選択市区町村を線幅4程度・高opacityで強調する。別市区町村タップで選択を置き換える。
+- 下部に正しい市区町村名と「この市区町村を選択」を表示する。
+
+AppBarのresetは選択と境界filterを解除し、日本全域へ戻す。確定値は、region全域なら `regionId/regionName`、市区町村ならそれらに `cityCode/cityName` を加え、既存の `NotificationSlotsNotifier.addRegionMutation` へ渡す。
+
+## 状態・非同期・cleanup
+
+地図状態は全国、region、市区町村の3状態を持つpage-scoped auto-dispose notifierで管理し、MapControllerはMap Widgetのライフサイクル内だけで保持する。
+
+style、JMAポリゴン、地域カタログがすべて揃うまで操作を受け付けない。準備後のタップは読み込み済みindexで解決し、タップごとにproviderをawaitしない。
+
+camera操作には世代番号を付ける。選択変更・reset・disposeで世代を進め、実行時または完了時に世代が異なる処理は状態へ反映しない。dispose時はMapController参照もクリアする。
+
+レイヤー追加、base filter更新、選択filter更新、cleanupは `MapOperationQueueScope` のキューで直列化する。選択変更はlayer再作成ではなく `updateFilter` を基本とする。cleanupは追加layerを個別に削除しbase filterを復元する。一操作の失敗で後続cleanupを止めず、破棄済みstyleの失敗は診断ログへ残す。
+
+## エラー表示
+
+- parameter、JMA map、styleの読み込み中はadaptive progress、失敗時は短い説明と再試行を表示する。
+- 検索0件は対象に応じた空表示にする。市区町村0件でもregion全域は選べる。
+- HTTP 402は既存Pro案内、それ以外の追加失敗は短いSnackBarにする。例外全文を本文へ出さない。
+- 解決不能な地図タップは現在選択を保持する。欠損を固定コード、ランダム値、別地域への推測で補わない。
+
+## テスト
+
+- カタログ結合、重複排除、複数region、対応不能データを単体テストする。
+- 漢字、ひらがな、カタカナ、全半角、空白を含む検索を単体テストする。
+- 全国→region→市区町村→region→全国の遷移とregion/city filter式を単体テストする。
+- 古い世代のcamera/tap完了とdispose後の処理が状態を更新しないことを単体テストする。
+- ID非表示、正しい市区町村名、かな検索、空・loading・error、二重送信防止、地図下部カードをWidgetテストする。
+- 実機またはSimulatorで全国初期表示、regionフォーカス、対象regionだけの市区町村線、選択太線、連続タップ、reset直後のタップ、即時closeを確認する。
+
+## 受け入れ条件
+
+1. region・市区町村一覧にID/codeがなく、余白を縮めても48 logical pixel以上のタップ領域がある。
+2. 観測点名ではなく正しい市区町村名が表示され、漢字・ふりがな・ひらがな／カタカナで検索できる。
+3. 地図は日本全域から始まり、タップしたEEW regionへフォーカスする。
+4. regionフォーカス中は当該regionの市区町村境界だけが表示され、市区町村タップ後は選択境界が太線になる。
+5. region全域または市区町村を確定でき、連続操作・rebuild・reset・disposeで古い処理が選択やcameraを上書きしない。
+6. 地域別最大震度の実装には変更がない。
+7. 関連テスト、format、analyzeが `mise exec --` 経由で成功する。

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2526,6 +2526,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  unorm_dart:
+    dependency: transitive
+    description:
+      name: unorm_dart
+      sha256: "0c69186b03ca6addab0774bcc0f4f17b88d4ce78d9d4d8f0619e30a99ead58e7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
   upgrader:
     dependency: transitive
     description:


### PR DESCRIPTION
## 概要

カスタム通知の地域選択を、正しい市区町村データ・ふりがな検索・地図選択に対応させます。

## 背景 / 原因

従来の市区町村一覧は `jma_code_table.areaInformationCity` の観測点名をそのまま表示していました。また、地域ID表示と大きな余白が選択操作を分かりにくくしていました。

## 変更内容

- 地域・市区町村のID表示を削除し、行高と検索欄の余白を縮小
- `EarthquakeParameter` の市区町村名・ふりがなを正本にし、観測点コードからEEW regionへ安全に結合
- 漢字、ひらがな、カタカナ、半角カナ、全角英数を正規化した検索を追加
- 日本全国から始まる地図選択画面を追加
- 地図タップでEEW regionへフォーカスし、region全域または市区町村を決定可能に変更
- フォーカス中region配下だけ市区町村境界を表示し、選択市区町村を太線で強調
- JMAポリゴン検索を常駐isolateで実行し、世代guardとMapLibre操作キューで古い結果・dispose後操作・style更新競合を抑止
- 地域追加Mutationとエラー表示を親画面へ集約

地域別最大震度の実装はこのPRでは変更していません。

## 検証

- `mise exec -- flutter test --no-pub test/feature/settings/features/notification_settings` — 81 tests passed
- 変更したproductionファイルの `mise exec -- dart analyze ...` — No issues found
- `git diff --check origin/develop...HEAD` — pass
- `app/lib/feature/intensity_history` / `app/test/feature/intensity_history` の差分なし
- `mise exec -- flutter analyze --no-pub` は最新develop既存のDart 3.14 constructor shorthand等のinfo 1,745件でexit 1（今回変更ファイルは限定解析で0件）

## 手動確認項目

- [ ] 実機またはSimulatorで全国→region→市区町村のタップ選択とカメラ遷移
- [ ] Light / Darkでregion境界、市区町村境界、選択太線の視認性
- [ ] region全域・市区町村の各決定後に通知地域が正しく追加されること