### PR TITLE
fix: iOS推計震度タイルのfill欠損を修正

### DIFF
--- a/app/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -118,15 +118,6 @@
       }
     },
     {
-      "identity" : "maplibre-gl-native-distribution",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/maplibre/maplibre-gl-native-distribution",
-      "state" : {
-        "revision" : "5ee345ca5d65238a6fce29bba87816204be7df20",
-        "version" : "6.28.0"
-      }
-    },
-    {
       "identity" : "nanopb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",

--- a/app/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -118,15 +118,6 @@
       }
     },
     {
-      "identity" : "maplibre-gl-native-distribution",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/maplibre/maplibre-gl-native-distribution",
-      "state" : {
-        "revision" : "5ee345ca5d65238a6fce29bba87816204be7df20",
-        "version" : "6.28.0"
-      }
-    },
-    {
       "identity" : "nanopb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -21,32 +21,32 @@ dependency_overrides:
   maplibre:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      ref: 59b744a1452e797e55806c82e9a443a1263a223a
       path: packages/maplibre
   maplibre_android:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      ref: 59b744a1452e797e55806c82e9a443a1263a223a
       path: packages/maplibre_android
   maplibre_ios:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      ref: 59b744a1452e797e55806c82e9a443a1263a223a
       path: packages/maplibre_ios
   maplibre_platform_interface:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      ref: 59b744a1452e797e55806c82e9a443a1263a223a
       path: packages/maplibre_platform_interface
   maplibre_web:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      ref: 59b744a1452e797e55806c82e9a443a1263a223a
       path: packages/maplibre_web
   maplibre_webview:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      ref: 59b744a1452e797e55806c82e9a443a1263a223a
       path: packages/maplibre_webview
 
 dependencies:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -21,32 +21,32 @@ dependency_overrides:
   maplibre:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 59b744a1452e797e55806c82e9a443a1263a223a
+      ref: 55dfdac42e142f31c64a00c9615edf61d3ffb615
       path: packages/maplibre
   maplibre_android:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 59b744a1452e797e55806c82e9a443a1263a223a
+      ref: 55dfdac42e142f31c64a00c9615edf61d3ffb615
       path: packages/maplibre_android
   maplibre_ios:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 59b744a1452e797e55806c82e9a443a1263a223a
+      ref: 55dfdac42e142f31c64a00c9615edf61d3ffb615
       path: packages/maplibre_ios
   maplibre_platform_interface:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 59b744a1452e797e55806c82e9a443a1263a223a
+      ref: 55dfdac42e142f31c64a00c9615edf61d3ffb615
       path: packages/maplibre_platform_interface
   maplibre_web:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 59b744a1452e797e55806c82e9a443a1263a223a
+      ref: 55dfdac42e142f31c64a00c9615edf61d3ffb615
       path: packages/maplibre_web
   maplibre_webview:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 59b744a1452e797e55806c82e9a443a1263a223a
+      ref: 55dfdac42e142f31c64a00c9615edf61d3ffb615
       path: packages/maplibre_webview
 
 dependencies:

--- a/docs/knowledge/20260823_ios_maplibre_metal_clip_mask.md
+++ b/docs/knowledge/20260823_ios_maplibre_metal_clip_mask.md
@@ -62,3 +62,31 @@ pmtiles show /tmp/eqmonitor-20260823020050.pmtiles
 - 第一候補は PR #4342 の merge/release 後に MapLibre Native を更新すること。
 - release を待てない場合は、同じ 1-line fix と upstream regression test を含む Native distribution を YumNumm 管理下で検証する。
 - Flutter 側で layer の再追加順序や opacity を変える対応は、根本原因を直さず再現条件をずらすだけなので恒久対策にしない。
+
+## 暫定配布版
+
+2026-08-23 に、upstream への書き込みを行わず YumNumm 管理下で次の版を作成した。
+
+- MapLibre Native fork: `YumNumm/maplibre-native`
+- ベース: upstream `main` の `0c7fbe2b2938b06ad671b7fcf43e967065e05376`
+- 修正版: `yumnumm/ios-metal-clip-mask` の `076b0e8af68b80da5ac389283f1406efea312da6`
+- Release: `ios-v6.29.0-yumnumm.2`
+- Asset: `MapLibre.dynamic.xcframework.zip`
+- SwiftPM checksum: `473ce393b16a54ba787d2d626968ec92614573f1ab00b5af9c65660cc5d18ebc`
+- flutter-maplibre: `YumNumm/flutter-maplibre` の `59b744a1452e797e55806c82e9a443a1263a223a`
+
+PR #4342 のテストは古い `mbgl` namespace のままだったため、最新 `main` に合わせて include と namespace を `mln` に移植した。Metal renderer を指定した `//test:tests` のコンパイル、および device arm64 / Simulator arm64・x86_64 を含む XCFramework の生成に成功している。
+
+Release asset は次の URL から直接取得する。
+
+```text
+https://github.com/YumNumm/maplibre-native/releases/download/ios-v6.29.0-yumnumm.2/MapLibre.dynamic.xcframework.zip
+```
+
+MapLibre Native と同じリポジトリに Swift Package 用ブランチと tag を置き、そのリポジトリを package dependency にすると、SwiftPM が巨大な Native リポジトリ全体を clone する。検証時は約 640 万 object を取得してディスク不足になった。そのため EQMonitor が参照する `flutter-maplibre` では、Package.swift の `binaryTarget` に Release asset URL と checksum を直接記述する。これなら Native リポジトリの source clone は発生しない。
+
+Release asset の同一 URL への上書きは GitHub CDN に古い内容が残り、manifest の checksum と一致しないことがある。配布ZIPを変更する場合は既存assetを上書きせず、新しいtagとURLを発行する。
+
+Xcode の package resolve で Release asset のダウンロードと展開を確認し、展開後の device binary の SHA-256 がビルド元と一致することも確認した。Xcode 27 beta では custom package cache を指定した resolve が PrivacyInfo resource 処理中に内部例外で終了したが、通常の DerivedData を使い Runner scheme と iOS Simulator を明示した build は成功した。生成された Runner.app に arm64 / x86_64 の MapLibre.framework が埋め込まれ、Simulator への install と process launch も成功した。
+
+ローカルに実値入りの `environment/.env.dev` がない場合、アプリは MapLibre 画面へ到達する前に Theme 用 dart-define 不足で停止する。XCFramework の取得・リンク確認と、対象PMTilesを表示した画面確認は区別して記録する。

--- a/docs/knowledge/20260823_ios_maplibre_metal_clip_mask.md
+++ b/docs/knowledge/20260823_ios_maplibre_metal_clip_mask.md
@@ -1,0 +1,64 @@
+# iOS MapLibre Metal のタイル単位 fill 欠損
+
+## 症状
+
+- 複数の vector source を重ねた地図で、fill がタイル境界に沿って断続的に欠損する。
+- 同じタイルの line や label は残ることがある。
+- 小さなカメラ移動で欠損位置が変わる。
+- Metal 固有の問題であり、Android と同じ MVT を使っても iOS でのみ発生する。
+
+EQMonitor では、ベース地図 PMTiles に推計震度 PMTiles を動的追加する地震履歴詳細画面がこの条件を満たす。
+
+## 原因
+
+MapLibre Native の Metal backend における clip mask 用 UBO の bind cache が原因。
+
+1 frame 内で 2 回目以降に `renderTileClippingMasks` が呼ばれると、clip UBO は stack-local な一時 `BufferResource` に入る。連続する再構築で同じ stack address と初期 version が再利用されると、`RenderPass` の vertex buffer bind cache が古い buffer と同一だと誤認し、`setVertexBuffer` を省略する。
+
+その結果、直前の tile matrix と stencil reference で clip mask が描かれ、stencil clipping を使う fill がタイル単位で消える。Flutter 側の source/layer lifecycle や PMTiles の欠損ではない。
+
+Upstream の修正と回帰テスト:
+
+- [maplibre-native PR #4342](https://github.com/maplibre/maplibre-native/pull/4342)
+- `Context::renderTileClippingMasks` で clip UBO slot を明示的に unbind してから bind する。
+- `MetalClipMask.RebuildBindsFreshBufferAfterAddressReuse` が、修正なしでは stale buffer bind を再現する。
+
+2026-08-23 時点で PR #4342 は open。EQMonitor が使用する iOS MapLibre Native 6.28.0 には未収録。
+
+## 実データの切り分け
+
+対象イベント `20260823020050` の PMTiles:
+
+```text
+https://tiles.eqmonitor.app/ixac41/20260823020050/86eecccd44b812c294b8d06e6224a373bede507ce21bd5380535ae0ae7eda2aa.pmtiles
+```
+
+検証結果:
+
+- SHA-256: `86eecccd44b812c294b8d06e6224a373bede507ce21bd5380535ae0ae7eda2aa`
+- go-pmtiles v1.31.2 の `verify` に成功
+- z0-14、addressed tiles 3999、MVT `seismic_intensity` layer
+- 3999 tile をすべて読み出し、repo 内 MVT decoder で decode できた
+
+```bash
+pmtiles verify /tmp/eqmonitor-20260823020050.pmtiles
+pmtiles show /tmp/eqmonitor-20260823020050.pmtiles
+```
+
+したがって、配信ファイルの tile 欠落や壊れた MVT geometry を原因として扱わない。
+
+## 再検証方法
+
+1. ベース地図 source を持つ style を読み込む。
+2. 推計震度 PMTiles を別 vector source として動的追加する。
+3. `seismic_intensity` の fill と line を同時に表示する。
+4. 推計震度範囲付近で zoom/pan を繰り返し、同じタイルで fill と line を比較する。
+5. PR #4342 を含む MapLibre Native build と現行 build を同じカメラ・style・PMTiles で比較する。
+
+最終確認では実機または Simulator の画面を使う。`MLNMapSnapshotter` は同じ style を正常描画する場合があり、snapshot だけを修正確認にしない。
+
+## 修正方針
+
+- 第一候補は PR #4342 の merge/release 後に MapLibre Native を更新すること。
+- release を待てない場合は、同じ 1-line fix と upstream regression test を含む Native distribution を YumNumm 管理下で検証する。
+- Flutter 側で layer の再追加順序や opacity を変える対応は、根本原因を直さず再現条件をずらすだけなので恒久対策にしない。

--- a/docs/superpowers/plans/2026-08-23-maplibre-native-metal-clip-mask-distribution.md
+++ b/docs/superpowers/plans/2026-08-23-maplibre-native-metal-clip-mask-distribution.md
@@ -1,0 +1,101 @@
+# MapLibre Native Metal Clip Mask Fix Distribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PR #4342を適用した最新MapLibre NativeのiOS XCFrameworkをYumNumm配下から配布し、EQMonitorで固定利用してfill欠損を解消する。
+
+**Architecture:** `YumNumm/maplibre-native`のソースブランチでupstream `main`へPR #4342の2コミットを適用し、生成したXCFrameworkは同リポジトリのGitHub Release Assetとして公開する。別の配布ブランチにはRelease Assetをchecksum付きで参照するSwiftPM manifestだけを置き、SemVerタグを付けて`YumNumm/flutter-maplibre`から固定参照する。
+
+**Tech Stack:** MapLibre Native, Metal, Bazel, XCFramework, Swift Package Manager, Flutter, GitHub Actions/Releases
+
+**Spec:** `docs/knowledge/20260823_ios_maplibre_metal_clip_mask.md`
+
+## Global Constraints
+
+- GitHub上の作成・push・Release操作はYumNumm org配下だけで行い、upstreamへPRやIssueを作成しない。
+- MapLibre Nativeは作業開始時点のupstream `main` commitを固定し、PR #4342の全2コミットを適用する。
+- EQMonitorとflutter-maplibreは可変ブランチではなく、検証済みcommit/tagへ固定する。
+- XCFrameworkのSHA-256 checksumをSwiftPM manifestへ記録し、Release Assetの改変を検出できるようにする。
+- 提示されたPMTilesを使い、iOS Simulatorでfill欠損の再現条件を確認する。
+
+---
+
+### Task 1: Native forkと修正ブランチ
+
+**Files:**
+- Modify: `YumNumm/maplibre-native` Git refs
+
+**Interfaces:**
+- Consumes: upstream `maplibre/maplibre-native:main`, PR #4342 head commits
+- Produces: PR #4342を含む固定source commit
+
+- [ ] **Step 1:** `YumNumm/maplibre-native`をGitHub forkとして作成する。
+- [ ] **Step 2:** upstream最新`main`を取得し、PR #4342の2コミットを順番どおり適用する。
+- [ ] **Step 3:** `src/mbgl/mtl/context.cpp`のunbind処理とMetal回帰テストが含まれることをdiffで確認する。
+- [ ] **Step 4:** 対象Metalテストを実行し、成功を確認する。
+- [ ] **Step 5:** 修正ブランチをYumNumm forkへpushする。
+
+### Task 2: XCFramework Release
+
+**Files:**
+- Modify: `YumNumm/maplibre-native/.github/workflows/ios-yumnumm-release.yml`
+
+**Interfaces:**
+- Consumes: Task 1の固定source commit
+- Produces: `MapLibre.dynamic.xcframework.zip`とchecksum
+
+- [ ] **Step 1:** 公式iOS release workflowからMetal dynamic XCFrameworkのビルド部分だけを抽出する。
+- [ ] **Step 2:** fork所有者と対象commitを検証し、YumNumm側GitHub Releaseへだけアップロードするworkflowを作成する。
+- [ ] **Step 3:** workflowの構文と参照actionを確認してcommit・pushする。
+- [ ] **Step 4:** workflowをdispatchし、完了まで監視する。
+- [ ] **Step 5:** Release Assetをダウンロードして`swift package compute-checksum`を実行する。
+
+### Task 3: 同一fork内SwiftPM配布ブランチ
+
+**Files:**
+- Create: `YumNumm/maplibre-native:spm-distribution/Package.swift`
+
+**Interfaces:**
+- Consumes: Task 2のRelease URLとchecksum
+- Produces: `MapLibre` productを提供する固定SemVerタグ
+
+- [ ] **Step 1:** orphanの`spm-distribution`ブランチを作成する。
+- [ ] **Step 2:** Release Assetを`binaryTarget(name:url:checksum:)`で参照する`Package.swift`を作成する。
+- [ ] **Step 3:** `swift package dump-package`でmanifestを検証する。
+- [ ] **Step 4:** 配布commitをpushし、SemVerタグを付けてpushする。
+- [ ] **Step 5:** 一時Swift packageからタグを解決し、XCFrameworkの取得とchecksum検証が成功することを確認する。
+
+### Task 4: flutter-maplibreのNative依存切り替え
+
+**Files:**
+- Modify: `packages/maplibre_ios/ios/maplibre_ios/Package.swift`
+
+**Interfaces:**
+- Consumes: Task 3のYumNumm MapLibre配布タグ
+- Produces: EQMonitorから固定参照できるflutter-maplibre commit
+
+- [ ] **Step 1:** `YumNumm/flutter-maplibre`を隔離checkoutし、現在のEQMonitor固定commitを基点にブランチを作成する。
+- [ ] **Step 2:** iOS package dependencyをYumNumm forkのexactタグへ変更する。
+- [ ] **Step 3:** `swift package resolve`とiOS package testsで依存解決を検証する。
+- [ ] **Step 4:** 差分をcommitしてYumNumm forkへpushする。
+
+### Task 5: EQMonitor導入とiOS回帰検証
+
+**Files:**
+- Modify: `app/pubspec.yaml`
+- Modify: `pubspec.lock`
+- Modify: `app/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`
+- Modify: `app/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved`
+- Modify: `docs/knowledge/20260823_ios_maplibre_metal_clip_mask.md`
+
+**Interfaces:**
+- Consumes: Task 4のflutter-maplibre固定commit、提示されたPMTiles
+- Produces: 修正版Native binaryを固定利用するEQMonitor commit
+
+- [ ] **Step 1:** 6個のflutter-maplibre dependency overrideをTask 4のcommitへ更新する。
+- [ ] **Step 2:** `mise exec -- flutter pub get`でlockfileを更新する。
+- [ ] **Step 3:** XcodeのSwiftPM解決結果がYumNumm Native配布タグとchecksum付きReleaseを参照することを確認する。
+- [ ] **Step 4:** 関連静的解析・既存テスト・iOSビルドを実行する。
+- [ ] **Step 5:** iOS Simulatorで提示された地震履歴詳細を表示し、カメラ移動を含めfill欠損が再発しないことを確認する。
+- [ ] **Step 6:** source commit、配布タグ、checksum、検証結果をknowledge文書へ追記する。
+- [ ] **Step 7:** EQMonitor差分を分割commitしてpushする。

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1503,8 +1503,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre"
-      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
-      resolved-ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      ref: "59b744a1452e797e55806c82e9a443a1263a223a"
+      resolved-ref: "59b744a1452e797e55806c82e9a443a1263a223a"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1512,8 +1512,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_android"
-      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
-      resolved-ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      ref: "59b744a1452e797e55806c82e9a443a1263a223a"
+      resolved-ref: "59b744a1452e797e55806c82e9a443a1263a223a"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1521,8 +1521,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_ios"
-      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
-      resolved-ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      ref: "59b744a1452e797e55806c82e9a443a1263a223a"
+      resolved-ref: "59b744a1452e797e55806c82e9a443a1263a223a"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1530,8 +1530,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_platform_interface"
-      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
-      resolved-ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      ref: "59b744a1452e797e55806c82e9a443a1263a223a"
+      resolved-ref: "59b744a1452e797e55806c82e9a443a1263a223a"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1539,8 +1539,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_web"
-      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
-      resolved-ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      ref: "59b744a1452e797e55806c82e9a443a1263a223a"
+      resolved-ref: "59b744a1452e797e55806c82e9a443a1263a223a"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1548,8 +1548,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_webview"
-      ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
-      resolved-ref: eecbdda1f7590d952449e8e4b309e09b04c30f9a
+      ref: "59b744a1452e797e55806c82e9a443a1263a223a"
+      resolved-ref: "59b744a1452e797e55806c82e9a443a1263a223a"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1503,8 +1503,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre"
-      ref: "59b744a1452e797e55806c82e9a443a1263a223a"
-      resolved-ref: "59b744a1452e797e55806c82e9a443a1263a223a"
+      ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
+      resolved-ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1512,8 +1512,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_android"
-      ref: "59b744a1452e797e55806c82e9a443a1263a223a"
-      resolved-ref: "59b744a1452e797e55806c82e9a443a1263a223a"
+      ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
+      resolved-ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1521,8 +1521,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_ios"
-      ref: "59b744a1452e797e55806c82e9a443a1263a223a"
-      resolved-ref: "59b744a1452e797e55806c82e9a443a1263a223a"
+      ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
+      resolved-ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1530,8 +1530,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_platform_interface"
-      ref: "59b744a1452e797e55806c82e9a443a1263a223a"
-      resolved-ref: "59b744a1452e797e55806c82e9a443a1263a223a"
+      ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
+      resolved-ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1539,8 +1539,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_web"
-      ref: "59b744a1452e797e55806c82e9a443a1263a223a"
-      resolved-ref: "59b744a1452e797e55806c82e9a443a1263a223a"
+      ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
+      resolved-ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1548,8 +1548,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_webview"
-      ref: "59b744a1452e797e55806c82e9a443a1263a223a"
-      resolved-ref: "59b744a1452e797e55806c82e9a443a1263a223a"
+      ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
+      resolved-ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"


### PR DESCRIPTION
## 概要

iOSの地震履歴詳細画面で、推計震度タイルのfillが一部欠損する問題を修正します。

## 原因

MapLibre NativeのMetal rendererでclip mask用stencil bufferがtile境界をまたいで保持され、後続tileのfill fragmentが誤って破棄されていました。

## 変更内容

- MapLibre関連6パッケージを修正版`YumNumm/flutter-maplibre` commitへ更新
- 旧MapLibre Native SwiftPM source dependencyをPackage.resolvedから除去
- 原因、Native fork、XCFramework Release配布、更新手順をknowledge/specへ記録

## 依存PR

- https://github.com/YumNumm/flutter-maplibre/pull/6

## 動作確認

- Xcode 27 / iPhone 17 Pro Simulator（iOS 26.4）でDebugビルド・起動に成功
- 対象イベント`20260823020050`を深いリンクから表示
- 推計震度ポリゴンの描画完了後も、問題だったtile境界に沿う矩形状のfill欠損が再現しないことをスクリーンショットで確認
- Impeller Metal backendでの実行をログ確認

## 補足

- Native forkおよびバイナリReleaseはYumNumm配下のみで管理
- upstreamにはPRを作成していません
