### PR TITLE
fix: CI の JDK を Temurin 17.0.20 へ更新し lint worker の NPE を解消する

### DIFF
--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -17,18 +17,17 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
-// AGP 9 の lint ワーカー (AndroidLintWorkAction) が CI の JDK では初期化できず、
-// pub 依存の Android module の lintVital / extract*Annotations が
-// release build ごと落ちるため無効化する。
-// 対象は third-party の生成物で、lint 結果や AAR annotations を我々が扱うことはない。
+// pub 依存 module の lintVital は third-party の生成物で結果を扱うことがないため
+// 無効化する (release build 時間の節約)。
+// かつて CI で AndroidLintWorkAction が初期化できなかった根本原因は
+// JDK 17.0.2 の cgroup v2 検出 NPE で、mise.toml の Temurin 更新で解消済み。
+// extract*Annotations は下流 (syncReleaseLibJars) が typedefs.txt を要求するため
+// 無効化してはならない。
 // NOTE: AGP 9 では lint DSL (checkReleaseBuilds) の設定が評価順の都合で
 // "It is too late to set checkReleaseBuilds" になるため、タスク自体を無効化する。
 subprojects {
     tasks.configureEach {
-        if (
-            name.startsWith("lintVital") ||
-            (name.startsWith("extract") && name.endsWith("Annotations"))
-        ) {
+        if (name.startsWith("lintVital")) {
             enabled = false
         }
     }

--- a/mise.lock
+++ b/mise.lock
@@ -515,39 +515,44 @@ url = "https://github.com/jdx/hk/releases/download/v1.53.0/hk-x86_64-pc-windows-
 url_api = "https://api.github.com/repos/jdx/hk/releases/assets/487429261"
 
 [[tools.java]]
-version = "17.0.2"
+version = "temurin-17.0.20+8"
 backend = "core:java"
 
-[tools.java.options]
-shorthand_vendor = "openjdk"
-
 [tools.java."platforms.linux-arm64"]
-checksum = "sha256:13bfd976acf8803f862e82c7113fb0e9311ca5458b1decaef8a09ffd91119fa4"
-url = "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-aarch64_bin.tar.gz"
+checksum = "sha256:d143936f473a4cb24e3b0e247d6d0775769d55ec9775c339540e753059a8d77a"
+url = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.20%2B8/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.20_8.tar.gz"
 
 [tools.java."platforms.linux-x64"]
-checksum = "sha256:0022753d0cceecacdd3a795dd4cea2bd7ffdf9dc06e22ffd1be98411742fbb44"
-url = "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz"
+checksum = "sha256:be7668bc030d578b83d6d5ef9221d6d6729bbbca8cf94a7d52e16ac68b5a5a35"
+url = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.20%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.20_8.tar.gz"
 
 [tools.java."platforms.linux-x64-baseline"]
-checksum = "sha256:0022753d0cceecacdd3a795dd4cea2bd7ffdf9dc06e22ffd1be98411742fbb44"
-url = "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz"
+checksum = "sha256:be7668bc030d578b83d6d5ef9221d6d6729bbbca8cf94a7d52e16ac68b5a5a35"
+url = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.20%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.20_8.tar.gz"
+
+[tools.java."platforms.linux-x64-musl"]
+checksum = "sha256:c8bb5bc6984762dbce2ab7403d90832b6897c07f36f8706e4a315aa7a566d04d"
+url = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.20%2B8/OpenJDK17U-jdk_x64_alpine-linux_hotspot_17.0.20_8.tar.gz"
+
+[tools.java."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:c8bb5bc6984762dbce2ab7403d90832b6897c07f36f8706e4a315aa7a566d04d"
+url = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.20%2B8/OpenJDK17U-jdk_x64_alpine-linux_hotspot_17.0.20_8.tar.gz"
 
 [tools.java."platforms.macos-arm64"]
-checksum = "sha256:602d7de72526368bb3f80d95c4427696ea639d2e0cc40455f53ff0bbb18c27c8"
-url = "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_macos-aarch64_bin.tar.gz"
+checksum = "sha256:524850138c742324fb21fca4ff6ef68ea25f25bf59366a864e45b4a0c45ed0df"
+url = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.20%2B8/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.20_8.tar.gz"
 
 [tools.java."platforms.macos-x64"]
-checksum = "sha256:b85c4aaf7b141825ad3a0ea34b965e45c15d5963677e9b27235aa05f65c6df06"
-url = "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_macos-x64_bin.tar.gz"
+checksum = "sha256:3710c3131c5d7c090582b357f1310133a90bf701183d065223f1a0b90b9ed5ae"
+url = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.20%2B8/OpenJDK17U-jdk_x64_mac_hotspot_17.0.20_8.tar.gz"
 
 [tools.java."platforms.macos-x64-baseline"]
-checksum = "sha256:b85c4aaf7b141825ad3a0ea34b965e45c15d5963677e9b27235aa05f65c6df06"
-url = "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_macos-x64_bin.tar.gz"
+checksum = "sha256:3710c3131c5d7c090582b357f1310133a90bf701183d065223f1a0b90b9ed5ae"
+url = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.20%2B8/OpenJDK17U-jdk_x64_mac_hotspot_17.0.20_8.tar.gz"
 
 [tools.java."platforms.windows-x64"]
-checksum = "sha256:b2208206bda47f2e0c971a39e057a5ec32c40b503d71e486790cb728d926b615"
-url = "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_windows-x64_bin.zip"
+checksum = "sha256:418497be5cf585bdd2203d6486a565d66d3f5e992d5630d45104cb873fab8122"
+url = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.20%2B8/OpenJDK17U-jdk_x64_windows_hotspot_17.0.20_8.zip"
 
 [[tools.node]]
 version = "24.18.1"

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,10 @@ gcloud = "https://github.com/jthegedus/asdf-gcloud"
 
 [tools]
 "aqua:suzuki-shunsuke/tfcmt" = "latest"
-java = "17"
+# NOTE: "17" は jdk.java.net の最終GA (17.0.2, 2022年) に解決され、GitHub Actions
+# runner の cgroup v2 構成で JDK-8272124 系の NPE を起こす (lint worker が全滅する)。
+# バグ修正済みの Temurin 17 を使う。
+java = "temurin-17.0.20+8"
 node = "lts"
 python = "latest"
 "pipx:codemagic-cli-tools" = "latest"


### PR DESCRIPTION
## 概要

AGP 9 更新以降 Build Android を落とし続けていた lint worker 初期化失敗の**根本原因**を特定し修正します。

## 根本原因

診断ラン ([32056476672](https://github.com/YumNumm/EQMonitor/actions/runs/32056476672), `org.gradle.logging.stacktrace=all`) で完全なスタックトレースを採取した結果:

```
Caused by: java.lang.ExceptionInInitializerError
Caused by: java.lang.NullPointerException:
  Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
```

mise の `java = "17"` は jdk.java.net 最終GA の **OpenJDK 17.0.2 (2022年)** に解決されます。この版には GitHub Actions runner の cgroup v2 構成でコンテナ検出が NPE を起こす既知バグ (JDK-8272124 系) があり、`AndroidLintWorkAction` の static init が全滅していました。lintVital (#1688, #1689) も extractReleaseAnnotations (#1690) もすべて同一原因です。

## 変更

- `mise.toml`: java を `temurin-17.0.20+8` へ更新 (`mise lock` で全プラットフォームの checksum/URL 更新)
- #1690 の `extract*Annotations` 無効化を取り消し — 下流の `syncReleaseLibJars` が `typedefs.txt` を入力として要求するため、無効化するとビルドが別の理由で失敗する (ローカルで確認済み)
- `lintVital*` の無効化はビルド時間節約のため維持

## 検証

- ローカル: `gradle :android_file_picker:extractReleaseAnnotations :app:help` → BUILD SUCCESSFUL
- マージ後の develop push ランで Build Android の成功を確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112hhp2oY12Txp3WqeBM3Fg