### PR TITLE
fix: 震度スケールの目盛り見切れを修正

### DIFF
--- a/app/lib/feature/kyoshin_monitor/page/components/kyoshin_monitor_scale.dart
+++ b/app/lib/feature/kyoshin_monitor/page/components/kyoshin_monitor_scale.dart
@@ -79,16 +79,64 @@ class KyoshinMonitorScale extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final resolvedTextStyle = textStyle ?? const TextStyle(fontSize: 10);
+    final textScaler = MediaQuery.textScalerOf(context);
+    final labels = colorStops.map((stop) {
+      final value = stop.value;
+      return switch (value) {
+        >= 1 || <= 0 => value.toStringAsFixed(0),
+        >= 0.1 => value.toStringAsFixed(1),
+        >= 0.01 => value.toStringAsFixed(2),
+        >= 0.001 => value.toStringAsFixed(3),
+        _ => value.toStringAsFixed(4),
+      };
+    }).toList();
+    final labelPainter = TextPainter(
+      textDirection: TextDirection.ltr,
+      textAlign: TextAlign.center,
+      textScaler: textScaler,
+    );
+    var maxLabelWidth = 0.0;
+    var maxLabelHeight = 0.0;
+    for (final label in labels) {
+      labelPainter
+        ..text = TextSpan(text: label, style: resolvedTextStyle)
+        ..layout();
+      maxLabelWidth = max(maxLabelWidth, labelPainter.width);
+      maxLabelHeight = max(maxLabelHeight, labelPainter.height);
+    }
+
+    const labelOffset = 6.0;
+    final isHorizontal =
+        orientation == KyoshinMonitorScaleOrientation.horizontal;
+    final isTextAtStart = textPosition == KyoshinMonitorScaleTextPosition.start;
+    final size = isHorizontal
+        ? Size(width + maxLabelWidth, height + labelOffset + maxLabelHeight)
+        : Size(width + labelOffset + maxLabelWidth, height + maxLabelHeight);
+    final gradientRect = Rect.fromLTWH(
+      isHorizontal
+          ? maxLabelWidth / 2
+          : (isTextAtStart ? maxLabelWidth + labelOffset : 0),
+      isHorizontal
+          ? (isTextAtStart ? maxLabelHeight + labelOffset : 0)
+          : maxLabelHeight / 2,
+      width,
+      height,
+    );
+
     return CustomPaint(
-      size: Size(width, height),
+      size: size,
       painter: _KyoshinMonitorScalePainter(
         type: type,
         colorStops: colorStops,
+        labels: labels,
+        gradientRect: gradientRect,
         tickInterval: tickInterval,
         orientation: orientation,
         textPosition: textPosition,
         textColor: textColor,
-        textStyle: textStyle ?? const TextStyle(fontSize: 10),
+        textStyle: resolvedTextStyle,
+        textScaler: textScaler,
         gradientDirection: gradientDirection,
       ),
     );
