### PR TITLE
地震履歴の震度速報フォーカスを修正

### DIFF
--- a/app/lib/feature/earthquake_history/data/logic/earthquake_history_map_bounds_calculator.dart
+++ b/app/lib/feature/earthquake_history/data/logic/earthquake_history_map_bounds_calculator.dart
@@ -1,0 +1,126 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_tree.dart';
+import 'package:jma_map/jma_map.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'earthquake_history_map_bounds_calculator.g.dart';
+
+typedef EarthquakeHistoryMapPoint = ({
+  double latitude,
+  double longitude,
+});
+
+@riverpod
+EarthquakeHistoryMapBoundsCalculator earthquakeHistoryMapBoundsCalculator(
+  Ref ref,
+) => const EarthquakeHistoryMapBoundsCalculator();
+
+/// 地震履歴詳細マップの表示領域に含める座標を算出する。
+class EarthquakeHistoryMapBoundsCalculator {
+  const new();
+
+  List<EarthquakeHistoryMapPoint> calculate({
+    required Earthquake earthquake,
+    required JmaMap_JmaMapData? regionMap,
+    ShindoDbIntensityTree? dbTree,
+  }) {
+    final stationPoints = dbTree == null
+        ? intensityStationPoints(earthquake)
+        : databaseStationPoints(dbTree);
+    final intensityPoints = dbTree != null || stationPoints.isNotEmpty
+        ? stationPoints
+        : regionMap == null
+        ? const <EarthquakeHistoryMapPoint>[]
+        : regionBoundsPoints(earthquake: earthquake, regionMap: regionMap);
+    final hypocenter = hypocenterPoint(earthquake);
+    return [...intensityPoints, if (hypocenter != null) hypocenter];
+  }
+
+  bool requiresRegionMap({
+    required Earthquake earthquake,
+    required ShindoDbIntensityTree? dbTree,
+  }) {
+    if (dbTree != null || intensityStationPoints(earthquake).isNotEmpty) {
+      return false;
+    }
+    return earthquake.intensity?.regions.values.any(
+          (regions) => regions.isNotEmpty,
+        ) ??
+        false;
+  }
+
+  List<EarthquakeHistoryMapPoint> intensityStationPoints(
+    Earthquake earthquake,
+  ) {
+    final intensity = earthquake.intensity;
+    if (intensity == null) {
+      return const [];
+    }
+    return [
+      for (final regions in intensity.intensityTree.values)
+        for (final region in regions)
+          for (final city in region.cities)
+            for (final stationNode in city.stations)
+              (
+                latitude: stationNode.station.location.lat,
+                longitude: stationNode.station.location.lon,
+              ),
+    ];
+  }
+
+  List<EarthquakeHistoryMapPoint> databaseStationPoints(
+    ShindoDbIntensityTree tree,
+  ) => [
+    for (final prefectures in tree.tree.values)
+      for (final prefecture in prefectures)
+        for (final city in prefecture.cities)
+          for (final station in city.stations)
+            if (station.location case final location?)
+              (latitude: location.lat, longitude: location.lon),
+    for (final stations in tree.unresolvedStations.values)
+      for (final station in stations)
+        if (station.location case final location?)
+          (latitude: location.lat, longitude: location.lon),
+  ];
+
+  List<EarthquakeHistoryMapPoint> regionBoundsPoints({
+    required Earthquake earthquake,
+    required JmaMap_JmaMapData regionMap,
+  }) {
+    final intensity = earthquake.intensity;
+    if (intensity == null) {
+      return const [];
+    }
+    final affectedCodes = {
+      for (final regions in intensity.regions.values)
+        for (final region in regions) region.region.code,
+    };
+    final items = regionMap.data.where(
+      (item) => affectedCodes.contains(item.property.code) && item.hasBounds(),
+    );
+    return [
+      for (final item in items)
+        if (item.bounds.hasSouthWest())
+          (
+            latitude: item.bounds.southWest.lat,
+            longitude: item.bounds.southWest.lng,
+          ),
+      for (final item in items)
+        if (item.bounds.hasNorthEast())
+          (
+            latitude: item.bounds.northEast.lat,
+            longitude: item.bounds.northEast.lng,
+          ),
+    ];
+  }
+
+  EarthquakeHistoryMapPoint? hypocenterPoint(Earthquake earthquake) =>
+      switch (earthquake.hypocenter?.coordinates) {
+        CoordinateLatLng(:final latitude, :final longitude) => (
+          latitude: latitude,
+          longitude: longitude,
+        ),
+        _ => null,
+      };
+}

