### PR TITLE
fix: 地震履歴詳細のレイヤー切り替え残留を修正

### DIFF
--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_fill_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_fill_layer.dart
@@ -87,7 +87,8 @@ class _EarthquakeHistoryFillLayerBody extends HookConsumerWidget {
     );
 
     final isInitialized = useRef(false);
-    final addedLayerIds = useRef(<String>[]);
+    final generationSequence = useRef(0);
+    final activeGeneration = useRef<({int id, List<String> layerIds})?>(null);
     final latestParameter = useRef(parameter);
     latestParameter.value = parameter;
     final latestIntensity = useRef(intensity);
@@ -105,9 +106,36 @@ class _EarthquakeHistoryFillLayerBody extends HookConsumerWidget {
           return null;
         }
 
+        generationSequence.value++;
+        final generation = (
+          id: generationSequence.value,
+          layerIds: <String>[],
+        );
+        var disposed = false;
+
         unawaited(
           enqueue(() async {
             try {
+              if (disposed) {
+                return;
+              }
+
+              final previousGeneration = activeGeneration.value;
+              if (previousGeneration != null &&
+                  previousGeneration.id != generation.id) {
+                for (final id in previousGeneration.layerIds.reversed) {
+                  try {
+                    await styleController.removeLayer(id);
+                  } on Exception catch (e) {
+                    talker.log(e);
+                  }
+                }
+                previousGeneration.layerIds.clear();
+              }
+              if (disposed) {
+                return;
+              }
+
               final layers = fillLayerBuilder.build(
                 intensity: intensity,
                 colorModel: colorModel,
@@ -115,16 +143,18 @@ class _EarthquakeHistoryFillLayerBody extends HookConsumerWidget {
                 showingLpgmIntensity: showingLpgmIntensity,
                 parameter: latestParameter.value,
               );
-              final newIds = <String>[];
+              activeGeneration.value = generation;
+              isInitialized.value = true;
               for (final layer in layers) {
+                if (disposed) {
+                  return;
+                }
                 await styleController.addLayer(
                   layer,
                   belowLayerId: BaseLayer.areaForecastLocalELine.name,
                 );
-                newIds.add(layer.id);
+                generation.layerIds.add(layer.id);
               }
-              addedLayerIds.value = newIds;
-              isInitialized.value = true;
             } on Exception catch (e) {
               talker.log(e);
             }
@@ -132,17 +162,22 @@ class _EarthquakeHistoryFillLayerBody extends HookConsumerWidget {
         );
 
         return () {
-          isInitialized.value = false;
+          disposed = true;
           unawaited(
             enqueue(() async {
-              for (final id in addedLayerIds.value.reversed) {
+              if (activeGeneration.value?.id != generation.id) {
+                return;
+              }
+              for (final id in generation.layerIds.reversed) {
                 try {
                   await styleController.removeLayer(id);
                 } on Exception catch (e) {
                   talker.log(e);
                 }
               }
-              addedLayerIds.value = [];
+              generation.layerIds.clear();
+              activeGeneration.value = null;
+              isInitialized.value = false;
             }),
           );
         };
@@ -169,15 +204,20 @@ class _EarthquakeHistoryFillLayerBody extends HookConsumerWidget {
 
         unawaited(
           enqueue(() async {
-            for (final id in addedLayerIds.value.reversed) {
+            final generation = activeGeneration.value;
+            if (generation == null) {
+              return;
+            }
+
+            for (final id in generation.layerIds.reversed) {
               try {
                 await styleController.removeLayer(id);
               } on Exception catch (e) {
                 talker.log(e);
               }
             }
+            generation.layerIds.clear();
 
-            final newIds = <String>[];
             try {
               final layers = fillLayerBuilder.build(
                 intensity: currentIntensity,
@@ -191,12 +231,11 @@ class _EarthquakeHistoryFillLayerBody extends HookConsumerWidget {
                   layer,
                   belowLayerId: BaseLayer.areaForecastLocalELine.name,
                 );
-                newIds.add(layer.id);
+                generation.layerIds.add(layer.id);
               }
             } on Exception catch (e) {
               talker.log(e);
             }
-            addedLayerIds.value = newIds;
           }),
         );
 

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_fill_layer_lifecycle_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_fill_layer_lifecycle_test.dart
@@ -1,0 +1,232 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/intensity/jma_lpgm_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_display_mode.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_tree.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/lpgm_intensity_tree.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_details_estimated_intensity_layer.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_fill_layer.dart';
+import 'package:eqmonitor/feature/map/ui/map_operation_queue_scope.dart';
+import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:maplibre/maplibre.dart';
+// ignore: implementation_imports
+import 'package:maplibre_platform_interface/src/widget/inherited_model.dart';
+
+import '../../../../core/util/map/fake_style_controller.dart';
+
+void main() {
+  testWidgets('JMAから長周期へ切り替えると長周期レイヤーだけが残る', (tester) async {
+    final styleController = FakeStyleController();
+    final showingLpgm = ValueNotifier(false);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: MapOperationQueueScope(
+            child: MapLibreInheritedModel(
+              mapController: EarthquakeHistoryLayerMapController(
+                styleController: styleController,
+              ),
+              mapCamera: null,
+              child: ValueListenableBuilder<bool>(
+                valueListenable: showingLpgm,
+                builder: (context, value, child) => EarthquakeHistoryFillLayer(
+                  earthquake: earthquake,
+                  parameter: const EarthquakeHistoryMapLayerParameter(),
+                  showingLpgmIntensity: value,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    showingLpgm.value = true;
+    await tester.pumpAndSettle();
+
+    expect(styleController.activeLayerIds, {
+      'eq-history-lpgm-two-region-fill',
+      'eq-history-lpgm-two-region-line',
+    });
+  });
+
+  testWidgets('震度データ更新で同じIDを再構築してもJMAレイヤーが残る', (tester) async {
+    final styleController = FakeStyleController();
+    final currentEarthquake = ValueNotifier(earthquake);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: MapOperationQueueScope(
+            child: MapLibreInheritedModel(
+              mapController: EarthquakeHistoryLayerMapController(
+                styleController: styleController,
+              ),
+              mapCamera: null,
+              child: ValueListenableBuilder<Earthquake>(
+                valueListenable: currentEarthquake,
+                builder: (context, value, child) => EarthquakeHistoryFillLayer(
+                  earthquake: value,
+                  parameter: const EarthquakeHistoryMapLayerParameter(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    currentEarthquake.value = updatedEarthquake;
+    await tester.pumpAndSettle();
+
+    expect(styleController.activeLayerIds, {
+      'eq-history-jma-four-region-fill',
+      'eq-history-jma-four-region-line',
+    });
+  });
+
+  testWidgets('JMAから長周期を経て推計震度へ切り替えると推計震度レイヤーだけが残る', (
+    tester,
+  ) async {
+    final styleController = FakeStyleController();
+    final displayMode = ValueNotifier(IntensityDisplayMode.jma);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: MapOperationQueueScope(
+            child: MapLibreInheritedModel(
+              mapController: EarthquakeHistoryLayerMapController(
+                styleController: styleController,
+              ),
+              mapCamera: null,
+              child: ValueListenableBuilder<IntensityDisplayMode>(
+                valueListenable: displayMode,
+                builder: (context, value, child) => switch (value) {
+                  IntensityDisplayMode.jma => EarthquakeHistoryFillLayer(
+                    earthquake: earthquake,
+                    parameter: const EarthquakeHistoryMapLayerParameter(),
+                  ),
+                  IntensityDisplayMode.lpgm => EarthquakeHistoryFillLayer(
+                    earthquake: earthquake,
+                    parameter: const EarthquakeHistoryMapLayerParameter(),
+                    showingLpgmIntensity: true,
+                  ),
+                  IntensityDisplayMode.estimated =>
+                    const EarthquakeHistoryDetailsEstimatedIntensityLayer(
+                      tileUrl: 'https://example.com/estimated.pmtiles',
+                    ),
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    displayMode.value = IntensityDisplayMode.lpgm;
+    await tester.pumpAndSettle();
+    displayMode.value = IntensityDisplayMode.estimated;
+    await tester.pumpAndSettle();
+
+    expect(styleController.activeLayerIds, {
+      'earthquake-history-estimated-intensity-fill',
+      'earthquake-history-estimated-intensity-line',
+    });
+  });
+}
+
+class EarthquakeHistoryLayerMapController implements MapController {
+  new({required this.styleController});
+
+  final StyleController styleController;
+
+  @override
+  StyleController get style => styleController;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+const region = EarthquakeParameterRegionItem(
+  code: '001',
+  name: LocalizedName(ja: 'テスト地域'),
+  kana: null,
+  cities: [],
+);
+
+const updatedRegion = EarthquakeParameterRegionItem(
+  code: '002',
+  name: LocalizedName(ja: '更新地域'),
+  kana: null,
+  cities: [],
+);
+
+final earthquake = Earthquake(
+  eventId: 'layer-lifecycle-test',
+  status: TelegramStatus.normal,
+  originTime: DateTime(2026),
+  originTimePrecision: OriginTimePrecision.second,
+  arrivalTime: DateTime(2026),
+  dataSources: const [EarthquakeDataSource.jmaDisasterInformationXml],
+  telegramTypes: const [],
+  hypocenter: null,
+  intensity: const EarthquakeIntensity(
+    maxIntensity: JmaIntensity.four,
+    maxLpgmIntensity: JmaLpgmIntensity.two,
+    regions: {
+      JmaIntensity.four: [
+        IntensityRegion(region: region, maxIntensity: JmaIntensity.four),
+      ],
+    },
+    intensityTree: {},
+    lpgmIntensityTree: {
+      JmaLpgmIntensity.two: [
+        PrefectureLpgmIntensityNode(
+          region: region,
+          maxLpgmIntensity: JmaLpgmIntensity.two,
+          cities: [],
+        ),
+      ],
+    },
+  ),
+  estimatedIntensityTileUrl: 'https://example.com/estimated.pmtiles',
+);
+
+final updatedEarthquake = earthquake.copyWith(
+  intensity: const EarthquakeIntensity(
+    maxIntensity: JmaIntensity.four,
+    maxLpgmIntensity: JmaLpgmIntensity.two,
+    regions: {
+      JmaIntensity.four: [
+        IntensityRegion(region: region, maxIntensity: JmaIntensity.four),
+        IntensityRegion(
+          region: updatedRegion,
+          maxIntensity: JmaIntensity.four,
+        ),
+      ],
+    },
+    intensityTree: {},
+    lpgmIntensityTree: {
+      JmaLpgmIntensity.two: [
+        PrefectureLpgmIntensityNode(
+          region: region,
+          maxLpgmIntensity: JmaLpgmIntensity.two,
+          cities: [],
+        ),
+      ],
+    },
+  ),
+);


### PR DESCRIPTION
## 概要

- 地震履歴詳細でJMA震度から長周期地震動階級へ切り替えた際、旧JMA塗り潰しが残る問題を修正
- レイヤーIDをeffect世代単位で所有し、新世代追加前に旧世代を削除
- 旧cleanupが新世代や同一IDの再構築後レイヤーを削除しないように制御
- JMA→長周期、JMA→長周期→推計震度、同一IDの震度データ更新を回帰テストで検証

## テスト

- `mise exec -- flutter test --reporter compact test/feature/map/ui/map_operation_queue_scope_test.dart test/feature/earthquake_history/ui/layer`（71件成功）
- `mise exec -- flutter test --reporter compact test/feature/earthquake_history/ui/layer/earthquake_history_fill_layer_lifecycle_test.dart`（3件成功）
- `mise exec -- flutter analyze --no-pub lib/feature/earthquake_history/ui/layer/earthquake_history_fill_layer.dart test/feature/earthquake_history/ui/layer/earthquake_history_fill_layer_lifecycle_test.dart`（問題なし）

## 補足

- アプリ全体のテストは1,941件成功、今回の差分外の既存領域で23件失敗しました（NTP時刻、設定画面、ProviderScope、Asset Pack等）。
- iOS Simulatorビルドは300秒でタイムアウトしたため、画面上での確認は未実施です。
