### PR TITLE
feat: flutter_hooks_lint_plugin を導入する

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -30,6 +30,35 @@ plugins:
       avoid_print: true
       avoid_eqmonitor_api_in_ui: true
       avoid_mixed_declaration_categories: true
+  # flutter_hooks 向けの lint (eslint-plugin-react-hooks 相当)
+  # - exhaustive_keys: useEffect などの keys の過不足を検出
+  # - rules_of_hooks: if/for/while 内での hook 呼び出しを検出
+  flutter_hooks_lint_plugin:
+    version: ^0.8.0
+    diagnostics:
+      exhaustive_keys: true
+      rules_of_hooks: true
+
+# flutter_hooks_lint_plugin 自体のオプション。
+# analyzer の `plugins:` 配下ではなくトップレベルから読まれる
+# (flutter_hooks_lint_plugin/src/lint/config.dart の
+#  FlutterHooksRulesPluginOptions._rootKey)。
+flutter_hooks_lint_plugin:
+  exhaustive_keys:
+    # ここを書くとプラグイン既定値を「置き換える」ため、既定の4つも明記する。
+    constant_hooks:
+      - useRef
+      - useIsMounted
+      - useFocusNode
+      - useContext
+      # useCallback(..., const []) を返すため、ビルド間で参照が変わらない。
+      #
+      # なお useTextEditingController のような「callableなconstオブジェクト」
+      # 形式のフックはここに書いても効かない。プラグインは初期化子が
+      # MethodInvocation の場合しかフック名を見ないため
+      # (exhaustive_keys.dart の _LocalVariableVisitor)。
+      # それらの箇所は個別に `// ignore_keys:` で抑制している。
+      - useMapOperationQueue
 
 linter:
   rules:

--- a/app/lib/core/component/chip/lat_lng_filter_chip.dart
+++ b/app/lib/core/component/chip/lat_lng_filter_chip.dart
@@ -356,6 +356,8 @@ class _CoordField extends HookWidget {
         controller.text = value == null ? '' : value.toString();
       }
       return null;
+      // controller は useTextEditingController が返す不変の参照。
+      // ignore_keys: controller
     }, [value]);
 
     return TextField(

--- a/app/lib/core/component/web_view/app_web_view_page.dart
+++ b/app/lib/core/component/web_view/app_web_view_page.dart
@@ -47,6 +47,9 @@ class AppWebViewPage extends HookWidget {
           );
         },
       ),
+      // navigation はコールバック内で自身を更新するだけの値。keysに入れると
+      // ページ遷移のたびに InAppWebView が作り直されて表示が壊れる。
+      // ignore_keys: navigation.value
       [generation, url],
     );
 

--- a/app/lib/feature/devices/ui/component/device_provisioning_banner.dart
+++ b/app/lib/feature/devices/ui/component/device_provisioning_banner.dart
@@ -163,6 +163,11 @@ class _WaitingBanner extends HookWidget {
         remaining.value = calcRemaining();
       });
       return timer.cancel;
+      // calcRemaining が捕捉するのは resumeAt だけで、それは keys にある。
+      // ローカル関数は毎ビルド識別子が変わるため keys に入れると
+      // Timer が毎ビルド作り直される。resumeAt も calcRemaining 経由で
+      // 実際に使っているので外せない。
+      // ignore_keys: calcRemaining, resumeAt
     }, [resumeAt]);
 
     final colorTheme = context.designSystem.colorTheme;

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -114,6 +114,9 @@ class _ProvisioningStartupSection extends HookConsumerWidget {
       tick();
       final timer = Timer.periodic(const Duration(seconds: 1), (_) => tick());
       return timer.cancel;
+      // マウント時に1度だけTimerを張る意図の const []。tick はローカル関数で
+      // 毎ビルド識別子が変わるため、keysに入れるとTimerが毎ビルド再生成される。
+      // ignore_keys: tick
     }, const []);
 
     final provisionStatus = ref.watch(deviceProvisioningProvider);

--- a/app/lib/feature/earthquake_history/ui/components/current_location_intensity_card.dart
+++ b/app/lib/feature/earthquake_history/ui/components/current_location_intensity_card.dart
@@ -33,6 +33,9 @@ class CurrentLocationIntensityCard extends HookConsumerWidget {
       () => position != null
           ? LatLng(position.latitude, position.longitude)
           : null,
+      // Position はストリーム更新のたびに別インスタンスになるため、
+      // 意図的に緯度経度の値だけを keys にしている。
+      // ignore_keys: position
       [position?.latitude, position?.longitude],
     );
 