--- a/app/lib/feature/earthquake_history/data/logic/earthquake_history_map_bounds_calculator.g.dart
+++ b/app/lib/feature/earthquake_history/data/logic/earthquake_history_map_bounds_calculator.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'earthquake_history_map_bounds_calculator.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(earthquakeHistoryMapBoundsCalculator)
+final earthquakeHistoryMapBoundsCalculatorProvider =
+    EarthquakeHistoryMapBoundsCalculatorProvider._();
+
+final class EarthquakeHistoryMapBoundsCalculatorProvider
+    extends
+        $FunctionalProvider<
+          EarthquakeHistoryMapBoundsCalculator,
+          EarthquakeHistoryMapBoundsCalculator,
+          EarthquakeHistoryMapBoundsCalculator
+        >
+    with $Provider<EarthquakeHistoryMapBoundsCalculator> {
+  EarthquakeHistoryMapBoundsCalculatorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'earthquakeHistoryMapBoundsCalculatorProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$earthquakeHistoryMapBoundsCalculatorHash();
+
+  @$internal
+  @override
+  $ProviderElement<EarthquakeHistoryMapBoundsCalculator> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EarthquakeHistoryMapBoundsCalculator create(Ref ref) {
+    return earthquakeHistoryMapBoundsCalculator(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EarthquakeHistoryMapBoundsCalculator value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride:
+          $SyncValueProvider<EarthquakeHistoryMapBoundsCalculator>(value),
+    );
+  }
+}
+
+String _$earthquakeHistoryMapBoundsCalculatorHash() =>
+    r'02676b45b29b8b707a3a5c16ceab26c815b015fe';

