### PR TITLE
fix: EEWフォーカスのズームしすぎを修正

### DIFF
--- a/app/lib/feature/map/data/logic/seismic_map_focus_builder.dart
+++ b/app/lib/feature/map/data/logic/seismic_map_focus_builder.dart
@@ -1,8 +1,22 @@
+import 'dart:math' as math;
+
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:eqmonitor/feature/shake_detection/data/model/shake_detection_event.dart';
 import 'package:maplibre/maplibre.dart';
 
 const seismicMapFocusMargin = 0.1;
+
+/// フォーカス対象の周囲に最低限確保する半径(km)。
+///
+/// EEW は震源1点しか対象を持たないため、余白のみでは bounds が極小になり
+/// [mapAutomaticFocusMaxZoom] に張り付いて過度に寄った表示になる。
+/// 中心から最低この半径ぶんは映るように bounds を広げる。
+const seismicMapFocusMinimumRadiusKm = 50.0;
+
+const _kilometersPerLatitudeDegree = 111.32;
+
+/// 高緯度で経度方向の換算が発散するのを防ぐための cos(緯度) の下限。
+const _minimumCosineLatitude = 0.01;
 
 typedef SeismicMapGeoCoordinate = ({double latitude, double longitude});
 
@@ -88,15 +102,50 @@ class SeismicMapFocusBuilder {
       first.longitude,
       (value, point) => point.longitude > value ? point.longitude : value,
     );
+    return expandToMinimumRadius(
+      west: minLng - seismicMapFocusMargin,
+      east: maxLng + seismicMapFocusMargin,
+      south: minLat - seismicMapFocusMargin,
+      north: maxLat + seismicMapFocusMargin,
+    );
+  }
+
+  /// 矩形の中心から [seismicMapFocusMinimumRadiusKm] を下回る辺を押し広げる。
+  ///
+  /// 既に十分広い矩形はそのまま維持する。
+  static LngLatBounds expandToMinimumRadius({
+    required double west,
+    required double east,
+    required double south,
+    required double north,
+  }) {
+    final centerLatitude = (south + north) / 2;
+    final centerLongitude = (west + east) / 2;
+    final latitudeRadius =
+        seismicMapFocusMinimumRadiusKm / _kilometersPerLatitudeDegree;
+    final cosineLatitude = math
+        .cos(centerLatitude * math.pi / 180)
+        .abs()
+        .clamp(_minimumCosineLatitude, 1.0);
+    final longitudeRadius = latitudeRadius / cosineLatitude;
+
     return LngLatBounds(
-      longitudeWest: (minLng - seismicMapFocusMargin)
+      longitudeWest: math
+          .min(west, centerLongitude - longitudeRadius)
           .clamp(-180, 180)
           .toDouble(),
-      longitudeEast: (maxLng + seismicMapFocusMargin)
+      longitudeEast: math
+          .max(east, centerLongitude + longitudeRadius)
           .clamp(-180, 180)
           .toDouble(),
-      latitudeSouth: (minLat - seismicMapFocusMargin).clamp(-90, 90).toDouble(),
-      latitudeNorth: (maxLat + seismicMapFocusMargin).clamp(-90, 90).toDouble(),
+      latitudeSouth: math
+          .min(south, centerLatitude - latitudeRadius)
+          .clamp(-90, 90)
+          .toDouble(),
+      latitudeNorth: math
+          .max(north, centerLatitude + latitudeRadius)
+          .clamp(-90, 90)
+          .toDouble(),
     );
   }
 

--- a/app/lib/feature/map/data/service/map_automatic_focus_controller.dart
+++ b/app/lib/feature/map/data/service/map_automatic_focus_controller.dart
@@ -3,7 +3,7 @@ import 'dart:math' as math;
 import 'package:material_ui/material_ui.dart';
 import 'package:maplibre/maplibre.dart';
 
-const mapAutomaticFocusMaxZoom = 8.0;
+const mapAutomaticFocusMaxZoom = 7.0;
 const mapAutomaticFocusMercatorMaxLatitude = 85.05112878;
 const mapAutomaticFocusTileSize = 512.0;
 

