### PR TITLE
fix: iOSのMapLibre色式修正を取り込む

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -21,32 +21,32 @@ dependency_overrides:
   maplibre:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 6c2251180f3d21541c066392faae5880d57510f8
+      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
       path: packages/maplibre
   maplibre_android:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 6c2251180f3d21541c066392faae5880d57510f8
+      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
       path: packages/maplibre_android
   maplibre_ios:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 6c2251180f3d21541c066392faae5880d57510f8
+      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
       path: packages/maplibre_ios
   maplibre_platform_interface:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 6c2251180f3d21541c066392faae5880d57510f8
+      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
       path: packages/maplibre_platform_interface
   maplibre_web:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 6c2251180f3d21541c066392faae5880d57510f8
+      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
       path: packages/maplibre_web
   maplibre_webview:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 6c2251180f3d21541c066392faae5880d57510f8
+      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
       path: packages/maplibre_webview
 
 dependencies:

--- a/docs/knowledge/20260823_maplibre_ios_match_color_expression.md
+++ b/docs/knowledge/20260823_maplibre_ios_match_color_expression.md
@@ -1,0 +1,31 @@
+# MapLibre iOS: match式の色出力は型付きで変換する
+
+## 事象
+
+市区町村別最大震度の塗り分けで、iOSだけ全市区町村が白く表示された。
+Dart側の式は `match` の出力に `rgba` を使っており、Androidでは正しく描画された。
+
+## 原因
+
+レイヤーの Initialize / Update / Dispose の競合や Pigeon の転送ではなく、
+flutter-maplibre iOS側でJSON式を `NSExpression(mglJSONObject:)` へ汎用変換した際、
+`match` の色出力が色型として保持されなかったことが原因だった。
+
+## 対処
+
+`YumNumm/flutter-maplibre` のiOS実装で、色プロパティの `match` 式を
+`NSExpression(forMGLMatching:in:defaultValue:)` により型付きで構築する。
+EQMonitorではMapLibreの6パッケージを同じ修正コミットへ固定する。
+
+## 検証
+
+依存更新後は次を確認する。
+
+```sh
+mise exec -- flutter pub get
+mise exec -- flutter analyze
+mise exec -- flutter test app/test/feature/intensity_history/intensity_fill_expression_test.dart
+```
+
+式構造のDartテストだけではiOSネイティブ変換の型問題を検出できないため、
+市区町村別最大震度をiOS Simulatorでも表示し、震度別の色を目視確認する。

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1503,8 +1503,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre"
-      ref: "6c2251180f3d21541c066392faae5880d57510f8"
-      resolved-ref: "6c2251180f3d21541c066392faae5880d57510f8"
+      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      resolved-ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1512,8 +1512,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_android"
-      ref: "6c2251180f3d21541c066392faae5880d57510f8"
-      resolved-ref: "6c2251180f3d21541c066392faae5880d57510f8"
+      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      resolved-ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1521,8 +1521,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_ios"
-      ref: "6c2251180f3d21541c066392faae5880d57510f8"
-      resolved-ref: "6c2251180f3d21541c066392faae5880d57510f8"
+      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      resolved-ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1530,8 +1530,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_platform_interface"
-      ref: "6c2251180f3d21541c066392faae5880d57510f8"
-      resolved-ref: "6c2251180f3d21541c066392faae5880d57510f8"
+      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      resolved-ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1539,8 +1539,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_web"
-      ref: "6c2251180f3d21541c066392faae5880d57510f8"
-      resolved-ref: "6c2251180f3d21541c066392faae5880d57510f8"
+      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      resolved-ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1548,8 +1548,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_webview"
-      ref: "6c2251180f3d21541c066392faae5880d57510f8"
-      resolved-ref: "6c2251180f3d21541c066392faae5880d57510f8"
+      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      resolved-ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"


### PR DESCRIPTION
## 概要

- `YumNumm/flutter-maplibre` PR #5 のマージコミットへMapLibre 6パッケージを統一
- iOSで `match` 式の色出力が型を失い、市区町村別最大震度が白くなる問題を修正
- 原因とiOS Simulator確認手順を knowledge に記録

## 検証

- `mise exec -- dart pub get --enforce-lockfile`
- `mise exec -- flutter analyze app/lib/feature/intensity_history app/test/feature/intensity_history`
- `mise exec -- flutter test app/test/feature/intensity_history`（61件成功）
- iPhone 17 Pro / iOS 26.4 Simulatorで修正元PRのコードを使い、市区町村ポリゴンの震度別色分けを目視確認済み

## 補足

リポジトリ全体の `mise exec -- flutter analyze` は、差分外の既存警告 `app/test/core/provider/clock/app_clock_test.dart:21`（`override_on_non_overriding_member`）1件で終了コード1です。

関連: YumNumm/flutter-maplibre#5