--- a/app/lib/feature/earthquake_history/ui/components/modal/earthquake_vxse_debug_editor.dart
+++ b/app/lib/feature/earthquake_history/ui/components/modal/earthquake_vxse_debug_editor.dart
@@ -1686,6 +1686,8 @@ class _JsonEditor extends HookWidget {
         );
       }
       return null;
+      // controller は useTextEditingController が返す不変の参照。
+      // ignore_keys: controller
     }, [state.jsonText]);
 
     return Card.outlined(
@@ -2914,6 +2916,8 @@ class _ControlledTextFormField extends HookWidget {
         );
       }
       return null;
+      // controller は useTextEditingController が返す不変の参照。
+      // ignore_keys: controller
     }, [displayed]);
     return TextFormField(
       key: fieldKey,

--- a/app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart
@@ -127,25 +127,39 @@ class EewForecastRegionLayer extends HookConsumerWidget {
           }),
         );
       };
-    }, [styleController, displayMode, colorModel]);
+      // BaseLayer は静的メンバ参照。regionMaxIntensities はレイヤー生成時の
+      // 初期filterにのみ使っており、以後の更新は下の「データ更新」effectが
+      // 担当する。keysに入れるとEEW更新のたびに全レイヤーが再生成される。
+      // colorModel は paint 生成に使っているため外せない。
+      // ignore_keys: BaseLayer, regionMaxIntensities, colorModel
+    }, [styleController, displayMode, colorModel, intensityFilterUpdater]);
 
     // 震度モード: データ更新
-    useEffect(() {
-      if (styleController == null || displayMode != EewDisplayMode.intensity) {
-        return null;
-      }
+    useEffect(
+      () {
+        if (styleController == null ||
+            displayMode != EewDisplayMode.intensity) {
+          return null;
+        }
 
-      unawaited(
-        enqueue(
-          () => intensityFilterUpdater.update(
-            styleController: styleController,
-            regionMaxIntensities: regionMaxIntensities,
+        unawaited(
+          enqueue(
+            () => intensityFilterUpdater.update(
+              styleController: styleController,
+              regionMaxIntensities: regionMaxIntensities,
+            ),
           ),
-        ),
-      );
+        );
 
-      return null;
-    }, [styleController, displayMode, regionMaxIntensities]);
+        return null;
+      },
+      [
+        styleController,
+        displayMode,
+        regionMaxIntensities,
+        intensityFilterUpdater,
+      ],
+    );
 
     // 警報モード: fill + line の2レイヤー
     useEffect(() {

--- a/app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart
@@ -205,6 +205,9 @@ class EewSimulationPsWaveLayer extends HookConsumerWidget {
         listenerDisposed = true;
         animationController.removeListener(listener);
       };
+      // 本体は ref.read 経由で読むため simulation の直接参照はないが、
+      // 上のコメントの通りリスナーの張り直し契機として意図的に keys に含める。
+      // ignore_keys: simulation
     }, [styleController, simulation, animationController]);
 
     return const SizedBox.shrink();

--- a/app/lib/feature/eew/ui/page/eew_details_by_event_id_page.dart
+++ b/app/lib/feature/eew/ui/page/eew_details_by_event_id_page.dart
@@ -37,7 +37,8 @@ class EewDetailsByEventIdPage extends HookConsumerWidget {
         selectedIndex.value = simulation.currentIndex;
       }
       return null;
-    }, [simulation?.currentIndex]);
+      // isPlaying だけが変わる場合も追従する必要があるため simulation 全体を見る
+    }, [simulation]);
 
     return Scaffold(
       appBar: AppBar(

--- a/app/lib/feature/home/ui/component/map/layer/eew_estimated_intensity_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_estimated_intensity_layer.dart
@@ -43,6 +43,9 @@ class EewEstimatedIntensityLayer extends HookConsumerWidget {
           )
           .values
           .toList();
+      // 'e' は sortedBy のクロージャ引数であり外部の値ではない。
+      // eewRegions は先頭で実際に参照している。
+      // ignore_keys: e, eewRegions
     }, [eewRegions]);
     latestRegionMaxIntensities.value = regionMaxIntensities;
 
@@ -102,6 +105,10 @@ class EewEstimatedIntensityLayer extends HookConsumerWidget {
           }),
         );
       };
