### PR TITLE
fix: 強震モニタレイヤーのzoom式ネストによるiOSクラッシュを修正

### DIFF
--- a/app/lib/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer.dart
@@ -194,34 +194,28 @@ class KyoshinMonitorObservationLayerBuilder {
       id: KyoshinMonitorObservationLayer._layerId,
       sourceId: KyoshinMonitorObservationLayer._sourceId,
       paint: {
+        // MapLibre iOS はズーム依存の式 (interpolate + zoom) が式ツリーの
+        // 最上位にないと NSException を投げるため、係数は stop の出力値へ畳み込む
         'circle-radius': [
-          '*',
-          radiusScaleFactor,
-          [
-            'interpolate',
-            ['linear'],
-            ['zoom'],
-            3,
-            1,
-            10,
-            10,
-          ],
+          'interpolate',
+          ['linear'],
+          ['zoom'],
+          3,
+          1 * radiusScaleFactor,
+          10,
+          10 * radiusScaleFactor,
         ],
         'circle-color': ['get', 'color'],
         'circle-stroke-color': '#808080',
         'circle-stroke-width': showMarkerBorder
             ? [
-                '*',
-                radiusScaleFactor,
-                [
-                  'interpolate',
-                  ['linear'],
-                  ['zoom'],
-                  3,
-                  0.2,
-                  10,
-                  1,
-                ],
+                'interpolate',
+                ['linear'],
+                ['zoom'],
+                3,
+                0.2 * radiusScaleFactor,
+                10,
+                1 * radiusScaleFactor,
               ]
             : 0,
       },

--- a/app/test/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer_test.dart
+++ b/app/test/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer_test.dart
@@ -3,61 +3,74 @@ import 'package:eqmonitor/feature/kyoshin_monitor/data/model/kyoshin_monitor_set
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('small medium largeの係数をcircle radiusへ適用する', () {
+  test('small medium largeの係数をcircle radiusのstop出力へ畳み込む', () {
     const builder = KyoshinMonitorObservationLayerBuilder();
-    const interpolation = [
+    List<Object> interpolation(double scale) => [
       'interpolate',
       ['linear'],
       ['zoom'],
       3,
-      1,
+      1 * scale,
       10,
-      10,
+      10 * scale,
     ];
 
-    for (final testCase in <({double scale, List<Object> expected})>[
-      (scale: 0.65, expected: ['*', 0.65, interpolation]),
-      (scale: 1, expected: ['*', 1.0, interpolation]),
-      (scale: 1.35, expected: ['*', 1.35, interpolation]),
-    ]) {
+    for (final scale in <double>[0.65, 1, 1.35]) {
       expect(
         builder
             .build(
-              radiusScaleFactor: testCase.scale,
+              radiusScaleFactor: scale,
               markerType: .never,
               hasActiveEew: false,
             )
             .paint['circle-radius'],
-        testCase.expected,
+        interpolation(scale),
       );
     }
   });
 
-  test('marker size係数をcircle stroke widthへ適用する', () {
+  test('marker size係数をcircle stroke widthのstop出力へ畳み込む', () {
     const builder = KyoshinMonitorObservationLayerBuilder();
-    const interpolation = [
+    List<Object> interpolation(double scale) => [
       'interpolate',
       ['linear'],
       ['zoom'],
       3,
-      0.2,
+      0.2 * scale,
       10,
-      1,
+      1 * scale,
     ];
 
-    for (final testCase in <({double scale, List<Object> expected})>[
-      (scale: 0.65, expected: ['*', 0.65, interpolation]),
-      (scale: 1.35, expected: ['*', 1.35, interpolation]),
-    ]) {
+    for (final scale in <double>[0.65, 1.35]) {
       expect(
         builder
             .build(
-              radiusScaleFactor: testCase.scale,
+              radiusScaleFactor: scale,
               markerType: .always,
               hasActiveEew: false,
             )
             .paint['circle-stroke-width'],
-        testCase.expected,
+        interpolation(scale),
+      );
+    }
+  });
+
+  test('zoom依存の式を式ツリーの最上位に置く (MapLibre iOS制約)', () {
+    const builder = KyoshinMonitorObservationLayerBuilder();
+    final paint = builder
+        .build(radiusScaleFactor: 1.35, markerType: .always, hasActiveEew: true)
+        .paint;
+
+    for (final key in ['circle-radius', 'circle-stroke-width']) {
+      final expression = paint[key];
+      expect(
+        expression,
+        isA<List<Object>>().having(
+          (e) => e.first,
+          'root operator',
+          'interpolate',
+        ),
+        reason: '$key のzoom式は最上位に置く必要がある',
       );
     }
   });
@@ -65,17 +78,13 @@ void main() {
   test('marker typeとEEW状態から枠表示を決定する', () {
     const builder = KyoshinMonitorObservationLayerBuilder();
     final visibleStrokeWidth = [
-      '*',
+      'interpolate',
+      ['linear'],
+      ['zoom'],
+      3,
+      0.2,
+      10,
       1.0,
-      [
-        'interpolate',
-        ['linear'],
-        ['zoom'],
-        3,
-        0.2,
-        10,
-        1,
-      ],
     ];
     Object? strokeWidth({
       required KyoshinMonitorMarkerType markerType,

--- a/docs/knowledge/20260817_maplibre_ios_zoom_expression_top_level.md
+++ b/docs/knowledge/20260817_maplibre_ios_zoom_expression_top_level.md
@@ -1,0 +1,37 @@
+# MapLibre iOS: zoom依存の式は式ツリーの最上位に置く
+
+## 事象
+
+TestFlight ビルド 3.0.0 (1824) で、起動約8秒後 (強震モニタレイヤー追加時) に
+iOS のみ SIGABRT でクラッシュした。クラッシュログの lastExceptionBacktrace は
+`-[NSObject(NSKeyValueCoding) setValue:forKey:]` → `MLNCircleStyleLayer.setCircleRadius:`
+→ `objc_exception_throw` を示していた。
+
+## 原因
+
+`kyoshin_monitor_observation_layer.dart` で `circle-radius` / `circle-stroke-width` を
+
+```
+['*', radiusScaleFactor, ['interpolate', ['linear'], ['zoom'], ...]]
+```
+
+という形にしていた。MapLibre iOS (MLN) は style JSON 式を NSExpression へ変換する際、
+**camera (zoom) 依存の `interpolate` 式が式ツリーの最上位にあることを要求**し、
+他の演算子の内側にネストされていると NSException を投げる。
+Android (MapLibre Android) はネストを許容するため、iOS だけがクラッシュする。
+
+## 対処
+
+係数の乗算は `interpolate` の各 stop 出力値へ畳み込み、zoom 式を最上位に保つ。
+
+```
+['interpolate', ['linear'], ['zoom'], 3, 1 * factor, 10, 10 * factor]
+```
+
+## 教訓
+
+- MapLibre のペイントプロパティ式を組み立てるときは、`['zoom']` を参照する式が
+  最上位演算子になっているかを必ず確認する (iOS 実機/シミュレータでの確認が必要)。
+- 式の形だけを検証するユニットテストでは iOS のこの制約は検出できない。
+  `kyoshin_monitor_observation_layer_test.dart` に「zoom式が最上位にあること」を
+  検証するテストを追加した。


### PR DESCRIPTION
## 概要

TestFlight 3.0.0 (1824) で起動約8秒後 (強震モニタレイヤー追加時) に iOS のみ SIGABRT でクラッシュする事象の修正です。

## 原因

クラッシュログ (`Runner-2026-08-17-184758.ips`) の lastExceptionBacktrace を MapLibre.xcframework (UUID一致: `16C638E1`) の ObjC メタデータで解決したところ、

```
-[NSObject(NSKeyValueCoding) setValue:forKey:]
  → MLNCircleStyleLayer setCircleRadius: (+0x70)
    → objc_exception_throw
```

で NSException が throw されていました。

#1673 (`9ea04c977`) で `circle-radius` / `circle-stroke-width` が

```
['*', radiusScaleFactor, ['interpolate', ['linear'], ['zoom'], ...]]
```

というネスト形式に変更されましたが、**MapLibre iOS は zoom 依存の interpolate 式が式ツリーの最上位にあることを要求**し、他の演算子の内側にネストされると NSException を投げます (Android は許容するため iOS のみクラッシュ)。

## 対処

- 係数の乗算を interpolate の各 stop 出力値へ畳み込み、zoom 式を最上位に戻す (#1673 の「観測点サイズ反映」の意図は維持)
- zoom 式が最上位にあることを検証するテストを追加
- `docs/knowledge/` に経緯と制約を記録

## テスト

- `dart analyze`: No issues found
- `flutter test test/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer_test.dart`: 4件全てパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112hhp2oY12Txp3WqeBM3Fg