### PR TITLE
fix(onboarding): デバイス登録から進まなくなる問題を修正する

### DIFF
--- a/app/lib/core/provider/api_dio_factory.dart
+++ b/app/lib/core/provider/api_dio_factory.dart
@@ -35,7 +35,13 @@ final class ApiDioFactory {
     dio.options
       ..headers.addAll(headers)
       ..connectTimeout = const Duration(seconds: 10)
-      ..sendTimeout = const Duration(seconds: 10);
+      ..sendTimeout = const Duration(seconds: 10)
+      // receiveTimeout が無いと、接続だけ成立してレスポンスが返らない状況
+      // (キャプティブポータル、停止したコネクション) でリクエストが永久に
+      // 完了せず、オンボーディングのデバイス登録がスピナーのまま固まる。
+      // 個別に厳しい上限が必要なエンドポイントは自前の Dio を持っているため、
+      // ここはハング防止のバックストップとして余裕のある値にする。
+      ..receiveTimeout = const Duration(seconds: 30);
     dio.interceptors.addAll(baseInterceptors);
     if (httpCacheStore != null) {
       dio.interceptors.add(HttpCacheInterceptor(httpCacheStore));

--- a/app/lib/core/provider/interceptor/app_check_interceptor.dart
+++ b/app/lib/core/provider/interceptor/app_check_interceptor.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
@@ -20,55 +22,66 @@ class AppCheckInterceptor extends Interceptor {
   new({
     required AppCheckTokenGetter getToken,
     required AppCheckTokenGetter getLimitedUseToken,
+    Duration tokenTimeout = const Duration(seconds: 10),
   }) : _getToken = getToken,
-       _getLimitedUseToken = getLimitedUseToken;
+       _getLimitedUseToken = getLimitedUseToken,
+       _tokenTimeout = tokenTimeout;
 
   final AppCheckTokenGetter _getToken;
   final AppCheckTokenGetter _getLimitedUseToken;
+
+  /// AppCheck トークン取得の上限時間。
+  ///
+  /// interceptor 内の待ち時間は Dio の各種 timeout の対象外なので、ここで
+  /// 明示的に打ち切らないと Play Integrity / App Attest の応答待ちで
+  /// リクエストが永久に発行されないままになる。
+  final Duration _tokenTimeout;
 
   @override
   Future<void> onRequest(
     RequestOptions options,
     RequestInterceptorHandler handler,
   ) async {
+    const deviceRegistrationPath = api.DeviceApiClientUrls.postV2Device;
+    const realtimeTicketPath = api.RealtimeApiClientUrls.getV2RealtimeTicket;
+    const getMethod = 'GET';
+    const postMethod = 'POST';
+    final isDeviceRegistration =
+        options.method == postMethod && options.path == deviceRegistrationPath;
+    final isRealtimeTicket =
+        options.method == getMethod && options.path == realtimeTicketPath;
+
+    if (!isDeviceRegistration && !isRealtimeTicket) {
+      handler.next(options);
+      return;
+    }
+
+    // backend は AppCheck 検証に失敗しても匿名デバイスとして登録を続行するため、
+    // トークンが取れない場合はヘッダー無しで進めるのが正しい。ここで reject すると
+    // 端末の Attestation が不調なだけのユーザーが登録できなくなる。
     try {
-      const deviceRegistrationPath = api.DeviceApiClientUrls.postV2Device;
-      const realtimeTicketPath = api.RealtimeApiClientUrls.getV2RealtimeTicket;
-      const getMethod = 'GET';
-      const postMethod = 'POST';
-      final isDeviceRegistration =
-          options.method == postMethod &&
-          options.path == deviceRegistrationPath;
-      final String? appCheckToken;
-
-      if (isDeviceRegistration) {
-        appCheckToken = await _getLimitedUseToken();
-      } else if (options.path == realtimeTicketPath &&
-          options.method == getMethod) {
-        appCheckToken = await _getToken();
-      } else {
-        handler.next(options);
-        return;
-      }
-
+      final appCheckToken =
+          await (isDeviceRegistration ? _getLimitedUseToken() : _getToken())
+              .timeout(_tokenTimeout);
       if (appCheckToken != null) {
         options.headers['X-Firebase-AppCheck'] = appCheckToken;
       }
-      handler.next(options);
-    } on FirebaseException catch (exception, stackTrace) {
+    } on TimeoutException catch (exception, stackTrace) {
+      talker.info(
+        'AppCheckInterceptor: AppCheck Tokenの取得が'
+        '${_tokenTimeout.inSeconds}秒でタイムアウトしました。headerは無しで続行します',
+        exception,
+        stackTrace,
+      );
+    } on Object catch (exception, stackTrace) {
+      // FirebaseException 以外 (PlatformException など) でもリクエスト自体を
+      // 失敗させない。
       talker.info(
         'AppCheckInterceptor: AppCheck Tokenの発行に失敗しました。headerは無しで続行します',
         exception,
         stackTrace,
       );
-      handler.next(options);
-      // handler.reject(
-      //   DioException.requestCancelled(
-      //     requestOptions: options,
-      //     reason: AppCheckRejection(exception),
-      //     stackTrace: stackTrace,
-      //   ),
-      // );
     }
+    handler.next(options);
   }
 }

--- a/app/lib/feature/onboarding/ui/components/onboarding_bottom_bar.dart
+++ b/app/lib/feature/onboarding/ui/components/onboarding_bottom_bar.dart
@@ -81,7 +81,7 @@ class _OnboardingBottomBar extends StatelessWidget {
               ),
               Expanded(
                 child: FilledButton(
-                  onPressed: isNextEnabled || !isProcessing ? onNext : null,
+                  onPressed: isNextEnabled && !isProcessing ? onNext : null,
                   style: FilledButton.styleFrom(
                     backgroundColor: isProcessing
                         ? designSystem.colorTheme.surfaceContainer

--- a/app/lib/feature/onboarding/ui/components/welcome_step_page.dart
+++ b/app/lib/feature/onboarding/ui/components/welcome_step_page.dart
@@ -23,6 +23,15 @@ class _WelcomeStepPage extends HookConsumerWidget {
         : 'デバイスの状態を確認しています...';
     final isMigrated =
         ref.watch(deviceMigratedFromLegacyProvider).value ?? false;
+    // 失敗を画面上にも残す。ダイアログを閉じても再試行できないと、
+    // provisionMutation が MutationError のまま自動再試行の条件
+    // (MutationIdle) を満たさず、無効な「次へ」だけが残って詰む。
+    final failureMessage = switch (deviceProvisioningMutation) {
+      MutationError(:final error) => const DeviceProvisioningErrorMessage().of(
+        error,
+      ),
+      _ => deviceProvisioningStatus is AsyncError ? 'デバイスの状態確認に失敗しました' : null,
+    };
 
     Future<void> startProvisioning() async {
       try {
@@ -68,15 +77,11 @@ class _WelcomeStepPage extends HookConsumerWidget {
 
     ref.listen(DeviceProvisioningNotifier.provisionMutation, (_, next) {
       if (next is MutationError) {
-        final errorMessage = switch (next.error) {
-          DeviceProvisioningException(:final userMessage) => userMessage,
-          _ => next.error.toString(),
-        };
         unawaited(
           DeviceRegistrationErrorDialogAction().show(
             context: context,
             ref: ref,
-            message: errorMessage,
+            message: const DeviceProvisioningErrorMessage().of(next.error),
             error: next.error,
             stackTrace: next.stackTrace,
             onRetry: retryProvisioning,
@@ -155,8 +160,82 @@ class _WelcomeStepPage extends HookConsumerWidget {
             ),
           ),
           const Spacer(),
-          const Center(child: _OnboardingAppIconHero()),
+          // 失敗時は装飾のヒーローより再試行の導線を優先する。差し替えることで
+          // 縦方向の高さが増えず、小さい画面でも溢れない。
+          if (failureMessage != null)
+            _DeviceProvisioningFailureCard(
+              message: failureMessage,
+              onRetry: retryProvisioning,
+            )
+          else
+            const Center(child: _OnboardingAppIconHero()),
           const Spacer(flex: 2),
+        ],
+      ),
+    );
+  }
+}
+
+/// プロビジョニングの失敗を UI 表示用の文言へ変換する。
+class DeviceProvisioningErrorMessage {
+  const new();
+
+  String of(Object error) => switch (error) {
+    DeviceProvisioningException(:final userMessage) => userMessage,
+    _ => error.toString(),
+  };
+}
+
+/// デバイス登録に失敗したことを画面上に残し、再試行の導線を提供するカード。
+class _DeviceProvisioningFailureCard extends StatelessWidget {
+  const new({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final designSystem = context.designSystem;
+
+    return Container(
+      padding: EdgeInsets.all(designSystem.spacing.md),
+      decoration: BoxDecoration(
+        color: designSystem.colorTheme.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(designSystem.shape.card),
+        border: Border.all(
+          color: designSystem.colorTheme.error.withValues(alpha: 0.3),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: .start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.error_outline_rounded,
+                color: designSystem.colorTheme.error,
+              ),
+              SizedBox(width: designSystem.spacing.sm),
+              Expanded(
+                child: Text(
+                  'デバイスの登録に失敗しました',
+                  style: designSystem.typography.titleSmall,
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: designSystem.spacing.sm),
+          Text(
+            message,
+            style: designSystem.typography.bodySmall.copyWith(
+              color: designSystem.colorTheme.onSurfaceVariant,
+            ),
+          ),
+          SizedBox(height: designSystem.spacing.sm),
+          Align(
+            alignment: .centerRight,
+            child: TextButton(onPressed: onRetry, child: const Text('再試行')),
+          ),
         ],
       ),
     );

--- a/app/lib/feature/onboarding/ui/page/onboarding_page.dart
+++ b/app/lib/feature/onboarding/ui/page/onboarding_page.dart
@@ -60,7 +60,10 @@ class OnboardingPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final pageController = usePageController();
     final currentPage = useState(0);
-    final stepNavigation = useState(_StepNavigationState.initial(_steps.first));
+    // 描画に影響する値だけを useState で持つ。onNext は毎ビルド新しいクロージャに
+    // なるため useRef に置き、識別子の変化で再ビルドを誘発しないようにする。
+    final stepView = useState(_StepNavigationView.initial(_steps.first));
+    final onNextRef = useRef<Future<void> Function()?>(null);
 
     final animateToNext = useCallback<Future<void> Function()>(() async {
       await pageController.nextPage(
@@ -86,11 +89,16 @@ class OnboardingPage extends HookConsumerWidget {
           nextPage: animateToNext,
           previousPage: goToPrevious,
           register: (state) {
+            if (step != _steps[currentPage.value]) {
+              return;
+            }
+            // onNext は常に最新へ差し替える。useRef なのでここでは再ビルドしない。
+            onNextRef.value = state.onNext;
             WidgetsBinding.instance.addPostFrameCallback((_) {
               if (!context.mounted || step != _steps[currentPage.value]) {
                 return;
               }
-              stepNavigation.value = state;
+              stepView.value = state.view;
             });
           },
         ),
@@ -98,18 +106,23 @@ class OnboardingPage extends HookConsumerWidget {
 
     void onPageChanged(int index) {
       currentPage.value = index;
-      stepNavigation.value = _StepNavigationState.initial(_steps[index]);
+      onNextRef.value = null;
+      stepView.value = _StepNavigationView.initial(_steps[index]);
     }
 
-    final navigation = stepNavigation.value;
+    final view = stepView.value;
 
     final showBack =
         currentPage.value > 0 && currentStep != _OnboardingStep.complete;
-    final isBackEnabled = showBack && !navigation.isProcessing;
+    final isBackEnabled = showBack && !view.isProcessing;
 
     Future<void> goToNext() async {
+      final onNext = onNextRef.value;
+      if (onNext == null) {
+        return;
+      }
       unawaited(HapticFeedback.mediumImpact());
-      await stepNavigation.value.onNext?.call();
+      await onNext();
     }
 
     return PopScope(
@@ -137,11 +150,13 @@ class OnboardingPage extends HookConsumerWidget {
               _OnboardingBottomBar(
                 currentPage: currentPage.value,
                 totalPages: _steps.length,
-                buttonLabel: navigation.buttonLabel,
-                processingLabel: navigation.processingLabel,
-                isNextEnabled: navigation.isNextEnabled,
+                buttonLabel: view.buttonLabel,
+                processingLabel: view.processingLabel,
+                // hasNext を含めることで、まだ onNext が登録されていない間に
+                // 「押せるのに何も起きない」ボタンが生まれないようにする。
+                isNextEnabled: view.isNextEnabled && view.hasNext,
                 isBackEnabled: isBackEnabled,
-                isProcessing: navigation.isProcessing,
+                isProcessing: view.isProcessing,
                 onNext: goToNext,
                 onPrevious: showBack ? goToPrevious : null,
               ),
@@ -153,6 +168,7 @@ class OnboardingPage extends HookConsumerWidget {
   }
 }
 
+/// 各ステップが [_OnboardingStepNavigation.register] に渡す状態。
 class _StepNavigationState {
   const new({
     required this.buttonLabel,
@@ -162,25 +178,69 @@ class _StepNavigationState {
     required this.onNext,
   });
 
-  factory initial(_OnboardingStep step) => _StepNavigationState(
+  final String buttonLabel;
+  final String processingLabel;
+  final bool isNextEnabled;
+  final bool isProcessing;
+  final Future<void> Function()? onNext;
+
+  _StepNavigationView get view => _StepNavigationView(
+    buttonLabel: buttonLabel,
+    processingLabel: processingLabel,
+    isNextEnabled: isNextEnabled,
+    isProcessing: isProcessing,
+    hasNext: onNext != null,
+  );
+}
+
+/// ボトムバーの描画に必要な値だけを持つ不変ビュー。
+///
+/// クロージャを含めず値等価を実装しているのが要点。含めてしまうと毎ビルド
+/// 新しいクロージャで不等になり、`register` → post-frame → `useState` 更新 →
+/// 再ビルド → `register` … のループでフレームを永久にスケジュールし続ける。
+class _StepNavigationView {
+  const new({
+    required this.buttonLabel,
+    required this.processingLabel,
+    required this.isNextEnabled,
+    required this.isProcessing,
+    required this.hasNext,
+  });
+
+  factory initial(_OnboardingStep step) => _StepNavigationView(
     buttonLabel: switch (step) {
       _OnboardingStep.complete => 'はじめる',
       _ => '次へ',
     },
     processingLabel: '処理しています...',
-    isNextEnabled: switch (step) {
-      _OnboardingStep.welcome => false,
-      _OnboardingStep.permissions => false,
-      _OnboardingStep.notificationSettings => false,
-      _OnboardingStep.complete => false,
-    },
+    isNextEnabled: false,
     isProcessing: false,
-    onNext: null,
+    hasNext: false,
   );
 
   final String buttonLabel;
   final String processingLabel;
   final bool isNextEnabled;
   final bool isProcessing;
-  final Future<void> Function()? onNext;
+
+  /// 有効な `onNext` が登録済みかどうか。
+  final bool hasNext;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _StepNavigationView &&
+      other.buttonLabel == buttonLabel &&
+      other.processingLabel == processingLabel &&
+      other.isNextEnabled == isNextEnabled &&
+      other.isProcessing == isProcessing &&
+      other.hasNext == hasNext;
+
+  @override
+  int get hashCode => Object.hash(
+    buttonLabel,
+    processingLabel,
+    isNextEnabled,
+    isProcessing,
+    hasNext,
+  );
 }

--- a/app/test/core/provider/api_dio_factory_test.dart
+++ b/app/test/core/provider/api_dio_factory_test.dart
@@ -43,6 +43,10 @@ void main() {
       expect(dio.options.headers['x-eqmonitor-version'], 'test');
       expect(dio.options.connectTimeout, const Duration(seconds: 10));
       expect(dio.options.sendTimeout, const Duration(seconds: 10));
+      // receiveTimeout が無いと、接続だけ成立してレスポンスが返らない状況で
+      // リクエストが永久に完了しない。
+      expect(dio.options.receiveTimeout, isNotNull);
+      expect(dio.options.receiveTimeout, const Duration(seconds: 30));
       expect(dio.options.contentType, 'application/json');
       expect(dio.options.listFormat, ListFormat.multiCompatible);
     }

--- a/app/test/core/provider/interceptor/device_registration_interceptor_test.dart
+++ b/app/test/core/provider/interceptor/device_registration_interceptor_test.dart
@@ -1,11 +1,18 @@
 // ignore_for_file: type_annotate_public_apis
 
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/provider/interceptor/app_check_interceptor.dart';
 import 'package:eqmonitor/core/provider/interceptor/device_id_interceptor.dart';
+import 'package:eqmonitor/core/provider/log/talker.dart' as talker_lib;
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:talker_flutter/talker_flutter.dart';
 
 void main() {
+  talker_lib.talker = Talker();
+
   test('DeviceIdInterceptor attaches device id to POST /v2/device', () {
     final interceptor = DeviceIdInterceptor(deviceId: 'device-1');
     final options = RequestOptions(path: '/v2/device', method: 'POST');
@@ -64,7 +71,90 @@ void main() {
       expect(handler.nextOptions, same(options));
     },
   );
+
+  test(
+    'AppCheckInterceptor uses regular token for the realtime ticket',
+    () async {
+      final tokenSource = _AppCheckTokenSource();
+      final interceptor = AppCheckInterceptor(
+        getToken: tokenSource.getToken,
+        getLimitedUseToken: tokenSource.getLimitedUseToken,
+      );
+      final options = RequestOptions(
+        path: '/v2/realtime/ticket',
+        method: 'GET',
+      );
+      final handler = _CapturingRequestHandler();
+
+      await interceptor.onRequest(options, handler);
+
+      expect(options.headers['X-Firebase-AppCheck'], 'regular-token');
+      expect(tokenSource.tokenCount, 1);
+      expect(tokenSource.limitedUseTokenCount, 0);
+    },
+  );
+
+  test(
+    'AppCheckInterceptor skips unrelated paths without fetching a token',
+    () async {
+      final tokenSource = _AppCheckTokenSource();
+      final interceptor = AppCheckInterceptor(
+        getToken: tokenSource.getToken,
+        getLimitedUseToken: tokenSource.getLimitedUseToken,
+      );
+      final options = RequestOptions(path: '/v2/device/me', method: 'GET');
+      final handler = _CapturingRequestHandler();
+
+      await interceptor.onRequest(options, handler);
+
+      expect(options.headers.containsKey('X-Firebase-AppCheck'), isFalse);
+      expect(tokenSource.tokenCount, 0);
+      expect(tokenSource.limitedUseTokenCount, 0);
+      expect(handler.nextOptions, same(options));
+    },
+  );
+
+  // interceptor 内の待ち時間は Dio の timeout の対象外なので、ここで打ち切らないと
+  // デバイス登録のリクエストが永久に発行されない。
+  test(
+    'AppCheckInterceptor gives up on a hanging token fetch and continues',
+    () async {
+      final interceptor = AppCheckInterceptor(
+        getToken: _never,
+        getLimitedUseToken: _never,
+        tokenTimeout: const Duration(milliseconds: 20),
+      );
+      final options = RequestOptions(path: '/v2/device', method: 'POST');
+      final handler = _CapturingRequestHandler();
+
+      await interceptor.onRequest(options, handler);
+
+      expect(options.headers.containsKey('X-Firebase-AppCheck'), isFalse);
+      expect(handler.nextOptions, same(options));
+    },
+  );
+
+  // backend は AppCheck 検証に失敗しても匿名デバイスとして登録を続行するため、
+  // トークンが取れないことを理由にリクエストを落としてはいけない。
+  test('AppCheckInterceptor continues when the token fetch throws', () async {
+    final interceptor = AppCheckInterceptor(
+      getToken: _throwing,
+      getLimitedUseToken: _throwing,
+    );
+    final options = RequestOptions(path: '/v2/device', method: 'POST');
+    final handler = _CapturingRequestHandler();
+
+    await interceptor.onRequest(options, handler);
+
+    expect(options.headers.containsKey('X-Firebase-AppCheck'), isFalse);
+    expect(handler.nextOptions, same(options));
+  });
 }
+
+Future<String?> _never() => Completer<String?>().future;
+
+Future<String?> _throwing() async =>
+    throw PlatformException(code: 'app-check-unavailable');
 
 final class _CapturingRequestHandler extends RequestInterceptorHandler {
   RequestOptions? nextOptions;

--- a/app/test/feature/onboarding/onboarding_page_test.dart
+++ b/app/test/feature/onboarding/onboarding_page_test.dart
@@ -13,15 +13,40 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 void main() {
+  // デバイス登録の状態が確定するまでの間、「次へ」は押せてはならない。
+  // 押せてしまうと onNext が未登録なのでタップが完全に無反応になり、
+  // 「デバイス登録から進まない」という体験になる。
+  testWidgets('welcome next button is disabled while the status is resolving', (
+    tester,
+  ) async {
+    final notifier = _GatedStatusDeviceProvisioningNotifier();
+    await tester.pumpWidget(_wrap(notifier: notifier));
+
+    for (var i = 0; i < 4; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(_nextButton(tester).onPressed, isNull);
+    }
+
+    // 無反応タップが起きないことを、実際に押して確認する。
+    expect(find.text('次へ'), findsOneWidget);
+    await tester.tap(find.text('次へ'), warnIfMissed: false);
+    await _pumpFrames(tester);
+    expect(find.text('EQMonitor へ\nようこそ'), findsOneWidget);
+    expect(find.text('通知と位置情報'), findsNothing);
+
+    notifier.releaseStatus();
+    await _pumpFrames(tester);
+  });
+
   testWidgets('device registration gates the welcome next button', (
     tester,
   ) async {
     final notifier = _ControlledDeviceProvisioningNotifier();
     await tester.pumpWidget(_wrap(notifier: notifier));
-    await tester.pump();
-    await tester.pump();
+    await _pumpFrames(tester, frames: 4);
 
     expect(_nextButton(tester).onPressed, isNull);
+    expect(find.text('デバイスを登録しています...'), findsOneWidget);
 
     notifier.completeProvisioning();
     await tester.pump();
@@ -42,31 +67,131 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
 
-    expect(find.text('デバイスの登録に失敗しました'), findsOneWidget);
-    expect(find.text('予期しないエラーが発生しました'), findsOneWidget);
+    expect(find.text('デバイスの登録に失敗しました'), findsWidgets);
+    expect(find.text('予期しないエラーが発生しました'), findsWidgets);
     expect(_nextButton(tester).onPressed, isNull);
+  });
+
+  // 登録に失敗したままオンボーディングを進めてしまうと、デバイス未登録=通知が
+  // 一切届かない状態で完了できてしまう。
+  testWidgets('a failed registration cannot be skipped past', (tester) async {
+    final notifier = _ControlledDeviceProvisioningNotifier();
+    await tester.pumpWidget(_wrap(notifier: notifier));
+    await tester.pump();
+    await tester.pump();
+
+    notifier.failProvisioning();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    await tester.tap(find.text('閉じる'));
+    await _pumpFrames(tester);
+
+    expect(_nextButton(tester).onPressed, isNull);
+    await tester.tap(find.text('次へ'), warnIfMissed: false);
+    await _pumpFrames(tester);
+    expect(find.text('通知と位置情報'), findsNothing);
+    expect(find.text('EQMonitor へ\nようこそ'), findsOneWidget);
+  });
+
+  // ダイアログを閉じたあとも再試行できる導線が画面上に残っていること。
+  // provisionMutation は MutationError のままなので自動再試行は発火しない。
+  testWidgets('an inline retry stays available after closing the dialog', (
+    tester,
+  ) async {
+    final notifier = _ControlledDeviceProvisioningNotifier();
+    await tester.pumpWidget(_wrap(notifier: notifier));
+    await tester.pump();
+    await tester.pump();
+
+    notifier.failProvisioning();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    await tester.tap(find.text('閉じる'));
+    await _pumpFrames(tester);
+
+    expect(find.text('デバイスの登録に失敗しました'), findsOneWidget);
+    expect(find.text('再試行'), findsOneWidget);
+
+    await tester.tap(find.text('再試行'));
+    await _pumpFrames(tester);
+    expect(notifier.provisionCallCount, greaterThan(1));
+  });
+
+  // register → post-frame callback → useState 更新 → 再ビルド → register の
+  // ループでフレームを永久にスケジュールし続けていた回帰のガード。
+  testWidgets('the onboarding page settles instead of rebuilding forever', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(notifier: _ImmediateDeviceProvisioningNotifier()),
+    );
+    await tester.pumpAndSettle(
+      const Duration(milliseconds: 100),
+      EnginePhase.sendSemanticsUpdate,
+      const Duration(seconds: 5),
+    );
+    expect(tester.binding.hasScheduledFrame, isFalse);
   });
 
   testWidgets('権限のスキップ状態はオンボーディング画面内で管理する', (tester) async {
     await tester.pumpWidget(
       _wrap(notifier: _ImmediateDeviceProvisioningNotifier()),
     );
-    await tester.pump();
-    await tester.pump();
+    await tester.pumpAndSettle(
+      const Duration(milliseconds: 100),
+      EnginePhase.sendSemanticsUpdate,
+      const Duration(seconds: 5),
+    );
 
     await tester.tap(find.text('次へ'));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pumpAndSettle(
+      const Duration(milliseconds: 100),
+      EnginePhase.sendSemanticsUpdate,
+      const Duration(seconds: 5),
+    );
 
+    // 通知をスキップすると「重大な通知」も併せてスキップ済みになる。
     await tester.tap(find.text('スキップ').first);
-    await tester.pump();
+    await tester.pumpAndSettle(
+      const Duration(milliseconds: 100),
+      EnginePhase.sendSemanticsUpdate,
+      const Duration(seconds: 5),
+    );
     expect(find.text('スキップしました'), findsNWidgets(2));
+    // 位置情報がまだ未処理なので「次へ」は押せない。
+    expect(_nextButton(tester).onPressed, isNull);
 
+    // 位置情報のカードはビューポート外にあるのでスクロールしてから押す。
+    // ListView は一度に全カードを保持しないため、全体の個数ではなく
+    // 「スキップ待ちが無くなり次へ進めるか」で検証する。
+    await tester.dragUntilVisible(
+      find.text('スキップ').last,
+      find.byType(ListView),
+      const Offset(0, -80),
+    );
+    await tester.pumpAndSettle(
+      const Duration(milliseconds: 100),
+      EnginePhase.sendSemanticsUpdate,
+      const Duration(seconds: 5),
+    );
     await tester.tap(find.text('スキップ').first);
-    await tester.pump();
-    expect(find.text('スキップしました'), findsNWidgets(4));
+    await tester.pumpAndSettle(
+      const Duration(milliseconds: 100),
+      EnginePhase.sendSemanticsUpdate,
+      const Duration(seconds: 5),
+    );
+    expect(find.text('スキップ'), findsNothing);
     expect(_nextButton(tester).onPressed, isNotNull);
   });
+}
+
+/// アニメーションと post-frame callback を消化するのに十分なフレームを進める。
+Future<void> _pumpFrames(WidgetTester tester, {int frames = 40}) async {
+  for (var i = 0; i < frames; i++) {
+    await tester.pump(const Duration(milliseconds: 16));
+  }
 }
 
 FilledButton _nextButton(WidgetTester tester) =>
@@ -112,10 +237,30 @@ final class _DeniedPermissionNotifier extends PermissionNotifier {
   );
 }
 
+/// `build()` が解決するまで待たせて、状態確認中のウィンドウを再現する。
+final class _GatedStatusDeviceProvisioningNotifier
+    extends DeviceProvisioningNotifier {
+  final _statusGate = Completer<void>();
+
+  @override
+  Future<DeviceProvisioningStatus> build() async {
+    await _statusGate.future;
+    return DeviceProvisioningStatus.required;
+  }
+
+  @override
+  Future<void> provision() async {
+    state = const AsyncData(DeviceProvisioningStatus.notRequired);
+  }
+
+  void releaseStatus() => _statusGate.complete();
+}
+
 final class _ControlledDeviceProvisioningNotifier
     extends DeviceProvisioningNotifier {
-  final _provisionCompleter = Completer<void>();
+  var _provisionCompleter = Completer<void>();
   UnexpectedProvisioningException? _provisioningError;
+  var provisionCallCount = 0;
 
   @override
   Future<DeviceProvisioningStatus> build() async =>
@@ -123,9 +268,13 @@ final class _ControlledDeviceProvisioningNotifier
 
   @override
   Future<void> provision() async {
+    provisionCallCount += 1;
     await _provisionCompleter.future;
     final error = _provisioningError;
     if (error != null) {
+      // 次の試行のためにゲートを張り直す。
+      _provisionCompleter = Completer<void>();
+      _provisioningError = null;
       throw error;
     }
     state = const AsyncData(DeviceProvisioningStatus.notRequired);


### PR DESCRIPTION
「オンボーディングのデバイス登録から進まない」という報告を調査し、原因となっていた 4 件を修正します。

backend 側の対になる修正は YumNumm/eqmonitor-backend#1084 です。

## 1. 「次へ」が押せるのに何も起きない（主因・4 日前のリグレッション）

`app/lib/feature/onboarding/ui/components/onboarding_bottom_bar.dart`

```dart
- onPressed: isNextEnabled ? onNext : null,
+ onPressed: isNextEnabled || !isProcessing ? onNext : null,   // eda0d155e (08-16)
```

演算子優先順位で `(isNextEnabled || !isProcessing)` になるため、**「処理中でなければ、準備できていなくても活性」** になっていました。

`_StepNavigationState.initial()` の `onNext` は `null` で、`goToNext()` は `onNext?.call()` です。結果として **押せる・ハプティクスも鳴る・何も起きない** 死んだボタンが生まれます。welcome ステップでは `deviceProvisioningProvider.build()`（SharedPreferences と flutter_secure_storage の読み出し）が解決するまでこの状態が続き、初回コールドスタートでは体感できる長さになります。

同じ条件式のせいで、登録失敗ダイアログを閉じると `isProcessing` が false になってボタンが活性化し、**デバイス未登録＝通知が一切届かない状態でオンボーディングを完走できてしまう** 問題もありました。

`isNextEnabled && !isProcessing` に戻し、さらに `onNext` の登録有無（`hasNext`）も条件に含めて、無反応ボタンが構造的に生まれないようにしています。

## 2. オンボーディング画面が毎フレーム再ビルドし続ける

`_OnboardingStepNavigation` と `_StepNavigationState` は値等価を持たず、`OnboardingPage.build` は毎ビルド新しい `_OnboardingStepNavigation` を作ります。各ステップページは `navigation` を `useEffect` の deps に入れているため、

`register` → post-frame callback → `useState` に新インスタンス代入（必ず不等）→ 再ビルド → `register` → …

とフレームを永久にスケジュールし続けていました（`pumpAndSettle` がタイムアウトすることで確認）。実機ではオンボーディング中ずっと CPU/GPU を焼き続け、低スペック機ではタップ自体が鈍くなります。

描画に必要な値だけを値等価つきの `_StepNavigationView` に分離して `useState` で保持し、毎ビルド変わる `onNext` は `useRef` に置いて解消しました。`useRef` は常に最新へ差し替えるので古いクロージャも残りません。

## 3. 登録失敗後に再試行の導線が消える

エラーダイアログを「閉じる」で消すと `provisionMutation` は `MutationError` のまま残ります。自動再試行の `useEffect` は `MutationIdle` を条件にしているため二度と発火せず、無効化された「次へ」だけが残ってアプリ再起動以外に手段がありませんでした。

welcome ステップに失敗内容と「再試行」を持つカードを表示して導線を残します。装飾のヒーローと差し替える形にしているのは、縦に積むと小さい画面で Column が溢れるためです。

## 4. リクエストが無限にハングしうる 2 箇所

- **API Dio に `receiveTimeout` が無い**（`api_dio_factory.dart`）。接続だけ成立してレスポンスが返らない状況（キャプティブポータル、停止したコネクション）でリクエストが永久に完了せず、「デバイスを登録しています...」のスピナーのまま固まります。アプリ内の他の Dio は設定済みです。ハング防止のバックストップとして 30 秒にしました。
- **AppCheck トークン取得に上限が無い**（`app_check_interceptor.dart`）。interceptor 内の待ち時間は Dio のどの timeout の対象外なので、`getLimitedUseToken()` が返らないとリクエスト自体が発行されません。10 秒（注入可能）で打ち切ります。

あわせて `FirebaseException` 以外（`PlatformException` など）でもリクエストを失敗させないようにしました。backend の `POST /v2/device` は AppCheck 検証に失敗しても `registrationType=null` の匿名デバイスとして登録を続行するため、トークンが取れないことを理由に落とすと Play Integrity / App Attest が不調な端末が登録できなくなります。

## テスト

`app/test/feature/onboarding/onboarding_page_test.dart` の 3 件は `eda0d155e` 以降 develop で赤でした。同コミットは PR を経由せず develop へ直 push されており、`pr-flutter-check` が走っていません。

実際の振る舞いを検証するよう書き換え、以下の回帰ガードを追加しています。

- 状態確認中は「次へ」が押せず、押しても画面が進まない
- 登録失敗後は権限ステップへ進めない
- ダイアログを閉じてもインラインの「再試行」が残り、押すと再実行される
- ページがフレームをスケジュールし続けず settle する
- AppCheck トークンが返らない／例外を投げてもリクエストは続行される
- API Dio に `receiveTimeout` が設定されている

`権限のスキップ状態は…` は ListView が全カードを同時に保持しない（実測で 2〜4 枚）ため、全体の個数ではなく「スキップ待ちが無くなり次へ進めるか」で検証する形に改めました。

### 検証結果

```
$ flutter test test/feature/onboarding/ test/feature/devices/ \
    test/core/provider/interceptor/ test/core/provider/api_dio_factory_test.dart
01:16 +132: All tests passed!
```

`dart analyze` は変更したパスで実診断 0 件です（出力に残る `RangeError` は `flutter_hooks_lint_plugin` の `exhaustive_keys` が hook 密度の高いファイルでクラッシュする既存の問題で、develop でも同様）。`dart format` 適用済み。

## この PR に含めていないもの

- **`POST /v2/device` のレート制限**（5 回/60 秒・`Retry-After` なし・拒否も加算）。詰まったユーザーが強制終了と再起動を繰り返すと 429 に落ちて悪化する構造で、backend 側 PR で対応しています。
- **登録の非冪等性**。`POST /v2/device` は毎回 `crypto.randomUUID()` で新しいデバイス行を作り、クライアントの `x-eqmonitor-device-id` を無視します。ただしこのヘッダは未認証かつクライアント制御なので、これをデバイス同一性の鍵にすると他人のデバイス行を主張できてしまいます。安全な修正には冪等キーの設計が必要なため、別途対応が必要です。
- **backend submodule pin の巻き戻り**（`role` を含まない枝への横移動）。develop の後続コミットで `169a743e` へ更新され、こちらは `resolveDeviceRole` を含むため既に解消済みでした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)