### PR TITLE
fix(theme): JMA Standard の震度色を気象庁配色に修正 / ライトの地図背景を白ベースに

### DIFF
--- a/app/lib/core/theme/model/app_theme.dart
+++ b/app/lib/core/theme/model/app_theme.dart
@@ -133,7 +133,8 @@ abstract class AppTheme with _$AppTheme {
         ),
       ),
       mapColors: MapColors(
-        background: Color(0xFF0D1B4A),
+        // 海: 白ベースの淡い色 (陸は白、海岸線で陸海を区別する)
+        background: Color(0xFFEDF3F9),
         worldLand: Color(0xFFFFFFFF),
         worldLine: Color(0xFF6B7280),
         japanLand: Color(0xFFFFFFFF),
@@ -266,6 +267,11 @@ abstract class AppTheme with _$AppTheme {
   bool supportsMode(ThemeBrightnessMode mode) => modes.contains(mode);
 
   // JMA標準カラー: eqmonitorDefaultベースで震度色のみ差し替え
+  //
+  // 色値は気象庁の震度分布図の配色に合わせる。
+  // 震度2が水色(#00AAFF)、震度3が青(#0041FF)で、2の方が明るい。
+  // backend/packages/seismic-intensity-geojson の INTENSITY_FILL_COLORS
+  // (推計震度分布の震度4以上) と同じ値を使うこと。
   static AppTheme jmaStandard() {
     final base = AppTheme.eqmonitorDefault();
     const jmaIntensity = IntensityColors(
@@ -278,39 +284,39 @@ abstract class AppTheme with _$AppTheme {
         foreground: IntensityTextColor.auto(),
       ),
       one: IntensityColorEntry(
-        background: Color(0xFF80C0E0),
+        background: Color(0xFFF2F2F2),
         foreground: IntensityTextColor.auto(),
       ),
       two: IntensityColorEntry(
-        background: Color(0xFF0000FF),
-        foreground: IntensityTextColor.auto(),
-      ),
-      three: IntensityColorEntry(
         background: Color(0xFF00AAFF),
         foreground: IntensityTextColor.auto(),
       ),
+      three: IntensityColorEntry(
+        background: Color(0xFF0041FF),
+        foreground: IntensityTextColor.auto(),
+      ),
       four: IntensityColorEntry(
-        background: Color(0xFFFFFF00),
+        background: Color(0xFFFAE6A0),
         foreground: IntensityTextColor.auto(),
       ),
       fiveLower: IntensityColorEntry(
-        background: Color(0xFFFFAA00),
+        background: Color(0xFFFFE600),
         foreground: IntensityTextColor.auto(),
       ),
       fiveUpper: IntensityColorEntry(
-        background: Color(0xFFFF5500),
+        background: Color(0xFFFF9900),
         foreground: IntensityTextColor.auto(),
       ),
       sixLower: IntensityColorEntry(
-        background: Color(0xFFFF0000),
+        background: Color(0xFFFF2800),
         foreground: IntensityTextColor.auto(),
       ),
       sixUpper: IntensityColorEntry(
-        background: Color(0xFFCC0000),
+        background: Color(0xFFA50021),
         foreground: IntensityTextColor.auto(),
       ),
       seven: IntensityColorEntry(
-        background: Color(0xFFAA0088),
+        background: Color(0xFFB40068),
         foreground: IntensityTextColor.auto(),
       ),
     );

--- a/app/test/core/theme/model/app_theme_test.dart
+++ b/app/test/core/theme/model/app_theme_test.dart
@@ -37,5 +37,36 @@ void main() {
         throwsA(anything),
       );
     });
+
+    test('jmaStandard の震度色はJMA標準配色と一致する', () {
+      final theme = AppTheme.jmaStandard();
+      for (final colorSet in [theme.light!, theme.dark!]) {
+        final intensity = colorSet.intensity;
+        expect(intensity.unknown.background, const Color(0xFF000000));
+        expect(intensity.zero.background, const Color(0xFFFFFFFF));
+        expect(intensity.one.background, const Color(0xFFF2F2F2));
+        expect(intensity.two.background, const Color(0xFF00AAFF));
+        expect(intensity.three.background, const Color(0xFF0041FF));
+        expect(intensity.four.background, const Color(0xFFFAE6A0));
+        expect(intensity.fiveLower.background, const Color(0xFFFFE600));
+        expect(intensity.fiveUpper.background, const Color(0xFFFF9900));
+        expect(intensity.sixLower.background, const Color(0xFFFF2800));
+        expect(intensity.sixUpper.background, const Color(0xFFA50021));
+        expect(intensity.seven.background, const Color(0xFFB40068));
+      }
+    });
+
+    test('jmaStandard の震度2は震度3より明るい', () {
+      final intensity = AppTheme.jmaStandard().light!.intensity;
+      expect(
+        intensity.two.background.computeLuminance(),
+        greaterThan(intensity.three.background.computeLuminance()),
+      );
+    });
+
+    test('light の地図背景は白ベースの明るい色', () {
+      final mapColors = AppTheme.eqmonitorDefault().light!.mapColors;
+      expect(mapColors.background.computeLuminance(), greaterThan(0.7));
+    });
   });
 }


