### PR TITLE
Fix: background_location_trackerをAGP 9 DSLへ移行

### DIFF
--- a/packages/background_location_tracker/android/build.gradle.kts
+++ b/packages/background_location_tracker/android/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.android.build.api.dsl.LibraryExtension
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 group = "net.yumnumm.background_location_tracker"
 version = "1.0"
 
@@ -6,7 +9,7 @@ plugins {
     id("kotlin-android")
 }
 
-android {
+extensions.configure<LibraryExtension>("android") {
     namespace = "net.yumnumm.background_location_tracker"
     compileSdk = 35
 
@@ -18,9 +21,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+}
 
-    kotlinOptions {
-        jvmTarget = "17"
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 


### PR DESCRIPTION
## 概要

`develop` への push で走る Android CD が本日ずっと落ちていた（12 回以上連続）。
原因は `packages/background_location_tracker/android/build.gradle.kts` が AGP 9 で
非推奨になった DSL を使っており、Kotlin DSL のスクリプトコンパイルがエラーになるため。

```
Build file 'packages/background_location_tracker/android/build.gradle.kts' line: 9
* What went wrong:
  Line 09: android {
           ^ 'fun Project.android(configure: Action<LibraryExtension>): Unit' is deprecated.
  Line 22:     kotlinOptions {
           ^ deprecated. Please migrate to the compilerOptions DSL.
  Line 23:         jvmTarget = "17"
           ^ deprecated. Please migrate to the compilerOptions DSL.
3 errors
```

AGP 9 の移行から漏れていたパッケージなので、`assets_util` に適用済みの
87c34bbba419efe7379109039b0d2573e7f0dc54 と同じ変換をそのまま当てる。

- `android {}` → `extensions.configure<LibraryExtension>("android") {}`
- `kotlinOptions { jvmTarget = "17" }` → トップレベル `kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }`

`compileSdk` などの挙動に関わる値は変更していない。

## 影響

直近の `v3.0.0-beta.3` 配布では iOS のみが配信され、Build Android が失敗して
Firebase App Distribution / Google Play への Android deploy は両方 skip されていた。
これを解消して Android beta を再開させるのが目的。

## 確認

手元に Android SDK がないためローカルビルド未実施。CI の Android ビルドで検証する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)