### PR TITLE
Fix: EEWシミュレーション停止中のP波・S波円を固定

### DIFF
--- a/app/lib/feature/eew/data/eew_simulation_notifier.dart
+++ b/app/lib/feature/eew/data/eew_simulation_notifier.dart
@@ -126,7 +126,7 @@ class EewSimulation extends _$EewSimulation {
 
   void resume() {
     final s = state;
-    if (s != null && !s.isComplete) {
+    if (s != null && !s.isPlaying && !s.isComplete) {
       state = s.copyWith(isPlaying: true, startedAt: clock.now());
       _scheduleNext();
     }

--- a/app/lib/feature/eew/data/eew_simulation_notifier.dart
+++ b/app/lib/feature/eew/data/eew_simulation_notifier.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -11,27 +12,48 @@ class EewSimulationState {
     required this.currentIndex,
     required this.isPlaying,
     required this.startedAt,
+    required this.elapsedBeforeRun,
   });
 
   final List<EewTelegramItem> reports;
   final int currentIndex;
   final bool isPlaying;
   final DateTime startedAt;
+  final Duration elapsedBeforeRun;
 
   int get totalReports => reports.length;
   EewTelegramItem get currentReport => reports[currentIndex];
   bool get isComplete => currentIndex >= reports.length - 1;
+
+  Duration playbackElapsedAt(DateTime now) =>
+      elapsedBeforeRun +
+      (isPlaying ? now.difference(startedAt) : Duration.zero);
+
+  Duration reportPlaybackOffset(int index) {
+    var elapsed = Duration.zero;
+    for (var i = 1; i <= index; i += 1) {
+      final interval = reports[i].reportTime.difference(
+        reports[i - 1].reportTime,
+      );
+      elapsed += Duration(
+        milliseconds: interval.inMilliseconds.clamp(500, 5000),
+      );
+    }
+    return elapsed;
+  }
 
   EewSimulationState copyWith({
     List<EewTelegramItem>? reports,
     int? currentIndex,
     bool? isPlaying,
     DateTime? startedAt,
+    Duration? elapsedBeforeRun,
   }) => EewSimulationState(
     reports: reports ?? this.reports,
     currentIndex: currentIndex ?? this.currentIndex,
     isPlaying: isPlaying ?? this.isPlaying,
     startedAt: startedAt ?? this.startedAt,
+    elapsedBeforeRun: elapsedBeforeRun ?? this.elapsedBeforeRun,
   );
 }
 
@@ -57,7 +79,8 @@ class EewSimulation extends _$EewSimulation {
       reports: sorted,
       currentIndex: 0,
       isPlaying: true,
-      startedAt: DateTime.now(),
+      startedAt: clock.now(),
+      elapsedBeforeRun: Duration.zero,
     );
     _scheduleNext();
   }
