### PR TITLE
feat(debug): Device APIのロールがADMINならデバッグメニューを開けるようにする

### DIFF
--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -10,6 +10,7 @@ import 'package:eqmonitor/core/theme/model/app_theme.dart';
 import 'package:eqmonitor/feature/beta_testing/data/notifier/beta_testing_notifier.dart';
 import 'package:eqmonitor/feature/beta_testing/ui/page/beta_testing_warning_page.dart';
 import 'package:eqmonitor/feature/changelog/ui/page/changelog_page.dart';
+import 'package:eqmonitor/feature/debug/data/provider/debug_menu_availability_provider.dart';
 import 'package:eqmonitor/feature/devices/ui/page/debug_device_settings_page.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_activity_query.dart';
@@ -105,7 +106,7 @@ GoRouter goRouter(Ref ref) => GoRouter(
     }
 
     final buildConfig = ref.read(buildConfigProvider);
-    if (!buildConfig.isDeveloperUiEnabled &&
+    if (!ref.read(isDebugMenuAvailableProvider) &&
         state.matchedLocation.startsWith(const DebugRoute().location)) {
       return const HomeRoute().location;
     }

--- a/app/lib/feature/debug/data/provider/debug_menu_availability_provider.dart
+++ b/app/lib/feature/debug/data/provider/debug_menu_availability_provider.dart
@@ -1,0 +1,57 @@
+import 'package:eqmonitor/core/model/environment.dart';
+import 'package:eqmonitor/core/provider/environment/environment.dart';
+import 'package:eqmonitor/feature/devices/data/model/device_role.dart';
+import 'package:eqmonitor/feature/devices/data/provider/device_role_provider.dart';
+import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_menu_availability_provider.g.dart';
+
+/// デバッグメニューを開いてよいかを判定する。
+///
+/// 判定順:
+/// 1. デバッグビルドなら常に許可
+/// 2. Device API のロールが [DeviceRole.admin] なら、ローカルのデバッグモード設定や
+///    BETA 配布かどうかに関係なく許可する。一般配布ビルド
+///    ([BuildConfig.isDeveloperUiEnabled] が false)では、デバッグモードを ON に
+///    するトグル自体がデバッグメニュー内にしか無いため、これが管理者の唯一の経路。
+/// 3. それ以外は [BuildConfig.isDeveloperUiEnabled] かつ
+///    (BETA 配布 または デバッグモード ON)
+///
+/// [role] が null(未登録・取得失敗)のときに権限ありへフォールバックしない。
+bool resolveDebugMenuAvailability({
+  required bool isDebugBuild,
+  required DeviceRole? role,
+  required BuildConfig buildConfig,
+  required bool isDebugEnabled,
+}) {
+  if (isDebugBuild) {
+    return true;
+  }
+  if (role == DeviceRole.admin) {
+    return true;
+  }
+  if (!buildConfig.isDeveloperUiEnabled) {
+    return false;
+  }
+  return buildConfig.isBetaTesting || isDebugEnabled;
+}
+
+/// デバッグメニュー(`/settings/debug` 配下)を開いてよいか。
+///
+/// 判定ロジックは [resolveDebugMenuAvailability] を参照。
+///
+/// go_router の `redirect` から同期的に読むため、非同期依存は
+/// [AsyncValue.value] を参照する。ロール取得前は null 扱いで権限なし側に倒れ、
+/// 取得完了後に再評価される。
+///
+/// keepAlive にしているのは、`redirect` の単発の [Ref.read] で
+/// 非同期依存が未解決のまま false と判定され、正当な遷移が弾かれるのを防ぐため。
+@Riverpod(keepAlive: true)
+bool isDebugMenuAvailable(Ref ref) => resolveDebugMenuAvailability(
+  isDebugBuild: kDebugMode,
+  role: ref.watch(deviceRoleProvider).value,
+  buildConfig: ref.watch(buildConfigProvider),
+  isDebugEnabled: ref.watch(debugProvider).value ?? false,
+);

--- a/app/lib/feature/debug/data/provider/debug_menu_availability_provider.g.dart
+++ b/app/lib/feature/debug/data/provider/debug_menu_availability_provider.g.dart
@@ -1,0 +1,85 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'debug_menu_availability_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// デバッグメニュー(`/settings/debug` 配下)を開いてよいか。
+///
+/// 判定ロジックは [resolveDebugMenuAvailability] を参照。
+///
+/// go_router の `redirect` から同期的に読むため、非同期依存は
+/// [AsyncValue.value] を参照する。ロール取得前は null 扱いで権限なし側に倒れ、
+/// 取得完了後に再評価される。
+///
+/// keepAlive にしているのは、`redirect` の単発の [Ref.read] で
+/// 非同期依存が未解決のまま false と判定され、正当な遷移が弾かれるのを防ぐため。
+
+@ProviderFor(isDebugMenuAvailable)
+final isDebugMenuAvailableProvider = IsDebugMenuAvailableProvider._();
+
+/// デバッグメニュー(`/settings/debug` 配下)を開いてよいか。
+///
+/// 判定ロジックは [resolveDebugMenuAvailability] を参照。
+///
+/// go_router の `redirect` から同期的に読むため、非同期依存は
+/// [AsyncValue.value] を参照する。ロール取得前は null 扱いで権限なし側に倒れ、
+/// 取得完了後に再評価される。
+///
+/// keepAlive にしているのは、`redirect` の単発の [Ref.read] で
+/// 非同期依存が未解決のまま false と判定され、正当な遷移が弾かれるのを防ぐため。
+
+final class IsDebugMenuAvailableProvider
+    extends $FunctionalProvider<bool, bool, bool>
+    with $Provider<bool> {
+  /// デバッグメニュー(`/settings/debug` 配下)を開いてよいか。
+  ///
+  /// 判定ロジックは [resolveDebugMenuAvailability] を参照。
+  ///
+  /// go_router の `redirect` から同期的に読むため、非同期依存は
+  /// [AsyncValue.value] を参照する。ロール取得前は null 扱いで権限なし側に倒れ、
+  /// 取得完了後に再評価される。
+  ///
+  /// keepAlive にしているのは、`redirect` の単発の [Ref.read] で
+  /// 非同期依存が未解決のまま false と判定され、正当な遷移が弾かれるのを防ぐため。
+  IsDebugMenuAvailableProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'isDebugMenuAvailableProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$isDebugMenuAvailableHash();
+
+  @$internal
+  @override
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  bool create(Ref ref) {
+    return isDebugMenuAvailable(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$isDebugMenuAvailableHash() =>
+    r'5c4578be7946880fd8d820ae71e5db65de936467';

--- a/app/lib/feature/debug/launcher/debug_launcher.dart
+++ b/app/lib/feature/debug/launcher/debug_launcher.dart
@@ -2,9 +2,8 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 
-import 'package:eqmonitor/core/provider/environment/environment.dart';
 import 'package:eqmonitor/core/router/router.dart';
-import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
+import 'package:eqmonitor/feature/debug/data/provider/debug_menu_availability_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -32,7 +31,8 @@ class GoRouterCurrentLocationResolver {
 
 /// 端末シェイクまたは Shift+D でデバッグページを開くラッパー。
 ///
-/// kDebugMode / Beta ビルドでのみ有効化することを想定。
+/// 有効かどうかの判定は [isDebugMenuAvailableProvider] に委譲する
+/// (kDebugMode / BETA ビルド / デバッグモード ON / ADMIN ロール)。
 class DebugLauncher extends HookConsumerWidget {
   const new({required this.child, super.key});
 
@@ -50,26 +50,12 @@ class DebugLauncher extends HookConsumerWidget {
     final lastOpen = useRef(DateTime.fromMillisecondsSinceEpoch(0));
 
     useEffect(() {
-      bool isLauncherEnabled() {
-        if (kDebugMode) {
-          return true;
-        }
-        final buildCfg = ref.read(buildConfigProvider);
-        if (!buildCfg.isDeveloperUiEnabled) {
-          return false;
-        }
-        if (buildCfg.isBetaTesting) {
-          return true;
-        }
-        return ref.read(debugProvider).value ?? false;
-      }
-
       void openDebugPage() {
         final now = DateTime.now();
         if (now.difference(lastOpen.value) < openCooldown) {
           return;
         }
-        if (!isLauncherEnabled()) {
+        if (!ref.read(isDebugMenuAvailableProvider)) {
           return;
         }
         lastOpen.value = now;

--- a/app/lib/feature/settings/settings_page.dart
+++ b/app/lib/feature/settings/settings_page.dart
@@ -12,6 +12,7 @@ import 'package:eqmonitor/feature/ads/data/notifier/ads_opt_out_notifier.dart';
 import 'package:eqmonitor/feature/ads/ui/component/ad_banner.dart';
 import 'package:eqmonitor/feature/asset_pack/data/notifier/asset_pack_manifest_provider.dart';
 import 'package:eqmonitor/feature/asset_pack/ui/component/asset_pack_update_card.dart';
+import 'package:eqmonitor/feature/debug/data/provider/debug_menu_availability_provider.dart';
 import 'package:eqmonitor/feature/settings/component/settings_section_header.dart';
 import 'package:eqmonitor/feature/settings/data/contact/contact_action.dart';
 import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
@@ -25,6 +26,7 @@ class SettingsPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isDebugEnabled = ref.watch(debugProvider).value;
+    final isDebugMenuAvailable = ref.watch(isDebugMenuAvailableProvider);
     final buildConfig = ref.watch(buildConfigProvider);
     final isDeveloperUiEnabled = buildConfig.isDeveloperUiEnabled;
     final isProFeaturesEnabled = buildConfig.isProFeaturesEnabled;
@@ -172,16 +174,17 @@ class SettingsPage extends ConsumerWidget {
                     ),
                   ),
                 ),
-                if (isDeveloperUiEnabled && (isDebugEnabled ?? false)) ...[
-                  Center(
-                    child: Text(
-                      'Debug Mode',
-                      style: textTheme.bodySmall?.copyWith(
-                        color: context.designSystem.colorTheme.onSurface
-                            .withValues(alpha: 0.8),
+                if (isDebugMenuAvailable) ...[
+                  if (isDebugEnabled ?? false)
+                    Center(
+                      child: Text(
+                        'Debug Mode',
+                        style: textTheme.bodySmall?.copyWith(
+                          color: context.designSystem.colorTheme.onSurface
+                              .withValues(alpha: 0.8),
+                        ),
                       ),
                     ),
-                  ),
                   const Divider(),
                   ListTile(
                     title: const Text('デバッグメニュー'),

--- a/app/lib/page/home_page.dart
+++ b/app/lib/page/home_page.dart
@@ -4,9 +4,9 @@ import 'package:eqmonitor/core/component/banner/app_banner.dart';
 import 'package:eqmonitor/core/component/scroll/bottom_bouncing_scroll_physics.dart';
 import 'package:eqmonitor/core/component/sheet/basic_modal_sheet.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
-import 'package:eqmonitor/core/provider/environment/environment.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/asset_pack/ui/component/asset_pack_update_card.dart';
+import 'package:eqmonitor/feature/debug/data/provider/debug_menu_availability_provider.dart';
 import 'package:eqmonitor/feature/devices/ui/component/device_provisioning_banner.dart';
 import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
 import 'package:eqmonitor/feature/home/ui/component/eew/home_eew_card.dart';
@@ -20,7 +20,6 @@ import 'package:eqmonitor/feature/location/data/notifier/location_permission_ban
 import 'package:eqmonitor/feature/permission/data/notification_permission_provider.dart';
 import 'package:eqmonitor/feature/permission/data/notifier/notification_permission_banner_dismissed_notifier.dart';
 import 'package:eqmonitor/feature/permission/ui/component/notification_permission_banner.dart';
-import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
 import 'package:eqmonitor/feature/shake_detection/data/provider/shake_detection_merge_provider.dart';
@@ -149,9 +148,7 @@ class _HomeActionsCard extends ConsumerWidget {
       indent: spacing.lg,
       endIndent: spacing.lg,
     );
-    final isDebugMenuVisible =
-        ref.watch(buildConfigProvider).isDeveloperUiEnabled &&
-        (ref.watch(debugProvider).value ?? false);
+    final isDebugMenuVisible = ref.watch(isDebugMenuAvailableProvider);
 
     return HomeSheetCard(
       children: [

--- a/app/test/feature/debug/debug_menu_availability_provider_test.dart
+++ b/app/test/feature/debug/debug_menu_availability_provider_test.dart
@@ -1,0 +1,107 @@
+import 'package:eqmonitor/core/model/environment.dart';
+import 'package:eqmonitor/feature/debug/data/provider/debug_menu_availability_provider.dart';
+import 'package:eqmonitor/feature/devices/data/model/device_role.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+BuildConfig _buildConfig({
+  required bool isBetaTesting,
+  Flavor flavor = Flavor.prod,
+}) => BuildConfig(
+  restApiUrl: '',
+  appIdSuffix: '',
+  appName: '',
+  commitInformation: '',
+  flavor: flavor,
+  wsApiUrl: '',
+  googleIosClientId: '',
+  googleAndroidClientId: '',
+  buildTimestamp: '',
+  buildCommitMessage: '',
+  revenueCatApiKeyIos: '',
+  revenueCatApiKeyAndroid: '',
+  isBetaTesting: isBetaTesting,
+);
+
+bool _resolve({
+  required DeviceRole? role,
+  required bool isDebugEnabled,
+  bool isBetaTesting = false,
+  Flavor flavor = Flavor.prod,
+}) => resolveDebugMenuAvailability(
+  isDebugBuild: false,
+  role: role,
+  buildConfig: _buildConfig(isBetaTesting: isBetaTesting, flavor: flavor),
+  isDebugEnabled: isDebugEnabled,
+);
+
+void main() {
+  group('resolveDebugMenuAvailability', () {
+    test('一般配布ビルド(BETA/prod)でもAdminロールなら開ける', () {
+      expect(
+        _resolve(
+          role: DeviceRole.admin,
+          isDebugEnabled: false,
+          isBetaTesting: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('デバッグモードOFFでもAdminロールなら開ける', () {
+      expect(
+        _resolve(role: DeviceRole.admin, isDebugEnabled: false),
+        isTrue,
+      );
+    });
+
+    test('一般配布ビルド(BETA/prod)ではAdmin以外は開けない', () {
+      expect(
+        _resolve(
+          role: DeviceRole.user,
+          isDebugEnabled: true,
+          isBetaTesting: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('ロールを取得できない場合は権限ありへフォールバックしない', () {
+      expect(
+        _resolve(role: null, isDebugEnabled: true, isBetaTesting: true),
+        isFalse,
+      );
+    });
+
+    test('デバッグUI有効なビルドではデバッグモードONで開ける', () {
+      expect(_resolve(role: DeviceRole.user, isDebugEnabled: true), isTrue);
+    });
+
+    test('デバッグUI有効なビルドでもデバッグモードOFFなら開けない', () {
+      expect(_resolve(role: DeviceRole.user, isDebugEnabled: false), isFalse);
+    });
+
+    test('BETA配布のdevビルドはデバッグモードOFFでも開ける', () {
+      expect(
+        _resolve(
+          role: DeviceRole.user,
+          isDebugEnabled: false,
+          isBetaTesting: true,
+          flavor: Flavor.dev,
+        ),
+        isTrue,
+      );
+    });
+
+    test('デバッグビルドならロールもデバッグモードも問わず開ける', () {
+      expect(
+        resolveDebugMenuAvailability(
+          isDebugBuild: true,
+          role: null,
+          buildConfig: _buildConfig(isBetaTesting: true),
+          isDebugEnabled: false,
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 概要

Device API が返す `role: ADMIN` でデバッグメニュー(`/settings/debug` 配下)を開けるようにします。

### 現状の課題

デバッグメニューの到達条件はビルド構成とローカル設定のみで判定されており、`DeviceRole.admin` は反映されていませんでした（`DeviceRole.admin` の参照は `isHomeEewEstimationDebugAvailableProvider` の1箇所のみ）。

| 箇所 | 変更前の条件 |
|---|---|
| ルータの redirect | `buildConfig.isDeveloperUiEnabled` |
| 設定画面のタイル | `isDeveloperUiEnabled && debugProvider` |
| ホームシートのタイル | `isDeveloperUiEnabled && debugProvider` |
| シェイク / Shift+D ランチャー | `kDebugMode \|\| (isDeveloperUiEnabled && (isBetaTesting \|\| debugProvider))` |

加えて、一般配布ビルド（BETA かつ prod flavor → `isDeveloperUiEnabled == false`）では、デバッグモードを ON にするトグル自体がデバッグメニュー内にしか無いため、**管理者であってもデバッグメニューへ到達する手段が存在しませんでした**。

## 変更内容

判定を `isDebugMenuAvailableProvider` に一元化し、上記4箇所をこれに統一しました。

判定順:
1. `kDebugMode` なら常に許可
2. ロールが `DeviceRole.admin` なら、デバッグモード設定や BETA 配布かどうかに関係なく許可
3. それ以外は従来どおり `isDeveloperUiEnabled && (isBetaTesting || debugProvider)`

- ロールが取得できない場合（未登録・取得失敗）は権限ありへフォールバックしません
- 判定ロジックは純粋関数 `resolveDebugMenuAvailability` として切り出し、テストが `kDebugMode` に潰されないようにしています
- provider は keepAlive。go_router の `redirect` は単発の `ref.read` なので、非同期依存が未解決のまま false と判定され正当な遷移が弾かれるのを防ぐためです
- 設定画面の `Debug Mode` ラベルは従来どおりデバッグモード ON のときのみ表示し、メニュータイルの表示条件とは分離しました

### 副作用として変わる挙動

BETA 配布の dev flavor ビルドでは、デバッグモードが OFF でも設定画面／ホームシートにデバッグメニューのタイルが表示されるようになります（従来からシェイク・Shift+D では開けていたため、経路間の条件を揃えた形です）。BETA かつ prod flavor の一般ユーザーは、ADMIN でない限り従来どおり全経路で非表示のままです。

## テスト

- `app/test/feature/debug/debug_menu_availability_provider_test.dart` を追加（8件）
- `dart analyze lib test` → No issues found
- `flutter test test/feature/debug test/feature/home/data/provider/home_eew_estimation_debug_provider_test.dart` → 全件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)