### PR TITLE
feat: 通知プリセット「すべて」の拡充と EEW警報の割り込みレベル設定

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/data/action/notification_preset_applier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/action/notification_preset_applier.dart
@@ -2,6 +2,7 @@ import 'package:eqmonitor/core/provider/shared_preferences.dart';
 import 'package:eqmonitor/feature/devices/data/persistence/shared_preferences_workflow_persistence.dart';
 import 'package:eqmonitor/feature/notification/data/notifier/general_notification_settings_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/action/notification_preset_slots_builder.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/eew_warning_settings.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_custom_snapshot.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot_draft.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/earthquake_global_settings_notifier.dart';
@@ -60,6 +61,11 @@ class NotificationPresetApplier {
         await step('updateGlobals', () => _updateGlobals(preset, snapshot));
         if (preset == NotificationPreset.custom && snapshot != null) {
           await step('restoreCustomExtras', () => _restoreExtras(snapshot));
+        }
+        if (preset == NotificationPreset.all) {
+          // updateGlobals の warningEnabled: true でサーバ側の target が
+          // current_location_only にリセットされるため、その後に全国対象へ上書きする
+          await step('applyNationwideWarning', _applyNationwideWarning);
         }
         await step('selectPreset', () async {
           await _ref.read(notificationPresetProvider.notifier).select(preset);
@@ -120,6 +126,8 @@ class NotificationPresetApplier {
           notificationEnabled: true,
           nankaiExtraordinaryEnabled: true,
           nankaiRegularEnabled: true,
+          vyse60Enabled: true,
+          earthquakeNoticeEnabled: true,
         );
       case NotificationPreset.custom:
         final general = snapshot?.general;
@@ -171,11 +179,25 @@ class NotificationPresetApplier {
     await earthquakeNotifier.updateSettings(enabled: true);
   }
 
+  /// 「すべて」の EEW 警報を現在地 + 全国対象にする。
+  Future<void> _applyNationwideWarning() async {
+    await _ref
+        .read(eewWarningConfigProvider.notifier)
+        .updateConfig(
+          target: EewWarningTarget.currentLocationAndNationwide,
+          currentLocationInterruptionLevel:
+              currentLocationEewWarningDefaultLevel,
+          nationwideInterruptionLevel: nationwideEewWarningDefaultLevel,
+        );
+  }
+
   Future<void> _restoreExtras(NotificationCustomSnapshot snapshot) async {
     await _ref
         .read(eewWarningConfigProvider.notifier)
         .updateConfig(
           target: snapshot.eewWarning.target,
+          currentLocationInterruptionLevel:
+              snapshot.eewWarning.currentLocationInterruptionLevel,
           nationwideInterruptionLevel:
               snapshot.eewWarning.nationwideInterruptionLevel,
         );

--- a/app/lib/feature/settings/features/notification_settings/data/flow/eew_warning_settings_action.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/flow/eew_warning_settings_action.dart
@@ -32,6 +32,7 @@ class EewWarningSettingsAction {
     WidgetRef ref, {
     required bool enabled,
   }) async {
+    final current = ref.read(eewWarningConfigProvider).value;
     await EewWarningConfigNotifier.updateConfigMutation.run(ref, (tsx) async {
       await tsx
           .get(eewWarningConfigProvider.notifier)
@@ -40,12 +41,40 @@ class EewWarningSettingsAction {
                 ? EewWarningTarget.currentLocationAndNationwide
                 : EewWarningTarget.currentLocationOnly,
             nationwideInterruptionLevel: enabled
-                ? InterruptionLevel.active
+                ? (current?.nationwideInterruptionLevel ??
+                      nationwideEewWarningDefaultLevel)
                 : null,
           );
     });
     ref
         .read(eewGlobalSettingsProvider.notifier)
         .synchronizeWarningEnabled(enabled: true);
+  }
+
+  /// 現在地の EEW 警報の割り込みレベルを変更する。
+  Future<void> updateCurrentLocationInterruptionLevel(
+    WidgetRef ref, {
+    required InterruptionLevel level,
+  }) async {
+    await EewWarningConfigNotifier.updateConfigMutation.run(ref, (tsx) async {
+      await tsx
+          .get(eewWarningConfigProvider.notifier)
+          .updateConfig(currentLocationInterruptionLevel: level);
+    });
+  }
+
+  /// 全国対象の EEW 警報の割り込みレベルを変更する。
+  Future<void> updateNationwideInterruptionLevel(
+    WidgetRef ref, {
+    required InterruptionLevel level,
+  }) async {
+    await EewWarningConfigNotifier.updateConfigMutation.run(ref, (tsx) async {
+      await tsx
+          .get(eewWarningConfigProvider.notifier)
+          .updateConfig(
+            target: EewWarningTarget.currentLocationAndNationwide,
+            nationwideInterruptionLevel: level,
+          );
+    });
   }
 }

--- a/app/lib/feature/settings/features/notification_settings/data/model/eew_warning_settings.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/eew_warning_settings.dart
@@ -7,10 +7,24 @@ part 'eew_warning_settings.g.dart';
 
 enum EewWarningTarget { currentLocationOnly, currentLocationAndNationwide }
 
+/// 現在地を対象とする EEW 警報の割り込みレベル既定値。
+///
+/// 現在地は生命に直結するため、おやすみモード等を無視する critical を既定とする。
+const InterruptionLevel currentLocationEewWarningDefaultLevel =
+    InterruptionLevel.critical;
+
+/// 全国を対象とする EEW 警報の割り込みレベル既定値。
+///
+/// 全国対象は「日本のどこかで警報」で必ず鳴るため、critical ではなく
+/// time sensitive を既定とする。
+const InterruptionLevel nationwideEewWarningDefaultLevel =
+    InterruptionLevel.timeSensitive;
+
 @freezed
 abstract class EewWarningSettings with _$EewWarningSettings {
   const factory({
     required EewWarningTarget target,
+    required InterruptionLevel currentLocationInterruptionLevel,
     required InterruptionLevel? nationwideInterruptionLevel,
   }) = _EewWarningSettings;
 
@@ -21,6 +35,8 @@ abstract class EewWarningSettings with _$EewWarningSettings {
 extension ApiEewWarningConfigResponseConverter on api.EewWarningConfigResponse {
   EewWarningSettings toEewWarningSettings() => EewWarningSettings(
     target: target.toAppTarget,
+    currentLocationInterruptionLevel:
+        currentLocationInterruptionLevel.toAppInterruptionLevel,
     nationwideInterruptionLevel:
         nationwideInterruptionLevel?.toAppInterruptionLevel,
   );

--- a/app/lib/feature/settings/features/notification_settings/data/model/eew_warning_settings.freezed.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/eew_warning_settings.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EewWarningSettings {
 
- EewWarningTarget get target; InterruptionLevel? get nationwideInterruptionLevel;
+ EewWarningTarget get target; InterruptionLevel get currentLocationInterruptionLevel; InterruptionLevel? get nationwideInterruptionLevel;
 /// Create a copy of EewWarningSettings
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $EewWarningSettingsCopyWith<EewWarningSettings> get copyWith => _$EewWarningSett
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewWarningSettings&&(identical(other.target, target) || other.target == target)&&(identical(other.nationwideInterruptionLevel, nationwideInterruptionLevel) || other.nationwideInterruptionLevel == nationwideInterruptionLevel));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewWarningSettings&&(identical(other.target, target) || other.target == target)&&(identical(other.currentLocationInterruptionLevel, currentLocationInterruptionLevel) || other.currentLocationInterruptionLevel == currentLocationInterruptionLevel)&&(identical(other.nationwideInterruptionLevel, nationwideInterruptionLevel) || other.nationwideInterruptionLevel == nationwideInterruptionLevel));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,target,nationwideInterruptionLevel);
+int get hashCode => Object.hash(runtimeType,target,currentLocationInterruptionLevel,nationwideInterruptionLevel);
 
 @override
 String toString() {
-  return 'EewWarningSettings(target: $target, nationwideInterruptionLevel: $nationwideInterruptionLevel)';
+  return 'EewWarningSettings(target: $target, currentLocationInterruptionLevel: $currentLocationInterruptionLevel, nationwideInterruptionLevel: $nationwideInterruptionLevel)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $EewWarningSettingsCopyWith<$Res>  {
   factory $EewWarningSettingsCopyWith(EewWarningSettings value, $Res Function(EewWarningSettings) _then) = _$EewWarningSettingsCopyWithImpl;
 @useResult
 $Res call({
- EewWarningTarget target, InterruptionLevel? nationwideInterruptionLevel
+ EewWarningTarget target, InterruptionLevel currentLocationInterruptionLevel, InterruptionLevel? nationwideInterruptionLevel
 });
 
 
@@ -66,10 +66,11 @@ class _$EewWarningSettingsCopyWithImpl<$Res>
 
 /// Create a copy of EewWarningSettings
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? target = null,Object? nationwideInterruptionLevel = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? target = null,Object? currentLocationInterruptionLevel = null,Object? nationwideInterruptionLevel = freezed,}) {
   return _then(EewWarningSettings(
 target: null == target ? _self.target : target // ignore: cast_nullable_to_non_nullable
-as EewWarningTarget,nationwideInterruptionLevel: freezed == nationwideInterruptionLevel ? _self.nationwideInterruptionLevel : nationwideInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as EewWarningTarget,currentLocationInterruptionLevel: null == currentLocationInterruptionLevel ? _self.currentLocationInterruptionLevel : currentLocationInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as InterruptionLevel,nationwideInterruptionLevel: freezed == nationwideInterruptionLevel ? _self.nationwideInterruptionLevel : nationwideInterruptionLevel // ignore: cast_nullable_to_non_nullable
 as InterruptionLevel?,
   ));
 }
@@ -155,10 +156,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( EewWarningTarget target,  InterruptionLevel? nationwideInterruptionLevel)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( EewWarningTarget target,  InterruptionLevel currentLocationInterruptionLevel,  InterruptionLevel? nationwideInterruptionLevel)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EewWarningSettings() when $default != null:
-return $default(_that.target,_that.nationwideInterruptionLevel);case _:
+return $default(_that.target,_that.currentLocationInterruptionLevel,_that.nationwideInterruptionLevel);case _:
   return orElse();
 
 }
@@ -176,10 +177,10 @@ return $default(_that.target,_that.nationwideInterruptionLevel);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( EewWarningTarget target,  InterruptionLevel? nationwideInterruptionLevel)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( EewWarningTarget target,  InterruptionLevel currentLocationInterruptionLevel,  InterruptionLevel? nationwideInterruptionLevel)  $default,) {final _that = this;
 switch (_that) {
 case _EewWarningSettings():
-return $default(_that.target,_that.nationwideInterruptionLevel);case _:
+return $default(_that.target,_that.currentLocationInterruptionLevel,_that.nationwideInterruptionLevel);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +197,10 @@ return $default(_that.target,_that.nationwideInterruptionLevel);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( EewWarningTarget target,  InterruptionLevel? nationwideInterruptionLevel)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( EewWarningTarget target,  InterruptionLevel currentLocationInterruptionLevel,  InterruptionLevel? nationwideInterruptionLevel)?  $default,) {final _that = this;
 switch (_that) {
 case _EewWarningSettings() when $default != null:
-return $default(_that.target,_that.nationwideInterruptionLevel);case _:
+return $default(_that.target,_that.currentLocationInterruptionLevel,_that.nationwideInterruptionLevel);case _:
   return null;
 
 }
@@ -211,10 +212,11 @@ return $default(_that.target,_that.nationwideInterruptionLevel);case _:
 @JsonSerializable()
 
 class _EewWarningSettings implements EewWarningSettings {
-  const _EewWarningSettings({required this.target, required this.nationwideInterruptionLevel});
+  const _EewWarningSettings({required this.target, required this.currentLocationInterruptionLevel, required this.nationwideInterruptionLevel});
   factory _EewWarningSettings.fromJson(Map<String, dynamic> json) => _$EewWarningSettingsFromJson(json);
 
 @override final  EewWarningTarget target;
+@override final  InterruptionLevel currentLocationInterruptionLevel;
 @override final  InterruptionLevel? nationwideInterruptionLevel;
 
 /// Create a copy of EewWarningSettings
@@ -230,16 +232,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewWarningSettings&&(identical(other.target, target) || other.target == target)&&(identical(other.nationwideInterruptionLevel, nationwideInterruptionLevel) || other.nationwideInterruptionLevel == nationwideInterruptionLevel));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewWarningSettings&&(identical(other.target, target) || other.target == target)&&(identical(other.currentLocationInterruptionLevel, currentLocationInterruptionLevel) || other.currentLocationInterruptionLevel == currentLocationInterruptionLevel)&&(identical(other.nationwideInterruptionLevel, nationwideInterruptionLevel) || other.nationwideInterruptionLevel == nationwideInterruptionLevel));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,target,nationwideInterruptionLevel);
+int get hashCode => Object.hash(runtimeType,target,currentLocationInterruptionLevel,nationwideInterruptionLevel);
 
 @override
 String toString() {
-  return 'EewWarningSettings(target: $target, nationwideInterruptionLevel: $nationwideInterruptionLevel)';
+  return 'EewWarningSettings(target: $target, currentLocationInterruptionLevel: $currentLocationInterruptionLevel, nationwideInterruptionLevel: $nationwideInterruptionLevel)';
 }
 
 
@@ -250,7 +252,7 @@ abstract mixin class _$EewWarningSettingsCopyWith<$Res> implements $EewWarningSe
   factory _$EewWarningSettingsCopyWith(_EewWarningSettings value, $Res Function(_EewWarningSettings) _then) = __$EewWarningSettingsCopyWithImpl;
 @override @useResult
 $Res call({
- EewWarningTarget target, InterruptionLevel? nationwideInterruptionLevel
+ EewWarningTarget target, InterruptionLevel currentLocationInterruptionLevel, InterruptionLevel? nationwideInterruptionLevel
 });
 
 
@@ -267,10 +269,11 @@ class __$EewWarningSettingsCopyWithImpl<$Res>
 
 /// Create a copy of EewWarningSettings
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? target = null,Object? nationwideInterruptionLevel = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? target = null,Object? currentLocationInterruptionLevel = null,Object? nationwideInterruptionLevel = freezed,}) {
   return _then(_EewWarningSettings(
 target: null == target ? _self.target : target // ignore: cast_nullable_to_non_nullable
-as EewWarningTarget,nationwideInterruptionLevel: freezed == nationwideInterruptionLevel ? _self.nationwideInterruptionLevel : nationwideInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as EewWarningTarget,currentLocationInterruptionLevel: null == currentLocationInterruptionLevel ? _self.currentLocationInterruptionLevel : currentLocationInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as InterruptionLevel,nationwideInterruptionLevel: freezed == nationwideInterruptionLevel ? _self.nationwideInterruptionLevel : nationwideInterruptionLevel // ignore: cast_nullable_to_non_nullable
 as InterruptionLevel?,
   ));
 }

