### PR TITLE
Fix: EEW警報地域の区域コードと初回警報判定を修正

### DIFF
--- a/app/lib/feature/eew/data/logic/eew_warning_area_selector.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_area_selector.dart
@@ -1,0 +1,22 @@
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_warning_area_selector.g.dart';
+
+@riverpod
+EewWarningAreaSelector eewWarningAreaSelector(Ref ref) =>
+    const EewWarningAreaSelector();
+
+class EewWarningAreaSelector {
+  const EewWarningAreaSelector();
+
+  List<String> selectPrefectureCodes({
+    required Iterable<EewTelegramItem> events,
+  }) => {
+    for (final event in events)
+      if (event.isWarning == true && !event.isCanceled)
+        for (final prefecture
+            in event.warning?.prefectures ?? const <EewWarningZoneInfo>[])
+          prefecture.code,
+  }.toList(growable: false);
+}

--- a/app/lib/feature/eew/data/logic/eew_warning_area_selector.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_area_selector.dart
@@ -8,7 +8,7 @@ EewWarningAreaSelector eewWarningAreaSelector(Ref ref) =>
     const EewWarningAreaSelector();
 
 class EewWarningAreaSelector {
-  const EewWarningAreaSelector();
+  const new();
 
   List<String> selectPrefectureCodes({
     required Iterable<EewTelegramItem> events,

--- a/app/lib/feature/eew/data/logic/eew_warning_area_selector.g.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_area_selector.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_area_selector.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eewWarningAreaSelector)
+final eewWarningAreaSelectorProvider = EewWarningAreaSelectorProvider._();
+
+final class EewWarningAreaSelectorProvider
+    extends
+        $FunctionalProvider<
+          EewWarningAreaSelector,
+          EewWarningAreaSelector,
+          EewWarningAreaSelector
+        >
+    with $Provider<EewWarningAreaSelector> {
+  EewWarningAreaSelectorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningAreaSelectorProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eewWarningAreaSelectorHash();
+
+  @$internal
+  @override
+  $ProviderElement<EewWarningAreaSelector> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EewWarningAreaSelector create(Ref ref) {
+    return eewWarningAreaSelector(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EewWarningAreaSelector value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EewWarningAreaSelector>(value),
+    );
+  }
+}
+
+String _$eewWarningAreaSelectorHash() =>
+    r'8a70b3461c6fad48b89dcf92b0a626a35a1563b1';

--- a/app/lib/feature/eew/data/logic/eew_warning_candidate_selector.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_candidate_selector.dart
@@ -18,8 +18,8 @@ class EewWarningCandidateSelector {
   }) {
     final candidates = <EewWarningOverlayCandidate>[];
     for (final event in aliveEews) {
-      final hasCurrentWarning = event.warning?.regions.any(
-        (region) => region.code == warningAreaCode && region.hadWarning,
+      final hasCurrentWarning = event.warning?.prefectures.any(
+        (prefecture) => prefecture.code == warningAreaCode,
       );
       if (event.isWarning != true ||
           event.isCanceled ||

--- a/app/lib/feature/eew/data/logic/eew_warning_display_model_builder.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_display_model_builder.dart
@@ -18,7 +18,7 @@ EewWarningDisplayModelBuilder eewWarningDisplayModelBuilder(Ref ref) =>
     );
 
 class EewWarningDisplayModelBuilder {
-  EewWarningDisplayModelBuilder({
+  new({
     EewWarningArrivalClassifier? arrivalClassifier,
     EewWarningRepresentativeSelector? representativeSelector,
   }) : _arrivalClassifier = arrivalClassifier ?? EewWarningArrivalClassifier(),

--- a/app/lib/feature/eew/data/logic/eew_warning_display_model_builder.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_display_model_builder.dart
@@ -50,9 +50,7 @@ class EewWarningDisplayModelBuilder {
     for (final candidate in sortedCandidates) {
       for (final zone
           in candidate.event.warning?.zones ?? const <EewWarningZoneInfo>[]) {
-        if (zone.hadWarning) {
-          zoneNamesByCode.putIfAbsent(zone.code, () => zone.name);
-        }
+        zoneNamesByCode.putIfAbsent(zone.code, () => zone.name);
       }
     }
     final zoneCodes = zoneNamesByCode.keys.toList()..sort();

--- a/app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
 import 'package:eqmonitor/core/theme/model/intensity_colors.dart';
 import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
 import 'package:eqmonitor/feature/eew/data/logic/eew_forecast_region_intensity_filter_updater.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_area_selector.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_display_mode.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:eqmonitor/feature/home/ui/component/map/layer/eew_area_filter.dart';
@@ -16,8 +17,8 @@ import 'package:maplibre/maplibre.dart';
 
 /// EEW震度予報区域レイヤー
 ///
-/// `displayMode` に応じて、府県地震予報区（areaForecastLocalEew）を
-/// 予想震度別 or 警報発表区域として塗りつぶす。
+/// `displayMode` に応じて、予報区を予想震度別、または府県予報区を
+/// 警報発表区域として塗りつぶす。
 class EewForecastRegionLayer extends HookConsumerWidget {
   const EewForecastRegionLayer({
     required this.eew,
@@ -31,7 +32,8 @@ class EewForecastRegionLayer extends HookConsumerWidget {
   final List<EewForecastRegionInfo>? additionalRegions;
 
   static const _sourceId = 'eqmonitor_map';
-  static const _sourceLayerId = 'areaForecastLocalE';
+  static const _intensitySourceLayerId = 'areaForecastLocalE';
+  static const _warningSourceLayerId = 'areaForecastLocalEew';
   static const _warningLayerId = 'eew-details-warning-fill';
   static const _warningLineLayerId = 'eew-details-warning-line';
   static const _areaFilterBuilder = EewAreaFilterBuilder();
@@ -40,6 +42,7 @@ class EewForecastRegionLayer extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final styleController = MapController.maybeOf(context)?.style;
     final colorModel = ref.watch(activeColorSetProvider).intensity;
+    final warningAreaSelector = ref.watch(eewWarningAreaSelectorProvider);
     final isDarkMode = Theme.brightnessOf(context) == Brightness.dark;
     final intensityFilterUpdater = ref.watch(
       eewForecastRegionIntensityFilterUpdaterProvider,
@@ -62,10 +65,15 @@ class EewForecastRegionLayer extends HookConsumerWidget {
           .toList();
     }, [eew, additionalRegions]);
 
-    final warningCodes = useMemoized(() {
-      final zones = eew?.warning?.regions ?? const [];
-      return zones.where((z) => z.hadWarning).map((z) => z.code).toList();
-    }, [eew]);
+    final warningCodes = useMemoized(
+      () => warningAreaSelector.selectPrefectureCodes(
+        events: switch (eew) {
+          final event? => [event],
+          null => const <EewTelegramItem>[],
+        },
+      ),
+      [warningAreaSelector, eew],
+    );
 
     final enqueue = useMapOperationQueue();
 
@@ -89,7 +97,7 @@ class EewForecastRegionLayer extends HookConsumerWidget {
               FillStyleLayer(
                 id: intensityFilterUpdater.detailLayerId(intensity),
                 sourceId: _sourceId,
-                sourceLayerId: _sourceLayerId,
+                sourceLayerId: _intensitySourceLayerId,
                 filter: _areaFilterBuilder.build(codes),
                 paint: {'fill-color': color.toHexString(), 'fill-opacity': 0.7},
               ),
@@ -159,17 +167,17 @@ class EewForecastRegionLayer extends HookConsumerWidget {
             FillStyleLayer(
               id: _warningLayerId,
               sourceId: _sourceId,
-              sourceLayerId: _sourceLayerId,
+              sourceLayerId: _warningSourceLayerId,
               filter: filter,
               paint: const {'fill-color': '#DD0000', 'fill-opacity': 1},
             ),
-            belowLayerId: BaseLayer.areaForecastLocalELine.name,
+            belowLayerId: BaseLayer.areaForecastLocalEewLine.name,
           );
           await styleController.addLayer(
             LineStyleLayer(
               id: _warningLineLayerId,
               sourceId: _sourceId,
-              sourceLayerId: _sourceLayerId,
+              sourceLayerId: _warningSourceLayerId,
               filter: filter,
               paint: {
                 'line-color': isDarkMode ? '#FFFFFF' : '#222222',

--- a/app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart
@@ -20,7 +20,7 @@ import 'package:maplibre/maplibre.dart';
 /// `displayMode` に応じて、予報区を予想震度別、または府県予報区を
 /// 警報発表区域として塗りつぶす。
 class EewForecastRegionLayer extends HookConsumerWidget {
-  const EewForecastRegionLayer({
+  const new({
     required this.eew,
     required this.displayMode,
     this.additionalRegions,

--- a/app/lib/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_area_selector.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:eqmonitor/feature/home/ui/component/map/layer/eew_area_filter.dart';
 import 'package:material_ui/material_ui.dart';
@@ -20,22 +21,12 @@ class EewWarningRegionsLayer extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final styleController = MapController.maybeOf(context)?.style;
+    final warningAreaSelector = ref.watch(eewWarningAreaSelectorProvider);
 
-    final codes = useMemoized(() {
-      final out = <String>{};
-      for (final e in eews) {
-        final zones = e.warning?.regions;
-        if (zones == null) {
-          continue;
-        }
-        for (final z in zones) {
-          if (z.hadWarning) {
-            out.add(z.code);
-          }
-        }
-      }
-      return out.toList();
-    }, [eews]);
+    final codes = useMemoized(
+      () => warningAreaSelector.selectPrefectureCodes(events: eews),
+      [warningAreaSelector, eews],
+    );
 
     final isInitialized = useRef(false);
     final latestCodes = useRef<List<String>>(codes);

--- a/app/lib/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart
@@ -11,7 +11,7 @@ import 'package:maplibre/maplibre.dart';
 
 /// 警報発表区域の塗りつぶし（府県予報区 `eqmonitor_map`）
 class EewWarningRegionsLayer extends HookConsumerWidget {
-  const EewWarningRegionsLayer({required this.eews, super.key});
+  const new({required this.eews, super.key});
 
   final List<EewTelegramItem> eews;
 

--- a/app/test/feature/eew/data/logic/eew_warning_area_selector_test.dart
+++ b/app/test/feature/eew/data/logic/eew_warning_area_selector_test.dart
@@ -1,0 +1,79 @@
+import 'package:eqmonitor/core/model/telegram/telegram_info_type.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_area_selector.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const selector = EewWarningAreaSelector();
+
+  test('初回警報でも府県予報区コードを返す', () {
+    final result = selector.selectPrefectureCodes(
+      events: [
+        warningEew(
+          eventId: 'initial-warning',
+          prefectureCode: '9020',
+          regionCode: '202',
+          hadWarning: false,
+        ),
+      ],
+    );
+
+    expect(result, ['9020']);
+  });
+
+  test('現在警報だけを対象に重複コードを除く', () {
+    final result = selector.selectPrefectureCodes(
+      events: [
+        warningEew(eventId: 'warning-a', prefectureCode: '9011'),
+        warningEew(eventId: 'warning-b', prefectureCode: '9011'),
+        warningEew(
+          eventId: 'canceled',
+          prefectureCode: '9020',
+          isCanceled: true,
+        ),
+        warningEew(
+          eventId: 'forecast',
+          prefectureCode: '9030',
+          isWarning: false,
+        ),
+      ],
+    );
+
+    expect(result, ['9011']);
+  });
+}
+
+EewTelegramItem warningEew({
+  required String eventId,
+  required String prefectureCode,
+  String regionCode = '100',
+  bool? isWarning = true,
+  bool isCanceled = false,
+  bool hadWarning = true,
+}) => EewTelegramItem(
+  eventId: eventId,
+  status: TelegramStatus.normal,
+  infoType: TelegramInfoType.publication,
+  serialNo: 1,
+  isCanceled: isCanceled,
+  isLastInfo: false,
+  reportTime: DateTime.utc(2026, 8, 17),
+  isPlum: false,
+  isWarning: isWarning,
+  warning: EewWarningInfo(
+    regions: [
+      EewWarningZoneInfo(code: regionCode, name: '予報区', hadWarning: hadWarning),
+    ],
+    zones: [
+      EewWarningZoneInfo(code: '9910', name: '地方', hadWarning: hadWarning),
+    ],
+    prefectures: [
+      EewWarningZoneInfo(
+        code: prefectureCode,
+        name: '府県予報区',
+        hadWarning: hadWarning,
+      ),
+    ],
+  ),
+);

--- a/app/test/feature/eew/data/logic/eew_warning_candidate_selector_test.dart
+++ b/app/test/feature/eew/data/logic/eew_warning_candidate_selector_test.dart
@@ -8,29 +8,28 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   final selector = EewWarningCandidateSelector();
 
-  test('現在のwarning regionにhadWarningがある警報だけを返す', () {
+  test('現在報のwarning prefectureに含まれる警報だけを返す', () {
     final result = selector.select(
       aliveEews: [
-        warningEew(eventId: 'eligible', warningRegionCode: '100'),
-        warningEew(eventId: 'other', warningRegionCode: '200'),
         warningEew(
-          eventId: 'previous-only',
-          warningRegionCode: '100',
+          eventId: 'eligible',
+          warningPrefectureCode: '9011',
           hadWarning: false,
         ),
+        warningEew(eventId: 'other', warningPrefectureCode: '9020'),
         warningEew(
           eventId: 'forecast',
-          warningRegionCode: '100',
+          warningPrefectureCode: '9011',
           isWarning: false,
         ),
         warningEew(
           eventId: 'canceled',
-          warningRegionCode: '100',
+          warningPrefectureCode: '9011',
           isCanceled: true,
         ),
       ],
-      warningAreaCode: '100',
-      warningAreaName: '石狩地方北部',
+      warningAreaCode: '9011',
+      warningAreaName: '北海道道央',
       forecastAreaCode: '100',
       forecastAreaName: '石狩地方北部',
     );
@@ -51,8 +50,8 @@ void main() {
               arrivalTime: arrival,
             ),
           ],
-          warningAreaCode: '100',
-          warningAreaName: '石狩地方北部',
+          warningAreaCode: '9011',
+          warningAreaName: '北海道道央',
           forecastAreaCode: '100',
           forecastAreaName: '石狩地方北部',
         )
@@ -66,8 +65,8 @@ void main() {
     final result = selector
         .select(
           aliveEews: [warningEew(eventId: 'event', warningRegionCode: '100')],
-          warningAreaCode: '100',
-          warningAreaName: '石狩地方北部',
+          warningAreaCode: '9011',
+          warningAreaName: '北海道道央',
           forecastAreaCode: null,
           forecastAreaName: null,
         )
@@ -81,6 +80,7 @@ EewTelegramItem warningEew({
   required String eventId,
   bool? isWarning = true,
   bool isCanceled = false,
+  String warningPrefectureCode = '9011',
   String warningRegionCode = '100',
   bool hadWarning = true,
   String forecastRegionCode = '999',
@@ -123,6 +123,12 @@ EewTelegramItem warningEew({
     zones: [
       EewWarningZoneInfo(code: '9910', name: '北海道', hadWarning: hadWarning),
     ],
-    prefectures: const [],
+    prefectures: [
+      EewWarningZoneInfo(
+        code: warningPrefectureCode,
+        name: '府県予報区',
+        hadWarning: hadWarning,
+      ),
+    ],
   ),
 );

--- a/app/test/feature/eew/data/logic/eew_warning_display_model_builder_test.dart
+++ b/app/test/feature/eew/data/logic/eew_warning_display_model_builder_test.dart
@@ -182,6 +182,17 @@ void main() {
     );
   });
 
+  test('初回警報のhadWarningがfalseのzoneも見出しに使う', () {
+    final initialWarning = candidate(warningZonesHadWarning: false);
+
+    expect(
+      EewWarningDisplayModelBuilder()
+          .build(candidates: [initialWarning], now: now)
+          ?.strongMotionHeadline,
+      '北海道で強い揺れ',
+    );
+  });
+
   test('候補が空なら表示しない', () {
     expect(
       EewWarningDisplayModelBuilder().build(candidates: const [], now: now),
@@ -195,7 +206,7 @@ void main() {
       now: now,
     );
 
-    expect(model?.currentRegionName, '石狩地方北部');
+    expect(model?.currentRegionName, '北海道道央');
     expect(model?.localIntensity, JmaIntensity.unknown);
     expect(model?.localIntensityIsOver, isFalse);
     expect(model?.arrivalState, EewWarningArrivalState.unknown);
@@ -211,6 +222,7 @@ EewWarningOverlayCandidate candidate({
   bool isLevelMethod = false,
   String? detailedHypocenterName,
   List<(String, String)> warningZones = const [('9910', '北海道')],
+  bool warningZonesHadWarning = true,
   JmaIntensity intensity = JmaIntensity.fiveLower,
   DateTime? arrivalTime,
   bool isArrived = false,
@@ -263,11 +275,13 @@ EewWarningOverlayCandidate candidate({
             (zone) => EewWarningZoneInfo(
               code: zone.$1,
               name: zone.$2,
-              hadWarning: true,
+              hadWarning: warningZonesHadWarning,
             ),
           )
           .toList(),
-      prefectures: const [],
+      prefectures: const [
+        EewWarningZoneInfo(code: '9011', name: '北海道道央', hadWarning: false),
+      ],
       regions: const [
         EewWarningZoneInfo(code: '100', name: '石狩地方北部', hadWarning: true),
       ],
@@ -277,8 +291,8 @@ EewWarningOverlayCandidate candidate({
   return EewWarningCandidateSelector()
       .select(
         aliveEews: [event],
-        warningAreaCode: '100',
-        warningAreaName: '石狩地方北部',
+        warningAreaCode: '9011',
+        warningAreaName: '北海道道央',
         forecastAreaCode: hasLocalForecast ? '100' : null,
         forecastAreaName: hasLocalForecast ? '現在地予報区' : null,
       )

--- a/app/test/feature/eew/data/provider/eew_warning_overlay_candidate_provider_test.dart
+++ b/app/test/feature/eew/data/provider/eew_warning_overlay_candidate_provider_test.dart
@@ -18,7 +18,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lat_lng/lat_lng.dart';
 
 class _StubEewAliveTelegram extends EewAliveTelegram {
-  _StubEewAliveTelegram(this.value);
+  new(this.value);
 
   final List<EewTelegramItem>? value;
 
@@ -27,7 +27,7 @@ class _StubEewAliveTelegram extends EewAliveTelegram {
 }
 
 class _StubEewWarningOverlayEnabled extends EewWarningOverlayEnabled {
-  _StubEewWarningOverlayEnabled(this.value);
+  new(this.value);
 
   final Future<bool> value;
 

--- a/app/test/feature/eew/data/provider/eew_warning_overlay_candidate_provider_test.dart
+++ b/app/test/feature/eew/data/provider/eew_warning_overlay_candidate_provider_test.dart
@@ -62,6 +62,7 @@ EewTelegramItem _warningEew({
   bool? isWarning = true,
   bool isCanceled = false,
   bool hadWarning = true,
+  String warningPrefectureCode = '9011',
   String warningRegionCode = '100',
   String forecastRegionCode = '200',
   JmaIntensity intensity = JmaIntensity.sixUpper,
@@ -89,7 +90,13 @@ EewTelegramItem _warningEew({
   ),
   warning: EewWarningInfo(
     zones: const [],
-    prefectures: const [],
+    prefectures: [
+      EewWarningZoneInfo(
+        code: warningPrefectureCode,
+        name: '府県予報区',
+        hadWarning: hadWarning,
+      ),
+    ],
     regions: [
       EewWarningZoneInfo(
         code: warningRegionCode,
@@ -121,7 +128,7 @@ ProviderContainer _container({
       ),
       jmaMapAreaForecastLocalEewInsideProvider.overrideWith(
         (ref, latLng) =>
-            warningArea ?? Future.value(_mapItem(code: '100', name: '警報判定区域')),
+            warningArea ?? Future.value(_mapItem(code: '9011', name: '警報判定区域')),
       ),
       jmaMapAreaForecastLocalEInsideProvider.overrideWith(
         (ref, latLng) =>
@@ -221,7 +228,7 @@ void main() {
       await _candidatesFor(
         alive: [_warningEew()],
         warningArea: Future.value(
-          _mapItem(code: '100', name: '警報判定区域', hasProperty: false),
+          _mapItem(code: '9011', name: '警報判定区域', hasProperty: false),
         ),
       ),
       isEmpty,
@@ -234,9 +241,12 @@ void main() {
       await _candidatesFor(alive: [_warningEew(isWarning: false)]),
       isEmpty,
     );
+  });
+
+  test('初回警報でhadWarningがfalseでも候補に残す', () async {
     expect(
       await _candidatesFor(alive: [_warningEew(hadWarning: false)]),
-      isEmpty,
+      hasLength(1),
     );
   });
 
@@ -282,7 +292,7 @@ void main() {
 
   test('警報区域が解決済みからloadingまたはerrorになると候補を消す', () async {
     var warningArea = Future<MapDataItem?>.value(
-      _mapItem(code: '100', name: '警報判定区域'),
+      _mapItem(code: '9011', name: '警報判定区域'),
     );
     final position = _position();
     final latLng = LatLng(position.latitude, position.longitude);
@@ -346,10 +356,7 @@ void main() {
     );
     addTearDown(subscription.close);
     final initial = await _waitForCandidates(container);
-    expect(
-      initial.single.localForecastRegion,
-      isNotNull,
-    );
+    expect(initial.single.localForecastRegion, isNotNull);
 
     forecastArea = Completer<MapDataItem?>().future;
     container.invalidate(jmaMapAreaForecastLocalEInsideProvider(latLng));

--- a/app/test/feature/home/ui/component/map/layer/eew_warning_regions_layer_lifecycle_test.dart
+++ b/app/test/feature/home/ui/component/map/layer/eew_warning_regions_layer_lifecycle_test.dart
@@ -89,8 +89,7 @@ void main() {
 }
 
 class WarningRegionStyleController extends FakeStyleController {
-  WarningRegionStyleController({required this.firstAddGate})
-    : super(throwOnDuplicateLayerIds: true);
+  new({required this.firstAddGate}) : super(throwOnDuplicateLayerIds: true);
 
   final Completer<void> firstAddGate;
   final operations = <String>[];
@@ -139,7 +138,7 @@ class WarningRegionStyleController extends FakeStyleController {
 }
 
 class WarningRegionMapController implements MapController {
-  WarningRegionMapController({required this.styleController});
+  new({required this.styleController});
 
   final StyleController styleController;
 

--- a/app/test/feature/home/ui/component/map/layer/eew_warning_regions_layer_lifecycle_test.dart
+++ b/app/test/feature/home/ui/component/map/layer/eew_warning_regions_layer_lifecycle_test.dart
@@ -1,0 +1,179 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/model/telegram/telegram_info_type.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart';
+import 'package:eqmonitor/feature/map/ui/map_operation_queue_scope.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:maplibre/maplibre.dart';
+// ignore: implementation_imports
+import 'package:maplibre_platform_interface/src/widget/inherited_model.dart';
+
+import '../../../../../../core/util/map/fake_style_controller.dart';
+
+void main() {
+  testWidgets('初期化中の更新とdispose後の再初期化を登録順に処理する', (tester) async {
+    final firstAddGate = Completer<void>();
+    final styleController = WarningRegionStyleController(
+      firstAddGate: firstAddGate,
+    );
+    final events = ValueNotifier<List<EewTelegramItem>>([
+      warningEew(prefectureCode: '9020', regionCode: '202'),
+    ]);
+    final isVisible = ValueNotifier(true);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: MapOperationQueueScope(
+            child: MapLibreInheritedModel(
+              mapController: WarningRegionMapController(
+                styleController: styleController,
+              ),
+              mapCamera: null,
+              child: ValueListenableBuilder<bool>(
+                valueListenable: isVisible,
+                builder: (context, visible, child) =>
+                    ValueListenableBuilder<List<EewTelegramItem>>(
+                      valueListenable: events,
+                      builder: (context, value, child) => visible
+                          ? EewWarningRegionsLayer(eews: value)
+                          : const SizedBox.shrink(),
+                    ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(styleController.operations, ['add-start']);
+
+    events.value = [warningEew(prefectureCode: '9030', regionCode: '211')];
+    await tester.pump();
+    isVisible.value = false;
+    await tester.pump();
+    events.value = [warningEew(prefectureCode: '9040', regionCode: '212')];
+    isVisible.value = true;
+    await tester.pump();
+
+    firstAddGate.complete();
+    await tester.pumpAndSettle();
+
+    expect(styleController.operations, [
+      'add-start',
+      'add-done',
+      'filter:9030',
+      'remove',
+      'add-start',
+      'add-done',
+      'filter:9040',
+    ]);
+    expect(styleController.activeLayerIds, {'eew-warning-regions-fill'});
+    expect(styleController.updatedCodes.last, ['9040']);
+
+    final layer = styleController.addedLayers.last as StyleLayerWithSource;
+    expect(layer.sourceLayerId, 'areaForecastLocalEew');
+    expect(layer.filter, [
+      'in',
+      ['get', 'code'],
+      [
+        'literal',
+        ['9040'],
+      ],
+    ]);
+  });
+}
+
+class WarningRegionStyleController extends FakeStyleController {
+  WarningRegionStyleController({required this.firstAddGate})
+    : super(throwOnDuplicateLayerIds: true);
+
+  final Completer<void> firstAddGate;
+  final operations = <String>[];
+  final updatedCodes = <List<String>>[];
+  var addCount = 0;
+
+  @override
+  Future<void> addLayer(
+    StyleLayer layer, {
+    String? belowLayerId,
+    String? aboveLayerId,
+    int? atIndex,
+  }) async {
+    addCount++;
+    operations.add('add-start');
+    if (addCount == 1) {
+      await firstAddGate.future;
+    }
+    await super.addLayer(
+      layer,
+      belowLayerId: belowLayerId,
+      aboveLayerId: aboveLayerId,
+      atIndex: atIndex,
+    );
+    operations.add('add-done');
+  }
+
+  @override
+  Future<void> updateFilter({
+    required String id,
+    required List<Object>? filter,
+  }) async {
+    final codes = switch (filter) {
+      ['in', ['get', 'code'], ['literal', final List<String> values]] => values,
+      _ => const <String>[],
+    };
+    updatedCodes.add(codes);
+    operations.add('filter:${codes.join(',')}');
+  }
+
+  @override
+  Future<void> removeLayer(String id) async {
+    operations.add('remove');
+    await super.removeLayer(id);
+  }
+}
+
+class WarningRegionMapController implements MapController {
+  WarningRegionMapController({required this.styleController});
+
+  final StyleController styleController;
+
+  @override
+  StyleController get style => styleController;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+EewTelegramItem warningEew({
+  required String prefectureCode,
+  required String regionCode,
+}) => EewTelegramItem(
+  eventId: prefectureCode,
+  status: TelegramStatus.normal,
+  infoType: TelegramInfoType.publication,
+  serialNo: 1,
+  isCanceled: false,
+  isLastInfo: false,
+  reportTime: DateTime.utc(2026, 8, 17),
+  isPlum: false,
+  isWarning: true,
+  warning: EewWarningInfo(
+    regions: [
+      EewWarningZoneInfo(code: regionCode, name: '予報区', hadWarning: false),
+    ],
+    zones: const [],
+    prefectures: [
+      EewWarningZoneInfo(
+        code: prefectureCode,
+        name: '府県予報区',
+        hadWarning: false,
+      ),
+    ],
+  ),
+);

--- a/docs/knowledge/20260725_eew_warning_message_sources.md
+++ b/docs/knowledge/20260725_eew_warning_message_sources.md
@@ -49,13 +49,28 @@ resolver の代表的な期待値は
 - 完成した通知文字列を空白や語尾で分割しない
 - backend の短縮震源名 `hypocenterReduceName` と警報地域 `warningZones` から UI 用モデルを作る
 - アプリでは短縮震源名を `hypocenter?.detailedName ?? hypocenter?.name`、警報地域を
-  `warning.zones.where((e) => e.hadWarning)` から得る
+  現在報の `warning.zones` 全件から得る
 - 警報地域は半角スペース区切りでまとめ、「で強い揺れ」は末尾に1回だけ付ける
 - アプリモデルにない backend の `isLevel` 相当は
   `accuracy?.epicenter == 1 && originTime == null` から導出する
 - `isPlum` / `isLevel` 相当または震源不明時は、推定できない震源名を主見出しにしない
 - `isWarning`、現在地の予想最大震度、到達情報は構造化フィールドから判定する
 - overlay では情報不足時に内容を捏造せず、独自の最終 fallback を `強い揺れに警戒` とする
+
+## 2026-08-17 追記: 現在警報と区域コード
+
+- `hadWarning` は現在報の警報状態ではなく、DMData の
+  `kind.lastKind.code == '31'`、つまり前回報ですでに警報だったかを示す。
+- 初回警報と後続報で新たに追加された区域は `hadWarning == false` になり得るため、
+  現在警報の抽出条件に使わない。
+- `areaForecastLocalEew` は `warning.prefectures`（90xx）と対応する。
+- `areaForecastLocalE` は `warning.regions`（3桁）および
+  `forecastIntensity.regions` と対応する。
+- 現在警報は `isWarning == true && !isCanceled` と現在報の警報配列で判定する。
+
+詳細は
+[`2026-08-17-eew-warning-area-mapping-design.md`](../superpowers/specs/2026-08-17-eew-warning-area-mapping-design.md)
+を参照する。
 
 ## backend 経路
 

--- a/docs/superpowers/plans/2026-08-17-eew-warning-area-mapping.md
+++ b/docs/superpowers/plans/2026-08-17-eew-warning-area-mapping.md
@@ -1,0 +1,342 @@
+# EEW Warning Area Mapping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** EEW の警報地域表示と現在地向け警報 overlay を、現在報の正しい気象庁区域コードで即時更新する。
+
+**Architecture:** `EewWarningAreaSelector` が現在警報イベントから `warning.prefectures` code を純粋に抽出し、ホーム地図と詳細地図が共有する。overlay は既存 selector / builder の責務を維持しつつ、府県予報区と地方予報区の現在報配列を `hadWarning` 非依存で参照する。
+
+**Tech Stack:** Flutter、Dart、Riverpod 3 code generation、flutter_hooks、MapLibre、flutter_test
+
+## Global Constraints
+
+- Flutter / Dart コマンドは常に `mise exec --` 経由で実行する。
+- `dynamic`、`Object`、null assertion (`!`) を追加しない。
+- MapLibre 操作は既存の `MapOperationQueueScope` で直列化する。
+- 固定地域、推測値、ランダム値へのフォールバックを追加しない。
+- 初回警報、追加地域、取消を同じ報で反映する。
+- ユーザーの既存未コミット差分を変更・stageしない。
+
+---
+
+### Task 1: 現在警報の府県予報区 selector
+
+**Files:**
+- Create: `app/lib/feature/eew/data/logic/eew_warning_area_selector.dart`
+- Create: `app/lib/feature/eew/data/logic/eew_warning_area_selector.g.dart`
+- Create: `app/test/feature/eew/data/logic/eew_warning_area_selector_test.dart`
+
+**Interfaces:**
+- Consumes: `Iterable<EewTelegramItem>`
+- Produces: `EewWarningAreaSelector.selectPrefectureCodes({required Iterable<EewTelegramItem> events}) -> List<String>`
+- Produces: `eewWarningAreaSelectorProvider`
+
+- [ ] **Step 1: Write the failing selector tests**
+
+```dart
+test('初回警報でもwarning.prefecturesのcodeを返す', () {
+  final codes = const EewWarningAreaSelector().selectPrefectureCodes(
+    events: [
+      warningEew(
+        prefectures: [
+          EewWarningZoneInfo(code: '9020', name: '青森', hadWarning: false),
+        ],
+        regions: [
+          EewWarningZoneInfo(code: '202', name: '青森県三八上北', hadWarning: false),
+        ],
+      ),
+    ],
+  );
+  expect(codes, ['9020']);
+});
+
+test('取消・非警報を除外し複数イベントを重複排除する', () {
+  final codes = const EewWarningAreaSelector().selectPrefectureCodes(
+    events: [
+      warningEew(prefectureCode: '9020'),
+      warningEew(prefectureCode: '9020'),
+      warningEew(prefectureCode: '9030', isCanceled: true),
+      warningEew(prefectureCode: '9040', isWarning: false),
+    ],
+  );
+  expect(codes, ['9020']);
+});
+```
+
+- [ ] **Step 2: Run the selector test and verify RED**
+
+Run:
+
+```bash
+mise exec -- flutter test --no-pub app/test/feature/eew/data/logic/eew_warning_area_selector_test.dart
+```
+
+Expected: FAIL because `EewWarningAreaSelector` does not exist.
+
+- [ ] **Step 3: Implement the minimal selector and provider**
+
+```dart
+@riverpod
+EewWarningAreaSelector eewWarningAreaSelector(Ref ref) =>
+    const EewWarningAreaSelector();
+
+class EewWarningAreaSelector {
+  const EewWarningAreaSelector();
+
+  List<String> selectPrefectureCodes({
+    required Iterable<EewTelegramItem> events,
+  }) => {
+    for (final event in events)
+      if (event.isWarning == true && !event.isCanceled)
+        for (final area
+            in event.warning?.prefectures ?? const <EewWarningZoneInfo>[])
+          area.code,
+  }.toList(growable: false);
+}
+```
+
+- [ ] **Step 4: Generate Riverpod code and verify GREEN**
+
+Run:
+
+```bash
+mise exec -- dart run build_runner build --delete-conflicting-outputs
+mise exec -- flutter test --no-pub app/test/feature/eew/data/logic/eew_warning_area_selector_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the selector slice**
+
+```bash
+git add app/lib/feature/eew/data/logic/eew_warning_area_selector.dart app/lib/feature/eew/data/logic/eew_warning_area_selector.g.dart app/test/feature/eew/data/logic/eew_warning_area_selector_test.dart
+git commit -m "fix: EEW現在警報の府県予報区抽出を修正"
+```
+
+### Task 2: 地図レイヤーの区域対応とライフサイクル回帰
+
+**Files:**
+- Modify: `app/lib/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart`
+- Modify: `app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart`
+- Create: `app/test/feature/home/ui/component/map/layer/eew_warning_regions_layer_lifecycle_test.dart`
+
+**Interfaces:**
+- Consumes: `eewWarningAreaSelectorProvider`
+- Produces: MapLibre `areaForecastLocalEew` filter containing `warning.prefectures` codes
+
+- [ ] **Step 1: Write a failing Widget lifecycle test**
+
+Build a `MapLibreInheritedModel` test harness with a delayed fake
+`StyleController`. Mount `EewWarningRegionsLayer` with region `202` and
+prefecture `9020`, both `hadWarning: false`, and assert the final filter is:
+
+```dart
+[
+  'in',
+  ['get', 'code'],
+  [
+    'literal',
+    ['9020'],
+  ],
+]
+```
+
+In the same test, delay the first add, update to `9030`, dispose, remount with
+`9040`, then assert operations are ordered `add -> filter:9030 -> remove -> add -> filter:9040`
+and exactly one `eew-warning-regions-fill` remains active.
+
+- [ ] **Step 2: Run the lifecycle test and verify RED**
+
+Run:
+
+```bash
+mise exec -- flutter test --no-pub app/test/feature/home/ui/component/map/layer/eew_warning_regions_layer_lifecycle_test.dart
+```
+
+Expected: FAIL because the current filter uses `warning.regions.where(hadWarning)`.
+
+- [ ] **Step 3: Use the shared selector in both map layers**
+
+In each Widget build:
+
+```dart
+final warningAreaSelector = ref.watch(eewWarningAreaSelectorProvider);
+final warningCodes = useMemoized(
+  () => warningAreaSelector.selectPrefectureCodes(events: events),
+  [warningAreaSelector, events],
+);
+```
+
+For the details layer, pass zero or one event through the same selector. Keep
+the existing source layer `areaForecastLocalEew`, empty filter handling,
+`latestCodes`, queue, and layer IDs unchanged.
+
+- [ ] **Step 4: Run map tests and verify GREEN**
+
+Run:
+
+```bash
+mise exec -- flutter test --no-pub \
+  app/test/feature/home/ui/component/map/layer/eew_warning_regions_layer_lifecycle_test.dart \
+  app/test/feature/home/ui/component/map/layer/eew_area_filter_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the map slice**
+
+```bash
+git add app/lib/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart app/test/feature/home/ui/component/map/layer/eew_warning_regions_layer_lifecycle_test.dart
+git commit -m "fix: EEW警報地域の地図コード対応を修正"
+```
+
+### Task 3: 現在地向け警報 overlay の現在報判定
+
+**Files:**
+- Modify: `app/lib/feature/eew/data/logic/eew_warning_candidate_selector.dart`
+- Modify: `app/lib/feature/eew/data/logic/eew_warning_display_model_builder.dart`
+- Modify: `app/test/feature/eew/data/logic/eew_warning_candidate_selector_test.dart`
+- Modify: `app/test/feature/eew/data/provider/eew_warning_overlay_candidate_provider_test.dart`
+- Modify: `app/test/feature/eew/data/logic/eew_warning_display_model_builder_test.dart`
+
+**Interfaces:**
+- Consumes: `warningAreaCode` resolved from `areaForecastLocalEew`
+- Produces: candidates matched against `event.warning.prefectures`
+- Produces: display warning zone names from all current `event.warning.zones`
+
+- [ ] **Step 1: Change tests to the correct current-report behavior and verify RED**
+
+Add assertions that:
+
+```dart
+expect(
+  selector.select(
+    aliveEews: [
+      warningEew(
+        eventId: 'initial-warning',
+        warningPrefectureCode: '9011',
+        warningRegionCode: '100',
+        hadWarning: false,
+      ),
+    ],
+    warningAreaCode: '9011',
+    warningAreaName: '北海道道央',
+    forecastAreaCode: '100',
+    forecastAreaName: '石狩地方北部',
+  ),
+  hasLength(1),
+);
+```
+
+Use a mismatched `warning.regions` code to prove it cannot make the candidate
+eligible. Add a display-model assertion that a `warning.zones` item with
+`hadWarning: false` appears in the initial-warning headline.
+
+Run:
+
+```bash
+mise exec -- flutter test --no-pub \
+  app/test/feature/eew/data/logic/eew_warning_candidate_selector_test.dart \
+  app/test/feature/eew/data/provider/eew_warning_overlay_candidate_provider_test.dart \
+  app/test/feature/eew/data/logic/eew_warning_display_model_builder_test.dart
+```
+
+Expected: FAIL because production code still checks `warning.regions` and
+`hadWarning`.
+
+- [ ] **Step 2: Implement the minimal overlay corrections**
+
+Candidate eligibility:
+
+```dart
+final hasCurrentWarning = event.warning?.prefectures.any(
+  (prefecture) => prefecture.code == warningAreaCode,
+) ?? false;
+```
+
+Display-model zone collection:
+
+```dart
+for (final zone
+    in candidate.event.warning?.zones ?? const <EewWarningZoneInfo>[]) {
+  warningZoneNamesByCode[zone.code] = zone.name;
+}
+```
+
+Keep existing `isWarning == true`, cancellation, sorting, deduplication,
+representative event, and forecast-area lookup behavior unchanged.
+
+- [ ] **Step 3: Run overlay tests and verify GREEN**
+
+Run the three-file command from Step 1. Expected: PASS.
+
+- [ ] **Step 4: Commit the overlay slice**
+
+```bash
+git add app/lib/feature/eew/data/logic/eew_warning_candidate_selector.dart app/lib/feature/eew/data/logic/eew_warning_display_model_builder.dart app/test/feature/eew/data/logic/eew_warning_candidate_selector_test.dart app/test/feature/eew/data/provider/eew_warning_overlay_candidate_provider_test.dart app/test/feature/eew/data/logic/eew_warning_display_model_builder_test.dart
+git commit -m "fix: EEW警報overlayの現在報判定を修正"
+```
+
+### Task 4: 文書訂正と全体検証
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-25-eew-warning-overlay-design.md`
+- Modify: `docs/knowledge/20260725_eew_warning_message_sources.md`
+- Delete: `docs/todo/950_eew_warning_region_fill_mapping.md`
+
+**Interfaces:**
+- Consumes: approved design `docs/superpowers/specs/2026-08-17-eew-warning-area-mapping-design.md`
+- Produces: current behavior matching implementation and backend contract
+
+- [ ] **Step 1: Correct active documentation**
+
+Replace current-warning eligibility references from
+`warning.regions.where(hadWarning)` to `warning.prefectures` and document that
+`hadWarning` is previous-report history. Replace headline references from
+`warning.zones.where(hadWarning)` to all current `warning.zones`. Add a link to
+the 2026-08-17 correction design.
+
+- [ ] **Step 2: Remove the resolved TODO**
+
+Delete `docs/todo/950_eew_warning_region_fill_mapping.md` only after all RED
+tests have turned GREEN.
+
+- [ ] **Step 3: Run format, targeted tests, analysis, and diff checks**
+
+```bash
+mise exec -- dart format app/lib/feature/eew app/lib/feature/home/ui/component/map/layer app/test/feature/eew app/test/feature/home/ui/component/map/layer
+mise exec -- flutter test --no-pub \
+  app/test/feature/eew/data/logic/eew_warning_area_selector_test.dart \
+  app/test/feature/eew/data/logic/eew_warning_candidate_selector_test.dart \
+  app/test/feature/eew/data/provider/eew_warning_overlay_candidate_provider_test.dart \
+  app/test/feature/eew/data/logic/eew_warning_display_model_builder_test.dart \
+  app/test/feature/home/ui/component/map/layer/eew_warning_regions_layer_lifecycle_test.dart \
+  app/test/feature/home/ui/component/map/layer/eew_area_filter_test.dart \
+  app/test/feature/eew/data/eew_realtime_test.dart \
+  app/test/feature/eew/data/eew_upsert_test.dart
+mise exec -- flutter analyze --no-pub \
+  app/lib/feature/eew/data/logic/eew_warning_area_selector.dart \
+  app/lib/feature/eew/data/logic/eew_warning_candidate_selector.dart \
+  app/lib/feature/eew/data/logic/eew_warning_display_model_builder.dart \
+  app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart \
+  app/lib/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart
+git --no-pager diff --check
+git --no-pager status --short
+```
+
+Expected: all tests pass, analyzer reports no issues, diff check is empty, and
+status contains only task files plus the user's pre-existing changes.
+
+- [ ] **Step 4: Commit documentation**
+
+```bash
+git add docs/superpowers/specs/2026-07-25-eew-warning-overlay-design.md docs/knowledge/20260725_eew_warning_message_sources.md docs/todo/950_eew_warning_region_fill_mapping.md
+git commit -m "docs: EEW現在警報の区域契約を訂正"
+```
+
+- [ ] **Step 5: Final diff review and push handoff**
+
+Review each commit with `git --no-pager show --stat` and
+`git --no-pager diff HEAD~4..HEAD`. This worktree is detached, so report the
+commit hashes and instruct the user to use Codex App **Create branch** before
+push.

--- a/docs/superpowers/specs/2026-07-25-eew-warning-overlay-design.md
+++ b/docs/superpowers/specs/2026-07-25-eew-warning-overlay-design.md
@@ -12,7 +12,7 @@
 ## スコープ
 
 - アプリが foreground にある時だけ表示するアプリ内 UI
-- 現在地に対応する細分区域が警報対象かを判定
+- 現在地に対応する EEW 府県予報区が警報対象かを判定
 - 全画面表示、最小化バナー、再展開、明示的な閉じる操作
 - 複数の有効な警報を1画面に集約し、代表イベントを選択
 - 最大10秒のパルス状バイブレーション
@@ -54,8 +54,11 @@
 3. `eewProvider` に存在する
 4. 生存判定上有効で、取消・期限切れではない
 5. `isWarning` が true
-6. 現在地から JMA の緊急地震速報用細分区域 `areaForecastLocalEew` を解決できる
-7. 解決した区域 code が `event.warning.regions.where((e) => e.hadWarning)` に含まれる
+6. 現在地から JMA の緊急地震速報用府県予報区 `areaForecastLocalEew` を解決できる
+7. 解決した区域 code が現在報の `event.warning.prefectures` に含まれる
+
+`hadWarning` は前回報ですでに警報だったかを示す履歴情報なので、現在警報の対象判定には
+使用しない。初回警報や後続報で追加された区域も、現在報の配列に存在すれば即時に対象とする。
 
 現在地・権限・区域解決が loading/error/不明の場合は表示しない。解決後に対象であれば、
 未処理の eventId として通常どおり表示する。対象地域から外れた場合は即座に消し、
@@ -130,7 +133,7 @@ EQMonitor の Material 3 テーマに合わせる。
 見出しは backend の Live Activity と同じ構造を採用し、完成済み文字列の分割ではなく、
 短縮震源名と警報地域の構造化データから組み立てる。アプリ側では短縮震源名を
 `hypocenter?.detailedName ?? hypocenter?.name`、見出し地域を
-`warning.zones.where((e) => e.hadWarning)` から得る。backend の `isLevel` 相当はアプリモデルに
+現在報の `warning.zones` 全件から得る。backend の `isLevel` 相当はアプリモデルに
 直接存在しないため、`accuracy?.epicenter == 1 && originTime == null` から明示的に導出する。
 PLUM 法・レベル法または震源不明時は不正確な震源を強調せず、地域側の
 「○○で強い揺れ」を主見出しにする。地域も得られない場合だけ、overlay 独自の安全な
@@ -172,8 +175,9 @@ iOS の haptics 制約を各プラットフォームで確認する。
 
 ## 検証方針
 
-ユーザー要望により Widget test は追加しない。ロジックを Widget から分離し、次を unit /
-provider / notifier test で検証する。
+ロジックを Widget から分離し、次を unit / provider / notifier test で検証する。
+地図レイヤーについては、非同期 initialize / update / dispose の順序を保証する Widget test
+も追加する。
 
 - 対象区域、警報状態、realtime 状態による候補抽出
 - 到達区分、予想震度、時刻、eventId による代表選択
@@ -185,6 +189,7 @@ provider / notifier test で検証する。
 - location 離脱・再進入、lifecycle、無効化の状態遷移
 - 設定の既定値・永続化・無効化
 - シミュレーションが provider を汚染せず、実警報に優先されること
+- 地図レイヤー初期化中の更新、dispose 後の再 mount、連続更新で最終 filter が残ること
 
 実機またはシミュレーション UI で、SafeArea、長い地域名、text scale、Light/Dark、
 Android back、実際の振動開始・停止を手動確認する。

--- a/docs/superpowers/specs/2026-08-17-eew-warning-area-mapping-design.md
+++ b/docs/superpowers/specs/2026-08-17-eew-warning-area-mapping-design.md
@@ -1,0 +1,88 @@
+# EEW 警報地域マッピング修正設計
+
+日付: 2026-08-17
+状態: 承認済み
+
+## 目的
+
+EEW の「警報地域」表示と現在地向け警報 overlay で、気象庁区域コードの種類を
+正しく対応付ける。初回警報、警報地域の追加、取消を同じ報で即時反映し、
+MapLibre レイヤーの initialize / update / dispose 競合を回帰テストで保護する。
+
+## データ契約
+
+backend は DMData の警報区域を次の3段階で保持する。
+
+- `warning.zones`: 地方予報区。例: `9920` 東北
+- `warning.prefectures`: EEW の府県予報区。例: `9020` 青森
+- `warning.regions`: 地域細分。例: `202` 青森県三八上北
+
+アプリ内の地図データは次の対応とする。
+
+- MapLibre `areaForecastLocalEew` / `JmaMapType.areaForecastLocalEew`
+  ↔ `warning.prefectures`
+- MapLibre `areaForecastLocalE` / `JmaMapType.areaForecastLocalE`
+  ↔ `warning.regions` および `forecastIntensity.regions`
+
+`hadWarning` は DMData の `kind.lastKind.code == '31'` を表し、現在の警報状態ではない。
+初回警報と追加直後の区域では `false` になるため、現在警報の抽出条件には使用しない。
+
+## 対象判定
+
+現在警報として扱うイベントは `isWarning == true && !isCanceled` を満たすものに限る。
+そのイベントの警報配列に存在する区域は `hadWarning` の値にかかわらず現在報の対象とする。
+
+- ホーム / Live Monitor の「警報地域」塗りつぶし:
+  `warning.prefectures` の code を重複排除して使用する。
+- EEW 詳細地図の警報表示:
+  `warning.prefectures` の code を使用する。
+- 現在地向け警報 overlay の候補判定:
+  `areaForecastLocalEew` で解決した code と `warning.prefectures` を比較する。
+- overlay の警報地方見出し:
+  `warning.zones` 全件を code で重複排除し、安定順で表示する。
+- 現在地予想震度:
+  従来どおり `areaForecastLocalE` と `forecastIntensity.regions` を比較する。
+
+取消報、非警報、警報配列欠損では空集合として扱い、地図 filter を空表示へ更新する。
+固定地域や推測値へのフォールバックは行わない。
+
+## 実装構造
+
+地図レイヤー2箇所で共通する区域抽出は、
+`feature/eew/data/logic/eew_warning_area_selector.dart` の
+`EewWarningAreaSelector` に切り出し、Riverpod で DI する。
+selector は外部状態を持たない純粋な処理とし、現在警報イベントの
+`warning.prefectures` code を重複なしで返す。
+
+候補選択と表示モデルは既存の責務を維持し、比較対象配列と `hadWarning` 条件だけを
+修正する。API モデルの `hadWarning` 自体は履歴情報として残し、名称変更や backend
+契約変更は今回の範囲外とする。
+
+## 非同期ライフサイクル
+
+既存の `MapOperationQueueScope` と `latestCodes` の設計を維持する。
+
+- init 中のデータ更新は、レイヤー追加完了直後に最新 code で再更新する。
+- update / remove / 再 add はマップ単位の共有キューで登録順に直列化する。
+- dispose 後の旧 remove が再 mount 後の add を消さない順序を保証する。
+- 空集合は常に空表示 filter を設定し、filter 未指定による全域表示を禁止する。
+
+## テスト
+
+次を自動テストで固定する。
+
+1. 初回警報で全区域が `hadWarning == false` でも府県予報区 code を返す。
+2. `warning.regions` と `warning.prefectures` の code が異なる場合、後者だけを採用する。
+3. 後続報で追加された府県予報区を同じ報で追加する。
+4. 取消・非警報・警報情報欠損を除外する。
+5. 複数イベントの府県予報区 code を重複排除する。
+6. overlay 候補判定が `warning.prefectures` を使い、`hadWarning` に依存しない。
+7. overlay 見出しが `warning.zones` の初回警報地域も含める。
+8. init 中更新、dispose → 再 mount、連続更新で最終 filter が残る。
+9. 空配列で全域を描画しない。
+
+## 文書更新
+
+既存の overlay 設計書と knowledge にある `hadWarning` / `warning.regions` の誤った
+現在警報判定を訂正する。修正完了後は
+`docs/todo/950_eew_warning_region_fill_mapping.md` を削除する。


### PR DESCRIPTION
## 概要

EEWの予想震度塗りつぶしで「警報地域」を選んだ際、警報区域が描画されない問題と、初回警報・追加地域が次報まで除外される問題を修正します。

## 原因

- MapLibreの `areaForecastLocalEew` はEEW府県予報区（90xx）ですが、3桁の `warning.regions` をfilterへ渡していました。
- `hadWarning` は現在報の警報状態ではなく、前回報ですでに警報だったかを示します。そのため初回警報や追加直後の地域では `false` になります。

## 変更内容

- `areaForecastLocalEew` と `warning.prefectures` のコード体系を統一
- 現在警報を `isWarning == true && !isCanceled` と現在報の警報配列から判定
- ホーム地図、EEW詳細地図、現在地overlay、警報地方見出しを同じ契約へ統一
- initialize中の更新、dispose、再mount、連続更新を直列化して最終filterを保持するWidgetテストを追加
- 区域コード契約と `hadWarning` の意味を仕様・knowledgeへ記録

## 影響

初回警報と後続報で追加された警報地域が同じ報で即時描画されます。取消報・非警報では空filterへ更新され、固定地域へのフォールバックは行いません。

## 検証

- 対象EEW回帰テスト: 37件成功（最新develop取り込み前）
- 最新develop取り込み後:
  - EEW選択・表示モデル・地図ライフサイクル等20件は成功
  - Provider/realtime/upsertの3ターゲットは、develop側の `TestNotificationFramework.displayLabel` 未定義によりロード失敗
- 対象production 5ファイル: `flutter analyze --no-pub` で `No issues found`
- `git diff --check origin/develop...HEAD`: 成功

通知コードのコンパイルエラーはこのPRの差分には含まれていません。