### PR TITLE
fix: Google Play API 用トークンに androidpublisher スコープを付与する

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -177,6 +177,10 @@ jobs:
           workload_identity_provider: ${{ env.GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: actions-eqmonitor-appdistro@eqmonitor-main.iam.gserviceaccount.com
           token_format: access_token
+          # androidpublisher API は cloud-platform スコープのトークンを拒否する
+          access_token_scopes: >-
+            https://www.googleapis.com/auth/cloud-platform,
+            https://www.googleapis.com/auth/androidpublisher
 
       - name: Generate Android release notes
         env:
@@ -848,6 +852,10 @@ jobs:
           workload_identity_provider: ${{ env.GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: actions-eqmonitor-appdistro@eqmonitor-main.iam.gserviceaccount.com
           token_format: access_token
+          # androidpublisher API は cloud-platform スコープのトークンを拒否する
+          access_token_scopes: >-
+            https://www.googleapis.com/auth/cloud-platform,
+            https://www.googleapis.com/auth/androidpublisher
 
       - name: Ensure Google Play track exists
         if: ${{ needs.define-matrix.outputs.android-track == 'external' }}


### PR DESCRIPTION
## 概要

v3.0.0-beta.5 の Deploy Android (Google Play) が「Ensure Google Play track exists」の最初の API 呼び出し (`POST /edits`) で即 403 になり失敗しました ([run 32062730246](https://github.com/YumNumm/EQMonitor/actions/runs/32062730246))。

## 原因

`google-github-actions/auth` の `access_token` 出力は既定で `cloud-platform` スコープのみですが、**androidpublisher API はこのスコープのトークンを受け付けません**。

- `google-play-cli` (Upload AAB) は credentials ファイル経由で自前の androidpublisher スコープのトークンを発行するため成功していた
- `ensure_google_play_track.sh` と `fetch_android_play_base_sha.sh` は raw access token を直接使うため 403
- release note 側は `|| true` で失敗が握り潰され、ベース SHA 解決が常に空振りしていた (表面化せず)

## 変更

Android 系 2 ジョブの auth ステップに `access_token_scopes` として `androidpublisher` を追加 (cloud-platform も維持)。

## 検証

- actionlint / zizmor: パス
- マージ後の beta タグ配信で Deploy Android (Google Play) 成功を確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112hhp2oY12Txp3WqeBM3Fg