### PR DESCRIPTION
## 概要

1. **JMA Standard プリセットの震度色が気象庁配色と一致していない**（震度2と3が逆転）のを修正
2. **ライトモードの地図背景（海）が濃紺**だったのを白ベースに変更

## 1. JMA Standard の震度色

`AppTheme.jmaStandard()` の配色が気象庁の震度分布図の配色と全階級でずれており、特に **震度2 が濃い青 `#0000FF`、震度3 が水色 `#00AAFF`** と明暗が逆転していた（気象庁配色では震度2の方が明るい水色）。

正本は2つあり、両者は一致している:

- テーマ刷新前の `IntensityColorModel.jma()`（`f146f66f9` で削除）
- `backend/packages/seismic-intensity-geojson/src/intensity-colors.ts` の `INTENSITY_FILL_COLORS`（震度4以上。コメントに「Flutter アプリ側の `IntensityColorModel.jma()` と一致させること」と明記）

これに合わせて全階級を修正した。

| 震度 | 変更前 | 変更後（気象庁） |
|---|---|---|
| 1 | `#80C0E0` | `#F2F2F2` |
| 2 | `#0000FF` | `#00AAFF` |
| 3 | `#00AAFF` | `#0041FF` |
| 4 | `#FFFF00` | `#FAE6A0` |
| 5弱 | `#FFAA00` | `#FFE600` |
| 5強 | `#FF5500` | `#FF9900` |
| 6弱 | `#FF0000` | `#FF2800` |
| 6強 | `#CC0000` | `#A50021` |
| 7 | `#AA0088` | `#B40068` |

震度0（`#FFFFFF`）と不明（`#000000`）は変更なし。文字色は既存どおり `auto` のまま（プリセット間で挙動を揃えるため）。

## 2. ライトモードの地図背景

`light.mapColors.background` が `#0D1B4A`（濃紺）で、ライトテーマなのに海が暗くなっていたため、白ベースの `#EDF3F9`（ライトの `surfaceContainer` と同値）に変更。陸は `#FFFFFF` のままで、海岸線（`#6B7280`）で陸海を区別する。ダークモードは変更なし。

## テスト

`app/test/core/theme/model/app_theme_test.dart` に追加:

- `jmaStandard` の震度色が気象庁配色と一致すること（light/dark 両方）
- `jmaStandard` の震度2が震度3より明るいこと（逆転の再発防止）
- light の地図背景が白ベースの明るい色であること

`flutter test test/core/theme/` は全件パス。`test/feature/settings` に13件の失敗があるが、これは `develop` 時点でも同じ13件が失敗する既存の失敗（`DropdownButton` のレイアウト assertion 等）で、本変更とは無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)