@@ -67,21 +90,20 @@ class EewSimulation extends _$EewSimulation {
     final s = state;
     if (s == null || !s.isPlaying || s.isComplete) {
       if (s != null && s.isComplete) {
-        state = s.copyWith(isPlaying: false);
+        state = s.copyWith(
+          isPlaying: false,
+          elapsedBeforeRun: s.playbackElapsedAt(clock.now()),
+        );
       }
       return;
     }
 
     final next = s.currentIndex + 1;
-    final delay = s.reports[next].reportTime.difference(
-      s.reports[s.currentIndex].reportTime,
-    );
-    // Clamp: at least 500ms, at most 5 seconds
-    final clamped = Duration(
-      milliseconds: delay.inMilliseconds.clamp(500, 5000),
-    );
+    final remaining =
+        s.reportPlaybackOffset(next) - s.playbackElapsedAt(clock.now());
+    final delay = remaining.isNegative ? Duration.zero : remaining;
 
-    _timer = Timer(clamped, () {
+    _timer = Timer(delay, () {
       final current = state;
       if (current == null || !current.isPlaying) {
         return;
@@ -95,14 +117,17 @@ class EewSimulation extends _$EewSimulation {
     _timer?.cancel();
     final s = state;
     if (s != null) {
-      state = s.copyWith(isPlaying: false);
+      state = s.copyWith(
+        isPlaying: false,
+        elapsedBeforeRun: s.playbackElapsedAt(clock.now()),
+      );
     }
   }
 
   void resume() {
     final s = state;
     if (s != null && !s.isComplete) {
-      state = s.copyWith(isPlaying: true);
+      state = s.copyWith(isPlaying: true, startedAt: clock.now());
       _scheduleNext();
     }
   }

--- a/app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart
@@ -70,8 +70,7 @@ class EewSimulationPsWaveLayer extends HookConsumerWidget {
         return null;
       }
 
-      // このリスナー自体の有効期間は `simulation`/`animationController` の
-      // 変化にも連動する（[styleController] のみに連動する [disposed] とは別軸）。
+      // simulationの状態遷移時はリスナーを張り直し、停止・完了位置を即時反映する。
       var listenerDisposed = false;
 
       void listener() {
@@ -201,6 +200,7 @@ class EewSimulationPsWaveLayer extends HookConsumerWidget {
       }
 
       animationController.addListener(listener);
+      listener();
       return () {
         listenerDisposed = true;
         animationController.removeListener(listener);

--- a/app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
@@ -56,13 +57,13 @@ class EewSimulationPsWaveLayer extends HookConsumerWidget {
     );
 
     useEffect(() {
-      if (simulation != null) {
+      if (simulation?.isPlaying ?? false) {
         unawaited(animationController.repeat());
       } else {
         animationController.stop();
       }
       return null;
-    }, [simulation != null]);
+    }, [simulation?.isPlaying]);
 
     useEffect(() {
       if (styleController == null) {
@@ -119,12 +120,11 @@ class EewSimulationPsWaveLayer extends HookConsumerWidget {
           return;
         }
 
-        final now = DateTime.now();
         final firstReportTime = sim.reports.first.reportTime;
         final offset =
             firstReportTime.difference(originTime).inMilliseconds / 1000;
         final simulationElapsed =
-            now.difference(sim.startedAt).inMilliseconds / 1000;
+            sim.playbackElapsedAt(clock.now()).inMilliseconds / 1000;
         final elapsed = offset + simulationElapsed;
 
         final travelTimeMap = ref.read(travelTimeDepthMapProvider);

--- a/app/lib/feature/eew/ui/page/eew_details_by_event_id_page.dart
+++ b/app/lib/feature/eew/ui/page/eew_details_by_event_id_page.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:clock/clock.dart';
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/component/widget/app_empty_state.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
@@ -170,7 +171,7 @@ class _SimulationView extends HookConsumerWidget {
     DateTime? virtualNow;
     if (simulation != null) {
       final firstReportTime = simulation.reports.first.reportTime;
-      final elapsed = DateTime.now().difference(simulation.startedAt);
+      final elapsed = simulation.playbackElapsedAt(clock.now());
       virtualNow = firstReportTime.add(elapsed);
     }
 

--- a/app/test/feature/eew/data/eew_simulation_notifier_test.dart
+++ b/app/test/feature/eew/data/eew_simulation_notifier_test.dart
@@ -1,0 +1,112 @@
+import 'package:clock/clock.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_info_type.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/eew/data/eew_simulation_notifier.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  test('pause中は再生位置と報を進めない', () {
+    fakeAsync((async) {
+      withClock(async.getClock(DateTime.utc(2026)), () {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        final subscription = container.listen(eewSimulationProvider, (_, _) {});
+        addTearDown(subscription.close);
+        final notifier = container.read(eewSimulationProvider.notifier);
+
+        notifier.start(_reports);
+        async.elapse(const Duration(seconds: 1));
+        notifier.pause();
+        final paused = container.read(eewSimulationProvider);
+
+        async.elapse(const Duration(seconds: 10));
+        final stillPaused = container.read(eewSimulationProvider);
+
+        expect(
+          paused?.playbackElapsedAt(clock.now()),
+          const Duration(seconds: 1),
+        );
+        expect(
+          stillPaused?.playbackElapsedAt(clock.now()),
+          const Duration(seconds: 1),
+        );
+        expect(stillPaused?.currentIndex, 0);
+      });
+    });
+  });
+
+  test('resume後は停止前の残り時間から報と再生位置を進める', () {
+    fakeAsync((async) {
+      withClock(async.getClock(DateTime.utc(2026)), () {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        final subscription = container.listen(eewSimulationProvider, (_, _) {});
+        addTearDown(subscription.close);
+        final notifier = container.read(eewSimulationProvider.notifier);
+
+        notifier.start(_reports);
+        async.elapse(const Duration(seconds: 1));
+        notifier.pause();
+        async.elapse(const Duration(seconds: 10));
+        notifier.resume();
+        async.elapse(const Duration(milliseconds: 999));
+
+        expect(container.read(eewSimulationProvider)?.currentIndex, 0);
+
+        async.elapse(const Duration(milliseconds: 1));
+        final resumed = container.read(eewSimulationProvider);
+
+        expect(resumed?.currentIndex, 1);
+        expect(
+          resumed?.playbackElapsedAt(clock.now()),
+          const Duration(seconds: 2),
+        );
+      });
+    });
+  });
+
+  test('最終報到達後は再生位置を固定する', () {
+    fakeAsync((async) {
+      withClock(async.getClock(DateTime.utc(2026)), () {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        final subscription = container.listen(eewSimulationProvider, (_, _) {});
+        addTearDown(subscription.close);
+        final notifier = container.read(eewSimulationProvider.notifier);
+
+        notifier.start(_reports.take(2).toList());
+        async.elapse(const Duration(seconds: 2));
+        final completed = container.read(eewSimulationProvider);
+        async.elapse(const Duration(seconds: 10));
+        final stillCompleted = container.read(eewSimulationProvider);
+
+        expect(completed?.isComplete, isTrue);
+        expect(completed?.isPlaying, isFalse);
+        expect(
+          completed?.playbackElapsedAt(clock.now()),
+          const Duration(seconds: 2),
+        );
+        expect(
+          stillCompleted?.playbackElapsedAt(clock.now()),
+          const Duration(seconds: 2),
+        );
+      });
+    });
+  });
+}
+
+final _reports = List.generate(3, (index) {
+  return EewTelegramItem(
+    eventId: 'event-1',
+    status: TelegramStatus.normal,
+    infoType: TelegramInfoType.publication,
+    serialNo: index + 1,
+    isCanceled: false,
+    isLastInfo: index == 2,
+    reportTime: DateTime.utc(2026).add(Duration(seconds: index * 2)),
+    isPlum: false,
+  );
+});

--- a/app/test/feature/eew/data/eew_simulation_notifier_test.dart
+++ b/app/test/feature/eew/data/eew_simulation_notifier_test.dart
@@ -68,6 +68,30 @@ void main() {
     });
   });
 
+  test('再生中のresumeは再生位置を巻き戻さない', () {
+    fakeAsync((async) {
+      withClock(async.getClock(DateTime.utc(2026)), () {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        final subscription = container.listen(eewSimulationProvider, (_, _) {});
+        addTearDown(subscription.close);
+        final notifier = container.read(eewSimulationProvider.notifier);
+
+        notifier.start(_reports);
+        async.elapse(const Duration(seconds: 1));
+        notifier.resume();
+        async.elapse(const Duration(seconds: 1));
+        final playing = container.read(eewSimulationProvider);
+
+        expect(playing?.currentIndex, 1);
+        expect(
+          playing?.playbackElapsedAt(clock.now()),
+          const Duration(seconds: 2),
+        );
+      });
+    });
+  });
+
   test('最終報到達後は再生位置を固定する', () {
     fakeAsync((async) {
       withClock(async.getClock(DateTime.utc(2026)), () {

--- a/docs/knowledge/20260823_eew_simulation_clock.md
+++ b/docs/knowledge/20260823_eew_simulation_clock.md
@@ -1,0 +1,22 @@
+# EEWシミュレーションの時刻管理
+
+## 原則
+
+EEW履歴シミュレーションでは、報の切り替え、P波・S波到達予想円、EEWカードが
+同じ再生経過時間を参照する。
+
+- Widgetで `DateTime.now() - startedAt` を直接計算しない。
+- pause時に累積再生時間を確定し、停止中は固定する。
+- resume時は停止前の再生位置を維持し、実時計の基準時刻だけを更新する。
+- 次報タイマーは報間隔全体ではなく、共通の再生位置から残り時間を計算する。
+- 最終報到達後も再生位置を固定する。
+
+## テスト
+
+`clock` と `fake_async` を組み合わせ、実時間を待たずに停止・再開・終了を確認する。
+
+```sh
+cd app
+mise exec -- flutter test --no-pub \
+  test/feature/eew/data/eew_simulation_notifier_test.dart
+```


### PR DESCRIPTION
## 概要

- EEW履歴シミュレーションの再生位置を単一の時刻軸に集約
- pause中は報・P波/S波円・EEWカードの時刻を固定
- resume時は停止前の残り時間から再開し、最終報到達時も波円を確定描画
- fake clockでpause・resume・重複resume・完了を回帰テスト
- シミュレーション時刻管理の知見を文書化

Fixes #1728

## テスト

- `mise exec -- flutter test --no-pub test/feature/eew/data/eew_simulation_notifier_test.dart`（4件成功）
- `mise exec -- dart analyze lib/feature/eew/data/eew_simulation_notifier.dart test/feature/eew/data/eew_simulation_notifier_test.dart`（No issues found）

## 補足

変更Widgetを含む解析では既存の `flutter_hooks_lint_plugin` が `RangeError` でクラッシュするため、状態管理と回帰テストを個別解析しています。