--- a/app/lib/feature/earthquake_history/ui/action/earthquake_history_map_fit_bounds_action.dart
+++ b/app/lib/feature/earthquake_history/ui/action/earthquake_history_map_fit_bounds_action.dart
@@ -1,0 +1,56 @@
+import 'package:eqmonitor/core/provider/map/jma_map_provider.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_history_map_bounds_calculator.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_tree.dart';
+import 'package:flutter/widgets.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:maplibre/maplibre.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'earthquake_history_map_fit_bounds_action.g.dart';
+
+@riverpod
+EarthquakeHistoryMapFitBoundsAction earthquakeHistoryMapFitBoundsAction(
+  Ref ref,
+) => const EarthquakeHistoryMapFitBoundsAction();
+
+class EarthquakeHistoryMapFitBoundsAction {
+  const new();
+
+  Future<void> handle({
+    required WidgetRef ref,
+    required MapController controller,
+    required Earthquake earthquake,
+    required ShindoDbIntensityTree? dbTree,
+  }) async {
+    final calculator = ref.read(earthquakeHistoryMapBoundsCalculatorProvider);
+    final regionMap =
+        calculator.requiresRegionMap(
+          earthquake: earthquake,
+          dbTree: dbTree,
+        )
+        ? (await ref.read(jmaMapProvider.future)).areaForecastLocalE
+        : null;
+    final points = calculator
+        .calculate(
+          earthquake: earthquake,
+          regionMap: regionMap,
+          dbTree: dbTree,
+        )
+        .map(
+          (point) => Geographic(
+            lon: point.longitude,
+            lat: point.latitude,
+          ),
+        )
+        .toList();
+    if (points.isEmpty) {
+      return;
+    }
+    await controller.fitBounds(
+      bounds: LngLatBounds.fromPoints(points),
+      padding: const EdgeInsets.all(48),
+      webMaxZoom: 10,
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/action/earthquake_history_map_fit_bounds_action.g.dart
+++ b/app/lib/feature/earthquake_history/ui/action/earthquake_history_map_fit_bounds_action.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'earthquake_history_map_fit_bounds_action.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(earthquakeHistoryMapFitBoundsAction)
+final earthquakeHistoryMapFitBoundsActionProvider =
+    EarthquakeHistoryMapFitBoundsActionProvider._();
+
+final class EarthquakeHistoryMapFitBoundsActionProvider
+    extends
+        $FunctionalProvider<
+          EarthquakeHistoryMapFitBoundsAction,
+          EarthquakeHistoryMapFitBoundsAction,
+          EarthquakeHistoryMapFitBoundsAction
+        >
+    with $Provider<EarthquakeHistoryMapFitBoundsAction> {
+  EarthquakeHistoryMapFitBoundsActionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'earthquakeHistoryMapFitBoundsActionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$earthquakeHistoryMapFitBoundsActionHash();
+
+  @$internal
+  @override
+  $ProviderElement<EarthquakeHistoryMapFitBoundsAction> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EarthquakeHistoryMapFitBoundsAction create(Ref ref) {
+    return earthquakeHistoryMapFitBoundsAction(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EarthquakeHistoryMapFitBoundsAction value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EarthquakeHistoryMapFitBoundsAction>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$earthquakeHistoryMapFitBoundsActionHash() =>
+    r'db2e28f18e0372b2a5d859a748b9eaf5213ebe3e';

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
@@ -5,7 +5,6 @@ import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/provider/map/jma_map_provider.dart';
 import 'package:eqmonitor/core/provider/map/jma_map_utility.dart';
 import 'package:eqmonitor/core/router/router.dart';
-import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_display_mode.dart';
@@ -15,6 +14,7 @@ import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intens
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_map_focus_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_map_layer_parameter_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/provider/shindo_db_intensity_tree_provider.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/action/earthquake_history_map_fit_bounds_action.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_map_camera.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_map_legend.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_map_popup.dart';
@@ -266,7 +266,14 @@ class _MapContent extends HookConsumerWidget {
                 if (controller == null) {
                   return;
                 }
-                await _fitBounds(controller, dbTree: dbTree);
+                await ref
+                    .read(earthquakeHistoryMapFitBoundsActionProvider)
+                    .handle(
+                      ref: ref,
+                      controller: controller,
+                      earthquake: earthquake,
+                      dbTree: dbTree,
+                    );
               },
               onDebugTap: isDebugger
                   ? () async {
@@ -512,67 +519,6 @@ class _MapContent extends HookConsumerWidget {
       }
     }
     return null;
-  }
-
-  Future<void> _fitBounds(
-    MapController controller, {
-    ShindoDbIntensityTree? dbTree,
-  }) async {
-    final points = <Geographic>[];
-
-    if (dbTree != null) {
-      for (final entry in dbTree.tree.entries) {
-        for (final pref in entry.value) {
-          for (final cityNode in pref.cities) {
-            for (final station in cityNode.stations) {
-              final loc = station.location;
-              if (loc != null) {
-                points.add(Geographic(lon: loc.lon, lat: loc.lat));
-              }
-            }
-          }
-        }
-      }
-      for (final entry in dbTree.unresolvedStations.entries) {
-        for (final station in entry.value) {
-          final loc = station.location;
-          if (loc != null) {
-            points.add(Geographic(lon: loc.lon, lat: loc.lat));
-          }
-        }
-      }
-    } else {
-      final intensity = earthquake.intensity;
-      if (intensity != null) {
-        for (final entry in intensity.intensityTree.entries) {
-          for (final region in entry.value) {
-            for (final city in region.cities) {
-              for (final stationNode in city.stations) {
-                final s = stationNode.station;
-                points.add(
-                  Geographic(lon: s.location.lon, lat: s.location.lat),
-                );
-              }
-            }
-          }
-        }
-      }
-    }
-
-    final coords = earthquake.hypocenter?.coordinates;
-    if (coords is CoordinateLatLng) {
-      points.add(Geographic(lon: coords.longitude, lat: coords.latitude));
-    }
-
-    if (points.isEmpty) {
-      return;
-    }
-
-    await controller.fitBounds(
-      bounds: LngLatBounds.fromPoints(points),
-      padding: const EdgeInsets.all(48),
-      webMaxZoom: 10,
-    );
   }
 }
 

--- a/app/test/feature/earthquake_history/data/logic/earthquake_history_map_bounds_calculator_test.dart
+++ b/app/test/feature/earthquake_history/data/logic/earthquake_history_map_bounds_calculator_test.dart
@@ -1,0 +1,202 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_history_map_bounds_calculator.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_depth.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_hypocenter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_magnitude.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_tree.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
+import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
+import 'package:jma_map/jma_map.dart';
+import 'package:lat_lng/lat_lng.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const calculator = EarthquakeHistoryMapBoundsCalculator();
+
+  test('震度速報のみの場合は対象細分区域の境界を表示領域に含める', () {
+    final points = calculator.calculate(
+      earthquake: _earthquake(intensity: _regionOnlyIntensity),
+      regionMap: _regionMap,
+    );
+
+    expect(points, const [
+      (latitude: 34.0, longitude: 138.0),
+      (latitude: 36.0, longitude: 140.0),
+    ]);
+  });
+
+  test('震度速報と震源情報がある場合は対象地域と震源を表示領域に含める', () {
+    final points = calculator.calculate(
+      earthquake: _earthquake(
+        intensity: _regionOnlyIntensity,
+        hypocenter: _hypocenter,
+      ),
+      regionMap: _regionMap,
+    );
+
+    expect(points, const [
+      (latitude: 34.0, longitude: 138.0),
+      (latitude: 36.0, longitude: 140.0),
+      (latitude: 37.0, longitude: 141.0),
+    ]);
+  });
+
+  test('観測点がある場合は従来どおり観測点と震源だけを表示領域に含める', () {
+    final points = calculator.calculate(
+      earthquake: _earthquake(
+        intensity: _stationIntensity,
+        hypocenter: _hypocenter,
+      ),
+      regionMap: _regionMap,
+    );
+
+    expect(points, const [
+      (latitude: 35.0, longitude: 139.0),
+      (latitude: 37.0, longitude: 141.0),
+    ]);
+  });
+
+  test('観測点のない震度速報だけが細分区域地図を必要とする', () {
+    expect(
+      calculator.requiresRegionMap(
+        earthquake: _earthquake(intensity: _regionOnlyIntensity),
+        dbTree: null,
+      ),
+      isTrue,
+    );
+    expect(
+      calculator.requiresRegionMap(
+        earthquake: _earthquake(intensity: _stationIntensity),
+        dbTree: null,
+      ),
+      isFalse,
+    );
+  });
+}
+
+Earthquake _earthquake({
+  required EarthquakeIntensity intensity,
+  EarthquakeHypocenter? hypocenter,
+}) => Earthquake(
+  eventId: '202608230001',
+  status: TelegramStatus.normal,
+  originTime: DateTime.utc(2026, 8, 23),
+  originTimePrecision: OriginTimePrecision.second,
+  arrivalTime: DateTime.utc(2026, 8, 23),
+  dataSources: const [EarthquakeDataSource.jmaDisasterInformationXml],
+  telegramTypes: const [EarthquakeTelegramType.vxse51],
+  hypocenter: hypocenter,
+  intensity: intensity,
+  estimatedIntensityTileUrl: null,
+);
+
+const _regionOnlyIntensity = EarthquakeIntensity(
+  maxIntensity: JmaIntensity.four,
+  maxLpgmIntensity: null,
+  regions: {
+    JmaIntensity.four: [
+      IntensityRegion(
+        region: _region,
+        maxIntensity: JmaIntensity.four,
+      ),
+    ],
+  },
+  intensityTree: {},
+  lpgmIntensityTree: {},
+);
+
+const _stationIntensity = EarthquakeIntensity(
+  maxIntensity: JmaIntensity.four,
+  maxLpgmIntensity: null,
+  regions: {
+    JmaIntensity.four: [
+      IntensityRegion(
+        region: _region,
+        maxIntensity: JmaIntensity.four,
+      ),
+    ],
+  },
+  intensityTree: {
+    JmaIntensity.four: [
+      PrefectureIntensityNode(
+        prefecture: IntensityPrefecture(
+          prefecture: _prefecture,
+          maxIntensity: JmaIntensity.four,
+        ),
+        cities: [
+          CityIntensityNode(
+            city: _city,
+            maxIntensity: JmaIntensity.four,
+            stations: [
+              StationIntensityNode(station: _station, intensity: null),
+            ],
+          ),
+        ],
+      ),
+    ],
+  },
+  lpgmIntensityTree: {},
+);
+
+const _region = EarthquakeParameterRegionItem(
+  code: '100',
+  name: LocalizedName(ja: 'テスト細分区域'),
+  kana: null,
+  cities: [],
+);
+
+const _prefecture = EarthquakeParameterPrefectureItem(
+  code: '10',
+  name: LocalizedName(ja: 'テスト都道府県'),
+  regions: [_region],
+);
+
+const _city = EarthquakeParameterCityItem(
+  code: '100001',
+  name: LocalizedName(ja: 'テスト市区町村'),
+  kana: null,
+  stations: [],
+);
+
+const _station = EarthquakeParameterStationItem(
+  code: '1000010',
+  noCode: '1000010',
+  name: LocalizedName(ja: 'テスト観測点'),
+  kana: null,
+  status: EarthquakeStationStatus.operating,
+  sourceStatus: 'test',
+  owner: 'test',
+  location: LatLng(35, 139),
+);
+
+const _hypocenter = EarthquakeHypocenter(
+  code: '100',
+  name: 'テスト震央',
+  coordinates: Coordinate.latLng(latitude: 37, longitude: 141),
+  magnitude: EarthquakeMagnitude.value(value: 5),
+  depth: EarthquakeDepth.value(value: 10),
+  detailedCode: null,
+  detailedName: null,
+);
+
+final _regionMap = JmaMap_JmaMapData(
+  mapType: JmaMap_JmaMapData_JmaMapType.AREA_FORECAST_LOCAL_E,
+  data: [
+    JmaMap_JmaMapData_JmaMapDataItem(
+      bounds: JmaMap_LatLngBounds(
+        southWest: JmaMap_LatLng(lat: 34, lng: 138),
+        northEast: JmaMap_LatLng(lat: 36, lng: 140),
+      ),
+      property: JmaMap_JmaMapData_JmaMapDataItem_Property(
+        code: _region.code,
+        name: _region.name.ja,
+      ),
+    ),
+  ],
+);


### PR DESCRIPTION
## 概要

- 地震履歴マップの表示領域計算を専用クラスへ分離
- 震度速報のみの場合は対象細分区域の境界へフォーカス
- 震度速報と震源情報がある場合は対象地域と震源の両方を表示領域へ含める
- 観測点がある通常電文・震度DBでは従来どおり観測点と震源を使用
- 細分区域地図データはフォールバックが必要な場合だけ読み込む

## 動作確認

- 地震履歴の表示領域計算・マップレイヤー: 16件成功
- VXSE52 debug sheetの既存Widgetテスト: 1件成功
- 追加した計算・Action・テストのdart analyze: 問題なし
- dart formatおよびgit diff --check: 問題なし

## 既知のテスト状況

rebase前の全体テストでは1,952件成功・23件失敗でした。失敗はWebView、通知設定、ホーム画面など今回の変更対象外のテストです。rebase後は上記の対象17件を再実行して成功しています。