@@ -250,27 +298,32 @@ class _KyoshinMonitorScalePainter extends CustomPainter {
   const new({
     required this.type,
     required this.colorStops,
+    required this.labels,
+    required this.gradientRect,
     required this.tickInterval,
     required this.orientation,
     required this.textPosition,
     required this.textColor,
     required this.textStyle,
+    required this.textScaler,
     required this.gradientDirection,
   });
 
   final KyoshinMonitorScaleType type;
   final List<({double position, double value, Color color})> colorStops;
+  final List<String> labels;
+  final Rect gradientRect;
   final int tickInterval;
   final KyoshinMonitorScaleOrientation orientation;
   final KyoshinMonitorScaleTextPosition textPosition;
   final Color textColor;
   final TextStyle textStyle;
+  final TextScaler textScaler;
   final KyoshinMonitorScaleGradientDirection gradientDirection;
 
   @override
   void paint(Canvas canvas, Size size) {
     // グラデーションの描画
-    final rect = Offset.zero & size;
     final colors = colorStops.map((e) => e.color).toList();
     final stops = colorStops.map((e) => e.position).toList();
 
@@ -329,15 +382,16 @@ class _KyoshinMonitorScalePainter extends CustomPainter {
       },
     );
     final paint = Paint()
-      ..shader = gradient.createShader(rect)
+      ..shader = gradient.createShader(gradientRect)
       ..style = PaintingStyle.fill;
 
-    canvas.drawRect(rect, paint);
+    canvas.drawRect(gradientRect, paint);
 
     // 目盛りの描画
     final textPainter = TextPainter(
       textDirection: TextDirection.ltr,
       textAlign: TextAlign.center,
+      textScaler: textScaler,
     );
 
     // 目盛り線の描画用のペイント
@@ -372,58 +426,64 @@ class _KyoshinMonitorScalePainter extends CustomPainter {
           : stop.position;
       final position =
           basePosition *
+              (orientation == KyoshinMonitorScaleOrientation.horizontal
+                  ? gradientRect.width
+                  : gradientRect.height) +
           (orientation == KyoshinMonitorScaleOrientation.horizontal
-              ? size.width
-              : size.height);
+              ? gradientRect.left
+              : gradientRect.top);
 
       // 目盛り線を描画
       switch (orientation) {
         case KyoshinMonitorScaleOrientation.horizontal:
+          final tickStart =
+              textPosition == KyoshinMonitorScaleTextPosition.start
+              ? gradientRect.top
+              : gradientRect.bottom;
+          final tickEnd = textPosition == KyoshinMonitorScaleTextPosition.start
+              ? tickStart - 4
+              : tickStart + 4;
           canvas.drawLine(
-            Offset(position, size.height),
-            Offset(position, size.height + 4),
+            Offset(position, tickStart),
+            Offset(position, tickEnd),
             tickPaint,
           );
         case KyoshinMonitorScaleOrientation.vertical:
+          final tickStart =
+              textPosition == KyoshinMonitorScaleTextPosition.start
+              ? gradientRect.left
+              : gradientRect.right;
+          final tickEnd = textPosition == KyoshinMonitorScaleTextPosition.start
+              ? tickStart - 4
+              : tickStart + 4;
           canvas.drawLine(
-            Offset(
-              textPosition == KyoshinMonitorScaleTextPosition.start
-                  ? 0
-                  : size.width,
-              position,
-            ),
-            Offset(
-              textPosition == KyoshinMonitorScaleTextPosition.start
-                  ? -4
-                  : size.width + 4,
-              position,
-            ),
+            Offset(tickStart, position),
+            Offset(tickEnd, position),
             tickPaint,
           );
       }
 
       // 値のテキストを描画
-      final text = _formatValue(stop.value);
-
       textPainter
         ..text = TextSpan(
-          text: text,
+          text: labels[i],
           style: textStyle.copyWith(color: textColor),
         )
         ..layout();
 
       switch (orientation) {
         case KyoshinMonitorScaleOrientation.horizontal:
-          // 重ならない場合は通常通り表示
+          final y = textPosition == KyoshinMonitorScaleTextPosition.start
+              ? gradientRect.top - textPainter.height - 6
+              : gradientRect.bottom + 6;
           textPainter.paint(
             canvas,
-            Offset(position - textPainter.width / 2, size.height + 6),
+            Offset(position - textPainter.width / 2, y),
           );
         case KyoshinMonitorScaleOrientation.vertical:
-          // 重ならない場合は通常通り表示
           final x = textPosition == KyoshinMonitorScaleTextPosition.start
-              ? -textPainter.width - 6
-              : size.width + 6;
+              ? gradientRect.left - textPainter.width - 6
+              : gradientRect.right + 6;
           textPainter.paint(
             canvas,
             Offset(x, position - textPainter.height / 2),
@@ -432,36 +492,17 @@ class _KyoshinMonitorScalePainter extends CustomPainter {
     }
   }
 
-  /// 値のフォーマット
-  ///
-  /// 値の大きさに応じて小数点以下の桁数を調整します
-  /// - 1以上: 整数
-  /// - 0.1以上: 小数点1桁
-  /// - 0.01以上: 小数点2桁
-  /// - 0.001以上: 小数点3桁
-  /// - それ以下: 小数点4桁
-  String _formatValue(double value) {
-    if (value >= 1 || value <= 0) {
-      return value.toStringAsFixed(0);
-    } else if (value >= 0.1) {
-      return value.toStringAsFixed(1);
-    } else if (value >= 0.01) {
-      return value.toStringAsFixed(2);
-    } else if (value >= 0.001) {
-      return value.toStringAsFixed(3);
-    } else {
-      return value.toStringAsFixed(4);
-    }
-  }
-
   @override
   bool shouldRepaint(covariant _KyoshinMonitorScalePainter oldDelegate) =>
       type != oldDelegate.type ||
       colorStops != oldDelegate.colorStops ||
+      labels != oldDelegate.labels ||
+      gradientRect != oldDelegate.gradientRect ||
       tickInterval != oldDelegate.tickInterval ||
       orientation != oldDelegate.orientation ||
       textPosition != oldDelegate.textPosition ||
       textColor != oldDelegate.textColor ||
       textStyle != oldDelegate.textStyle ||
+      textScaler != oldDelegate.textScaler ||
       gradientDirection != oldDelegate.gradientDirection;
 }

--- a/app/lib/feature/kyoshin_monitor/ui/components/kyoshin_monitor_scale_card.dart
+++ b/app/lib/feature/kyoshin_monitor/ui/components/kyoshin_monitor_scale_card.dart
@@ -87,15 +87,13 @@ class KyoshinMonitorScaleCard extends ConsumerWidget {
                 textBaseline: TextBaseline.alphabetic,
                 fontWeight: FontWeight.w700,
                 fontFamily: FontFamily.googleSansCode,
-                fontFamilyFallback: [
-                  FontFamily.notoSansJP,
-                ],
+                fontFamilyFallback: [FontFamily.notoSansJP],
               ),
             ),
             SizedBox(height: designSystem.spacing.sm),
             KyoshinMonitorScale(
               type: type,
-              width: 15,
+              width: 8,
               height: 150,
               gradientDirection: KyoshinMonitorScaleGradientDirection.reverse,
               orientation: KyoshinMonitorScaleOrientation.vertical,
@@ -105,9 +103,7 @@ class KyoshinMonitorScaleCard extends ConsumerWidget {
                 textBaseline: TextBaseline.alphabetic,
                 fontSize: 10,
                 fontFamily: FontFamily.googleSansCode,
-                fontFamilyFallback: [
-                  FontFamily.notoSansJP,
-                ],
+                fontFamilyFallback: [FontFamily.notoSansJP],
               ),
             ),
           ],

