### PR TITLE
fix: compileSdk を 37 へ更新する

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -49,7 +49,8 @@ val stageBundledAssetPack = tasks.register<StageBundledAssetPackTask>(
 android {
     namespace = "net.yumnumm.eqmonitor"
     buildToolsVersion = "36.1.0"
-    compileSdk = 36
+    // permission_handler_android 14.x が compileSdk 37 以上を要求する
+    compileSdk = 37
     ndkVersion = "29.0.14206865"
 
     // AGP 9 では既定で無効。app_name を dart-define から差し替えるために必要


### PR DESCRIPTION
## 概要

#1691 (JDK 更新) で lint worker NPE が解消した結果、Build Android は次の段階まで進み、`:app:checkReleaseAarMetadata` で失敗するようになりました ([run 32058028588](https://github.com/YumNumm/EQMonitor/actions/runs/32058028588))。

```
Dependency :permission_handler_android requires libraries and applications that
depend on it to compile against version 37 or later of the Android APIs.
:app is currently compiled against android-36.
```

## 変更

- `compileSdk` 36 → 37 (targetSdk / minSdk は据え置き)

permission_handler_android 14.x は7月から入っていましたが、これまで lint worker NPE が先に落ちていたため AAR metadata 検査まで到達していませんでした。

## 検証

- ローカル: `gradle :app:checkReleaseAarMetadata` → BUILD SUCCESSFUL (android-37 platform 自動取得)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112hhp2oY12Txp3WqeBM3Fg