+      // BaseLayer は静的メンバ参照であり変数ではない。
+      // colorModel は addLayer の paint 生成に使っているため keys から外せない
+      // (プラグインがネストしたクロージャ内の参照を拾えず誤検出する)。
+      // ignore_keys: BaseLayer, colorModel
     }, [styleController, colorModel]);
 
     // データ更新

--- a/app/lib/feature/home/ui/component/map/layer/eew_hypocenter_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_hypocenter_layer.dart
@@ -86,6 +86,9 @@ class EewHypocenterLayer extends HookConsumerWidget {
         isVisible.value = !isVisible.value;
       });
       return timer.cancel;
+      // isVisible はこのTimer自身がトグルする値。keysに入れると500msごとに
+      // Timerが破棄・再生成され点滅が破綻するため、意図的に含めない。
+      // ignore_keys: isVisible.value
     }, [enableBlink]);
 
     final iconOpacity = isVisible.value ? 1.0 : 0.75;
@@ -222,6 +225,9 @@ class EewHypocenterLayer extends HookConsumerWidget {
           }),
         );
       };
+      // Assets は flutter_gen の静的クラス、latestIconOpacity は useRef。
+      // どちらもビルド間で変化しない。
+      // ignore_keys: Assets, latestIconOpacity
     }, [styleController]);
 
     useEffect(() {
@@ -255,6 +261,10 @@ class EewHypocenterLayer extends HookConsumerWidget {
       );
 
       return null;
+      // 3つとも enqueue に渡すクロージャ内で実際に参照している
+      // (updateGeoJsonSource の features 生成)。keys から外すと
+      // EEWの更新でソースが再描画されなくなるため残す。
+      // ignore_keys: normalEews, lowPreciseEews, iconOpacity
     }, [styleController, normalEews, lowPreciseEews, iconOpacity]);
 
     return const SizedBox.shrink();

--- a/app/lib/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart
@@ -171,6 +171,9 @@ class _EewPsWaveLayerBody extends HookConsumerWidget {
           ),
         );
       };
+      // BaseLayer / EewPsWaveLayer は静的メンバ参照であり変数ではない
+      // (プラグインが型名をローカル変数として誤検出する)。
+      // ignore_keys: BaseLayer, EewPsWaveLayer
     }, [styleController]);
 
     final animationController = useAnimationController(

--- a/app/lib/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart
@@ -65,6 +65,10 @@ class EewWarningRegionsLayer extends HookConsumerWidget {
           }),
         );
       };
