### PR TITLE
fix(ci): iOS の CFBundleShortVersionString を x.y.z に固定する

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -283,9 +283,21 @@ jobs:
           if [ "$DEPLOY_IOS_EXTERNAL" = "true" ]; then
             BETA_ARGS+=(--dart-define IS_SHAKE_DETECTION_ENABLED="false")
           fi
+          # pubspec の `3.0.0-beta.11` を flutter にそのまま渡すと、iOS 向けサニタイズが
+          # 数字とドット以外を除去して CFBundleShortVersionString が `3.0.0.11` になる。
+          # 4 セグメントは App Store Connect に ITMS-90060 で弾かれるため、
+          # プレリリース識別子とビルドメタデータを落とした x.y.z を明示的に渡す。
+          BUILD_NAME=$(sed -n 's/^version: *\([^ #]*\).*/\1/p' pubspec.yaml)
+          BUILD_NAME=${BUILD_NAME%%-*}
+          BUILD_NAME=${BUILD_NAME%%+*}
+          if ! [[ "$BUILD_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::unexpected build-name '${BUILD_NAME}' derived from app/pubspec.yaml"
+            exit 1
+          fi
           flutter build ios --config-only \
             --no-codesign \
             --no-pub \
+            --build-name="$BUILD_NAME" \
             --build-number=${{ github.run_number }} \
             --dart-define-from-file=../environment/.env.prod \
             --dart-define COMMIT_INFORMATION="$COMMIT_INFORMATION" \


### PR DESCRIPTION
## 事象

beta タグ (`v3.0.0-beta.11`) の Deploy App が App Store Connect 側で FAILED になり、ITMS-90060 が 4 件返っていた。

> The value for key CFBundleShortVersionString '3.0.0.11' ... must be a period-separated list of at most three non-negative integers.

Runner.app / AppIntentExtension.appex / FcmServiceExtension.appex / WidgetExtension.appex の 4 バンドルすべてが対象。いずれも Info.plist で `$(FLUTTER_BUILD_NAME)` を参照している。

該当 run: https://github.com/YumNumm/EQMonitor/actions/runs/32239119958

## 原因

release-please が `app/pubspec.yaml` の version を `3.0.0-beta.11` に更新する。`flutter build ios` は `--build-name` 未指定時にこれをそのまま使い、`validatedBuildNameForPlatform` が iOS 向けに数字とドット以外を除去する。

- `3.0.0-beta.11` → `beta` が消えて `3.0.0.11`
- サニタイズは 3 セグメント未満の穴埋めしかせず、4 セグメントへの切り詰めは行わない

結果 `FLUTTER_BUILD_NAME=3.0.0.11` となり、App Store Connect の 3 セグメント制限に抵触していた。

## 対応

`flutter build ios --config-only` に、プレリリース識別子とビルドメタデータを落とした `x.y.z` を `--build-name` で明示的に渡す。想定外の値になった場合はビルドを止める。

beta ビルドかどうかは `COMMIT_INFORMATION`(タグ名 `v3.0.0-beta.11` がそのまま入る)で従来どおり識別できる。CFBundleVersion は `github.run_number` のままで変更なし。

## 補足(このPRの対象外)

同 run の Android ジョブは `Version code 1157 has already been used.` で失敗しているが、これは run_attempt 2 の再実行で `github.run_number` 由来の versionCode が重複したもので、今回の ITMS-90060 とは別件。

https://claude.ai/code/session_01X4ky3ibHJWHWrh3FfakwEY