--- a/docs/knowledge/20260822_flutter-test-sourcepackages-directory.md
+++ b/docs/knowledge/20260822_flutter-test-sourcepackages-directory.md
@@ -1,0 +1,33 @@
+# クリーンなworktreeでFlutter Testを実行する際のSourcePackages作成
+
+## 症状
+
+クリーンなworktreeで初めて `flutter test` を実行すると、
+Apple向けプラグインの同期処理が次のエラーで停止する場合がある。
+
+```text
+rsync: [Receiver] mkdir "app/build/ios/SourcePackages/<plugin>" failed:
+No such file or directory
+```
+
+macOS向けの同期では `app/build/macos/SourcePackages` でも同様に停止する。
+テストコードや製品コードのコンパイルより前に発生するため、
+テスト失敗とは分けて判断する。
+
+## 回避手順
+
+`app` ディレクトリで、同期先の親ディレクトリを作成してから再実行する。
+
+```shell
+mkdir -p build/ios/SourcePackages build/macos/SourcePackages
+mise exec -- flutter test <test-path>
+```
+
+`build/` は生成物でありGit管理対象ではない。
+依存関係は先にリポジトリルートでロックファイルどおり解決する。
+
+```shell
+mise exec -- dart pub get --enforce-lockfile
+```
+
+再実行時は、`All tests passed!` と終了コード0の両方を確認する。


### PR DESCRIPTION
## 概要

リアルタイム強震モニタの縦向きカラースケールで、下端の `-1`〜`-3` を含む目盛り文字が見切れる問題を修正します。

## 変更内容

- 現在の `TextScaler` で目盛り文字を事前計測し、ラベルと目盛り線を含む描画領域を確保
- グラデーション本体と目盛りの描画位置を領域内に再配置
- グラデーション幅を15pxから8pxへ縮小
- PGA / PGV / PGDの縦向きスケールにも同じレイアウト処理を適用
- クリーンなworktreeでのFlutter Test実行時に必要な知見を記録

## 検証

- `mise exec -- dart analyze lib/feature/kyoshin_monitor/page/components/kyoshin_monitor_scale.dart lib/feature/kyoshin_monitor/ui/components/kyoshin_monitor_scale_card.dart --fatal-infos`
- `mise exec -- flutter test test/feature/kyoshin_monitor test/feature/home/ui/home_map_layer_page_test.dart`（34件成功）

Widget Testは表示専用の軽微な変更であり、Issue対応方針に基づき追加していません。テスト起動時に未生成の `assets/platform` に関する既存警告が出ますが、対象テストは成功しています。

Closes #1724
Related #1732