--- a/app/test/feature/map/data/logic/seismic_map_focus_builder_test.dart
+++ b/app/test/feature/map/data/logic/seismic_map_focus_builder_test.dart
@@ -126,6 +126,52 @@ void main() {
     expect(bounds, _fallback);
   });
 
+  test('EEW単独でも中心から最小半径ぶんのboundsを確保する', () {
+    final bounds = builder.forRealtime(
+      fallbackBounds: _fallback,
+      eews: [_eew(latitude: 35, longitude: 139)],
+      shakes: const [],
+    );
+
+    // 最小半径 50km は緯度およそ 0.449 度に相当する。
+    expect(bounds.latitudeNorth - 35, greaterThan(0.4));
+    expect(35 - bounds.latitudeSouth, greaterThan(0.4));
+    // 経度方向は cos(緯度) で割るぶん緯度方向より広くなる。
+    expect(
+      bounds.longitudeEast - bounds.longitudeWest,
+      greaterThan(bounds.latitudeNorth - bounds.latitudeSouth),
+    );
+  });
+
+  test('最小半径より広い揺れ検知の矩形は縮められない', () {
+    final bounds = builder.forRealtime(
+      fallbackBounds: _fallback,
+      eews: const [],
+      shakes: [_shake(minLat: 33, maxLat: 38, minLng: 130, maxLng: 140)],
+    );
+
+    expect(bounds.latitudeSouth, closeTo(33 - seismicMapFocusMargin, 1e-9));
+    expect(bounds.latitudeNorth, closeTo(38 + seismicMapFocusMargin, 1e-9));
+    expect(bounds.longitudeWest, closeTo(130 - seismicMapFocusMargin, 1e-9));
+    expect(bounds.longitudeEast, closeTo(140 + seismicMapFocusMargin, 1e-9));
+  });
+
+  test('複数EEWの震源をすべて内包する', () {
+    final bounds = builder.forRealtime(
+      fallbackBounds: _fallback,
+      eews: [
+        _eew(latitude: 35, longitude: 139),
+        _eew(latitude: 43, longitude: 145),
+      ],
+      shakes: const [],
+    );
+
+    expect(bounds.latitudeSouth, lessThan(35));
+    expect(bounds.latitudeNorth, greaterThan(43));
+    expect(bounds.longitudeWest, lessThan(139));
+    expect(bounds.longitudeEast, greaterThan(145));
+  });
+
   test('不正座標は除外して有効なEEWのみをfocusに使う', () {
     final bounds = builder.forRealtime(
       fallbackBounds: _fallback,

--- a/app/test/feature/map/data/service/map_automatic_focus_controller_test.dart
+++ b/app/test/feature/map/data/service/map_automatic_focus_controller_test.dart
@@ -21,7 +21,7 @@ void main() {
   );
 
   group('mapAutomaticFocusTargetForBounds', () {
-    test('狭いboundsはMercator中心とzoom 8のtargetになる', () {
+    test('狭いboundsはMercator中心とzoom上限のtargetになる', () {
       final target = MapAutomaticFocusController.targetForBounds(
         bounds: bounds,
         viewportSize: const Size(375, 667),
@@ -31,10 +31,10 @@ void main() {
       expect(target, isNotNull);
       expect(target?.center.lon, 139.5);
       expect(target?.center.lat, closeTo(35.5015, 0.0001));
-      expect(target?.zoom, 8);
+      expect(target?.zoom, mapAutomaticFocusMaxZoom);
     });
 
-    test('広いboundsはviewportへ収まるzoom 8未満のtargetになる', () {
+    test('広いboundsはviewportへ収まるzoom上限未満のtargetになる', () {
       const wideBounds = LngLatBounds(
         longitudeWest: 122.5,
         longitudeEast: 146,
@@ -49,7 +49,7 @@ void main() {
       );
 
       expect(target, isNotNull);
-      expect(target?.zoom, lessThan(8));
+      expect(target?.zoom, lessThan(mapAutomaticFocusMaxZoom));
       expect(target?.zoom, greaterThanOrEqualTo(0));
       final zoom = target?.zoom;
       if (zoom == null) {
@@ -233,7 +233,7 @@ void main() {
   });
 
   group('MapAutomaticFocusController', () {
-    test('事前計算したzoom 8のcameraを一度だけ送る', () async {
+    test('事前計算したzoom上限のcameraを一度だけ送る', () async {
       final controller = MockMapController();
       when(
         controller.animateCamera(
@@ -259,7 +259,7 @@ void main() {
       verify(
         controller.animateCamera(
           center: anyNamed('center'),
-          zoom: 8,
+          zoom: mapAutomaticFocusMaxZoom,
           bearing: 0,
           pitch: 0,
         ),
@@ -470,7 +470,7 @@ void main() {
       verify(
         controller.animateCamera(
           center: anyNamed('center'),
-          zoom: 8,
+          zoom: mapAutomaticFocusMaxZoom,
           bearing: 0,
           pitch: 0,
         ),


### PR DESCRIPTION
## 課題

EEW受信時の自動フォーカスが常にズーム上限に張り付き、震源周辺しか映らない状態だった。

`SeismicMapFocusBuilder.eewTargetCoordinates` はEEWから**震源1点しか**フォーカス対象を作らない。そこに `seismicMapFocusMargin = 0.1`（約11km）の余白しか付かないため、bounds が 0.2°角の極小矩形になる。`MapAutomaticFocusController.targetForBounds` が算出する fit ズームは当然上限を超え、`mapAutomaticFocusMaxZoom = 8.0` で clamp される。ズーム8は端末画面で概ね100km程度しか映らないため、規模の大きいEEWでも震源周辺しか見えなかった。

## 変更

**1. フォーカスbounds に最小半径 50km を導入** (`seismic_map_focus_builder.dart`)

```dart
const seismicMapFocusMinimumRadiusKm = 50.0;
```

`boundsForTargets` が既存の余白を付けたあと、新設の `expandToMinimumRadius` で中心から最低50kmぶんを確保するよう bounds を押し広げる。経度方向は `cos(緯度)` で割って距離を揃え、高緯度で換算が発散しないよう `cos` に下限を設けている。

既に十分広い矩形（複数EEW・揺れ検知の広域bbox）は `min`/`max` でそのまま維持されるため縮まない。

**2. ズーム上限を 8.0 → 7.0** (`map_automatic_focus_controller.dart`)

最小半径と上限の広い方が採用される形になる。

## 対象の決め方は変更なし

- 複数EEW → 全震源を内包（`realtimeTargetCoordinates` が `eews.expand(...)` で全件収集）
- 揺れ検知 → EEWと未結合のものは min/max bbox を同じ bounds に合流

## 副次的な影響

- `SeismicMapFocusBuilder.forRealtime` はライブモニタのrealtimeフォーカスからも呼ばれる（`live_monitor_map_focus_builder.dart:50`）ため、そちらのEEWフォーカスにも同じ改善が入る
- `mapAutomaticFocusMaxZoom` はホーム復帰・ライブモニタの地震フォーカスとも共有だが、それらの bounds は元々広くズーム7未満に収まるため実質影響なし。ホームのカスタム範囲を極端に狭く設定した場合のみ、以前より1段引いた表示になる

## テスト

`test/feature/map/` は全70件パス。`dart analyze` / `dart format` クリーン。

`seismic_map_focus_builder_test.dart` に3件追加:
- EEW単独でも中心から最小半径ぶんのboundsを確保する
- 最小半径より広い揺れ検知の矩形は縮められない
- 複数EEWの震源をすべて内包する

ズーム値を直書きしていた既存テスト3箇所は `mapAutomaticFocusMaxZoom` 参照に置き換えた。

> [!NOTE]
> `test/feature/home/home_feed_sheet_banner_test.dart`（9件）と `test/feature/live_monitor/data/live_monitor_detected_event_notifier_test.dart`（2件）が落ちるが、本変更前の `develop` 時点でも同様に落ちる既存failureであり、本PRとは無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)