### PR TITLE
docs: Admin デバイス ID の管理を SealedSecret 前提に更新する

### DIFF
--- a/docs/knowledge/20260814_device_role_admin_gate.md
+++ b/docs/knowledge/20260814_device_role_admin_gate.md
@@ -45,7 +45,30 @@ UI に理由を表示する前提で設計する。
 
 ## 運用
 
-Admin 扱いにするデバイスは、backend の Helm values
-（`deploy/k8s/values/tokyo/{develop,production}.yaml` の
-`eqmonitorApi.adminDeviceIds`）へ UUID をカンマ区切りで追加する。
-デバイス ID はデバッグ画面のデバイス情報から確認できる。
+Admin 扱いにするデバイス ID は **SealedSecret で管理する**。values に平文で
+書くと ArgoCD のレンダリング結果と git 履歴の両方に端末識別子が残るため。
+
+- 値の実体: SealedSecret `eqmonitor-secrets` の `ADMIN_DEVICE_IDS`
+  （`deploy/k8s/charts/eqmonitor/templates/sealed-eqmonitor-secrets.yaml`）。
+  カンマ区切りの UUID 一覧。cluster-wide スコープなので develop / production で
+  同じ値が復号される。
+- 注入の ON/OFF: `deploy/k8s/values/tokyo/{develop,production}.yaml` の
+  `eqmonitorApi.adminDeviceIds.enabled`。**両方を true にする。**
+  片方だけだと、その環境へ繋いだアプリが常に `role: USER` になる。
+- デバイス ID はアプリのデバッグ画面のデバイス情報から確認できる。
+
+デバイスを追加するときは、既存の値へ追記した上で再シールする:
+
+```bash
+kubectl create secret generic eqmonitor-secrets \
+  --namespace eqmonitor-tokyo-production \
+  --from-literal=ADMIN_DEVICE_IDS='<既存の一覧>,<追加する UUID>' \
+  --dry-run=client -o json \
+  | kubeseal --scope cluster-wide --format yaml \
+      --controller-namespace kube-system --controller-name sealed-secrets-controller
+```
+
+出力の `ADMIN_DEVICE_IDS:` 行だけを `sealed-eqmonitor-secrets.yaml` の
+`encryptedData` へ差し替える（キーは個別に暗号化されるため他の行は触らない）。
+検証は `kubeseal --validate`、レンダリングの回帰は
+`deploy/k8s/charts/eqmonitor/test/api-admin-device-ids.sh` で確認する。


### PR DESCRIPTION
## 背景

`GET /v2/device/me` の `role` が Admin にならない問題を調査したところ、原因は backend の deploy 設定側だった（develop の values に `eqmonitorApi.adminDeviceIds` が無く、API Deployment に `ADMIN_DEVICE_IDS` 環境変数自体が生えていなかった）。

修正: YumNumm/eqmonitor-backend#1081

## 変更

`docs/knowledge/20260814_device_role_admin_gate.md` の運用手順が「values に UUID を平文で追加する」前提だったので、SealedSecret 前提へ更新する。

- 値の実体は SealedSecret `eqmonitor-secrets` の `ADMIN_DEVICE_IDS`
- `eqmonitorApi.adminDeviceIds.enabled` は develop / production の**両方**を有効にすること（片方だけだと、その環境へ繋いだアプリが常に `role: USER` になる）
- デバイス追加時の再シール手順と検証方法を追記

ドキュメントのみの変更で、アプリのコードには手を入れていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
