### PR TITLE
fix: AGP 9 lint ワーカーを使う annotations 抽出タスクも無効化する

### DIFF
--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -17,14 +17,18 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
-// AGP 9 の lintVital が pub 依存の Android module (android_file_picker) で
-// AndroidLintWorkAction を初期化できず release build ごと落ちるため無効化する。
-// 対象は third-party の生成物で、lint 結果を我々が扱うことはない。
+// AGP 9 の lint ワーカー (AndroidLintWorkAction) が CI の JDK では初期化できず、
+// pub 依存の Android module の lintVital / extract*Annotations が
+// release build ごと落ちるため無効化する。
+// 対象は third-party の生成物で、lint 結果や AAR annotations を我々が扱うことはない。
 // NOTE: AGP 9 では lint DSL (checkReleaseBuilds) の設定が評価順の都合で
 // "It is too late to set checkReleaseBuilds" になるため、タスク自体を無効化する。
 subprojects {
     tasks.configureEach {
-        if (name.startsWith("lintVital")) {
+        if (
+            name.startsWith("lintVital") ||
+            (name.startsWith("extract") && name.endsWith("Annotations"))
+        ) {
             enabled = false
         }
     }


### PR DESCRIPTION
## 概要

#1689 で `lintVital*` を無効化しましたが、develop の Build Android ([run 32029452749](https://github.com/YumNumm/EQMonitor/actions/runs/32029452749)) は引き続き

```
Execution failed for task :google_api_availability_android:extractReleaseAnnotations.
> A failure occurred while executing com.android.build.gradle.internal.lint.AndroidLintWorkAction
   > Could not create an instance of type AndroidLintWorkAction.
```

で失敗していました。`extract*Annotations` (AAR の nullability annotations 抽出) も同じ AGP 9 lint ワーカーを使うためです。

## 対処

無効化対象を `extract*Annotations` にも拡大。対象は pub 依存モジュールの AAR annotations で、アプリのビルド成果物には影響しません。

## 検証

- ローカル (Gradle 9.3.1): `gradle :google_api_availability_android:extractReleaseAnnotations` → **SKIPPED** / BUILD SUCCESSFUL
- `gradle :app:help`: 構成フェーズ成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112hhp2oY12Txp3WqeBM3Fg