### PR TITLE
CI: Flutter analyzeを全件成功させる

### DIFF
--- a/.github/workflows/wc-check-dart-analyze.yaml
+++ b/.github/workflows/wc-check-dart-analyze.yaml
@@ -43,16 +43,6 @@ jobs:
       - name: Analyze app
         run: mise exec -- dart analyze app --fatal-infos --format machine
 
-      # eqmonitor_custom_lints (avoid_direct_color_scheme 等) は
-      # analysis_options.yaml の `plugins:` 経由で上記 Analyze app から
-      # 既に実行されるため、ここではルール実装自体の回帰防止として
-      # パッケージ単体のユニットテストのみ実行する。
-      - name: Test eqmonitor_custom_lints
-        working-directory: tools/eqmonitor_custom_lints
-        run: |
-          mise exec -- dart pub get
-          mise exec -- dart test
-
       # tools/ は melos workspace 外のため `melos run test` の対象にならない。
       # ルール実装の回帰防止としてここで実行する。
       - name: Test eqmonitor_lints_plugin

--- a/app/lib/feature/home/data/flow/save_home_map_bounds_flow.dart
+++ b/app/lib/feature/home/data/flow/save_home_map_bounds_flow.dart
@@ -5,28 +5,36 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lat_lng/lat_lng.dart';
 import 'package:maplibre/maplibre.dart';
 
-Future<void> saveHomeMapBoundsFlow({
-  required BuildContext context,
-  required WidgetRef ref,
-  required MapController controller,
-}) async {
-  final region = controller.getVisibleRegion();
-  final current = await ref.read(homeConfigurationProvider.future);
-  await HomeConfigurationNotifier.saveMutation.run(
-    ref,
-    (tsx) async => tsx
-        .get(homeConfigurationProvider.notifier)
-        .updateMap(
-          current.map.copyWith(
-            defaultBounds: HomeMapDefaultBounds.custom,
-            customBounds: LatLngBoundary.fromTwo(
-              LatLng(region.latitudeSouth, region.longitudeWest),
-              LatLng(region.latitudeNorth, region.longitudeEast),
+final saveHomeMapBoundsFlowProvider = Provider<SaveHomeMapBoundsFlow>(
+  (ref) => const SaveHomeMapBoundsFlow(),
+);
+
+class SaveHomeMapBoundsFlow {
+  const new();
+
+  Future<void> save({
+    required BuildContext context,
+    required WidgetRef ref,
+    required MapController controller,
+  }) async {
+    final region = controller.getVisibleRegion();
+    final current = await ref.read(homeConfigurationProvider.future);
+    await HomeConfigurationNotifier.saveMutation.run(
+      ref,
+      (tsx) async => tsx
+          .get(homeConfigurationProvider.notifier)
+          .updateMap(
+            current.map.copyWith(
+              defaultBounds: HomeMapDefaultBounds.custom,
+              customBounds: LatLngBoundary.fromTwo(
+                LatLng(region.latitudeSouth, region.longitudeWest),
+                LatLng(region.latitudeNorth, region.longitudeEast),
+              ),
             ),
           ),
-        ),
-  );
-  if (context.mounted) {
-    Navigator.of(context).pop();
+    );
+    if (context.mounted) {
+      Navigator.of(context).pop();
+    }
   }
 }

--- a/app/lib/feature/home/ui/page/home_map_bounds_selector_page.dart
+++ b/app/lib/feature/home/ui/page/home_map_bounds_selector_page.dart
@@ -73,11 +73,13 @@ class _Body extends HookConsumerWidget {
           if (controller == null) {
             return;
           }
-          await saveHomeMapBoundsFlow(
-            context: context,
-            ref: ref,
-            controller: controller,
-          );
+          await ref
+              .read(saveHomeMapBoundsFlowProvider)
+              .save(
+                context: context,
+                ref: ref,
+                controller: controller,
+              );
         },
         icon: const Icon(Icons.save),
         label: const Text('この範囲を保存'),

--- a/app/test/feature/devices/push_token_platform_capabilities_test.dart
+++ b/app/test/feature/devices/push_token_platform_capabilities_test.dart
@@ -107,7 +107,7 @@ void main() {
 
 final class _FakeApnsTokenCallbackDataSource
     implements ApnsTokenCallbackDataSource {
-  const _FakeApnsTokenCallbackDataSource();
+  const new();
 
   @override
   Stream<String> get tokenUpdates => const Stream.empty();

--- a/app/test/feature/home/data/flow/save_home_map_bounds_flow_test.dart
+++ b/app/test/feature/home/data/flow/save_home_map_bounds_flow_test.dart
@@ -12,7 +12,7 @@ import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MapController extends Mock implements MapController {
-  _MapController({required this.visibleRegion});
+  new({required this.visibleRegion});
 
   final LngLatBounds visibleRegion;
 
@@ -45,11 +45,13 @@ void main() {
             '/selector': (_) => Consumer(
               builder: (context, ref, _) => Scaffold(
                 body: FilledButton(
-                  onPressed: () => saveHomeMapBoundsFlow(
-                    context: context,
-                    ref: ref,
-                    controller: controller,
-                  ),
+                  onPressed: () => ref
+                      .read(saveHomeMapBoundsFlowProvider)
+                      .save(
+                        context: context,
+                        ref: ref,
+                        controller: controller,
+                      ),
                   child: const Text('保存'),
                 ),
               ),

--- a/app/test/feature/home/ui/home_map_layer_page_test.dart
+++ b/app/test/feature/home/ui/home_map_layer_page_test.dart
@@ -5,7 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:material_ui/material_ui.dart';
 
 class _TestApp extends StatelessWidget {
-  const _TestApp();
+  const new();
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## 概要

#1681 後に残ったCI workflowの古い参照と、developへ追加されたanalyze指摘を解消します。

## 変更

- 削除済み tools/eqmonitor_custom_lints のtest stepを除去
- 現行 tools/eqmonitor_lints_plugin のtest stepは維持
- home map bounds保存処理をDI可能なFlow classへ移行
- developへ追加されたtest constructorをDart 3.13記法へ統一

## 検証

- CI flutter-analyze / Flutter Analyze: success
  - Analyze app: success
  - Test eqmonitor_lints_plugin: success
- CI integration-test: success
- actionlint / ghalint / pinact / zizmor / gitleaks: success
- ローカル app analyze: info・warning・error 0件
- home / push token対象テスト: 7/7 passed

## 補足

全体Flutter Testでは今回差分外のdevelop既存失敗（NANKAI fixture、WebView表示、live monitor設定）が検出されました。analyze jobと今回の変更対象テストは成功しています。

Related: #1681