### PR TITLE
Fix: 予想最大震度が不明の EEW で震度を表示し Dynamic Island の字形切れを直す

### DIFF
--- a/app/ios/Shared/EewDisplay.swift
+++ b/app/ios/Shared/EewDisplay.swift
@@ -11,6 +11,41 @@
 
 import Foundation
 
+/// バッジに描く震度。
+///
+/// 予想震度は震源が深い場合など JMA が発表しない報がある。値が無いときに
+/// バッジごと消すと「震度の欄が存在しない」ように見え、震度が発表されて
+/// いないのか表示が壊れているのか区別できない。アプリ本体の EEW カードが
+/// `JmaIntensity.unknown`（「不明」）を出しているのと同じく、
+/// 「不明」も震度と同じ形で扱えるようにする。
+enum EewIntensityBadge: Equatable {
+    case value(IntensityValue)
+    /// 予想震度が発表されていない / 届いていない
+    case unknown
+
+    /// 値が無い場合を「不明」として扱う
+    init(_ intensity: IntensityValue?) {
+        guard let intensity else {
+            self = .unknown
+            return
+        }
+        self = .value(intensity)
+    }
+
+    /// 「不明」の文言。アプリ本体の `JmaIntensity.unknown.label` に揃える。
+    static let unknownText = "不明"
+
+    /// バッジに描く文字。「不明」は震度階級ではないため弱/強の suffix を持たない。
+    var parts: (main: String, sub: String?) {
+        switch self {
+        case let .value(intensity):
+            return intensity.formattedParts
+        case .unknown:
+            return (Self.unknownText, nil)
+        }
+    }
+}
+
 /// Dynamic Island 展開時のレイアウト。
 ///
 /// 展開領域は狭く、要素を並べるほど切り取られて読めなくなる。
