### PR TITLE
ci: iOS/Android のデバッグシンボルを CD Artifact として保存する

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -384,6 +384,15 @@ jobs:
           path: app/adhoc/EQMonitor.ipa
           if-no-files-found: error
 
+      # クラッシュログのシンボリケート用に dSYM を保存する
+      # https://github.com/actions/upload-artifact
+      - name: Upload dSYMs as artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: EQMonitor-ios-dSYMs
+          path: app/build/ios/Runner.xcarchive/dSYMs
+          if-no-files-found: error
+
   deploy-ios:
     name: Deploy iOS (App Store Connect)
     needs:
@@ -682,6 +691,18 @@ jobs:
         with:
           name: EQMonitor-android.aab
           path: app/build/app/outputs/bundle/release/app-release.aab
+          if-no-files-found: error
+
+      # クラッシュログのシンボリケート用に R8 mapping を保存する。
+      # native debug symbols (.sym) と proguard.map は debugSymbolLevel の設定により
+      # AAB の BUNDLE-METADATA へ埋め込まれるため、AAB artifact 自体に同梱される。
+      # (gradle の build dir は root の app/build へリダイレクトされている)
+      # https://github.com/actions/upload-artifact
+      - name: Upload debug symbols as artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: EQMonitor-android-debug-symbols
+          path: app/build/app/outputs/mapping/release/mapping.txt
           if-no-files-found: error
 
   deploy-android-firebase-app-distribution:

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -101,6 +101,10 @@ android {
             )
             multiDexEnabled = true
             resValue("string", "app_name", "EQMonitor")
+            // クラッシュログのシンボリケート用に native-debug-symbols.zip を生成する
+            ndk {
+                debugSymbolLevel = "SYMBOL_TABLE"
+            }
         }
         getByName("debug") {
             versionNameSuffix = ".d"


### PR DESCRIPTION
## 概要

クラッシュログのシンボリケート用に、iOS/Android のデバッグシンボルを CD の Artifact として保存します。

今回の iOS クラッシュ (#1687) の調査では、TestFlight ビルドの `.ips` を手元の MapLibre.xcframework と突き合わせてシンボリケートする必要がありました。dSYM が Artifact に残っていれば App.framework (Dart AOT) のフレームも即座に解決できます。

## 変更

### iOS
- `EQMonitor-ios-dSYMs`: xcarchive の dSYMs ディレクトリ (Runner / App / Flutter / plugin frameworks) を upload

### Android
- release ビルドで `ndk.debugSymbolLevel = "SYMBOL_TABLE"` を有効化
  - native debug symbols (.sym) が AAB の `BUNDLE-METADATA/com.android.tools.build.debugsymbols/` へ埋め込まれ、AAB artifact 自体に同梱される (Play Console にも自動で渡る)
- `EQMonitor-android-debug-symbols`: R8 の `mapping.txt` を upload
  - gradle の build dir は root へリダイレクトされているため実パスは `app/build/app/outputs/mapping/release/mapping.txt`

## 検証

- ローカル `gradle :app:bundleRelease` (+ `:app:mergeReleaseNativeDebugMetadata`) で AAB 内に `.sym` が埋め込まれることを unzip -l で確認
- mapping.txt の出力パスを実ビルドで確認
- actionlint パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112hhp2oY12Txp3WqeBM3Fg