+      // codes は初期filterにのみ使用し、以後の更新は latestCodes(useRef) と
+      // 下の更新用effectが担当する。keysに入れるとEEW更新のたびに
+      // レイヤーが再生成される。
+      // ignore_keys: codes
     }, [styleController]);
 
     useEffect(() {

--- a/app/lib/feature/home/ui/component/sheet/component/home_scope_unavailable_body.dart
+++ b/app/lib/feature/home/ui/component/sheet/component/home_scope_unavailable_body.dart
@@ -113,6 +113,9 @@ class _CurrentLocationUnavailable extends HookWidget {
     useEffect(() {
       unawaited(Future.microtask(refreshPermission));
       return null;
+      // マウント時に1度だけ権限を読む意図の const []。ローカル関数は毎ビルド
+      // 識別子が変わるため、keysに入れると毎ビルド再取得してしまう。
+      // ignore_keys: refreshPermission
     }, const []);
 
     // 権限取得中はスケルトンを避けて軽量プレースホルダ

--- a/app/lib/feature/knet_waveform/ui/media/knet_fig_view.dart
+++ b/app/lib/feature/knet_waveform/ui/media/knet_fig_view.dart
@@ -65,6 +65,11 @@ class _FigContent extends HookWidget {
     useEffect(() {
       unawaited(loadImage());
       return null;
+      // loadImage はローカル関数なので毎ビルド識別子が変わる。keysに入れると
+      // 毎ビルド再取得になる。selectedType/eventTime は loadImage 内で
+      // 実際に使っており（プラグインはローカル関数越しの参照を追えない）、
+      // 再ロードの契機そのものなので外せない。
+      // ignore_keys: loadImage, selectedType.value, eventTime
     }, [selectedType.value, eventTime]);
 
     return Column(

--- a/app/lib/feature/knet_waveform/ui/media/knet_movie_view.dart
+++ b/app/lib/feature/knet_waveform/ui/media/knet_movie_view.dart
@@ -76,6 +76,9 @@ class _MovieContent extends HookWidget {
     useEffect(() {
       unawaited(loadVideo(selectedType.value));
       return null;
+      // ローカル関数のため毎ビルド識別子が変わる。keysに入れると毎ビルド
+      // 動画を読み直してしまう。
+      // ignore_keys: loadVideo
     }, [selectedType.value]);
 
     // ページ離脱時にコントローラーを解放
@@ -83,6 +86,10 @@ class _MovieContent extends HookWidget {
       () => () {
         unawaited(controller.value?.dispose());
       },
+      // アンマウント時に「その時点の」controller を解放するための const []。
+      // keysに入れると差し替えのたびにcleanupが走り、loadVideo側の
+      // dispose と二重解放になる。
+      // ignore_keys: controller.value
       const [],
     );
 

--- a/app/lib/feature/knet_waveform/ui/settings/knet_credentials_settings_page.dart
+++ b/app/lib/feature/knet_waveform/ui/settings/knet_credentials_settings_page.dart
@@ -25,6 +25,8 @@ class KnetCredentialsSettingsPage extends HookConsumerWidget {
         }
       });
       return null;
+      // どちらも useTextEditingController が返す不変の参照。
+      // ignore_keys: userIdController, passwordController
     }, [credentials]);
 
     return Scaffold(

--- a/app/lib/feature/live_monitor/ui/components/live_monitor_control_panel.dart
+++ b/app/lib/feature/live_monitor/ui/components/live_monitor_control_panel.dart
@@ -96,6 +96,10 @@ class LiveMonitorControlPanel extends HookConsumerWidget {
 
       durationFocusNode.addListener(handleFocusChanged);
       return () => durationFocusNode.removeListener(handleFocusChanged);
+      // saveDuration は毎ビルド生成されるローカルなクロージャ。keysに入れると
+      // 毎ビルド リスナーの解除・再登録が走る。内部の値は ref.read で
+      // 都度読み直しているため、1度の登録で最新の状態を扱える。
+      // ignore_keys: saveDuration
     }, [durationController, durationFocusNode]);
 
     useEffect(() {

--- a/app/lib/feature/live_monitor/ui/components/live_monitor_map_host.dart
+++ b/app/lib/feature/live_monitor/ui/components/live_monitor_map_host.dart
@@ -66,6 +66,9 @@ class _LiveMonitorMapViewport extends HookConsumerWidget {
       ),
       _ => null,
     };
+    // instanceKey はコールバック本体からは参照されないが、インスタンスを
+    // 作り直す契機そのものなので keys から外せない。
+    // ignore_keys: instanceKey
     final instanceIdentity = useMemoized(instanceOwner.switchInstance, [
       instanceKey,
     ]);

--- a/app/lib/feature/live_monitor/ui/components/live_monitor_split_view.dart
+++ b/app/lib/feature/live_monitor/ui/components/live_monitor_split_view.dart
@@ -26,6 +26,9 @@ class LiveMonitorSplitView extends HookConsumerWidget {
     final storedRatio = isPortrait
         ? settings.portraitRealtimeRatio
         : settings.landscapeRealtimeRatio;
+    // orientation は本体から参照しないが、縦横で別の ValueNotifier を持たせる
+    // ための契機。storedRatio が同値でも作り直したいので keys に残す。
+    // ignore_keys: orientation
     final localRatio = useMemoized(() => ValueNotifier(storedRatio), [
       orientation,
       storedRatio,

--- a/app/lib/feature/nied/ui/aqua/aqua_catalog_page.dart
+++ b/app/lib/feature/nied/ui/aqua/aqua_catalog_page.dart
@@ -61,7 +61,7 @@ class _AquaCatalogList extends HookConsumerWidget {
       );
       final parser = AquaHtmlParser();
       return parser.parseCatalog(bytes: Uint8List.fromList(response.data));
-    }, [selectedMonth]);
+    }, [selectedMonth, niedApiClient]);
 
     final snapshot = useFuture(future);
 

--- a/app/lib/feature/nied/ui/fnet/fnet_catalog_page.dart
+++ b/app/lib/feature/nied/ui/fnet/fnet_catalog_page.dart
@@ -53,7 +53,7 @@ class _FnetCatalogList extends HookConsumerWidget {
         year: selectedMonth?.year ?? now.year,
         month: selectedMonth?.month ?? now.month,
       );
-    }, [selectedMonth]);
+    }, [selectedMonth, niedApiClient]);
 
     final snapshot = useFuture(future);
 