@@ -30,7 +65,7 @@ struct EewDisplay: Equatable {
     let isWarning: Bool
     let isFinal: Bool
     let serialNo: Int?
-    /// 全国の予想最大震度
+    /// 全国の予想最大震度。震源が深い場合など JMA が予想震度を発表しない報では nil
     let maxIntensity: IntensityValue?
     /// 現在地の予想震度
     let forecastIntensity: IntensityValue?
@@ -51,6 +86,19 @@ struct EewDisplay: Equatable {
     /// [intensity] がどちらの震度かを示すラベル
     var intensityLabel: String {
         forecastIntensity != nil ? "予想震度" : "最大震度"
+    }
+
+    /// 面積が限られる場所（Dynamic Island）に描く震度バッジ。
+    /// 震度が発表されていない報でも欄を空けず「不明」を描く。
+    /// 取消報だけは震度そのものが無効なため、欄ごと出さない。
+    var intensityBadge: EewIntensityBadge? {
+        isCanceled ? nil : EewIntensityBadge(intensity)
+    }
+
+    /// Lock Screen 左の「最大震度」欄に描くバッジ。
+    /// 現在地の予想震度は別枠で出すため、ここは全国の予想最大震度だけを見る。
+    var maxIntensityBadge: EewIntensityBadge? {
+        isCanceled ? nil : EewIntensityBadge(maxIntensity)
     }
 
     /// 主要動到達カウントダウンに使う時刻。取消報では到達予想も無効。

--- a/app/ios/Shared/IntensityBadge.swift
+++ b/app/ios/Shared/IntensityBadge.swift
@@ -15,11 +15,14 @@ struct IntensityBadge: View {
     /// 角丸比率。アプリの JmaIntensityIcon に準拠（size / 4 = 25%）
     var cornerRatio: CGFloat = 0.25
     var weight: Font.Weight = .bold
+    /// バッジ寸法に対する主表示の文字サイズ比。
+    /// 「不明」のように数字以外を描くときだけ呼び出し側で下げる。
+    var mainFontScale: CGFloat?
 
     var body: some View {
         HStack(alignment: .lastTextBaseline, spacing: 0) {
             Text(intensity.main)
-                .font(AppFonts.code(size: size * 0.62, weight: .bold))
+                .font(AppFonts.code(size: size * (mainFontScale ?? 0.62), weight: .bold))
             if let sub = intensity.sub {
                 Text(sub)
                     .font(AppFonts.code(size: size * 0.30, weight: .bold))

--- a/app/ios/Widget/LiveActivity/Common/SharedComponents.swift
+++ b/app/ios/Widget/LiveActivity/Common/SharedComponents.swift
@@ -42,6 +42,51 @@ extension View {
     }
 }
 
+// MARK: - 震度バッジの配色
+
+extension EewIntensityBadge {
+    var backgroundColor: Color {
+        switch self {
+        case let .value(intensity):
+            return intensity.backgroundColor
+        case .unknown:
+            // アプリ本体の unknown は黒。Dynamic Island の地とも Live Activity の
+            // ダーク背景とも同化してバッジが消えるため、グレーで置き換える
+            // （取消シンボル・揺れ検知の level 不明と同じ扱い）。
+            return .gray
+        }
+    }
+
+    var textColor: Color {
+        switch self {
+        case let .value(intensity):
+            return intensity.textColor
+        case .unknown:
+            return .white
+        }
+    }
+
+    /// バッジ寸法に対する主表示の文字サイズ比。
+    /// 「不明」は 2 文字あり、震度の数字と同じ比率では正方形に収まらない。
+    /// 震度を描くときは各バッジ既定の比率に任せるため nil。
+    var unknownMainFontScale: CGFloat? {
+        self == .unknown ? 0.34 : nil
+    }
+}
+
+// MARK: - カスタムフォントの字形切れ対策
+
+extension View {
+    /// GoogleSans 系は可変フォントを実行時登録し `weight` を付けて使うため、
+    /// 太さの実体を持たないぶん擬似ボールドで描かれ、描画幅が SwiftUI の計測幅を
+    /// わずかに超える。末尾が欧文の Text はその差分だけ字形が切り取られる
+    /// （Dynamic Island の「深さ40km」で m の右端が欠けていた）。
+    /// 欧文で終わるラベルには差分ぶんの逃げを右に確保する。
+    func latinTrailingBleed(fontSize: CGFloat) -> some View {
+        padding(.trailing, (fontSize * 0.2).rounded(.up))
+    }
+}
+
 // MARK: - 主要動到達カウントダウン
 
 /// 主要動到達までの残り時間。桁が変わっても幅が揺れないよう等幅フォントで描く。

--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -94,16 +94,11 @@ struct EewCompactLeadingView: View {
     let state: EewContentState
 
     var body: some View {
-        if state.display.isCanceled {
-            EewCanceledSymbol(size: 20)
-        } else if let intensity = state.display.intensity {
+        if let intensity = state.display.intensityBadge {
             DynamicIslandIntensityBadge(intensity: intensity, size: 24)
         } else {
-            Image("AppIconForeground")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 20, height: 20)
-                .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+            // 取消報。震度が無効なので取消シンボルに差し替える
+            EewCanceledSymbol(size: 20)
         }
     }
 }
@@ -134,16 +129,11 @@ struct EewMinimalView: View {
     let state: EewContentState
 
     var body: some View {
-        if state.display.isCanceled {
-            EewCanceledSymbol(size: 18)
-        } else if let intensity = state.display.intensity {
+        if let intensity = state.display.intensityBadge {
             DynamicIslandIntensityBadge(intensity: intensity, size: 22)
         } else {
-            Image("AppIconForeground")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 18, height: 18)
-                .clipShape(RoundedRectangle(cornerRadius: 4.5, style: .continuous))
+            // 取消報。震度が無効なので取消シンボルに差し替える
+            EewCanceledSymbol(size: 18)
         }
     }
 }
@@ -159,7 +149,9 @@ struct EewExpandedLeadingView: View {
         case .canceled:
             EewCanceledSymbol(size: DynamicIslandMetrics.expandedBadgeSize * 0.75)
         case .countdown, .summary:
-            if let intensity = state.display.intensity {
+            // 震度が発表されていない報でも「不明」を描く。leading を空にすると
+            // 展開時の左半分がまるごと空白になり、表示が壊れて見える。
+            if let intensity = state.display.intensityBadge {
                 DynamicIslandIntensityBadge(
                     intensity: intensity,
                     size: DynamicIslandMetrics.expandedBadgeSize
@@ -255,7 +247,7 @@ struct EewExpandedCenterView: View {
                     .minimumScaleFactor(0.7)
             }
             .foregroundStyle(Color.eqTextSecondary)
-        } else if state.display.intensity != nil {
+        } else if state.display.intensityBadge != nil {
             captionText(state.display.intensityLabel)
         }
     }
@@ -346,6 +338,7 @@ struct EewHypocenterDetailView: View {
                 .foregroundStyle(Color.eqTextSecondary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
+                .latinTrailingBleed(fontSize: size * 0.8)
         } else {
             HStack(alignment: .firstTextBaseline, spacing: 10) {
                 if let magnitude = state.magnitude {
@@ -371,6 +364,7 @@ struct EewHypocenterDetailView: View {
                         Text("km")
                             .font(AppFonts.flex(size: size * 0.7, weight: .medium))
                             .foregroundStyle(Color.eqTextSecondary)
+                            .latinTrailingBleed(fontSize: size * 0.7)
                     }
                 }
             }
@@ -558,15 +552,16 @@ enum DynamicIslandMetrics {
 
 @available(iOS 16.1, *)
 struct DynamicIslandIntensityBadge: View {
-    let intensity: IntensityValue
+    let intensity: EewIntensityBadge
     var size: CGFloat = 24
 
     var body: some View {
         IntensityBadge(
-            intensity: intensity.formattedParts,
+            intensity: intensity.parts,
             backgroundColor: intensity.backgroundColor,
             textColor: intensity.textColor,
-            size: size
+            size: size,
+            mainFontScale: intensity.unknownMainFontScale
         )
     }
 }

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
@@ -140,6 +140,28 @@ extension EewContentState {
         location: nil
     )
 
+    /// 予想最大震度が発表されていない報。JMA は震源が深い場合など予想震度を
+    /// 出さないことがある。震度バッジが消えず「不明」と描かれることの確認用。
+    static let unknownIntensity = EewContentState(
+        eventId: "20240102123456",
+        type: "eew",
+        hypocenterName: "茨城県沖",
+        magnitude: 4.2,
+        depth: 40,
+        time: "2024-01-02T12:34:56+09:00",
+        isOriginTime: true,
+        maxIntensity: nil,
+        serialNo: 1,
+        isFinal: false,
+        isWarning: false,
+        isCanceled: false,
+        headline: "茨城県沖で地震",
+        isPlum: false,
+        isLevel: false,
+        isOnePoint: false,
+        location: nil
+    )
+
     static let plum = EewContentState(
         eventId: "20240103123456",
         type: "eew",

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
@@ -157,13 +157,16 @@ struct EewLockScreenView: View {
 
     private var earthquakeContentView: some View {
         HStack(alignment: .bottom, spacing: 10) {
-            if let intensity = state.display.maxIntensity {
+            // 予想最大震度が発表されていない報でも欄は残し「不明」を描く。
+            // バッジごと消すと震度の欄が無いように見え、発表されていないのか
+            // 表示が壊れているのか区別できない。
+            if let maxIntensity = state.display.maxIntensityBadge {
                 VStack(spacing: 2) {
                     Text("最大震度")
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundColor(eewSecondaryTextColor)
                     SquareIntensityBadge(
-                        intensity: intensity,
+                        intensity: maxIntensity,
                         size: .normal
                     )
                 }
@@ -301,7 +304,7 @@ struct EewLockScreenView: View {
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
             }
-            SquareIntensityBadge(intensity: intensity, size: .normal)
+            SquareIntensityBadge(intensity: .value(intensity), size: .normal)
         }
     }
 }
@@ -355,18 +358,18 @@ struct SquareIntensityBadge: View {
         }
     }
 
-    let intensity: IntensityValue
+    let intensity: EewIntensityBadge
     var size: Size = .normal
 
     var body: some View {
-        let parts = intensity.formattedParts
+        let parts = intensity.parts
         HStack(alignment: .firstTextBaseline, spacing: 0) {
             Text(parts.main)
                 .font(
                     .system(
-                        size: size.mainFontSize,
+                        size: mainFontSize,
                         weight: .bold,
-                        design: .monospaced
+                        design: mainFontDesign
                     )
                 )
             if let sub = parts.sub {
@@ -374,6 +377,8 @@ struct SquareIntensityBadge: View {
                     .font(.system(size: size.subFontSize, weight: .heavy))
             }
         }
+        .lineLimit(1)
+        .minimumScaleFactor(0.5)
         .foregroundColor(intensity.textColor)
         .frame(height: size.badgeSize)
         .frame(minWidth: size.badgeSize)
@@ -385,6 +390,19 @@ struct SquareIntensityBadge: View {
                 style: .continuous
             )
         )
+    }
+
+    /// 「不明」は 2 文字あり、震度の数字と同じ大きさではバッジに収まらない
+    private var mainFontSize: CGFloat {
+        guard let scale = intensity.unknownMainFontScale else {
+            return size.mainFontSize
+        }
+        return size.badgeSize * scale
+    }
+
+    /// 等幅は震度の数字を桁揃えするためのもの。「不明」には使わない。
+    private var mainFontDesign: Font.Design {
+        intensity == .unknown ? .default : .monospaced
     }
 }
 
@@ -402,6 +420,10 @@ struct EewLiveActivityWidget_Previews: PreviewProvider {
         attributes
             .previewContext(.ibarakiForecast, viewKind: .content)
             .previewDisplayName("Lock Screen - 予報")
+
+        attributes
+            .previewContext(.unknownIntensity, viewKind: .content)
+            .previewDisplayName("Lock Screen - 予想最大震度が不明")
 
         attributes
             .previewContext(.notoFinal, viewKind: .content)
@@ -449,6 +471,10 @@ struct EewLiveActivityWidget_Previews: PreviewProvider {
             .previewDisplayName("Compact - 予報")
 
         attributes
+            .previewContext(.unknownIntensity, viewKind: .dynamicIsland(.compact))
+            .previewDisplayName("Compact - 予想最大震度が不明")
+
+        attributes
             .previewContext(.canceled, viewKind: .dynamicIsland(.compact))
             .previewDisplayName("Compact - 取消")
 
@@ -464,6 +490,10 @@ struct EewLiveActivityWidget_Previews: PreviewProvider {
         attributes
             .previewContext(.ibarakiForecast, viewKind: .dynamicIsland(.expanded))
             .previewDisplayName("Expanded - 予報")
+
+        attributes
+            .previewContext(.unknownIntensity, viewKind: .dynamicIsland(.expanded))
+            .previewDisplayName("Expanded - 予想最大震度が不明")
 
         attributes
             .previewContext(.notoFinal, viewKind: .dynamicIsland(.expanded))
@@ -485,5 +515,9 @@ struct EewLiveActivityWidget_Previews: PreviewProvider {
         attributes
             .previewContext(.ibarakiForecast, viewKind: .dynamicIsland(.minimal))
             .previewDisplayName("Minimal - 予報")
+
+        attributes
+            .previewContext(.unknownIntensity, viewKind: .dynamicIsland(.minimal))
+            .previewDisplayName("Minimal - 予想最大震度が不明")
     }
 }

--- a/app/ios/WidgetModelsTests/EewDisplayTests.swift
+++ b/app/ios/WidgetModelsTests/EewDisplayTests.swift
@@ -78,6 +78,45 @@ struct EewDisplayTests {
         #expect(display(maxIntensity: nil, forecastIntensity: nil).intensity == nil)
     }
 
+    // MARK: - 震度バッジ（不明の明示）
+
+    /// 予想震度が発表されない報でバッジを消すと、震度の欄そのものが無いように
+    /// 見えてしまう。値が無いときは「不明」として欄を残す。
+    @Test func intensityBadgeFallsBackToUnknown() {
+        let subject = display(maxIntensity: nil, forecastIntensity: nil)
+        #expect(subject.intensityBadge == .unknown)
+        #expect(subject.maxIntensityBadge == .unknown)
+        #expect(subject.intensityLabel == "最大震度")
+    }
+
+    @Test func intensityBadgeCarriesValueWhenPublished() {
+        let subject = display(maxIntensity: .sixUpper, forecastIntensity: .fiveLower)
+        #expect(subject.intensityBadge == .value(.fiveLower))
+        #expect(subject.maxIntensityBadge == .value(.sixUpper))
+    }
+
+    /// 現在地の予想震度だけが届いた報でも、Lock Screen の「最大震度」欄は
+    /// 全国の予想最大震度で判断する（現在地の値を最大震度として出さない）。
+    @Test func maxIntensityBadgeIgnoresCurrentLocationForecast() {
+        let subject = display(maxIntensity: nil, forecastIntensity: .fiveLower)
+        #expect(subject.maxIntensityBadge == .unknown)
+        #expect(subject.intensityBadge == .value(.fiveLower))
+    }
+
+    /// 取消報では震度そのものが無効。「不明」ですらなく欄ごと出さない。
+    @Test func canceledReportHidesIntensityBadgeEntirely() {
+        let subject = display(isCanceled: true, maxIntensity: nil, forecastIntensity: nil)
+        #expect(subject.intensityBadge == nil)
+        #expect(subject.maxIntensityBadge == nil)
+    }
+
+    @Test func unknownBadgeDrawsUnknownText() {
+        #expect(EewIntensityBadge.unknown.parts.main == "不明")
+        #expect(EewIntensityBadge.unknown.parts.sub == nil)
+        #expect(EewIntensityBadge.value(.fiveLower).parts.main == "5")
+        #expect(EewIntensityBadge.value(.fiveLower).parts.sub == "弱")
+    }
+
     // MARK: - 文言
 
     @Test func typeLabelDistinguishesWarningFromForecast() {

--- a/app/lib/feature/home/ui/component/eew/eew_card.dart
+++ b/app/lib/feature/home/ui/component/eew/eew_card.dart
@@ -257,8 +257,11 @@ class _EewMainCard extends StatelessWidget {
                   if (maxLpgmIntensity != null &&
                       maxLpgmIntensity != JmaLpgmIntensity.zero)
                     _EewLpgmSection(intensity: maxLpgmIntensity),
+                  // JMA は深さ150km以上の地震では震度予想を行わずマグニチュードのみ
+                  // 発表する。予想震度が「不明」になる理由がこれで説明できる場合だけ
+                  // 添える（浅い地震で震度が届かない場合は理由が別なので出さない）。
                   if (eew.hypocenter?.depth case final depth?
-                      when depth < 150 && maxIntensity == .unknown)
+                      when depth >= 150 && maxIntensity == .unknown)
                     Text(
                       '震源の深さが150km以上のため、予想震度は発表されていません',
                       style: designSystem.typography.labelMedium,


### PR DESCRIPTION
## 背景

EEW の Live Activity で 2 点の表示不具合が報告された。

1. **予想最大震度が不明のときに何も出ない** — 震度が届かない報では震度バッジが消え、Lock Screen の「最大震度」欄も Dynamic Island 展開時の leading もまるごと空になっていた。震度が発表されていないのか表示が壊れているのか区別できない
2. **Dynamic Island の表示が見切れる** — 「深さ40km」の `m` の右端が欠けていた

## 変更

### 1. 予想最大震度が不明でも「不明」を描く

`EewDisplay.maxIntensity` / `intensity` が optional で、各 View が `if let` で握っていたためバッジごと消えていた。アプリ本体の EEW カードが `JmaIntensity.unknown`（「不明」）を出しているのと表示を揃える。

- `EewIntensityBadge`（`.value` / `.unknown`）を追加し、値の有無を「不明」込みで表現する
- `EewDisplay.intensityBadge` / `maxIntensityBadge` を追加。**取消報だけ**は震度そのものが無効なので、従来どおり欄ごと出さない（テストで固定）
- 配色はグレー地＋白文字。アプリ本体の unknown は黒(`0xFF000000`)だが、Dynamic Island の地やダーク背景と同化してバッジが消えるため、取消シンボル・揺れ検知の level 不明と同じグレー扱いにした
- 「不明」は 2 文字あるのでバッジ寸法比 0.34 に落として正方形に収める（`IntensityBadge` に `mainFontScale` を追加）
- 震度が無いときの AppIcon フォールバック（compact / minimal）は不要になったので削除

Lock Screen / 展開 / compact / minimal のすべてで「最大震度・不明」が出る。

### 2. Dynamic Island の字形切れ

スクリーンショットを拡大すると、切れていたのは `m` の 3 本目の縦棒で、コンテナ右端までは 15pt 空いていた。レイアウトの溢れではなく **Text の計測幅より実描画幅がわずかに広い**ための字形切れ（3x で約 4px ≒ 1.3pt 不足）。`AppFonts.flex` は可変フォントを実行時登録して `.weight()` を付けているため太さの実体が無く擬似ボールドで描かれるのが原因と見ている。同じ行の「深さ」がシステムフォントにフォールバックしていて無事だったのも符合する。

`latinTrailingBleed(fontSize:)` を追加し、欧文で終わるラベル（`km`、検知方法の「1点検知(低精度)」）に文字サイズの 20% 分の逃げを右に確保した。Text 自身のクリップでも領域端のクリップでも効く。

震度不明時に leading が空だと展開時の左半分がまるごと空白になっていた点も、1 の修正で埋まる。

### 3. あわせて: アプリ内 EEW カードの注記条件が反転していた

```dart
// before
when depth < 150 && maxIntensity == .unknown
  → Text('震源の深さが150km以上のため、予想震度は発表されていません')
```

深さ 150km **未満**のときに「150km以上のため」という説明が出ていた。今回の報告ケース（深さ 40km・震度不明）でも誤った理由が表示されるため `depth >= 150` に修正。

## 検証

- `swiftc -parse`: 変更した Swift 7 ファイルすべて通過
- `EewDisplay` のバッジ判定はスタブと組んでコンパイル・実行し、追加した 5 テストの期待値と一致することを確認
- `dart analyze`（`eew_card.dart`）issue 0 件 / 既存 EewCard ウィジェットテスト 5 件パス

⚠️ **SwiftUI のレイアウト（見切れの解消・「不明」バッジの収まり）は未検証。** Linux 環境ではビルドできないため、プレビュー `unknownIntensity`（茨城県沖 M4.2 深さ40km / maxIntensity nil = 報告のケースそのまま）を Lock Screen・compact・expanded・minimal に追加した。Xcode プレビューか実機で確認をお願いしたい。字形切れの逃げ量 (20% ≒ 2pt) は実測不足分 1.3pt に対して足りる見込みだが、ここも実機確認が確実。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