--- a/app/lib/feature/settings/features/notification_settings/data/model/eew_warning_settings.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/eew_warning_settings.g.dart
@@ -18,6 +18,10 @@ _EewWarningSettings _$EewWarningSettingsFromJson(Map<String, dynamic> json) =>
             'target',
             (v) => $enumDecode(_$EewWarningTargetEnumMap, v),
           ),
+          currentLocationInterruptionLevel: $checkedConvert(
+            'current_location_interruption_level',
+            (v) => $enumDecode(_$InterruptionLevelEnumMap, v),
+          ),
           nationwideInterruptionLevel: $checkedConvert(
             'nationwide_interruption_level',
             (v) => $enumDecodeNullable(_$InterruptionLevelEnumMap, v),
@@ -26,16 +30,21 @@ _EewWarningSettings _$EewWarningSettingsFromJson(Map<String, dynamic> json) =>
         return val;
       },
       fieldKeyMap: const {
+        'currentLocationInterruptionLevel':
+            'current_location_interruption_level',
         'nationwideInterruptionLevel': 'nationwide_interruption_level',
       },
     );
 
-Map<String, dynamic> _$EewWarningSettingsToJson(_EewWarningSettings instance) =>
-    <String, dynamic>{
-      'target': _$EewWarningTargetEnumMap[instance.target]!,
-      'nationwide_interruption_level':
-          _$InterruptionLevelEnumMap[instance.nationwideInterruptionLevel],
-    };
+Map<String, dynamic> _$EewWarningSettingsToJson(
+  _EewWarningSettings instance,
+) => <String, dynamic>{
+  'target': _$EewWarningTargetEnumMap[instance.target]!,
+  'current_location_interruption_level':
+      _$InterruptionLevelEnumMap[instance.currentLocationInterruptionLevel]!,
+  'nationwide_interruption_level':
+      _$InterruptionLevelEnumMap[instance.nationwideInterruptionLevel],
+};
 
 const _$EewWarningTargetEnumMap = {
   EewWarningTarget.currentLocationOnly: 'currentLocationOnly',

--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_min_intensity.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_min_intensity.dart
@@ -1,10 +1,69 @@
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_kind.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
 
 const JmaIntensity currentLocationEewMinIntensity = JmaIntensity.four;
 const JmaIntensity currentLocationEarthquakeMinIntensity = JmaIntensity.one;
 
 /// 最小の震度0。配信判定は `最小震度 <= イベント震度` のため常に条件を満たす。
 const JmaIntensity allMinIntensity = JmaIntensity.zero;
+
+/// スロット種別・通知種別ごとに選べる最小震度を決める。
+class NotificationMinIntensityPolicy {
+  const new();
+
+  /// 現在地・地域スロットの最小震度の下限。
+  ///
+  /// 現在地と地域は「自分に関係のある揺れ」を知らせるスロットのため、EEW(予報) は
+  /// 震度4以上、地震情報は震度1以上より低い閾値を選べない。「すべて」(震度0) を
+  /// 選べるのは全国スロットのみ。
+  JmaIntensity? floorOf({
+    required NotificationSlotType slotType,
+    required NotificationKind kind,
+  }) => switch (slotType) {
+    NotificationSlotType.nationwide => null,
+    NotificationSlotType.currentLocation ||
+    NotificationSlotType.region => switch (kind) {
+      NotificationKind.eew => currentLocationEewMinIntensity,
+      NotificationKind.earthquake => currentLocationEarthquakeMinIntensity,
+    },
+  };
+
+  /// 選択できる最小震度の一覧を返す。
+  List<JmaIntensity> optionsOf({
+    required NotificationSlotType slotType,
+    required NotificationKind kind,
+  }) {
+    final floor = floorOf(slotType: slotType, kind: kind);
+    if (floor == null) {
+      return JmaIntensity.selectableValues;
+    }
+    return JmaIntensity.selectableValues
+        .where((i) => i.orderIndex >= floor.orderIndex)
+        .toList();
+  }
+
+  /// [minIntensity] を下限まで引き上げる。
+  ///
+  /// 下限のないスロット、または [minIntensity] が null の場合はそのまま返す。
+  JmaIntensity? clamp({
+    required NotificationSlotType slotType,
+    required NotificationKind kind,
+    required JmaIntensity? minIntensity,
+  }) {
+    if (minIntensity == null) {
+      return null;
+    }
+    final floor = floorOf(slotType: slotType, kind: kind);
+    if (floor == null) {
+      return minIntensity;
+    }
+    return minIntensity.orderIndex < floor.orderIndex ? floor : minIntensity;
+  }
+}
+
+const NotificationMinIntensityPolicy notificationMinIntensityPolicy =
+    NotificationMinIntensityPolicy();
 
 extension NotificationMinIntensityLabel on JmaIntensity {
   String get minIntensityLabel => this == allMinIntensity ? 'すべて' : '震度$label';

--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_override.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_override.dart
@@ -62,6 +62,18 @@ extension ApiNationwideInterruptionLevelConverter
   InterruptionLevel get toAppInterruptionLevel => switch (this) {
     .passive => .passive,
     .active => .active,
+    .timeSensitive => .timeSensitive,
+    .critical => .critical,
+  };
+}
+
+extension ApiCurrentLocationInterruptionLevelConverter
+    on api.CurrentLocationInterruptionLevel {
+  InterruptionLevel get toAppInterruptionLevel => switch (this) {
+    .passive => .passive,
+    .active => .active,
+    .timeSensitive => .timeSensitive,
+    .critical => .critical,
   };
 }
 
@@ -81,12 +93,21 @@ extension InterruptionLevelToApi on InterruptionLevel {
         .critical => api.DefaultInterruptionLevel.critical,
       };
 
-  api.NationwideInterruptionLevel? get toApiNationwideInterruptionLevel =>
+  api.NationwideInterruptionLevel get toApiNationwideInterruptionLevel =>
       switch (this) {
         .passive => .passive,
         .active => .active,
-        _ => null,
+        .timeSensitive => .timeSensitive,
+        .critical => .critical,
       };
+
+  api.CurrentLocationInterruptionLevel
+  get toApiCurrentLocationInterruptionLevel => switch (this) {
+    .passive => .passive,
+    .active => .active,
+    .timeSensitive => .timeSensitive,
+    .critical => .critical,
+  };
 }
 
 extension NotificationOverrideToApi on NotificationOverride {

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/eew_warning_config_notifier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/eew_warning_config_notifier.dart
@@ -23,20 +23,30 @@ class EewWarningConfigNotifier extends _$EewWarningConfigNotifier {
 
   Future<void> updateConfig({
     EewWarningTarget? target,
+    InterruptionLevel? currentLocationInterruptionLevel,
     InterruptionLevel? nationwideInterruptionLevel,
   }) async {
     final repo = await ref.read(notificationSlotRepositoryProvider.future);
     final result = await repo.patchEewWarningConfig(
       target: target,
+      currentLocationInterruptionLevel: currentLocationInterruptionLevel,
       nationwideInterruptionLevel: nationwideInterruptionLevel,
     );
     state = AsyncData(result);
   }
 
+  /// EEW 警報の有効トグルを OFF/ON したときのローカル状態同期。
+  ///
+  /// サーバ側は `warning_enabled: true` で target を現在地のみへ戻すため、
+  /// 現在地の割り込みレベル以外を初期状態に揃える。
   void synchronizeWithGlobalToggle() {
-    state = const AsyncData(
+    final currentLevel =
+        state.value?.currentLocationInterruptionLevel ??
+        currentLocationEewWarningDefaultLevel;
+    state = AsyncData(
       EewWarningSettings(
         target: EewWarningTarget.currentLocationOnly,
+        currentLocationInterruptionLevel: currentLevel,
         nationwideInterruptionLevel: null,
       ),
     );

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/eew_warning_config_notifier.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/eew_warning_config_notifier.g.dart
@@ -37,7 +37,7 @@ final class EewWarningConfigNotifierProvider
 }
 
 String _$eewWarningConfigNotifierHash() =>
-    r'88562921cb4db1e9c4885052df0a82680b6ef65b';
+    r'ad3963793a2b5d95b0a39288f95169be33b51ea4';
 
 abstract class _$EewWarningConfigNotifier
     extends $AsyncNotifier<EewWarningSettings> {

--- a/app/lib/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart
@@ -3,6 +3,7 @@ import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/earthquake_global_settings.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/eew_global_settings.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/eew_warning_settings.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_kind.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_min_intensity.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_override.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
@@ -24,17 +25,26 @@ Future<NotificationSlotRepository> notificationSlotRepository(Ref ref) async =>
 /// 無条件発火しないよう [defaultNotificationSlotMinIntensity] を補う。
 /// [enabled] が false/未指定のときは [minIntensity] をそのまま返す
 /// (無効スロットの震度指定は意味を持たないため補完しない)。
+///
+/// 現在地・地域スロットは UI を経由しない経路でも下限を下回らないよう
+/// [NotificationMinIntensityPolicy.clamp] で引き上げる。
 class NotificationSlotMinIntensityResolver {
   const new();
 
   JmaIntensity? resolve({
+    required NotificationSlotType slotType,
+    required NotificationKind kind,
     required bool? enabled,
     required JmaIntensity? minIntensity,
   }) {
     if (enabled != true) {
       return minIntensity;
     }
-    return minIntensity ?? defaultNotificationSlotMinIntensity;
+    return notificationMinIntensityPolicy.clamp(
+      slotType: slotType,
+      kind: kind,
+      minIntensity: minIntensity ?? defaultNotificationSlotMinIntensity,
+    );
   }
 }
 
@@ -68,17 +78,29 @@ class NotificationSlotRepository {
           body: api.UpsertSingletonSlotRequest(
             eewEnabled: resolvedEewEnabled,
             eewMinIntensity: resolvedEewEnabled
-                ? (eewMinIntensity ?? currentLocationEewMinIntensity)
-                      .toApiJmaIntensity
+                ? notificationMinIntensityPolicy
+                      .clamp(
+                        slotType: NotificationSlotType.currentLocation,
+                        kind: NotificationKind.eew,
+                        minIntensity:
+                            eewMinIntensity ?? currentLocationEewMinIntensity,
+                      )
+                      ?.toApiJmaIntensity
                 : null,
             eewOverrides: eewOverrides
                 ?.map((o) => o.toApiSlotOverride())
                 .toList(),
             earthquakeEnabled: resolvedEarthquakeEnabled,
             earthquakeMinIntensity: resolvedEarthquakeEnabled
-                ? (earthquakeMinIntensity ??
-                          currentLocationEarthquakeMinIntensity)
-                      .toApiJmaIntensity
+                ? notificationMinIntensityPolicy
+                      .clamp(
+                        slotType: NotificationSlotType.currentLocation,
+                        kind: NotificationKind.earthquake,
+                        minIntensity:
+                            earthquakeMinIntensity ??
+                            currentLocationEarthquakeMinIntensity,
+                      )
+                      ?.toApiJmaIntensity
                 : null,
             earthquakeOverrides: earthquakeOverrides
                 ?.map((o) => o.toApiSlotOverride())
@@ -91,14 +113,32 @@ class NotificationSlotRepository {
   /// 通知スロットを全件置換する
   ///
   /// 既存スロットはサーバ側で削除されるため、渡した構成がそのまま反映される。
+  /// カスタム設定のスナップショット復元など下限導入前の値が混じる経路があるため、
+  /// 最小震度はスロット種別ごとの下限まで引き上げてから送信する。
   Future<List<NotificationSlot>> replaceSlots(
     List<NotificationSlotDraft> slots,
   ) async {
     final response = await _api.device.putV2DeviceMeSettingsSlots(
-      body: slots.map((slot) => slot.toApiReplaceSlotEntry()).toList(),
+      body: slots
+          .map((slot) => _clampDraftMinIntensity(slot).toApiReplaceSlotEntry())
+          .toList(),
     );
     return response.data.map((s) => s.toNotificationSlot()).toList();
   }
+
+  NotificationSlotDraft _clampDraftMinIntensity(NotificationSlotDraft slot) =>
+      slot.copyWith(
+        eewMinIntensity: notificationMinIntensityPolicy.clamp(
+          slotType: slot.slotType,
+          kind: NotificationKind.eew,
+          minIntensity: slot.eewMinIntensity,
+        ),
+        earthquakeMinIntensity: notificationMinIntensityPolicy.clamp(
+          slotType: slot.slotType,
+          kind: NotificationKind.earthquake,
+          minIntensity: slot.earthquakeMinIntensity,
+        ),
+      );
 
   Future<void> deleteCurrentLocation() async {
     await _api.device.deleteV2DeviceMeSettingsSlotsCurrentLocation();
@@ -130,12 +170,19 @@ class NotificationSlotRepository {
       body: api.UpsertSingletonSlotRequest(
         eewEnabled: resolvedEewEnabled,
         eewMinIntensity: _minIntensityResolver
-            .resolve(enabled: resolvedEewEnabled, minIntensity: eewMinIntensity)
+            .resolve(
+              slotType: NotificationSlotType.nationwide,
+              kind: NotificationKind.eew,
+              enabled: resolvedEewEnabled,
+              minIntensity: eewMinIntensity,
+            )
             ?.toApiJmaIntensity,
         eewOverrides: eewOverrides?.map((o) => o.toApiSlotOverride()).toList(),
         earthquakeEnabled: resolvedEarthquakeEnabled,
         earthquakeMinIntensity: _minIntensityResolver
             .resolve(
+              slotType: NotificationSlotType.nationwide,
+              kind: NotificationKind.earthquake,
               enabled: resolvedEarthquakeEnabled,
               minIntensity: earthquakeMinIntensity,
             )
@@ -172,12 +219,19 @@ class NotificationSlotRepository {
         cityName: cityName,
         eewEnabled: eewEnabled,
         eewMinIntensity: _minIntensityResolver
-            .resolve(enabled: eewEnabled, minIntensity: eewMinIntensity)
+            .resolve(
+              slotType: NotificationSlotType.region,
+              kind: NotificationKind.eew,
+              enabled: eewEnabled,
+              minIntensity: eewMinIntensity,
+            )
             ?.toApiJmaIntensity,
         eewOverrides: eewOverrides?.map((o) => o.toApiSlotOverride()).toList(),
         earthquakeEnabled: earthquakeEnabled,
         earthquakeMinIntensity: _minIntensityResolver
             .resolve(
+              slotType: NotificationSlotType.region,
+              kind: NotificationKind.earthquake,
               enabled: earthquakeEnabled,
               minIntensity: earthquakeMinIntensity,
             )
@@ -211,7 +265,12 @@ class NotificationSlotRepository {
             cityName: cityName,
             eewEnabled: eewEnabled,
             eewMinIntensity: _minIntensityResolver
-                .resolve(enabled: eewEnabled, minIntensity: eewMinIntensity)
+                .resolve(
+                  slotType: NotificationSlotType.region,
+                  kind: NotificationKind.eew,
+                  enabled: eewEnabled,
+                  minIntensity: eewMinIntensity,
+                )
                 ?.toApiJmaIntensity,
             eewOverrides: eewOverrides
                 ?.map((o) => o.toApiSlotOverride())
@@ -219,6 +278,8 @@ class NotificationSlotRepository {
             earthquakeEnabled: earthquakeEnabled,
             earthquakeMinIntensity: _minIntensityResolver
                 .resolve(
+                  slotType: NotificationSlotType.region,
+                  kind: NotificationKind.earthquake,
                   enabled: earthquakeEnabled,
                   minIntensity: earthquakeMinIntensity,
                 )
@@ -246,11 +307,14 @@ class NotificationSlotRepository {
 
   Future<EewWarningSettings> patchEewWarningConfig({
     EewWarningTarget? target,
+    InterruptionLevel? currentLocationInterruptionLevel,
     InterruptionLevel? nationwideInterruptionLevel,
   }) async {
     final response = await _api.device.patchV2DeviceMeSettingsEewWarning(
       body: api.EewWarningConfigRequest(
         target: target?.toApiTarget,
+        currentLocationInterruptionLevel: currentLocationInterruptionLevel
+            ?.toApiCurrentLocationInterruptionLevel,
         nationwideInterruptionLevel:
             nationwideInterruptionLevel?.toApiNationwideInterruptionLevel,
       ),

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_min_intensity_field.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_min_intensity_field.dart
@@ -26,19 +26,25 @@ class NotificationMinIntensityField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final resolved =
-        value != null && JmaIntensity.selectableValues.contains(value)
-        ? value
-        : switch ((slotType, kind)) {
-            (NotificationSlotType.currentLocation, NotificationKind.eew) =>
-              currentLocationEewMinIntensity,
-            (
-              NotificationSlotType.currentLocation,
-              NotificationKind.earthquake,
-            ) =>
-              currentLocationEarthquakeMinIntensity,
-            _ => defaultNotificationSlotMinIntensity,
-          };
+    final options = notificationMinIntensityPolicy.optionsOf(
+      slotType: slotType,
+      kind: kind,
+    );
+    final fallback = switch ((slotType, kind)) {
+      (NotificationSlotType.currentLocation, NotificationKind.eew) =>
+        currentLocationEewMinIntensity,
+      (NotificationSlotType.currentLocation, NotificationKind.earthquake) =>
+        currentLocationEarthquakeMinIntensity,
+      _ => defaultNotificationSlotMinIntensity,
+    };
+    // 下限導入前に保存された値・選択肢外の値は下限へ引き上げて表示する
+    final resolved = notificationMinIntensityPolicy.clamp(
+      slotType: slotType,
+      kind: kind,
+      minIntensity: JmaIntensity.selectableValues.contains(value)
+          ? value
+          : fallback,
+    );
 
     return DropdownMenu<JmaIntensity>(
       initialSelection: resolved,
@@ -51,7 +57,7 @@ class NotificationMinIntensityField extends StatelessWidget {
         }
       },
       dropdownMenuEntries: [
-        for (final intensity in JmaIntensity.selectableValues)
+        for (final intensity in options)
           DropdownMenuEntry(
             value: intensity,
             label: intensity.minIntensityLabel,

--- a/app/lib/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart
@@ -36,7 +36,8 @@ class SlotDetailPage extends HookConsumerWidget {
     final warningEnabled = ref.watch(
       eewGlobalSettingsProvider.select((s) => s.value?.warningEnabled ?? true),
     );
-    final warningTarget = ref.watch(eewWarningConfigProvider).value?.target;
+    final warningConfig = ref.watch(eewWarningConfigProvider).value;
+    final warningTarget = warningConfig?.target;
 
     void listenMutationError(Mutation<void> mutation) {
       ref.listen(mutation, (_, next) async {
@@ -101,11 +102,18 @@ class SlotDetailPage extends HookConsumerWidget {
                 if (slot.slotType != NotificationSlotType.region) ...[
                   const SettingsSectionHeader(text: '緊急地震速報（警報）'),
                   _WarningSettingsCard(
+                    slotType: slot.slotType,
                     enabled:
                         slot.slotType == NotificationSlotType.currentLocation
                         ? warningEnabled
                         : warningTarget ==
                               EewWarningTarget.currentLocationAndNationwide,
+                    interruptionLevel:
+                        slot.slotType == NotificationSlotType.currentLocation
+                        ? (warningConfig?.currentLocationInterruptionLevel ??
+                              currentLocationEewWarningDefaultLevel)
+                        : (warningConfig?.nationwideInterruptionLevel ??
+                              nationwideEewWarningDefaultLevel),
                     onChanged: (next) async {
                       switch (slot.slotType) {
                         case NotificationSlotType.currentLocation:
@@ -116,6 +124,23 @@ class SlotDetailPage extends HookConsumerWidget {
                           await ref
                               .read(eewWarningSettingsActionProvider)
                               .updateNationwide(ref, enabled: next);
+                        case NotificationSlotType.region:
+                          return;
+                      }
+                    },
+                    onInterruptionLevelChanged: (next) async {
+                      final action = ref.read(eewWarningSettingsActionProvider);
+                      switch (slot.slotType) {
+                        case NotificationSlotType.currentLocation:
+                          await action.updateCurrentLocationInterruptionLevel(
+                            ref,
+                            level: next,
+                          );
+                        case NotificationSlotType.nationwide:
+                          await action.updateNationwideInterruptionLevel(
+                            ref,
+                            level: next,
+                          );
                         case NotificationSlotType.region:
                           return;
                       }
@@ -268,10 +293,19 @@ class _NotificationConditionCard extends StatelessWidget {
 }
 
 class _WarningSettingsCard extends StatelessWidget {
-  const new({required this.enabled, required this.onChanged});
+  const new({
+    required this.slotType,
+    required this.enabled,
+    required this.interruptionLevel,
+    required this.onChanged,
+    required this.onInterruptionLevelChanged,
+  });
 
+  final NotificationSlotType slotType;
   final bool enabled;
+  final InterruptionLevel interruptionLevel;
   final ValueChanged<bool> onChanged;
+  final ValueChanged<InterruptionLevel> onInterruptionLevelChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -304,10 +338,37 @@ class _WarningSettingsCard extends StatelessWidget {
             onTap: () => onChanged(!enabled),
           ),
           const Divider(height: 1),
+          ListTile(
+            enabled: enabled,
+            title: const Text('割り込みレベル'),
+            trailing: DropdownMenu<InterruptionLevel>(
+              initialSelection: interruptionLevel,
+              enabled: enabled,
+              requestFocusOnTap: false,
+              width: 180,
+              onSelected: (next) {
+                if (next != null) {
+                  onInterruptionLevelChanged(next);
+                }
+              },
+              dropdownMenuEntries: [
+                for (final level in InterruptionLevel.values)
+                  DropdownMenuEntry(value: level, label: level.label),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
           Padding(
             padding: EdgeInsets.all(spacing.md),
             child: Text(
-              '緊急地震速報（警報）は、現在地や全国を対象に重大な通知として配信されます。',
+              switch (slotType) {
+                NotificationSlotType.currentLocation =>
+                  '現在地が警報地域に入ったときに配信されます。'
+                      'クリティカルにすると、おやすみモードやマナーモードを無視して通知します。',
+                _ =>
+                  '日本のどこかで緊急地震速報（警報）が発表されるたびに配信されます。'
+                      '発表回数が多いため、既定は「時間重要」です。',
+              },
               style: designSystem.typography.bodySmall.copyWith(
                 color: colorTheme.onSurfaceVariant,
               ),

--- a/app/test/feature/settings/features/notification_settings/eew_warning_settings_model_test.dart
+++ b/app/test/feature/settings/features/notification_settings/eew_warning_settings_model_test.dart
@@ -8,6 +8,8 @@ void main() {
     test('converts current_location_only target', () {
       const response = api.EewWarningConfigResponse(
         target: api.Target.currentLocationOnly,
+        currentLocationInterruptionLevel:
+            api.CurrentLocationInterruptionLevel.critical,
         nationwideInterruptionLevel: null,
       );
 
@@ -20,6 +22,8 @@ void main() {
     test('converts current_location_and_nationwide target', () {
       const response = api.EewWarningConfigResponse(
         target: api.Target.currentLocationAndNationwide,
+        currentLocationInterruptionLevel:
+            api.CurrentLocationInterruptionLevel.critical,
         nationwideInterruptionLevel: api.NationwideInterruptionLevel.active,
       );
 

--- a/app/test/feature/settings/features/notification_settings/notification_custom_snapshot_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_custom_snapshot_test.dart
@@ -41,6 +41,7 @@ void main() {
       ],
       eewWarning: EewWarningSettings(
         target: EewWarningTarget.currentLocationAndNationwide,
+        currentLocationInterruptionLevel: InterruptionLevel.critical,
         nationwideInterruptionLevel: InterruptionLevel.active,
       ),
       eewGlobal: EewGlobalSettings(

--- a/app/test/feature/settings/features/notification_settings/notification_min_intensity_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_min_intensity_test.dart
@@ -1,5 +1,7 @@
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_kind.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_min_intensity.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -19,6 +21,105 @@ void main() {
     test('予報は震度4、地震情報は震度1', () {
       expect(currentLocationEewMinIntensity, JmaIntensity.four);
       expect(currentLocationEarthquakeMinIntensity, JmaIntensity.one);
+    });
+  });
+
+  group('NotificationMinIntensityPolicy', () {
+    const policy = NotificationMinIntensityPolicy();
+
+    test('全国スロットは「すべて」を含む全選択肢', () {
+      for (final kind in NotificationKind.values) {
+        expect(
+          policy.optionsOf(
+            slotType: NotificationSlotType.nationwide,
+            kind: kind,
+          ),
+          JmaIntensity.selectableValues,
+        );
+        expect(
+          policy.floorOf(slotType: NotificationSlotType.nationwide, kind: kind),
+          isNull,
+        );
+      }
+    });
+
+    test('現在地・地域の EEW は震度4以上のみ', () {
+      for (final slotType in [
+        NotificationSlotType.currentLocation,
+        NotificationSlotType.region,
+      ]) {
+        expect(
+          policy.optionsOf(slotType: slotType, kind: NotificationKind.eew),
+          const [
+            JmaIntensity.four,
+            JmaIntensity.fiveLower,
+            JmaIntensity.fiveUpper,
+            JmaIntensity.sixLower,
+            JmaIntensity.sixUpper,
+            JmaIntensity.seven,
+          ],
+        );
+      }
+    });
+
+    test('現在地・地域の地震情報は震度1以上のみ（「すべて」を含まない）', () {
+      for (final slotType in [
+        NotificationSlotType.currentLocation,
+        NotificationSlotType.region,
+      ]) {
+        final options = policy.optionsOf(
+          slotType: slotType,
+          kind: NotificationKind.earthquake,
+        );
+        expect(options.first, JmaIntensity.one);
+        expect(options, isNot(contains(allMinIntensity)));
+      }
+    });
+
+    test('下限を下回る値は引き上げ、下限以上はそのまま', () {
+      expect(
+        policy.clamp(
+          slotType: NotificationSlotType.region,
+          kind: NotificationKind.eew,
+          minIntensity: allMinIntensity,
+        ),
+        JmaIntensity.four,
+      );
+      expect(
+        policy.clamp(
+          slotType: NotificationSlotType.region,
+          kind: NotificationKind.earthquake,
+          minIntensity: allMinIntensity,
+        ),
+        JmaIntensity.one,
+      );
+      expect(
+        policy.clamp(
+          slotType: NotificationSlotType.currentLocation,
+          kind: NotificationKind.eew,
+          minIntensity: JmaIntensity.sixLower,
+        ),
+        JmaIntensity.sixLower,
+      );
+    });
+
+    test('全国スロットと null はそのまま返す', () {
+      expect(
+        policy.clamp(
+          slotType: NotificationSlotType.nationwide,
+          kind: NotificationKind.eew,
+          minIntensity: allMinIntensity,
+        ),
+        allMinIntensity,
+      );
+      expect(
+        policy.clamp(
+          slotType: NotificationSlotType.region,
+          kind: NotificationKind.eew,
+          minIntensity: null,
+        ),
+        isNull,
+      );
     });
   });
 }

--- a/app/test/feature/settings/features/notification_settings/notification_override_model_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_override_model_test.dart
@@ -89,7 +89,7 @@ void main() {
       );
     });
 
-    test('toApiNationwideInterruptionLevel returns null for unsupported', () {
+    test('toApiNationwideInterruptionLevel maps every level', () {
       expect(
         InterruptionLevel.passive.toApiNationwideInterruptionLevel,
         api.NationwideInterruptionLevel.passive,
@@ -100,11 +100,44 @@ void main() {
       );
       expect(
         InterruptionLevel.timeSensitive.toApiNationwideInterruptionLevel,
-        isNull,
+        api.NationwideInterruptionLevel.timeSensitive,
       );
       expect(
         InterruptionLevel.critical.toApiNationwideInterruptionLevel,
-        isNull,
+        api.NationwideInterruptionLevel.critical,
+      );
+    });
+
+    test('toApiCurrentLocationInterruptionLevel maps every level', () {
+      expect(
+        InterruptionLevel.passive.toApiCurrentLocationInterruptionLevel,
+        api.CurrentLocationInterruptionLevel.passive,
+      );
+      expect(
+        InterruptionLevel.active.toApiCurrentLocationInterruptionLevel,
+        api.CurrentLocationInterruptionLevel.active,
+      );
+      expect(
+        InterruptionLevel.timeSensitive.toApiCurrentLocationInterruptionLevel,
+        api.CurrentLocationInterruptionLevel.timeSensitive,
+      );
+      expect(
+        InterruptionLevel.critical.toApiCurrentLocationInterruptionLevel,
+        api.CurrentLocationInterruptionLevel.critical,
+      );
+    });
+
+    test('ApiCurrentLocationInterruptionLevelConverter maps back', () {
+      expect(
+        api
+            .CurrentLocationInterruptionLevel
+            .timeSensitive
+            .toAppInterruptionLevel,
+        InterruptionLevel.timeSensitive,
+      );
+      expect(
+        api.NationwideInterruptionLevel.critical.toAppInterruptionLevel,
+        InterruptionLevel.critical,
       );
     });
   });
@@ -127,5 +160,4 @@ void main() {
       );
     });
   });
-
 }

--- a/app/test/feature/settings/features/notification_settings/notification_preset_applier_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_preset_applier_test.dart
@@ -40,6 +40,7 @@ const _earthquakeGlobal = EarthquakeGlobalSettings(
 
 const _eewWarning = EewWarningSettings(
   target: EewWarningTarget.currentLocationOnly,
+  currentLocationInterruptionLevel: InterruptionLevel.critical,
   nationwideInterruptionLevel: null,
 );
 
@@ -88,6 +89,8 @@ class _RecordingGeneralNotifier extends GeneralNotificationSettingsNotifier {
       'notificationEnabled': notificationEnabled,
       'nankaiExtraordinaryEnabled': nankaiExtraordinaryEnabled,
       'nankaiRegularEnabled': nankaiRegularEnabled,
+      'vyse60Enabled': vyse60Enabled,
+      'earthquakeNoticeEnabled': earthquakeNoticeEnabled,
     });
   }
 }
@@ -136,6 +139,8 @@ class _RecordingEarthquakeGlobalNotifier
 
 class _RecordingEewWarningNotifier extends EewWarningConfigNotifier {
   final calls = <EewWarningTarget?>[];
+  final currentLocationLevels = <InterruptionLevel?>[];
+  final nationwideLevels = <InterruptionLevel?>[];
 
   @override
   Future<EewWarningSettings> build() async => _eewWarning;
@@ -143,9 +148,12 @@ class _RecordingEewWarningNotifier extends EewWarningConfigNotifier {
   @override
   Future<void> updateConfig({
     EewWarningTarget? target,
+    InterruptionLevel? currentLocationInterruptionLevel,
     InterruptionLevel? nationwideInterruptionLevel,
   }) async {
     calls.add(target);
+    currentLocationLevels.add(currentLocationInterruptionLevel);
+    nationwideLevels.add(nationwideInterruptionLevel);
   }
 }
 
@@ -260,7 +268,22 @@ void main() {
       expect(general.calls.single['notificationEnabled'], isTrue);
       expect(general.calls.single['nankaiExtraordinaryEnabled'], isTrue);
       expect(general.calls.single['nankaiRegularEnabled'], isTrue);
+      expect(general.calls.single['vyse60Enabled'], isTrue);
+      expect(general.calls.single['earthquakeNoticeEnabled'], isTrue);
       expect(eewGlobal.calls.single['startLiveActivity'], isTrue);
+      // EEW 警報は現在地 + 全国対象にする（warningEnabled: true の後に上書き）
+      expect(
+        eewWarning.calls.single,
+        EewWarningTarget.currentLocationAndNationwide,
+      );
+      expect(
+        eewWarning.nationwideLevels.single,
+        InterruptionLevel.timeSensitive,
+      );
+      expect(
+        eewWarning.currentLocationLevels.single,
+        InterruptionLevel.critical,
+      );
       expect(preset.selected, [NotificationPreset.all]);
     });
 
@@ -360,6 +383,7 @@ void main() {
           ],
           eewWarning: EewWarningSettings(
             target: EewWarningTarget.currentLocationAndNationwide,
+            currentLocationInterruptionLevel: InterruptionLevel.critical,
             nationwideInterruptionLevel: InterruptionLevel.active,
           ),
           eewGlobal: _eewGlobal,

--- a/app/test/feature/settings/features/notification_settings/notification_settings_page_eew_warning_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_settings_page_eew_warning_test.dart
@@ -251,6 +251,7 @@ class _FakeEewWarningConfigNotifier extends EewWarningConfigNotifier {
   @override
   Future<EewWarningSettings> build() async => const EewWarningSettings(
     target: EewWarningTarget.currentLocationAndNationwide,
+    currentLocationInterruptionLevel: InterruptionLevel.critical,
     nationwideInterruptionLevel: InterruptionLevel.active,
   );
 }

--- a/app/test/feature/settings/features/notification_settings/notification_slot_repository_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_slot_repository_test.dart
@@ -37,7 +37,7 @@ void main() {
   });
 
   group('putCurrentLocation', () {
-    test('sends selected minimum intensities when enabling', () async {
+    test('clamps minimum intensities below the floor when enabling', () async {
       final slot = await repository.putCurrentLocation(
         eewEnabled: true,
         eewMinIntensity: JmaIntensity.three,
@@ -51,7 +51,7 @@ void main() {
       expect(adapter.lastRequestBody!['eew_enabled'], isTrue);
       expect(
         adapter.lastRequestBody!['eew_min_intensity'],
-        api.JmaIntensity.value3,
+        api.JmaIntensity.value4,
       );
       expect(adapter.lastRequestBody!['earthquake_enabled'], isTrue);
       expect(
@@ -158,7 +158,7 @@ void main() {
   });
 
   group('updateRegion', () {
-    test('sends default eew minimum intensity when enabling eew', () async {
+    test('clamps the default eew minimum intensity to the floor', () async {
       await repository.updateRegion(
         slotId: 'slot-123',
         eewEnabled: true,
@@ -168,7 +168,7 @@ void main() {
       expect(adapter.lastRequestBody!['eew_enabled'], isTrue);
       expect(
         adapter.lastRequestBody!['eew_min_intensity'],
-        api.JmaIntensity.value3,
+        api.JmaIntensity.value4,
       );
       expect(adapter.lastRequestBody!['earthquake_enabled'], isFalse);
       expect(
@@ -212,6 +212,10 @@ void main() {
       final settings = await repository.getEewWarningConfig();
 
       expect(settings.target, EewWarningTarget.currentLocationOnly);
+      expect(
+        settings.currentLocationInterruptionLevel,
+        InterruptionLevel.critical,
+      );
       expect(settings.nationwideInterruptionLevel, isNull);
     });
   });
@@ -220,11 +224,23 @@ void main() {
     test('sends patch and returns updated settings', () async {
       final settings = await repository.patchEewWarningConfig(
         target: EewWarningTarget.currentLocationAndNationwide,
-        nationwideInterruptionLevel: InterruptionLevel.active,
+        currentLocationInterruptionLevel: InterruptionLevel.critical,
+        nationwideInterruptionLevel: InterruptionLevel.timeSensitive,
       );
 
+      expect(
+        adapter.lastRequestBody!['current_location_interruption_level'],
+        api.CurrentLocationInterruptionLevel.critical,
+      );
+      expect(
+        adapter.lastRequestBody!['nationwide_interruption_level'],
+        api.NationwideInterruptionLevel.timeSensitive,
+      );
       expect(settings.target, EewWarningTarget.currentLocationAndNationwide);
-      expect(settings.nationwideInterruptionLevel, InterruptionLevel.active);
+      expect(
+        settings.nationwideInterruptionLevel,
+        InterruptionLevel.timeSensitive,
+      );
     });
   });
 
@@ -394,12 +410,14 @@ final List<Map<String, Object?>> _slotsListResponse = [
 
 const Map<String, String?> _eewWarningResponse = {
   'target': 'current_location_only',
+  'current_location_interruption_level': 'critical',
   'nationwide_interruption_level': null,
 };
 
 const _eewWarningResponseNationwide = {
   'target': 'current_location_and_nationwide',
-  'nationwide_interruption_level': 'active',
+  'current_location_interruption_level': 'critical',
+  'nationwide_interruption_level': 'time_sensitive',
 };
 
 const Map<String, Object?> _eewGlobalResponseEnabled = {

--- a/app/test/feature/settings/features/notification_settings/slot_detail_page_test.dart
+++ b/app/test/feature/settings/features/notification_settings/slot_detail_page_test.dart
@@ -13,7 +13,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:material_ui/material_ui.dart';
 
-const _warningDescription = '緊急地震速報（警報）は、現在地や全国を対象に重大な通知として配信されます。';
+const _currentLocationWarningDescription =
+    '現在地が警報地域に入ったときに配信されます。'
+    'クリティカルにすると、おやすみモードやマナーモードを無視して通知します。';
+const _nationwideWarningDescription =
+    '日本のどこかで緊急地震速報（警報）が発表されるたびに配信されます。'
+    '発表回数が多いため、既定は「時間重要」です。';
 
 void main() {
   testWidgets('current location updates warning and selected EEW intensity', (
@@ -38,7 +43,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('緊急地震速報（警報）'), findsOneWidget);
-    expect(find.text(_warningDescription), findsOneWidget);
+    expect(find.text(_currentLocationWarningDescription), findsOneWidget);
     expect(find.byType(DropdownMenu<JmaIntensity>), findsNWidgets(2));
 
     final warningTile = find.widgetWithText(ListTile, '有効').at(1);
@@ -62,9 +67,30 @@ void main() {
 
     final eewDropdown = find.byType(DropdownMenu<JmaIntensity>).first;
     final dropdown = tester.widget<DropdownMenu<JmaIntensity>>(eewDropdown);
-    dropdown.onSelected?.call(JmaIntensity.three);
+    // 現在地の EEW は震度4未満・「すべて」を選択肢に持たない
+    expect(
+      dropdown.dropdownMenuEntries.map((e) => e.value),
+      const [
+        JmaIntensity.four,
+        JmaIntensity.fiveLower,
+        JmaIntensity.fiveUpper,
+        JmaIntensity.sixLower,
+        JmaIntensity.sixUpper,
+        JmaIntensity.seven,
+      ],
+    );
+    dropdown.onSelected?.call(JmaIntensity.fiveLower);
     await tester.pumpAndSettle();
-    expect(slotsNotifier.lastEewMinIntensity, JmaIntensity.three);
+    expect(slotsNotifier.lastEewMinIntensity, JmaIntensity.fiveLower);
+
+    final earthquakeDropdown = tester.widget<DropdownMenu<JmaIntensity>>(
+      find.byType(DropdownMenu<JmaIntensity>).at(1),
+    );
+    // 現在地の地震情報は震度1以上のみ
+    expect(
+      earthquakeDropdown.dropdownMenuEntries.first.value,
+      JmaIntensity.one,
+    );
   });
 
   testWidgets('nationwide warning can be enabled without Pro', (tester) async {
@@ -85,7 +111,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('緊急地震速報（警報）'), findsOneWidget);
-    expect(find.text(_warningDescription), findsOneWidget);
+    expect(find.text(_nationwideWarningDescription), findsOneWidget);
 
     final warningTile = find.widgetWithText(ListTile, '有効').at(1);
     await tester.ensureVisible(warningTile);
@@ -98,7 +124,7 @@ void main() {
     );
     expect(
       warningNotifier.lastNationwideInterruptionLevel,
-      InterruptionLevel.active,
+      InterruptionLevel.timeSensitive,
     );
     expect(eewNotifier.state.requireValue.warningEnabled, isTrue);
 
@@ -123,7 +149,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('緊急地震速報（警報）'), findsNothing);
-    expect(find.text(_warningDescription), findsNothing);
+    expect(find.text(_currentLocationWarningDescription), findsNothing);
+    expect(find.text(_nationwideWarningDescription), findsNothing);
     expect(find.byType(AppSwitch), findsNWidgets(2));
   });
 }
@@ -208,24 +235,31 @@ class _RecordingEewWarningConfigNotifier extends EewWarningConfigNotifier {
 
   final EewWarningTarget initialTarget;
   EewWarningTarget? lastTarget;
+  InterruptionLevel? lastCurrentLocationInterruptionLevel;
   InterruptionLevel? lastNationwideInterruptionLevel;
 
   @override
   Future<EewWarningSettings> build() async => EewWarningSettings(
     target: initialTarget,
+    currentLocationInterruptionLevel: InterruptionLevel.critical,
     nationwideInterruptionLevel: null,
   );
 
   @override
   Future<void> updateConfig({
     EewWarningTarget? target,
+    InterruptionLevel? currentLocationInterruptionLevel,
     InterruptionLevel? nationwideInterruptionLevel,
   }) async {
     lastTarget = target;
+    lastCurrentLocationInterruptionLevel = currentLocationInterruptionLevel;
     lastNationwideInterruptionLevel = nationwideInterruptionLevel;
     state = AsyncData(
       EewWarningSettings(
         target: target ?? state.requireValue.target,
+        currentLocationInterruptionLevel:
+            currentLocationInterruptionLevel ??
+            state.requireValue.currentLocationInterruptionLevel,
         nationwideInterruptionLevel: nationwideInterruptionLevel,
       ),
     );

--- a/packages/eqmonitor_api/lib/src/clients/device_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/device_api_client.dart
@@ -224,7 +224,7 @@ abstract class DeviceApiClient {
   @GET(DeviceApiClientUrls.getV2DeviceMeSettingsEewWarning)
   Future<HttpResponse<EewWarningConfigResponse>> getV2DeviceMeSettingsEewWarning();
 
-  /// EEW 警報設定を更新（Free プランは nationwide 不可）
+  /// EEW 警報設定を更新
   @PATCH(DeviceApiClientUrls.patchV2DeviceMeSettingsEewWarning)
   Future<HttpResponse<EewWarningConfigResponse>> patchV2DeviceMeSettingsEewWarning({
     @Body() required EewWarningConfigRequest body,

--- a/packages/eqmonitor_api/lib/src/export.dart
+++ b/packages/eqmonitor_api/lib/src/export.dart
@@ -385,6 +385,7 @@ export 'models/slot_type.dart';
 export 'models/eew_min_intensity.dart';
 export 'models/earthquake_min_intensity.dart';
 export 'models/target.dart';
+export 'models/current_location_interruption_level.dart';
 export 'models/nationwide_interruption_level.dart';
 export 'models/framework.dart';
 export 'models/result.dart';

--- a/packages/eqmonitor_api/lib/src/models/current_location_interruption_level.dart
+++ b/packages/eqmonitor_api/lib/src/models/current_location_interruption_level.dart
@@ -5,7 +5,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 @JsonEnum()
-enum NationwideInterruptionLevel {
+enum CurrentLocationInterruptionLevel {
   @JsonValue('passive')
   passive('passive'),
   @JsonValue('active')
@@ -15,7 +15,7 @@ enum NationwideInterruptionLevel {
   @JsonValue('critical')
   critical('critical');
 
-  const NationwideInterruptionLevel(this.json);
+  const CurrentLocationInterruptionLevel(this.json);
 
   final String? json;
   String toJson() {

--- a/packages/eqmonitor_api/lib/src/models/eew_warning_config_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_warning_config_request.dart
@@ -4,6 +4,7 @@
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'current_location_interruption_level.dart';
 import 'nationwide_interruption_level.dart';
 import 'target.dart';
 
@@ -15,6 +16,8 @@ abstract class EewWarningConfigRequest with _$EewWarningConfigRequest {
   const factory EewWarningConfigRequest({
     @JsonKey(includeIfNull: false)
     Target? target,
+    @JsonKey(includeIfNull: false,name: 'current_location_interruption_level')
+    CurrentLocationInterruptionLevel? currentLocationInterruptionLevel,
     @JsonKey(includeIfNull: false,name: 'nationwide_interruption_level')
     NationwideInterruptionLevel? nationwideInterruptionLevel,
   }) = _EewWarningConfigRequest;

--- a/packages/eqmonitor_api/lib/src/models/eew_warning_config_request.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_warning_config_request.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EewWarningConfigRequest {
 
-@JsonKey(includeIfNull: false) Target? get target;@JsonKey(includeIfNull: false, name: 'nationwide_interruption_level') NationwideInterruptionLevel? get nationwideInterruptionLevel;
+@JsonKey(includeIfNull: false) Target? get target;@JsonKey(includeIfNull: false, name: 'current_location_interruption_level') CurrentLocationInterruptionLevel? get currentLocationInterruptionLevel;@JsonKey(includeIfNull: false, name: 'nationwide_interruption_level') NationwideInterruptionLevel? get nationwideInterruptionLevel;
 /// Create a copy of EewWarningConfigRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $EewWarningConfigRequestCopyWith<EewWarningConfigRequest> get copyWith => _$EewW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewWarningConfigRequest&&(identical(other.target, target) || other.target == target)&&(identical(other.nationwideInterruptionLevel, nationwideInterruptionLevel) || other.nationwideInterruptionLevel == nationwideInterruptionLevel));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewWarningConfigRequest&&(identical(other.target, target) || other.target == target)&&(identical(other.currentLocationInterruptionLevel, currentLocationInterruptionLevel) || other.currentLocationInterruptionLevel == currentLocationInterruptionLevel)&&(identical(other.nationwideInterruptionLevel, nationwideInterruptionLevel) || other.nationwideInterruptionLevel == nationwideInterruptionLevel));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,target,nationwideInterruptionLevel);
+int get hashCode => Object.hash(runtimeType,target,currentLocationInterruptionLevel,nationwideInterruptionLevel);
 
 @override
 String toString() {
-  return 'EewWarningConfigRequest(target: $target, nationwideInterruptionLevel: $nationwideInterruptionLevel)';
+  return 'EewWarningConfigRequest(target: $target, currentLocationInterruptionLevel: $currentLocationInterruptionLevel, nationwideInterruptionLevel: $nationwideInterruptionLevel)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $EewWarningConfigRequestCopyWith<$Res>  {
   factory $EewWarningConfigRequestCopyWith(EewWarningConfigRequest value, $Res Function(EewWarningConfigRequest) _then) = _$EewWarningConfigRequestCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(includeIfNull: false) Target? target,@JsonKey(includeIfNull: false, name: 'nationwide_interruption_level') NationwideInterruptionLevel? nationwideInterruptionLevel
+@JsonKey(includeIfNull: false) Target? target,@JsonKey(includeIfNull: false, name: 'current_location_interruption_level') CurrentLocationInterruptionLevel? currentLocationInterruptionLevel,@JsonKey(includeIfNull: false, name: 'nationwide_interruption_level') NationwideInterruptionLevel? nationwideInterruptionLevel
 });
 
 
@@ -66,10 +66,11 @@ class _$EewWarningConfigRequestCopyWithImpl<$Res>
 
 /// Create a copy of EewWarningConfigRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? target = freezed,Object? nationwideInterruptionLevel = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? target = freezed,Object? currentLocationInterruptionLevel = freezed,Object? nationwideInterruptionLevel = freezed,}) {
   return _then(EewWarningConfigRequest(
 target: freezed == target ? _self.target : target // ignore: cast_nullable_to_non_nullable
-as Target?,nationwideInterruptionLevel: freezed == nationwideInterruptionLevel ? _self.nationwideInterruptionLevel : nationwideInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as Target?,currentLocationInterruptionLevel: freezed == currentLocationInterruptionLevel ? _self.currentLocationInterruptionLevel : currentLocationInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as CurrentLocationInterruptionLevel?,nationwideInterruptionLevel: freezed == nationwideInterruptionLevel ? _self.nationwideInterruptionLevel : nationwideInterruptionLevel // ignore: cast_nullable_to_non_nullable
 as NationwideInterruptionLevel?,
   ));
 }
@@ -155,10 +156,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false)  Target? target, @JsonKey(includeIfNull: false, name: 'nationwide_interruption_level')  NationwideInterruptionLevel? nationwideInterruptionLevel)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false)  Target? target, @JsonKey(includeIfNull: false, name: 'current_location_interruption_level')  CurrentLocationInterruptionLevel? currentLocationInterruptionLevel, @JsonKey(includeIfNull: false, name: 'nationwide_interruption_level')  NationwideInterruptionLevel? nationwideInterruptionLevel)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EewWarningConfigRequest() when $default != null:
-return $default(_that.target,_that.nationwideInterruptionLevel);case _:
+return $default(_that.target,_that.currentLocationInterruptionLevel,_that.nationwideInterruptionLevel);case _:
   return orElse();
 
 }
@@ -176,10 +177,10 @@ return $default(_that.target,_that.nationwideInterruptionLevel);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false)  Target? target, @JsonKey(includeIfNull: false, name: 'nationwide_interruption_level')  NationwideInterruptionLevel? nationwideInterruptionLevel)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false)  Target? target, @JsonKey(includeIfNull: false, name: 'current_location_interruption_level')  CurrentLocationInterruptionLevel? currentLocationInterruptionLevel, @JsonKey(includeIfNull: false, name: 'nationwide_interruption_level')  NationwideInterruptionLevel? nationwideInterruptionLevel)  $default,) {final _that = this;
 switch (_that) {
 case _EewWarningConfigRequest():
-return $default(_that.target,_that.nationwideInterruptionLevel);case _:
+return $default(_that.target,_that.currentLocationInterruptionLevel,_that.nationwideInterruptionLevel);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +197,10 @@ return $default(_that.target,_that.nationwideInterruptionLevel);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: false)  Target? target, @JsonKey(includeIfNull: false, name: 'nationwide_interruption_level')  NationwideInterruptionLevel? nationwideInterruptionLevel)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: false)  Target? target, @JsonKey(includeIfNull: false, name: 'current_location_interruption_level')  CurrentLocationInterruptionLevel? currentLocationInterruptionLevel, @JsonKey(includeIfNull: false, name: 'nationwide_interruption_level')  NationwideInterruptionLevel? nationwideInterruptionLevel)?  $default,) {final _that = this;
 switch (_that) {
 case _EewWarningConfigRequest() when $default != null:
-return $default(_that.target,_that.nationwideInterruptionLevel);case _:
+return $default(_that.target,_that.currentLocationInterruptionLevel,_that.nationwideInterruptionLevel);case _:
   return null;
 
 }
@@ -211,10 +212,11 @@ return $default(_that.target,_that.nationwideInterruptionLevel);case _:
 @JsonSerializable()
 
 class _EewWarningConfigRequest implements EewWarningConfigRequest {
-  const _EewWarningConfigRequest({@JsonKey(includeIfNull: false) this.target, @JsonKey(includeIfNull: false, name: 'nationwide_interruption_level') this.nationwideInterruptionLevel});
+  const _EewWarningConfigRequest({@JsonKey(includeIfNull: false) this.target, @JsonKey(includeIfNull: false, name: 'current_location_interruption_level') this.currentLocationInterruptionLevel, @JsonKey(includeIfNull: false, name: 'nationwide_interruption_level') this.nationwideInterruptionLevel});
   factory _EewWarningConfigRequest.fromJson(Map<String, dynamic> json) => _$EewWarningConfigRequestFromJson(json);
 
 @override@JsonKey(includeIfNull: false) final  Target? target;
+@override@JsonKey(includeIfNull: false, name: 'current_location_interruption_level') final  CurrentLocationInterruptionLevel? currentLocationInterruptionLevel;
 @override@JsonKey(includeIfNull: false, name: 'nationwide_interruption_level') final  NationwideInterruptionLevel? nationwideInterruptionLevel;
 
 /// Create a copy of EewWarningConfigRequest
@@ -230,16 +232,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewWarningConfigRequest&&(identical(other.target, target) || other.target == target)&&(identical(other.nationwideInterruptionLevel, nationwideInterruptionLevel) || other.nationwideInterruptionLevel == nationwideInterruptionLevel));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewWarningConfigRequest&&(identical(other.target, target) || other.target == target)&&(identical(other.currentLocationInterruptionLevel, currentLocationInterruptionLevel) || other.currentLocationInterruptionLevel == currentLocationInterruptionLevel)&&(identical(other.nationwideInterruptionLevel, nationwideInterruptionLevel) || other.nationwideInterruptionLevel == nationwideInterruptionLevel));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,target,nationwideInterruptionLevel);
+int get hashCode => Object.hash(runtimeType,target,currentLocationInterruptionLevel,nationwideInterruptionLevel);
 
 @override
 String toString() {
-  return 'EewWarningConfigRequest(target: $target, nationwideInterruptionLevel: $nationwideInterruptionLevel)';
+  return 'EewWarningConfigRequest(target: $target, currentLocationInterruptionLevel: $currentLocationInterruptionLevel, nationwideInterruptionLevel: $nationwideInterruptionLevel)';
 }
 
 
@@ -250,7 +252,7 @@ abstract mixin class _$EewWarningConfigRequestCopyWith<$Res> implements $EewWarn
   factory _$EewWarningConfigRequestCopyWith(_EewWarningConfigRequest value, $Res Function(_EewWarningConfigRequest) _then) = __$EewWarningConfigRequestCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(includeIfNull: false) Target? target,@JsonKey(includeIfNull: false, name: 'nationwide_interruption_level') NationwideInterruptionLevel? nationwideInterruptionLevel
+@JsonKey(includeIfNull: false) Target? target,@JsonKey(includeIfNull: false, name: 'current_location_interruption_level') CurrentLocationInterruptionLevel? currentLocationInterruptionLevel,@JsonKey(includeIfNull: false, name: 'nationwide_interruption_level') NationwideInterruptionLevel? nationwideInterruptionLevel
 });
 
 
@@ -267,10 +269,11 @@ class __$EewWarningConfigRequestCopyWithImpl<$Res>
 
 /// Create a copy of EewWarningConfigRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? target = freezed,Object? nationwideInterruptionLevel = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? target = freezed,Object? currentLocationInterruptionLevel = freezed,Object? nationwideInterruptionLevel = freezed,}) {
   return _then(_EewWarningConfigRequest(
 target: freezed == target ? _self.target : target // ignore: cast_nullable_to_non_nullable
-as Target?,nationwideInterruptionLevel: freezed == nationwideInterruptionLevel ? _self.nationwideInterruptionLevel : nationwideInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as Target?,currentLocationInterruptionLevel: freezed == currentLocationInterruptionLevel ? _self.currentLocationInterruptionLevel : currentLocationInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as CurrentLocationInterruptionLevel?,nationwideInterruptionLevel: freezed == nationwideInterruptionLevel ? _self.nationwideInterruptionLevel : nationwideInterruptionLevel // ignore: cast_nullable_to_non_nullable
 as NationwideInterruptionLevel?,
   ));
 }

--- a/packages/eqmonitor_api/lib/src/models/eew_warning_config_request.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_warning_config_request.g.dart
@@ -19,6 +19,11 @@ _EewWarningConfigRequest _$EewWarningConfigRequestFromJson(
         'target',
         (v) => $enumDecodeNullable(_$TargetEnumMap, v),
       ),
+      currentLocationInterruptionLevel: $checkedConvert(
+        'current_location_interruption_level',
+        (v) =>
+            $enumDecodeNullable(_$CurrentLocationInterruptionLevelEnumMap, v),
+      ),
       nationwideInterruptionLevel: $checkedConvert(
         'nationwide_interruption_level',
         (v) => $enumDecodeNullable(_$NationwideInterruptionLevelEnumMap, v),
@@ -27,6 +32,7 @@ _EewWarningConfigRequest _$EewWarningConfigRequestFromJson(
     return val;
   },
   fieldKeyMap: const {
+    'currentLocationInterruptionLevel': 'current_location_interruption_level',
     'nationwideInterruptionLevel': 'nationwide_interruption_level',
   },
 );
@@ -35,6 +41,8 @@ Map<String, dynamic> _$EewWarningConfigRequestToJson(
   _EewWarningConfigRequest instance,
 ) => <String, dynamic>{
   'target': ?instance.target,
+  'current_location_interruption_level':
+      ?instance.currentLocationInterruptionLevel,
   'nationwide_interruption_level': ?instance.nationwideInterruptionLevel,
 };
 
@@ -43,7 +51,16 @@ const _$TargetEnumMap = {
   Target.currentLocationAndNationwide: 'current_location_and_nationwide',
 };
 
+const _$CurrentLocationInterruptionLevelEnumMap = {
+  CurrentLocationInterruptionLevel.passive: 'passive',
+  CurrentLocationInterruptionLevel.active: 'active',
+  CurrentLocationInterruptionLevel.timeSensitive: 'time_sensitive',
+  CurrentLocationInterruptionLevel.critical: 'critical',
+};
+
 const _$NationwideInterruptionLevelEnumMap = {
   NationwideInterruptionLevel.passive: 'passive',
   NationwideInterruptionLevel.active: 'active',
+  NationwideInterruptionLevel.timeSensitive: 'time_sensitive',
+  NationwideInterruptionLevel.critical: 'critical',
 };

--- a/packages/eqmonitor_api/lib/src/models/eew_warning_config_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_warning_config_response.dart
@@ -4,6 +4,7 @@
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'current_location_interruption_level.dart';
 import 'nationwide_interruption_level.dart';
 import 'target.dart';
 
@@ -14,6 +15,8 @@ part 'eew_warning_config_response.g.dart';
 abstract class EewWarningConfigResponse with _$EewWarningConfigResponse {
   const factory EewWarningConfigResponse({
     required Target target,
+    @JsonKey(name: 'current_location_interruption_level')
+    required CurrentLocationInterruptionLevel currentLocationInterruptionLevel,
     @JsonKey(includeIfNull: true,name: 'nationwide_interruption_level')
     required NationwideInterruptionLevel? nationwideInterruptionLevel,
   }) = _EewWarningConfigResponse;

--- a/packages/eqmonitor_api/lib/src/models/eew_warning_config_response.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_warning_config_response.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EewWarningConfigResponse {
 
- Target get target;@JsonKey(includeIfNull: true, name: 'nationwide_interruption_level') NationwideInterruptionLevel? get nationwideInterruptionLevel;
+ Target get target;@JsonKey(name: 'current_location_interruption_level') CurrentLocationInterruptionLevel get currentLocationInterruptionLevel;@JsonKey(includeIfNull: true, name: 'nationwide_interruption_level') NationwideInterruptionLevel? get nationwideInterruptionLevel;
 /// Create a copy of EewWarningConfigResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $EewWarningConfigResponseCopyWith<EewWarningConfigResponse> get copyWith => _$Ee
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewWarningConfigResponse&&(identical(other.target, target) || other.target == target)&&(identical(other.nationwideInterruptionLevel, nationwideInterruptionLevel) || other.nationwideInterruptionLevel == nationwideInterruptionLevel));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewWarningConfigResponse&&(identical(other.target, target) || other.target == target)&&(identical(other.currentLocationInterruptionLevel, currentLocationInterruptionLevel) || other.currentLocationInterruptionLevel == currentLocationInterruptionLevel)&&(identical(other.nationwideInterruptionLevel, nationwideInterruptionLevel) || other.nationwideInterruptionLevel == nationwideInterruptionLevel));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,target,nationwideInterruptionLevel);
+int get hashCode => Object.hash(runtimeType,target,currentLocationInterruptionLevel,nationwideInterruptionLevel);
 
 @override
 String toString() {
-  return 'EewWarningConfigResponse(target: $target, nationwideInterruptionLevel: $nationwideInterruptionLevel)';
+  return 'EewWarningConfigResponse(target: $target, currentLocationInterruptionLevel: $currentLocationInterruptionLevel, nationwideInterruptionLevel: $nationwideInterruptionLevel)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $EewWarningConfigResponseCopyWith<$Res>  {
   factory $EewWarningConfigResponseCopyWith(EewWarningConfigResponse value, $Res Function(EewWarningConfigResponse) _then) = _$EewWarningConfigResponseCopyWithImpl;
 @useResult
 $Res call({
- Target target,@JsonKey(includeIfNull: true, name: 'nationwide_interruption_level') NationwideInterruptionLevel? nationwideInterruptionLevel
+ Target target,@JsonKey(name: 'current_location_interruption_level') CurrentLocationInterruptionLevel currentLocationInterruptionLevel,@JsonKey(includeIfNull: true, name: 'nationwide_interruption_level') NationwideInterruptionLevel? nationwideInterruptionLevel
 });
 
 
@@ -66,10 +66,11 @@ class _$EewWarningConfigResponseCopyWithImpl<$Res>
 
 /// Create a copy of EewWarningConfigResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? target = null,Object? nationwideInterruptionLevel = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? target = null,Object? currentLocationInterruptionLevel = null,Object? nationwideInterruptionLevel = freezed,}) {
   return _then(EewWarningConfigResponse(
 target: null == target ? _self.target : target // ignore: cast_nullable_to_non_nullable
-as Target,nationwideInterruptionLevel: freezed == nationwideInterruptionLevel ? _self.nationwideInterruptionLevel : nationwideInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as Target,currentLocationInterruptionLevel: null == currentLocationInterruptionLevel ? _self.currentLocationInterruptionLevel : currentLocationInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as CurrentLocationInterruptionLevel,nationwideInterruptionLevel: freezed == nationwideInterruptionLevel ? _self.nationwideInterruptionLevel : nationwideInterruptionLevel // ignore: cast_nullable_to_non_nullable
 as NationwideInterruptionLevel?,
   ));
 }
@@ -155,10 +156,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Target target, @JsonKey(includeIfNull: true, name: 'nationwide_interruption_level')  NationwideInterruptionLevel? nationwideInterruptionLevel)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Target target, @JsonKey(name: 'current_location_interruption_level')  CurrentLocationInterruptionLevel currentLocationInterruptionLevel, @JsonKey(includeIfNull: true, name: 'nationwide_interruption_level')  NationwideInterruptionLevel? nationwideInterruptionLevel)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EewWarningConfigResponse() when $default != null:
-return $default(_that.target,_that.nationwideInterruptionLevel);case _:
+return $default(_that.target,_that.currentLocationInterruptionLevel,_that.nationwideInterruptionLevel);case _:
   return orElse();
 
 }
@@ -176,10 +177,10 @@ return $default(_that.target,_that.nationwideInterruptionLevel);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Target target, @JsonKey(includeIfNull: true, name: 'nationwide_interruption_level')  NationwideInterruptionLevel? nationwideInterruptionLevel)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Target target, @JsonKey(name: 'current_location_interruption_level')  CurrentLocationInterruptionLevel currentLocationInterruptionLevel, @JsonKey(includeIfNull: true, name: 'nationwide_interruption_level')  NationwideInterruptionLevel? nationwideInterruptionLevel)  $default,) {final _that = this;
 switch (_that) {
 case _EewWarningConfigResponse():
-return $default(_that.target,_that.nationwideInterruptionLevel);case _:
+return $default(_that.target,_that.currentLocationInterruptionLevel,_that.nationwideInterruptionLevel);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +197,10 @@ return $default(_that.target,_that.nationwideInterruptionLevel);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Target target, @JsonKey(includeIfNull: true, name: 'nationwide_interruption_level')  NationwideInterruptionLevel? nationwideInterruptionLevel)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Target target, @JsonKey(name: 'current_location_interruption_level')  CurrentLocationInterruptionLevel currentLocationInterruptionLevel, @JsonKey(includeIfNull: true, name: 'nationwide_interruption_level')  NationwideInterruptionLevel? nationwideInterruptionLevel)?  $default,) {final _that = this;
 switch (_that) {
 case _EewWarningConfigResponse() when $default != null:
-return $default(_that.target,_that.nationwideInterruptionLevel);case _:
+return $default(_that.target,_that.currentLocationInterruptionLevel,_that.nationwideInterruptionLevel);case _:
   return null;
 
 }
@@ -211,10 +212,11 @@ return $default(_that.target,_that.nationwideInterruptionLevel);case _:
 @JsonSerializable()
 
 class _EewWarningConfigResponse implements EewWarningConfigResponse {
-  const _EewWarningConfigResponse({required this.target, @JsonKey(includeIfNull: true, name: 'nationwide_interruption_level') required this.nationwideInterruptionLevel});
+  const _EewWarningConfigResponse({required this.target, @JsonKey(name: 'current_location_interruption_level') required this.currentLocationInterruptionLevel, @JsonKey(includeIfNull: true, name: 'nationwide_interruption_level') required this.nationwideInterruptionLevel});
   factory _EewWarningConfigResponse.fromJson(Map<String, dynamic> json) => _$EewWarningConfigResponseFromJson(json);
 
 @override final  Target target;
+@override@JsonKey(name: 'current_location_interruption_level') final  CurrentLocationInterruptionLevel currentLocationInterruptionLevel;
 @override@JsonKey(includeIfNull: true, name: 'nationwide_interruption_level') final  NationwideInterruptionLevel? nationwideInterruptionLevel;
 
 /// Create a copy of EewWarningConfigResponse
@@ -230,16 +232,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewWarningConfigResponse&&(identical(other.target, target) || other.target == target)&&(identical(other.nationwideInterruptionLevel, nationwideInterruptionLevel) || other.nationwideInterruptionLevel == nationwideInterruptionLevel));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewWarningConfigResponse&&(identical(other.target, target) || other.target == target)&&(identical(other.currentLocationInterruptionLevel, currentLocationInterruptionLevel) || other.currentLocationInterruptionLevel == currentLocationInterruptionLevel)&&(identical(other.nationwideInterruptionLevel, nationwideInterruptionLevel) || other.nationwideInterruptionLevel == nationwideInterruptionLevel));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,target,nationwideInterruptionLevel);
+int get hashCode => Object.hash(runtimeType,target,currentLocationInterruptionLevel,nationwideInterruptionLevel);
 
 @override
 String toString() {
-  return 'EewWarningConfigResponse(target: $target, nationwideInterruptionLevel: $nationwideInterruptionLevel)';
+  return 'EewWarningConfigResponse(target: $target, currentLocationInterruptionLevel: $currentLocationInterruptionLevel, nationwideInterruptionLevel: $nationwideInterruptionLevel)';
 }
 
 
@@ -250,7 +252,7 @@ abstract mixin class _$EewWarningConfigResponseCopyWith<$Res> implements $EewWar
   factory _$EewWarningConfigResponseCopyWith(_EewWarningConfigResponse value, $Res Function(_EewWarningConfigResponse) _then) = __$EewWarningConfigResponseCopyWithImpl;
 @override @useResult
 $Res call({
- Target target,@JsonKey(includeIfNull: true, name: 'nationwide_interruption_level') NationwideInterruptionLevel? nationwideInterruptionLevel
+ Target target,@JsonKey(name: 'current_location_interruption_level') CurrentLocationInterruptionLevel currentLocationInterruptionLevel,@JsonKey(includeIfNull: true, name: 'nationwide_interruption_level') NationwideInterruptionLevel? nationwideInterruptionLevel
 });
 
 
@@ -267,10 +269,11 @@ class __$EewWarningConfigResponseCopyWithImpl<$Res>
 
 /// Create a copy of EewWarningConfigResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? target = null,Object? nationwideInterruptionLevel = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? target = null,Object? currentLocationInterruptionLevel = null,Object? nationwideInterruptionLevel = freezed,}) {
   return _then(_EewWarningConfigResponse(
 target: null == target ? _self.target : target // ignore: cast_nullable_to_non_nullable
-as Target,nationwideInterruptionLevel: freezed == nationwideInterruptionLevel ? _self.nationwideInterruptionLevel : nationwideInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as Target,currentLocationInterruptionLevel: null == currentLocationInterruptionLevel ? _self.currentLocationInterruptionLevel : currentLocationInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as CurrentLocationInterruptionLevel,nationwideInterruptionLevel: freezed == nationwideInterruptionLevel ? _self.nationwideInterruptionLevel : nationwideInterruptionLevel // ignore: cast_nullable_to_non_nullable
 as NationwideInterruptionLevel?,
   ));
 }

--- a/packages/eqmonitor_api/lib/src/models/eew_warning_config_response.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_warning_config_response.g.dart
@@ -16,6 +16,10 @@ _EewWarningConfigResponse _$EewWarningConfigResponseFromJson(
   ($checkedConvert) {
     final val = _EewWarningConfigResponse(
       target: $checkedConvert('target', (v) => $enumDecode(_$TargetEnumMap, v)),
+      currentLocationInterruptionLevel: $checkedConvert(
+        'current_location_interruption_level',
+        (v) => $enumDecode(_$CurrentLocationInterruptionLevelEnumMap, v),
+      ),
       nationwideInterruptionLevel: $checkedConvert(
         'nationwide_interruption_level',
         (v) => $enumDecodeNullable(_$NationwideInterruptionLevelEnumMap, v),
@@ -24,6 +28,7 @@ _EewWarningConfigResponse _$EewWarningConfigResponseFromJson(
     return val;
   },
   fieldKeyMap: const {
+    'currentLocationInterruptionLevel': 'current_location_interruption_level',
     'nationwideInterruptionLevel': 'nationwide_interruption_level',
   },
 );
@@ -32,6 +37,8 @@ Map<String, dynamic> _$EewWarningConfigResponseToJson(
   _EewWarningConfigResponse instance,
 ) => <String, dynamic>{
   'target': instance.target,
+  'current_location_interruption_level':
+      instance.currentLocationInterruptionLevel,
   'nationwide_interruption_level': instance.nationwideInterruptionLevel,
 };
 
@@ -40,7 +47,16 @@ const _$TargetEnumMap = {
   Target.currentLocationAndNationwide: 'current_location_and_nationwide',
 };
 
+const _$CurrentLocationInterruptionLevelEnumMap = {
+  CurrentLocationInterruptionLevel.passive: 'passive',
+  CurrentLocationInterruptionLevel.active: 'active',
+  CurrentLocationInterruptionLevel.timeSensitive: 'time_sensitive',
+  CurrentLocationInterruptionLevel.critical: 'critical',
+};
+
 const _$NationwideInterruptionLevelEnumMap = {
   NationwideInterruptionLevel.passive: 'passive',
   NationwideInterruptionLevel.active: 'active',
+  NationwideInterruptionLevel.timeSensitive: 'time_sensitive',
+  NationwideInterruptionLevel.critical: 'critical',
 };


### PR DESCRIPTION
## 背景

通知プリセット「すべて」の説明は「すべての緊急地震速報・地震情報を通知します」だが、実際には届かないものが残っていた。

- **VZSE40（地震・津波に関するお知らせ）が届かない**: `earthquakeNoticeEnabled` の DB 既定値が `false` で、プリセットも触っていなかった
- **全国の EEW警報が届かない**: `eew_warning_config.target` が `current_location_only` のままで、プリセットが上書きしていなかった
- **現在地・地域スロットで「すべて」(震度0) が選べる**: 自分と関係のない全国のすべての EEW/地震情報が現在地スロット経由で流れてしまう
- **EEW警報の割り込みレベルが設定できない**: 現在地も全国も配信側で critical 固定

## 変更内容

### プリセット「すべて」

`notification_preset_applier.dart`:

- `earthquakeNoticeEnabled`（VZSE40）と `vyse60Enabled`（北海道・三陸沖後発地震注意情報）を ON にする
- EEW警報を現在地 + 全国対象にする `applyNationwideWarning` ステップを追加

`PATCH /settings/eew` の `warning_enabled: true` はサーバ側で target を `current_location_only` へ戻すため、**`updateGlobals` の後**に target を上書きしています。

### 最小震度の下限

`NotificationMinIntensityPolicy` を新設。

| スロット | EEW(予報) | 地震情報 |
|---|---|---|
| 現在地・地域 | 震度4以上 〜 震度7 | 震度1以上 〜 震度7 |
| 全国 | すべて 〜 震度7（従来どおり） | すべて 〜 震度7（従来どおり） |

- UI の選択肢を絞るだけでなく、`NotificationSlotRepository` の全経路（`putCurrentLocation` / `addRegion` / `updateRegion` / `replaceSlots`）でクランプ。カスタム設定のスナップショット復元で下限未満の値が戻る経路も塞いでいます
- 下限導入前に保存された値はドロップダウン表示時に下限へ引き上げます

### EEW警報の割り込みレベル

- `EewWarningSettings` に `currentLocationInterruptionLevel` を追加。既定は**現在地 critical / 全国 time_sensitive**
- スロット詳細の警報カードに割り込みレベルのドロップダウンを追加し、スロット種別ごとの配信条件を説明文で出す
- `toApiNationwideInterruptionLevel` が `timeSensitive` / `critical` で null に落ちる（= レベル指定が API に届かない）バグを解消し、`CurrentLocationInterruptionLevel` の変換を追加
- backend の `openapi.json` 更新に伴う `eqmonitor_api` の再生成

## 検証

| 対象 | 結果 |
|---|---|
| `dart analyze` | error 0（変更パスに警告なし） |
| `flutter test test/feature/settings/features/notification_settings test/feature/notification` | 108 passed |

追加・更新したテスト:
- `NotificationMinIntensityPolicy` の選択肢・下限・クランプ（全国は「すべて」を含み、現在地・地域は含まない）
- スロット詳細で現在地の EEW 選択肢が震度4〜7 になること、地震情報が震度1始まりであること
- プリセット「すべて」で VZSE40 / VYSE60 が ON、警報が現在地+全国、レベルが現在地 critical / 全国 time_sensitive になること
- `putCurrentLocation` / `updateRegion` が下限未満の指定をクランプして送ること
- 割り込みレベル変換の4段階往復

## 依存関係

**YumNumm/eqmonitor-backend#1043 に依存します。** 割り込みレベルの API（`current_location_interruption_level`、全国レベルの enum 拡張）と DB カラムは backend 側の PR で追加しています。

この PR には再生成した API クライアントのみ含めており、**submodule pin は更新していません**。backend#1043 が main にマージされた後、別途 `backend` の gitlink を更新してください。それまでは開発環境の API が旧スキーマのため、警報の割り込みレベル変更は 400 になります。

## 補足

- 現在地の割り込みレベルは passive / active も選べます（Pro 制限なし）。生命に関わる通知を静かにできてしまうため、警告文の追加や選択肢の絞り込みが必要なら追って対応します
- `docs/superpowers/specs/2026-08-14-notification-preset-all-redesign-design.md` のプリセット定義表・震度選択 UI 表はこの変更で古くなります

🤖 Generated with [Claude Code](https://claude.com/claude-code)