### PR TITLE
refactor: 割り込みレベルの表示名を「重大な通知」などの表現に統一

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_override.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_override.dart
@@ -24,10 +24,10 @@ enum InterruptionLevel { passive, active, timeSensitive, critical }
 
 extension InterruptionLevelLabel on InterruptionLevel {
   String get label => switch (this) {
-    .passive => '通常',
-    .active => 'アクティブ',
-    .timeSensitive => '時間重要',
-    .critical => 'クリティカル',
+    .passive => 'サイレント',
+    .active => 'デフォルト',
+    .timeSensitive => '即時通知',
+    .critical => '重大な通知',
   };
 }
 

--- a/app/lib/feature/settings/features/notification_settings/ui/page/override_edit_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/override_edit_page.dart
@@ -455,7 +455,7 @@ class _OverrideFormDialog extends HookWidget {
                 children: [
                   for (final level in InterruptionLevel.values)
                     RadioListTile<InterruptionLevel>(
-                      title: Text(level.name),
+                      title: Text(level.label),
                       value: level,
                       contentPadding: EdgeInsets.zero,
                       dense: true,

--- a/app/lib/feature/settings/features/notification_settings/ui/page/sound_interruption_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/sound_interruption_settings_page.dart
@@ -190,8 +190,14 @@ class _SoundInterruptionCard extends StatelessWidget {
                   await onSoundChanged(selected);
                 }
               },
-              dropdownMenuEntries:
-NotificationSound.values.map((sound) => DropdownMenuEntry(value: sound, label: sound.displayName)).toList(),
+              dropdownMenuEntries: NotificationSound.values
+                  .map(
+                    (sound) => DropdownMenuEntry(
+                      value: sound,
+                      label: sound.displayName,
+                    ),
+                  )
+                  .toList(),
             ),
           ),
           const Divider(height: 1),
@@ -208,15 +214,7 @@ NotificationSound.values.map((sound) => DropdownMenuEntry(value: sound, label: s
               },
               dropdownMenuEntries: [
                 for (final level in InterruptionLevel.values)
-                  DropdownMenuEntry(
-                    value: level,
-                    label: switch (level) {
-                      .passive => 'サイレント',
-                      .active => 'デフォルト',
-                      .timeSensitive => '即時通知',
-                      .critical => '重大な通知',
-                    },
-                  ),
+                  DropdownMenuEntry(value: level, label: level.label),
               ],
             ),
           ),

--- a/app/test/feature/settings/features/notification_settings/override_edit_page_test.dart
+++ b/app/test/feature/settings/features/notification_settings/override_edit_page_test.dart
@@ -78,12 +78,12 @@ void main() {
     await tester.tap(find.byType(FloatingActionButton));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('デフォルト').last);
+    await tester.tap(find.byType(DropdownButton<NotificationSound>));
     await tester.pumpAndSettle();
     await tester.tap(find.text('EEW警報音').last);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text(InterruptionLevel.critical.name).last);
+    await tester.tap(find.text(InterruptionLevel.critical.label).last);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('追加'));
@@ -127,7 +127,7 @@ void main() {
       InterruptionLevel.active,
     );
 
-    await tester.tap(find.text(InterruptionLevel.passive.name).last);
+    await tester.tap(find.text(InterruptionLevel.passive.label).last);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('保存'));


### PR DESCRIPTION
## 概要

`InterruptionLevel` の表示名が画面ごとに異なっていたため、通知音・優先度設定ページ (`sound_interruption_settings_page.dart`) で使っていた表現に統一しました。

| | Before | After |
| --- | --- | --- |
| `passive` | 通常 | サイレント |
| `active` | アクティブ | デフォルト |
| `timeSensitive` | 時間重要 | 即時通知 |
| `critical` | クリティカル | 重大な通知 |

## 変更点

- `notification_override.dart` — `InterruptionLevelLabel.label` を上記の表現に変更。スロット詳細画面(全国/現在地/地域の通知設定)の「割り込みレベル」はこの label を参照しているため、そのまま反映される
- `sound_interruption_settings_page.dart` — 同じ文言をインラインの `switch` で重複定義していたので `level.label` に寄せて重複を削除
- `override_edit_page.dart` — 震度別設定ダイアログの割り込みレベルが enum 名 (`passive` / `critical` など) を生で表示していたので `level.label` に変更
- 上記に伴い `override_edit_page_test.dart` を更新。通知音の「デフォルト」とレベルの「デフォルト」が同一ダイアログ内で衝突するため、通知音のタップは `find.byType(DropdownButton<NotificationSound>)` に変更

## 確認

- `dart analyze` (notification_settings 配下 lib/test): No issues
- `dart format`: 適用済み
- `flutter test test/feature/settings/features/notification_settings/override_edit_page_test.dart`: All tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)