### PR TITLE
fix(home): 市区町村別最大観測震度の導線を有効化する

### DIFF
--- a/app/lib/page/home_page.dart
+++ b/app/lib/page/home_page.dart
@@ -157,43 +157,25 @@ class _HomeActionsCard extends ConsumerWidget {
           child: Column(
             crossAxisAlignment: .stretch,
             children: [
-              Stack(
-                children: [
-                  ListTile(
-                    title: Text.rich(
+              ListTile(
+                title: Text.rich(
+                  TextSpan(
+                    children: [
                       TextSpan(
-                        children: [
-                          TextSpan(
-                            text: '市区町村別 ',
-                            style: typography.bodySmall.copyWith(
-                              fontWeight: .bold,
-                            ),
-                          ),
-                          TextSpan(
-                            text: '最大観測震度',
-                            style: typography.titleSmall,
-                          ),
-                        ],
-                      ),
-                    ),
-                    onTap: null,
-                    // TODO(YumNumm): 後で戻す
-                    // onTap: () async =>
-                    //     const IntensityHistoryRoute().push<void>(context),
-                  ),
-                  Positioned.fill(
-                    child: ColoredBox(
-                      color: context.designSystem.colorTheme.surface.withValues(
-                        alpha: 0.8,
-                      ),
-                      child: Center(
-                        child: Text(
-                          'このビルドではこの機能は利用できません',
+                        text: '市区町村別 ',
+                        style: typography.bodySmall.copyWith(
+                          fontWeight: .bold,
                         ),
                       ),
-                    ),
+                      TextSpan(
+                        text: '最大観測震度',
+                        style: typography.titleSmall,
+                      ),
+                    ],
                   ),
-                ],
+                ),
+                onTap: () async =>
+                    const IntensityHistoryRoute().push<void>(context),
               ),
               divider,
               ListTile(


### PR DESCRIPTION
## 概要

- ホームの「市区町村別 最大観測震度」をタップ可能に戻す
- 一時的な利用不可オーバーレイと TODO を削除する
- IntensityHistoryRoute への遷移を復元する

## 確認

- mise exec -- dart format --output=none --set-exit-if-changed app/lib/page/home_page.dart
- mise exec -- flutter analyze app/lib/page/home_page.dart
- mise exec -- flutter test --concurrency=1 app/test/feature/intensity_history（67 tests passed）

Widget Test は依頼者の指定により追加していません。既存の intensity_history テスト群と対象ファイルの静的解析で回帰確認しています。