### PR TITLE
fix: iOSでオンボーディングの「アプリを開いていない時の位置情報」が許可できない問題を修正

### DIFF
--- a/app/lib/feature/permission/data/repository/permission_repository.dart
+++ b/app/lib/feature/permission/data/repository/permission_repository.dart
@@ -1,8 +1,11 @@
+import 'dart:io';
+
 import 'package:eqmonitor/core/provider/app_group_settings_writer.dart';
 import 'package:eqmonitor/core/provider/firebase/firebase_messaging.dart';
 import 'package:eqmonitor/core/provider/notification/os_notification_permission.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'permission_repository.g.dart';
@@ -11,23 +14,81 @@ part 'permission_repository.g.dart';
 PermissionRepository permissionRepository(Ref ref) => PermissionRepository(
   readMessaging: () => ref.read(firebaseMessagingProvider),
   requestLocationPermission: Geolocator.requestPermission,
+  requestAlwaysLocationPermission: requestAlwaysLocationPermission,
   onLocationPermissionGranted: () async {
     ref.invalidate(appGroupSettingsWriterProvider, asReload: true);
     await ref.read(appGroupSettingsWriterProvider.future);
   },
 );
 
+/// 「常に許可」(バックグラウンド位置情報) を要求する。
+///
+/// Apple 系プラットフォームでは `Geolocator.requestPermission()` が使えない:
+/// - 権限が未決定でない場合は何もせず現在の状態を返す
+///   (= 使用中の許可を得た後に呼んでも昇格ダイアログが出ない)
+/// - `NSLocationWhenInUseUsageDescription` があると常に
+///   `requestWhenInUseAuthorization` しか呼ばない
+///
+/// そのため permission_handler 経由で `requestAlwaysAuthorization` を呼ぶ。
+/// Android は geolocator が `ACCESS_BACKGROUND_LOCATION` への昇格に対応している
+/// ため、そのまま `Geolocator.requestPermission()` を使う。
+Future<LocationPermission> requestAlwaysLocationPermission() async {
+  if (!Platform.isIOS && !Platform.isMacOS) {
+    return Geolocator.requestPermission();
+  }
+  // iOS では「使用中の許可」がないと「常に許可」を要求できないため、先に要求する
+  if (await Geolocator.checkPermission() == LocationPermission.denied) {
+    final foreground = await Geolocator.requestPermission();
+    if (foreground != LocationPermission.whileInUse &&
+        foreground != LocationPermission.always) {
+      return foreground;
+    }
+  }
+
+  // permission_handler の戻り値は信用できない:
+  // 要求のたびに `CLLocationManager` を生成するため、昇格前の
+  // `authorizedWhenInUse` が届くデリゲート通知で `denied` を返してしまう。
+  // 逆に、使用中の許可済みからの昇格ではダイアログが出ず
+  // (= provisional always) 通知が来ないこともあり、その場合は完了しない。
+  // そのため要求だけ投げて、OS のステータス自体を見て判定する。
+  Permission.locationAlways.request().ignore();
+  return _waitForAlwaysAuthorization();
+}
+
+/// `requestAlwaysAuthorization` の結果が OS に反映されるまで待つ。
+///
+/// 使用中の許可済みから昇格する場合、ダイアログを挟まずに
+/// `authorizedAlways` (provisional always) になるため、短い待機で確定する。
+/// 昇格しなかった場合はタイムアウトして現在のステータスを返す。
+Future<LocationPermission> _waitForAlwaysAuthorization() async {
+  const interval = Duration(milliseconds: 100);
+  const timeout = Duration(seconds: 2);
+
+  final stopwatch = Stopwatch()..start();
+  var permission = await Geolocator.checkPermission();
+  while (permission != LocationPermission.always &&
+      stopwatch.elapsed < timeout) {
+    await Future<void>.delayed(interval);
+    permission = await Geolocator.checkPermission();
+  }
+  return permission;
+}
+
 class PermissionRepository {
   const new({
     required FirebaseMessaging Function() readMessaging,
     required Future<LocationPermission> Function() requestLocationPermission,
+    required Future<LocationPermission> Function()
+    requestAlwaysLocationPermission,
     required Future<void> Function() onLocationPermissionGranted,
   }) : _readMessaging = readMessaging,
        _requestLocationPermission = requestLocationPermission,
+       _requestAlwaysLocationPermission = requestAlwaysLocationPermission,
        _onLocationPermissionGranted = onLocationPermissionGranted;
 
   final FirebaseMessaging Function() _readMessaging;
   final Future<LocationPermission> Function() _requestLocationPermission;
+  final Future<LocationPermission> Function() _requestAlwaysLocationPermission;
   final Future<void> Function() _onLocationPermissionGranted;
 
   Future<OsNotificationPermission> getNotificationPermission() async {
@@ -63,7 +124,7 @@ class PermissionRepository {
   }
 
   Future<bool> requestBackgroundLocationPermission() async {
-    final permission = await _requestLocationPermission();
+    final permission = await _requestAlwaysLocationPermission();
     final isGranted = permission == LocationPermission.always;
     if (isGranted) {
       await _onLocationPermissionGranted();

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -149,6 +149,7 @@ dependencies:
   paging_view: ^2.8.1
   path: ^1.9.0
   path_provider: ^2.1.5
+  permission_handler: ^13.0.1
   purchases_flutter: ^10.0.1
   riverpod: ^3.3.2
   riverpod_annotation: ^4.0.3

--- a/app/test/feature/permission/permission_repository_test.dart
+++ b/app/test/feature/permission/permission_repository_test.dart
@@ -44,6 +44,7 @@ void main() {
         readMessaging: () =>
             _FakeMessaging(_settings(AuthorizationStatus.authorized)),
         requestLocationPermission: () async => LocationPermission.denied,
+        requestAlwaysLocationPermission: () async => LocationPermission.denied,
         onLocationPermissionGranted: () async {},
       );
 
@@ -57,6 +58,7 @@ void main() {
         readMessaging: () =>
             _FakeMessaging(_settings(AuthorizationStatus.provisional)),
         requestLocationPermission: () async => LocationPermission.denied,
+        requestAlwaysLocationPermission: () async => LocationPermission.denied,
         onLocationPermissionGranted: () async {},
       );
 
@@ -73,6 +75,8 @@ void main() {
         readMessaging: () =>
             _FakeMessaging(_settings(AuthorizationStatus.denied)),
         requestLocationPermission: () async => LocationPermission.whileInUse,
+        requestAlwaysLocationPermission: () async =>
+            LocationPermission.whileInUse,
         onLocationPermissionGranted: () async {
           await Future<void>.delayed(Duration.zero);
           syncRequested = true;
@@ -91,10 +95,45 @@ void main() {
         readMessaging: () =>
             _FakeMessaging(_settings(AuthorizationStatus.denied)),
         requestLocationPermission: () async => LocationPermission.denied,
+        requestAlwaysLocationPermission: () async => LocationPermission.denied,
         onLocationPermissionGranted: () async => syncRequested = true,
       );
 
       final isGranted = await repository.requestForegroundLocationPermission();
+
+      expect(isGranted, isFalse);
+      expect(syncRequested, isFalse);
+    });
+  });
+
+  group('PermissionRepository.requestBackgroundLocationPermission', () {
+    test('always への昇格用の要求を使う', () async {
+      final repository = PermissionRepository(
+        readMessaging: () =>
+            _FakeMessaging(_settings(AuthorizationStatus.denied)),
+        // 使用中の許可しか返さない要求が使われていたら false になる
+        requestLocationPermission: () async => LocationPermission.whileInUse,
+        requestAlwaysLocationPermission: () async => LocationPermission.always,
+        onLocationPermissionGranted: () async {},
+      );
+
+      final isGranted = await repository.requestBackgroundLocationPermission();
+
+      expect(isGranted, isTrue);
+    });
+
+    test('whileInUse のままなら許可されていない', () async {
+      var syncRequested = false;
+      final repository = PermissionRepository(
+        readMessaging: () =>
+            _FakeMessaging(_settings(AuthorizationStatus.denied)),
+        requestLocationPermission: () async => LocationPermission.whileInUse,
+        requestAlwaysLocationPermission: () async =>
+            LocationPermission.whileInUse,
+        onLocationPermissionGranted: () async => syncRequested = true,
+      );
+
+      final isGranted = await repository.requestBackgroundLocationPermission();
 
       expect(isGranted, isFalse);
       expect(syncRequested, isFalse);


### PR DESCRIPTION
## 概要

iOS で、オンボーディングの「アプリを開いていない時の位置情報」を「許可する」しても必ず `権限が許可されませんでした。必要になったら設定から変更できます。` になり、`Always` を取得できない問題を修正します。

## 原因

`PermissionRepository.requestBackgroundLocationPermission()` が `Geolocator.requestPermission()` を使っていましたが、これは iOS では「常に許可」を取得できません。`geolocator_apple` の `PermissionHandler.m` に2つの壁があります。

1. **早期リターン** — 権限が `notDetermined` 以外なら、ダイアログを出さず現在のステータスをそのまま返す。オンボーディングでは先に「アプリを開いている時の位置情報」で `whileInUse` を許可済みなので、ここで必ず `whileInUse` が返る。
2. **`requestAlwaysAuthorization` を呼ばない** — `NSLocationWhenInUseUsageDescription` が Info.plist にあると常に `requestWhenInUseAuthorization` 側の分岐に入る。`Always` 側は `else if` なので到達しない。

結果として `permission != LocationPermission.always` → `isGranted = false` になっていました。

Android 側は `geolocator` が `ACCESS_BACKGROUND_LOCATION` への昇格に対応しているため、これまでも正常に動作していたはずです。

## 修正

Apple 系プラットフォームのみ `permission_handler` の `Permission.locationAlways.request()` を使い、`requestAlwaysAuthorization` を呼ぶようにしました。

ただし `permission_handler` の戻り値は信用できません。要求のたびに `CLLocationManager` を生成するため、**昇格前の `authorizedWhenInUse`** が届くデリゲート通知で `denied` を返して完了扱いになります（`requestAlwaysAuthorization` 自体は正しく発行されている）。逆に、使用中の許可済みからの昇格はダイアログが出ない（provisional always）ため、条件次第では完了ハンドラが呼ばれず Future が解決しない可能性もあります。

そのため要求だけ投げて、OS のステータス自体を見て判定します。

```dart
Permission.locationAlways.request().ignore();
return _waitForAlwaysAuthorization();
```

`_waitForAlwaysAuthorization()` は `Geolocator.checkPermission()` を 100ms 間隔で最大 2 秒ポーリングし、`always` になった時点で確定、ならなければ現在のステータスを返します。provisional always はダイアログを挟まず即座に `authorizedAlways` になるため、実際にはほぼ待たずに確定します。

## 変更点

- `app/pubspec.yaml` — `permission_handler: ^13.0.1` を直接依存に追加（これまで transitive）
- `app/lib/feature/permission/data/repository/permission_repository.dart` — `requestAlwaysLocationPermission` を DI パラメータとして追加し、バックグラウンド要求のみそちらを使用
- `app/test/feature/permission/permission_repository_test.dart` — 新パラメータ対応 + `requestBackgroundLocationPermission` のテスト2件追加

`app/ios/Runner/Info.plist` は `NSLocationAlwaysAndWhenInUseUsageDescription` と `UIBackgroundModes` の `location` が揃っているため、`permission_handler_apple` の SPM マニフェストが `PERMISSION_LOCATION_ALWAYS` を自動で有効化します（ネイティブ側の追加設定は不要）。

## 確認

- [x] `flutter analyze`（`lib/feature/permission`, `test/feature/permission`）
- [x] `dart format`
- [x] `flutter test test/feature/permission`（21件パス）
- [ ] iOS 実機/シミュレータでのオンボーディング動作確認（ネイティブ依存が増えているため要再ビルド）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