--- a/app/lib/feature/seismicity/ui/layer/hypocenter_pmtiles_layer.dart
+++ b/app/lib/feature/seismicity/ui/layer/hypocenter_pmtiles_layer.dart
@@ -85,6 +85,11 @@ class HypocenterPmTilesLayer extends HookWidget {
           ),
         );
       };
+      // archives はリストの同一性が毎ビルド変わりうるため、安定した
+      // archiveKey を再構築の契機として使っている（archives を直接 keys に
+      // 入れると毎ビルド全ソース・レイヤーを貼り直すことになる）。
+      // tick.value は定期リフレッシュの契機で、本体からは参照しない。
+      // ignore_keys: archives, archiveKey, tick.value
     }, [styleController, archiveKey, colorMode, tick.value]);
 
     return const SizedBox.shrink();

--- a/app/lib/feature/seismicity/ui/seismicity_page.dart
+++ b/app/lib/feature/seismicity/ui/seismicity_page.dart
@@ -68,6 +68,9 @@ class SeismicityPage extends HookConsumerWidget {
       selectedArchiveIds.value = selected.map((archive) => archive.id).toSet();
       hasSynchronizedManifest.value = true;
       return null;
+      // このeffect自身が selectedArchiveIds を書き換えるため、keysに入れると
+      // 無限に再実行される。manifest の変化にのみ追従させる。
+      // ignore_keys: selectedArchiveIds.value
     }, [manifest]);
     final selectedArchives =
         manifest?.archives

--- a/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
+++ b/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
@@ -69,6 +69,9 @@ class _DebugDeviceAdminBody extends HookConsumerWidget {
       }
     }
 
+    // fetch は関数参照で渡しているためプラグインが本体の参照を追えないが、
+    // deviceId は fetch 内で使用し、refreshTick は reload() の再取得契機。
+    // ignore_keys: deviceId, refreshTick.value
     final future = useMemoized(fetch, [deviceId, refreshTick.value]);
     final snapshot = useFuture(future);
 

--- a/app/lib/feature/settings/children/config/debug/earthquake_history/debug_earthquake_history_card_page.dart
+++ b/app/lib/feature/settings/children/config/debug/earthquake_history/debug_earthquake_history_card_page.dart
@@ -68,7 +68,7 @@ class _DebugBody extends HookWidget {
         count: count.value,
         seed: seed.value,
       ),
-      [mode.value, maxIntensity.value, count.value, seed.value],
+      [param, mode.value, maxIntensity.value, count.value, seed.value],
     );
 
     return ListView(

--- a/app/lib/feature/settings/children/config/debug/navigation/navigation_debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/navigation/navigation_debug_page.dart
@@ -40,6 +40,9 @@ class _RouteDropdownMenu extends HookWidget {
             .map((path) => DropdownMenuEntry<String>(value: path, label: path))
             .toList();
       },
+      // keys にリテラルではなく routeBases 自体を渡しているため、
+      // プラグインが keys 側の識別子を拾えず未指定と誤検出する。
+      // ignore_keys: routeBases
       routeBases,
     );
     final pathEditController = useTextEditingController();

