### PR TITLE
fix: AGP 9 で lintVital 無効化が構成エラーになる問題を修正

### DIFF
--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.android.build.api.dsl.ApplicationExtension
-import com.android.build.api.dsl.LibraryExtension
-
 allprojects {
     repositories {
         google()
@@ -23,19 +20,12 @@ subprojects {
 // AGP 9 の lintVital が pub 依存の Android module (android_file_picker) で
 // AndroidLintWorkAction を初期化できず release build ごと落ちるため無効化する。
 // 対象は third-party の生成物で、lint 結果を我々が扱うことはない。
+// NOTE: AGP 9 では lint DSL (checkReleaseBuilds) の設定が評価順の都合で
+// "It is too late to set checkReleaseBuilds" になるため、タスク自体を無効化する。
 subprojects {
-    plugins.withId("com.android.application") {
-        extensions.configure<ApplicationExtension>("android") {
-            lint {
-                checkReleaseBuilds = false
-            }
-        }
-    }
-    plugins.withId("com.android.library") {
-        extensions.configure<LibraryExtension>("android") {
-            lint {
-                checkReleaseBuilds = false
-            }
+    tasks.configureEach {
+        if (name.startsWith("lintVital")) {
+            enabled = false
         }
     }
 }


### PR DESCRIPTION
## 概要

#1688 の `lint { checkReleaseBuilds = false }` (DSL方式) は、AGP 9 + `evaluationDependsOn(":app")` の評価順の都合で

```
It is too late to set checkReleaseBuilds
It has already been read to configure this project.
```

となり、Android ビルドが configuration フェーズごと失敗します (ローカルで `gradle :app:help` により再現確認済み)。

## 対処

DSL での設定をやめ、`lintVital*` タスクを直接 `enabled = false` にする方式へ変更。
#1688 が本来対処したかった「pub 依存モジュール (android_file_picker) の lintVital 失敗」もタスク無効化でカバーされます。

## 検証

- `gradle :app:help` (Gradle 9.3.1): 修正前は上記エラーで失敗 → 修正後は成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112hhp2oY12Txp3WqeBM3Fg