### PR TITLE
Fix: 通知配信ログ詳細のlint違反を修正

### DIFF
--- a/app/lib/feature/notification/data/logic/notification_delivery_log_detail_builder.dart
+++ b/app/lib/feature/notification/data/logic/notification_delivery_log_detail_builder.dart
@@ -10,7 +10,7 @@ NotificationDeliveryLogDetailBuilder notificationDeliveryLogDetailBuilder(
 ) => NotificationDeliveryLogDetailBuilder();
 
 final class NotificationDeliveryLogDetail {
-  const NotificationDeliveryLogDetail({required this.rows});
+  const new({required this.rows});
 
   final List<NotificationDeliveryLogDetailRow> rows;
 
@@ -19,7 +19,7 @@ final class NotificationDeliveryLogDetail {
 }
 
 final class NotificationDeliveryLogDetailRow {
-  const NotificationDeliveryLogDetailRow({
+  const new({
     required this.label,
     required this.value,
   });

--- a/app/lib/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart
+++ b/app/lib/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart
@@ -12,7 +12,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class DebugNotificationDeliveryLogPage extends HookConsumerWidget {
-  const DebugNotificationDeliveryLogPage({super.key});
+  const new({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -193,7 +193,7 @@ class DebugNotificationDeliveryLogPage extends HookConsumerWidget {
 }
 
 class _NotificationLogTile extends StatelessWidget {
-  const _NotificationLogTile({required this.item, required this.onTap});
+  const new({required this.item, required this.onTap});
 
   final PushNotificationLogEntry item;
   final VoidCallback onTap;
@@ -220,7 +220,7 @@ class _NotificationLogTile extends StatelessWidget {
 }
 
 class _LogDetailSheet extends StatelessWidget {
-  const _LogDetailSheet({required this.detail});
+  const new({required this.detail});
 
   final NotificationDeliveryLogDetail detail;
 
@@ -279,7 +279,7 @@ class _LogDetailSheet extends StatelessWidget {
 }
 
 class _LogDetailRow extends StatelessWidget {
-  const _LogDetailRow({required this.row});
+  const new({required this.row});
 
   final NotificationDeliveryLogDetailRow row;
 


### PR DESCRIPTION
## 概要

PR #1671 の競合解消後に残った `unnecessary_type_name_in_constructor` を修正します。
機能ロジックや表示内容には変更ありません。

## 変更内容

- 通知配信ログ詳細モデルのコンストラクタを省略記法へ変更
- 通知配信ログ画面内Widgetのコンストラクタを省略記法へ変更

## 確認

- `mise exec -- flutter analyze --no-pub ...`: No issues found
- `mise exec -- flutter test test/feature/notification/data/logic/notification_delivery_log_detail_builder_test.dart`: 5 tests passed

## 関連

- #1671