--- a/app/lib/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart
+++ b/app/lib/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart
@@ -79,6 +79,9 @@ class DebugNotificationDeliveryLogPage extends HookConsumerWidget {
     useEffect(() {
       unawaited(loadFirstPage());
       return null;
+      // loadFirstPage はローカル関数で毎ビルド識別子が変わるため keys に
+      // 入れると毎ビルド再取得になる。refreshTick は再取得の契機そのもの。
+      // ignore_keys: loadFirstPage, refreshTick.value
     }, [refreshTick.value]);
 
     return Scaffold(

--- a/app/lib/feature/settings/children/config/debug/shared_preferences/debug_shared_preferences_page.dart
+++ b/app/lib/feature/settings/children/config/debug/shared_preferences/debug_shared_preferences_page.dart
@@ -378,22 +378,11 @@ class _ValueEditor extends HookConsumerWidget {
 
     switch (value) {
       case final bool boolValue:
-        final state = useState(boolValue);
-        return Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            SwitchListTile(
-              title: Text(state.value.toString()),
-              value: state.value,
-              onChanged: (v) => state.value = v,
-            ),
-            _SaveButton(
-              onPressed: () => save(
-                (key) =>
-                    editorAction.setBool(ref, kind, key, value: state.value),
-              ),
-            ),
-          ],
+        return _BoolEditor(
+          initialValue: boolValue,
+          onSave: (newValue) => save(
+            (key) => editorAction.setBool(ref, kind, key, value: newValue),
+          ),
         );
       case final int intValue:
         final controller = useTextEditingController(text: intValue.toString());
@@ -445,6 +434,34 @@ class _ValueEditor extends HookConsumerWidget {
       default:
         return Text('未対応の型: ${value.runtimeType}');
     }
+  }
+}
+
+/// bool 用のエディタ。
+///
+/// `_ValueEditor.build` の switch の中で直接 `useState` を呼ぶと、
+/// 値の実行時型によってフックの呼び出し順が変わってしまう
+/// (Rules of Hooks 違反)。専用のHookWidgetへ切り出して回避する。
+class _BoolEditor extends HookWidget {
+  const new({required this.initialValue, required this.onSave});
+
+  final bool initialValue;
+  final ValueChanged<bool> onSave;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = useState(initialValue);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SwitchListTile(
+          title: Text(state.value.toString()),
+          value: state.value,
+          onChanged: (v) => state.value = v,
+        ),
+        _SaveButton(onPressed: () => onSave(state.value)),
+      ],
+    );
   }
 }
 

--- a/app/lib/feature/settings/children/config/debug/telemetry/debug_telemetry_page.dart
+++ b/app/lib/feature/settings/children/config/debug/telemetry/debug_telemetry_page.dart
@@ -33,6 +33,9 @@ class DebugTelemetryPage extends HookConsumerWidget {
         unawaited(refresh());
         return null;
       },
+      // 初回のみ取得する意図の const []。ローカル関数を keys に入れると
+      // 毎ビルド再取得になる。
+      // ignore_keys: refresh
       const [],
     );
 
@@ -77,21 +80,20 @@ class DebugTelemetryPage extends HookConsumerWidget {
         children: [
           _SummaryCard(
             totalCount: totalCount.value,
-            unsyncedCount:
-                events.value.where((e) => !e.synced).length,
+            unsyncedCount: events.value.where((e) => !e.synced).length,
           ),
           const Divider(height: 1),
           Expanded(
             child: isLoading.value
                 ? const Center(child: CircularProgressIndicator.adaptive())
                 : events.value.isEmpty
-                    ? const Center(child: Text('イベントはまだありません'))
-                    : ListView.separated(
-                        itemCount: events.value.length,
-                        separatorBuilder: (_, _) => const Divider(height: 1),
-                        itemBuilder: (context, index) =>
-                            _EventTile(event: events.value[index]),
-                      ),
+                ? const Center(child: Text('イベントはまだありません'))
+                : ListView.separated(
+                    itemCount: events.value.length,
+                    separatorBuilder: (_, _) => const Divider(height: 1),
+                    itemBuilder: (context, index) =>
+                        _EventTile(event: events.value[index]),
+                  ),
           ),
         ],
       ),
@@ -248,7 +250,10 @@ class _EventTile extends StatelessWidget {
                           width: double.infinity,
                           padding: const EdgeInsets.all(12),
                           decoration: BoxDecoration(
-                            color: context.designSystem.colorTheme.surfaceContainerHighest,
+                            color: context
+                                .designSystem
+                                .colorTheme
+                                .surfaceContainerHighest,
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: SelectableText(

--- a/app/lib/feature/settings/features/display_settings/ui/theme/theme_json_dialogs.dart
+++ b/app/lib/feature/settings/features/display_settings/ui/theme/theme_json_dialogs.dart
@@ -47,6 +47,9 @@ class ThemeImportExportSection extends HookConsumerWidget {
         context: context,
         builder: (dialogContext) => HookBuilder(
           builder: (context) {
+            // HookBuilder は独立したフックスコープを作るため、この useState は
+            // 条件分岐下のフック呼び出しには当たらない。
+            // ignore: flutter_hooks_lint_plugin/nested_hooks
             final state = useState<Set<ThemeBrightnessMode>>({...theme.modes});
             return AlertDialog.adaptive(
               title: const Text('適用先を選択'),

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart
@@ -52,6 +52,10 @@ class NotificationPresetSelector extends HookConsumerWidget {
         onChanged(NotificationPreset.none);
       }
       return null;
+      // onChanged は親が毎ビルド生成しうるコールバック。keysに入れると
+      // 親の再ビルドのたびにeffectが再実行される。ここで見たいのは
+      // 権限と選択中プリセットの変化だけ。
+      // ignore_keys: onChanged
     }, [permission, selectedPreset]);
 
     void handlePresetTap(NotificationPreset preset) {

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_layer.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_map_layer.dart
@@ -146,6 +146,10 @@ class NotificationRegionMapLayer extends HookConsumerWidget {
           }),
         );
       };
+      // これらは初期filterにのみ使う。選択変更への追従は下の
+      // 「filter更新」effect (keys に selection を持つ) が担当しており、
+      // keysに入れると選択のたびにレイヤーごと貼り直しになる。
+      // ignore_keys: region, regionCityCodes, cityCode
     }, [style, enqueue, filterBuilder, focusColor, boundaryColor]);
 
     useEffect(() {

--- a/app/lib/feature/start/ui/component/forced_update_dialog.dart
+++ b/app/lib/feature/start/ui/component/forced_update_dialog.dart
@@ -33,6 +33,9 @@ class ForcedUpdateWrapper extends HookConsumerWidget {
     useEffect(() {
       scheduleCheck();
       return null;
+      // 初回のみ実行する意図の const []（更新時の再チェックは下の
+      // ref.listen が担当）。ローカル関数を keys に入れると毎ビルド走る。
+      // ignore_keys: scheduleCheck
     }, const []);
 
     // Start APIが更新されたときにも再チェックする

--- a/app/lib/feature/telegram_list/ui/telegram_list_by_event_id_page.dart
+++ b/app/lib/feature/telegram_list/ui/telegram_list_by_event_id_page.dart
@@ -62,6 +62,9 @@ class TelegramListByEventIdPage extends HookConsumerWidget {
 
       scrollController.addListener(onScroll);
       return () => scrollController.removeListener(onScroll);
+      // telegramListByEventIdProvider はトップレベルのproviderファミリで
+      // 再ビルドで変化する値ではない（プラグインがクラスフィールドと誤認する）。
+      // ignore_keys: telegramListByEventIdProvider
     }, [scrollController]);
 
     return Scaffold(

--- a/app/lib/feature/tsunami/ui/components/tsunami_details_map_view.dart
+++ b/app/lib/feature/tsunami/ui/components/tsunami_details_map_view.dart
@@ -239,6 +239,9 @@ class _TsunamiRegionLineLayer extends HookConsumerWidget {
           ),
         );
       };
+      // layerIds は静的な warningKinds から毎ビルド同じ内容で作り直される
+      // だけのリスト。keysに入れると同一性の変化だけでレイヤーを貼り直す。
+      // ignore_keys: layerIds
     }, [styleController]);
 
     useEffect(() {

--- a/tools/eqmonitor_lints_plugin/pubspec.yaml
+++ b/tools/eqmonitor_lints_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: eqmonitor_lints_plugin
-description: Custom analyzer plugin (lint rules) for EQMonitor. Standalone (not in pub workspace) to use analyzer 13 independently of the app workspace.
+description: Custom analyzer plugin (lint rules) for EQMonitor. Keeps a wide analyzer constraint so it can co-resolve with other analyzer plugins in the analysis server's synthetic plugin package.
 publish_to: none
 
 environment:
@@ -9,7 +9,11 @@ resolution: workspace
 
 dependencies:
   analysis_server_plugin: ^0.3.8
-  analyzer: ^13.0.0
+  # analysis server は analysis_options.yaml の `plugins:` に並ぶ全プラグインを
+  # 1つの合成パッケージへまとめて `pub upgrade` する。
+  # flutter_hooks_lint_plugin ^0.8.0 が analyzer ^14.1.0 を要求するため、
+  # ここを ^13.0.0 に固定すると両プラグインが解決不能になる。
+  analyzer: ">=13.0.0 <15.0.0"
 
 dev_dependencies:
   test: ^1.15.0


### PR DESCRIPTION
## 概要

[flutter_hooks_lint_plugin](https://pub.dev/packages/flutter_hooks_lint_plugin) `^0.8.0` を導入します。eslint-plugin-react-hooks 相当の 2 ルールを有効化しました。

- `exhaustive_keys` — `useEffect` / `useMemoized` の keys の過不足を検出
- `rules_of_hooks` — `if` / `for` / `switch` 内でのフック呼び出しを検出

## `tools/eqmonitor_lints_plugin` の analyzer 制約を緩めた理由

analysis server は `analysis_options.yaml` の `plugins:` に並ぶ**全プラグインを 1 つの合成パッケージへまとめて `pub upgrade`** します（[using_plugins.md](https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server_plugin/doc/using_plugins.md)）。

既存の `eqmonitor_lints_plugin` は `analyzer: ^13.0.0` 固定で、`flutter_hooks_lint_plugin` 0.8.0 は `analyzer: ^14.1.0` を要求するため、そのままだと**依存解決に失敗して両プラグインとも読み込めなくなります**。そのため `>=13.0.0 <15.0.0` へ緩和しました。

app workspace 側の `dependency_overrides: analyzer: ^13.0.0` はプラグインの合成パッケージには効かないため、そちらは変更していません。

## 110 件の指摘への対応

導入直後は `app` に 110 件（`missing_key` 90 / `unnecessary_key` 18 / `nested_hooks` 2）が出ました。内訳と対応は以下です。

### 1. `constant_hooks` に `useMapOperationQueue` を登録 → 49 件解消

`useMapOperationQueue()` は `useCallback(..., const [])` を返す安定参照なので、keys に入れても意味がありません。コード変更なしで最多パターン（`enqueue`）が解消しました。

### 2. 実際に不足していたキーを追加（コード修正）

| 箇所 | 追加したキー |
|---|---|
| `aqua_catalog_page` / `fnet_catalog_page` | `niedApiClient` |
| `eew_forecast_region_layer` | `intensityFilterUpdater` |
| `debug_earthquake_history_card_page` | `param` |
| `eew_details_by_event_id_page` | `simulation`（`isPlaying` のみ変化した場合に追従していなかった） |

### 3. Rules of Hooks 違反を 1 件修正

`debug_shared_preferences_page` の `_ValueEditor.build` が `switch` の分岐内で `useState` を呼んでおり、**値の実行時型でフックの呼び出し順が変わる**状態でした。専用の `_BoolEditor extends HookWidget` へ切り出しています。プラグインが実際のバグを 1 件見つけた形です。

### 4. 残りは理由コメント付きで `// ignore_keys:` 抑制

キーを足すと壊れる／プラグイン側の誤検出、の 2 種です。抑制はすべて 1 行コメントで理由を書いています。

- **キーを足すと壊れる**: `Timer` が自分でトグルする state（`isVisible.value`）、effect 自身が書き換える state（`selectedArchiveIds.value` → 無限ループ）、初期化 effect にデータを入れるとレイヤーごと貼り直しになるケース（各マップレイヤー）、`const []` でマウント時 1 回だけ走らせたい箇所のローカル関数
- **プラグインの誤検出**: 静的クラス参照を変数と誤認（`BaseLayer` / `Assets` / `EewPsWaveLayer`）、クロージャ引数を外部値と誤認（`e`）、keys にリスト literal ではなく変数を渡した場合に keys 側を読めない（`routeBases`）、ネストしたクロージャ内の参照を追えず**実際に使っているキーを `unnecessary` と誤報**（`normalEews` / `lowPreciseEews` / `iconOpacity` 等）

## 検証

`melos run analyze` と同じ `dart analyze . --fatal-infos` を `app` で実行し、フック系の指摘は 0 件です。

```
1 issue found.
error - lib/feature/devices/data/model/registered_device.dart:25:15 -
  The type 'DeviceType' isn't exhaustively matched ... - non_exhaustive_switch_expression
```

残る 1 件は**本 PR と無関係の既存エラー**です（同ファイルは未変更で、プラグイン導入前のベースラインでも同じエラーが出ます）。生成された `DeviceType` に `desktop` が増えた一方、手書きの switch が `android` / `ios` しか見ていないことが原因で、`DevicePlatform` 側に対応する値がないため本 PR では触っていません。

`packages/*` は各パッケージ単位の `dart analyze` ではルート の `plugins:` を拾わないため影響ありません（`packages/core` で確認済み）。

## 既知の注意点

プラグイン 0.8.0 は解析中に **`RangeError` で analysis server の内部エラーを 15 回出します**（本 PR の変更とは無関係で、プラグインを有効にした時点から発生）。`arguments` の要素数が診断メッセージのプレースホルダ数と一致しないパスがあるためで、終了コードには影響しませんがログが汚れます。upstream へ報告予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)