### PR TITLE
feat: 地図操作でEEWフォーカスを解除する

### DIFF
--- a/app/lib/feature/home/data/logic/home_map_eew_focus_transition.dart
+++ b/app/lib/feature/home/data/logic/home_map_eew_focus_transition.dart
@@ -1,0 +1,75 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'home_map_eew_focus_transition.g.dart';
+
+final class HomeMapEewFocusSession {
+  const new({
+    required this.eventIds,
+    required this.isFocused,
+  });
+
+  static const initial = HomeMapEewFocusSession(
+    eventIds: <String>{},
+    isFocused: false,
+  );
+
+  final Set<String> eventIds;
+  final bool isFocused;
+}
+
+final class HomeMapEewFocusDecision {
+  const new({
+    required this.session,
+    required this.shouldFocus,
+  });
+
+  final HomeMapEewFocusSession session;
+  final bool shouldFocus;
+}
+
+class HomeMapEewFocusTransition {
+  const new();
+
+  HomeMapEewFocusDecision sync({
+    required HomeMapEewFocusSession previous,
+    required Set<String> eventIds,
+  }) {
+    final currentEventIds = Set<String>.unmodifiable(eventIds);
+    final hasNewEvent = currentEventIds.any(
+      (eventId) => !previous.eventIds.contains(eventId),
+    );
+    final isFocused =
+        currentEventIds.isNotEmpty && (previous.isFocused || hasNewEvent);
+    return HomeMapEewFocusDecision(
+      session: HomeMapEewFocusSession(
+        eventIds: currentEventIds,
+        isFocused: isFocused,
+      ),
+      shouldFocus: isFocused,
+    );
+  }
+
+  HomeMapEewFocusSession dismiss({
+    required HomeMapEewFocusSession previous,
+  }) => HomeMapEewFocusSession(
+    eventIds: previous.eventIds,
+    isFocused: false,
+  );
+
+  HomeMapEewFocusDecision refocus({
+    required HomeMapEewFocusSession previous,
+  }) {
+    final isFocused = previous.eventIds.isNotEmpty;
+    return HomeMapEewFocusDecision(
+      session: HomeMapEewFocusSession(
+        eventIds: previous.eventIds,
+        isFocused: isFocused,
+      ),
+      shouldFocus: isFocused,
+    );
+  }
+}
+
+@riverpod
+HomeMapEewFocusTransition homeMapEewFocusTransition(Ref ref) =>
+    const HomeMapEewFocusTransition();

--- a/app/lib/feature/home/data/logic/home_map_eew_focus_transition.g.dart
+++ b/app/lib/feature/home/data/logic/home_map_eew_focus_transition.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'home_map_eew_focus_transition.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(homeMapEewFocusTransition)
+final homeMapEewFocusTransitionProvider = HomeMapEewFocusTransitionProvider._();
+
+final class HomeMapEewFocusTransitionProvider
+    extends
+        $FunctionalProvider<
+          HomeMapEewFocusTransition,
+          HomeMapEewFocusTransition,
+          HomeMapEewFocusTransition
+        >
+    with $Provider<HomeMapEewFocusTransition> {
+  HomeMapEewFocusTransitionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'homeMapEewFocusTransitionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$homeMapEewFocusTransitionHash();
+
+  @$internal
+  @override
+  $ProviderElement<HomeMapEewFocusTransition> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  HomeMapEewFocusTransition create(Ref ref) {
+    return homeMapEewFocusTransition(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(HomeMapEewFocusTransition value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<HomeMapEewFocusTransition>(value),
+    );
+  }
+}
+
+String _$homeMapEewFocusTransitionHash() =>
+    r'304375393c58a1346ece2331c4bdaea0a497d5da';

--- a/app/lib/feature/home/data/model/map_camera_state.dart
+++ b/app/lib/feature/home/data/model/map_camera_state.dart
@@ -12,6 +12,7 @@ abstract class MapCameraState with _$MapCameraState {
     @Default(0.0) double bearing,
     @Default(0.0) double pitch,
     @Default(true) bool isAtHome,
+    @Default(false) bool isEewFocusActive,
   }) = _MapCameraState;
 
   factory home() => const MapCameraState(

--- a/app/lib/feature/home/data/model/map_camera_state.freezed.dart
+++ b/app/lib/feature/home/data/model/map_camera_state.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MapCameraState {
 
- Geographic get center; double get zoom; double get bearing; double get pitch; bool get isAtHome;
+ Geographic get center; double get zoom; double get bearing; double get pitch; bool get isAtHome; bool get isEewFocusActive;
 /// Create a copy of MapCameraState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $MapCameraStateCopyWith<MapCameraState> get copyWith => _$MapCameraStateCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MapCameraState&&(identical(other.center, center) || other.center == center)&&(identical(other.zoom, zoom) || other.zoom == zoom)&&(identical(other.bearing, bearing) || other.bearing == bearing)&&(identical(other.pitch, pitch) || other.pitch == pitch)&&(identical(other.isAtHome, isAtHome) || other.isAtHome == isAtHome));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MapCameraState&&(identical(other.center, center) || other.center == center)&&(identical(other.zoom, zoom) || other.zoom == zoom)&&(identical(other.bearing, bearing) || other.bearing == bearing)&&(identical(other.pitch, pitch) || other.pitch == pitch)&&(identical(other.isAtHome, isAtHome) || other.isAtHome == isAtHome)&&(identical(other.isEewFocusActive, isEewFocusActive) || other.isEewFocusActive == isEewFocusActive));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,center,zoom,bearing,pitch,isAtHome);
+int get hashCode => Object.hash(runtimeType,center,zoom,bearing,pitch,isAtHome,isEewFocusActive);
 
 @override
 String toString() {
-  return 'MapCameraState(center: $center, zoom: $zoom, bearing: $bearing, pitch: $pitch, isAtHome: $isAtHome)';
+  return 'MapCameraState(center: $center, zoom: $zoom, bearing: $bearing, pitch: $pitch, isAtHome: $isAtHome, isEewFocusActive: $isEewFocusActive)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $MapCameraStateCopyWith<$Res>  {
   factory $MapCameraStateCopyWith(MapCameraState value, $Res Function(MapCameraState) _then) = _$MapCameraStateCopyWithImpl;
 @useResult
 $Res call({
- Geographic center, double zoom, double bearing, double pitch, bool isAtHome
+ Geographic center, double zoom, double bearing, double pitch, bool isAtHome, bool isEewFocusActive
 });
 
 
@@ -63,13 +63,14 @@ class _$MapCameraStateCopyWithImpl<$Res>
 
 /// Create a copy of MapCameraState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? center = null,Object? zoom = null,Object? bearing = null,Object? pitch = null,Object? isAtHome = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? center = null,Object? zoom = null,Object? bearing = null,Object? pitch = null,Object? isAtHome = null,Object? isEewFocusActive = null,}) {
   return _then(MapCameraState(
 center: null == center ? _self.center : center // ignore: cast_nullable_to_non_nullable
 as Geographic,zoom: null == zoom ? _self.zoom : zoom // ignore: cast_nullable_to_non_nullable
 as double,bearing: null == bearing ? _self.bearing : bearing // ignore: cast_nullable_to_non_nullable
 as double,pitch: null == pitch ? _self.pitch : pitch // ignore: cast_nullable_to_non_nullable
 as double,isAtHome: null == isAtHome ? _self.isAtHome : isAtHome // ignore: cast_nullable_to_non_nullable
+as bool,isEewFocusActive: null == isEewFocusActive ? _self.isEewFocusActive : isEewFocusActive // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -155,10 +156,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Geographic center,  double zoom,  double bearing,  double pitch,  bool isAtHome)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Geographic center,  double zoom,  double bearing,  double pitch,  bool isAtHome,  bool isEewFocusActive)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _MapCameraState() when $default != null:
-return $default(_that.center,_that.zoom,_that.bearing,_that.pitch,_that.isAtHome);case _:
+return $default(_that.center,_that.zoom,_that.bearing,_that.pitch,_that.isAtHome,_that.isEewFocusActive);case _:
   return orElse();
 
 }
@@ -176,10 +177,10 @@ return $default(_that.center,_that.zoom,_that.bearing,_that.pitch,_that.isAtHome
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Geographic center,  double zoom,  double bearing,  double pitch,  bool isAtHome)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Geographic center,  double zoom,  double bearing,  double pitch,  bool isAtHome,  bool isEewFocusActive)  $default,) {final _that = this;
 switch (_that) {
 case _MapCameraState():
-return $default(_that.center,_that.zoom,_that.bearing,_that.pitch,_that.isAtHome);case _:
+return $default(_that.center,_that.zoom,_that.bearing,_that.pitch,_that.isAtHome,_that.isEewFocusActive);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +197,10 @@ return $default(_that.center,_that.zoom,_that.bearing,_that.pitch,_that.isAtHome
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Geographic center,  double zoom,  double bearing,  double pitch,  bool isAtHome)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Geographic center,  double zoom,  double bearing,  double pitch,  bool isAtHome,  bool isEewFocusActive)?  $default,) {final _that = this;
 switch (_that) {
 case _MapCameraState() when $default != null:
-return $default(_that.center,_that.zoom,_that.bearing,_that.pitch,_that.isAtHome);case _:
+return $default(_that.center,_that.zoom,_that.bearing,_that.pitch,_that.isAtHome,_that.isEewFocusActive);case _:
   return null;
 
 }
@@ -211,7 +212,7 @@ return $default(_that.center,_that.zoom,_that.bearing,_that.pitch,_that.isAtHome
 
 
 class _MapCameraState implements MapCameraState {
-  const _MapCameraState({required this.center, required this.zoom, this.bearing = 0.0, this.pitch = 0.0, this.isAtHome = true});
+  const _MapCameraState({required this.center, required this.zoom, this.bearing = 0.0, this.pitch = 0.0, this.isAtHome = true, this.isEewFocusActive = false});
   
 
 @override final  Geographic center;
@@ -219,6 +220,7 @@ class _MapCameraState implements MapCameraState {
 @override@JsonKey() final  double bearing;
 @override@JsonKey() final  double pitch;
 @override@JsonKey() final  bool isAtHome;
+@override@JsonKey() final  bool isEewFocusActive;
 
 /// Create a copy of MapCameraState
 /// with the given fields replaced by the non-null parameter values.
@@ -230,16 +232,16 @@ _$MapCameraStateCopyWith<_MapCameraState> get copyWith => __$MapCameraStateCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MapCameraState&&(identical(other.center, center) || other.center == center)&&(identical(other.zoom, zoom) || other.zoom == zoom)&&(identical(other.bearing, bearing) || other.bearing == bearing)&&(identical(other.pitch, pitch) || other.pitch == pitch)&&(identical(other.isAtHome, isAtHome) || other.isAtHome == isAtHome));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MapCameraState&&(identical(other.center, center) || other.center == center)&&(identical(other.zoom, zoom) || other.zoom == zoom)&&(identical(other.bearing, bearing) || other.bearing == bearing)&&(identical(other.pitch, pitch) || other.pitch == pitch)&&(identical(other.isAtHome, isAtHome) || other.isAtHome == isAtHome)&&(identical(other.isEewFocusActive, isEewFocusActive) || other.isEewFocusActive == isEewFocusActive));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,center,zoom,bearing,pitch,isAtHome);
+int get hashCode => Object.hash(runtimeType,center,zoom,bearing,pitch,isAtHome,isEewFocusActive);
 
 @override
 String toString() {
-  return 'MapCameraState(center: $center, zoom: $zoom, bearing: $bearing, pitch: $pitch, isAtHome: $isAtHome)';
+  return 'MapCameraState(center: $center, zoom: $zoom, bearing: $bearing, pitch: $pitch, isAtHome: $isAtHome, isEewFocusActive: $isEewFocusActive)';
 }
 
 
@@ -250,7 +252,7 @@ abstract mixin class _$MapCameraStateCopyWith<$Res> implements $MapCameraStateCo
   factory _$MapCameraStateCopyWith(_MapCameraState value, $Res Function(_MapCameraState) _then) = __$MapCameraStateCopyWithImpl;
 @override @useResult
 $Res call({
- Geographic center, double zoom, double bearing, double pitch, bool isAtHome
+ Geographic center, double zoom, double bearing, double pitch, bool isAtHome, bool isEewFocusActive
 });
 
 
@@ -267,13 +269,14 @@ class __$MapCameraStateCopyWithImpl<$Res>
 
 /// Create a copy of MapCameraState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? center = null,Object? zoom = null,Object? bearing = null,Object? pitch = null,Object? isAtHome = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? center = null,Object? zoom = null,Object? bearing = null,Object? pitch = null,Object? isAtHome = null,Object? isEewFocusActive = null,}) {
   return _then(_MapCameraState(
 center: null == center ? _self.center : center // ignore: cast_nullable_to_non_nullable
 as Geographic,zoom: null == zoom ? _self.zoom : zoom // ignore: cast_nullable_to_non_nullable
 as double,bearing: null == bearing ? _self.bearing : bearing // ignore: cast_nullable_to_non_nullable
 as double,pitch: null == pitch ? _self.pitch : pitch // ignore: cast_nullable_to_non_nullable
 as double,isAtHome: null == isAtHome ? _self.isAtHome : isAtHome // ignore: cast_nullable_to_non_nullable
+as bool,isEewFocusActive: null == isEewFocusActive ? _self.isEewFocusActive : isEewFocusActive // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/app/lib/feature/home/data/provider/map_camera_state_provider.dart
+++ b/app/lib/feature/home/data/provider/map_camera_state_provider.dart
@@ -2,6 +2,7 @@ import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:eqmonitor/feature/home/data/model/map_camera_state.dart';
 import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
+import 'package:eqmonitor/feature/home/data/logic/home_map_eew_focus_transition.dart';
 import 'package:eqmonitor/feature/home/data/service/home_map_camera_coordinator.dart';
 import 'package:eqmonitor/feature/shake_detection/data/model/shake_detection_event.dart';
 import 'package:eqmonitor/feature/shake_detection/data/provider/shake_detection_merge_provider.dart';
@@ -13,6 +14,8 @@ part 'map_camera_state_provider.g.dart';
 
 @Riverpod(keepAlive: true)
 class HomeMapCameraState extends _$HomeMapCameraState {
+  HomeMapEewFocusSession _eewFocusSession = HomeMapEewFocusSession.initial;
+
   @override
   MapCameraState build() {
     ref.listen(eewAliveTelegramProvider, (_, _) async {
@@ -35,6 +38,23 @@ class HomeMapCameraState extends _$HomeMapCameraState {
     required List<EewTelegramItem> eews,
     required List<ShakeDetectionEvent> shakes,
   }) async {
+    final decision = ref
+        .read(homeMapEewFocusTransitionProvider)
+        .sync(
+          previous: _eewFocusSession,
+          eventIds: eews.map((eew) => eew.eventId).toSet(),
+        );
+    _eewFocusSession = decision.session;
+    if (eews.isNotEmpty && !decision.shouldFocus) {
+      return;
+    }
+    final focusSession = decision.session;
+    if (eews.isNotEmpty) {
+      state = state.copyWith(isAtHome: false, isEewFocusActive: true);
+    }
+    if (eews.isEmpty && state.isEewFocusActive) {
+      state = state.copyWith(isEewFocusActive: false);
+    }
     final isAtHome = await ref
         .read(homeMapCameraCoordinatorProvider)
         .handleRealtimeTransition(
@@ -42,8 +62,17 @@ class HomeMapCameraState extends _$HomeMapCameraState {
           eews: eews,
           shakes: shakes,
         );
+    if (!identical(_eewFocusSession, focusSession)) {
+      return;
+    }
     if (isAtHome != null) {
-      state = state.copyWith(isAtHome: isAtHome);
+      state = state.copyWith(
+        isAtHome: isAtHome,
+        isEewFocusActive:
+            eews.isNotEmpty && !isAtHome && decision.session.isFocused,
+      );
+    } else if (eews.isNotEmpty) {
+      state = state.copyWith(isEewFocusActive: false);
     }
   }
 
@@ -51,17 +80,41 @@ class HomeMapCameraState extends _$HomeMapCameraState {
     required MapController controller,
     required Size viewportSize,
   }) async {
+    final eews = ref.read(eewAliveTelegramProvider) ?? [];
+    final shakes = ref.read(shakeDetectionVisibleProvider);
+    final decision = ref
+        .read(homeMapEewFocusTransitionProvider)
+        .sync(
+          previous: _eewFocusSession,
+          eventIds: eews.map((eew) => eew.eventId).toSet(),
+        );
+    _eewFocusSession = decision.session;
+    final shouldApplyInitialFocus = eews.isEmpty || decision.shouldFocus;
+    final focusSession = decision.session;
+    if (eews.isNotEmpty && decision.shouldFocus) {
+      state = state.copyWith(isAtHome: false, isEewFocusActive: true);
+    }
     final isAtHome = await ref
         .read(homeMapCameraCoordinatorProvider)
         .setController(
           controller: controller,
           viewportSize: viewportSize,
           home: ref.read(homeConfigurationProvider.future),
-          eews: ref.read(eewAliveTelegramProvider) ?? [],
-          shakes: ref.read(shakeDetectionVisibleProvider),
+          eews: eews,
+          shakes: shakes,
+          applyInitialFocus: shouldApplyInitialFocus,
         );
+    if (!identical(_eewFocusSession, focusSession)) {
+      return;
+    }
     if (isAtHome != null) {
-      state = state.copyWith(isAtHome: isAtHome);
+      state = state.copyWith(
+        isAtHome: isAtHome,
+        isEewFocusActive:
+            eews.isNotEmpty && !isAtHome && decision.session.isFocused,
+      );
+    } else if (eews.isNotEmpty) {
+      state = state.copyWith(isEewFocusActive: false);
     }
   }
 
@@ -72,12 +125,63 @@ class HomeMapCameraState extends _$HomeMapCameraState {
         .clearController(controller: controller);
   }
 
+  void handleUserMapGesture() {
+    if (!state.isEewFocusActive) {
+      return;
+    }
+    _eewFocusSession = ref
+        .read(homeMapEewFocusTransitionProvider)
+        .dismiss(previous: _eewFocusSession);
+    ref.read(homeMapCameraCoordinatorProvider).cancelAutomaticFocus();
+    state = state.copyWith(isAtHome: false, isEewFocusActive: false);
+  }
+
   Future<void> returnToHome() async {
+    final eews = ref.read(eewAliveTelegramProvider) ?? [];
+    if (eews.isNotEmpty) {
+      final transition = ref.read(homeMapEewFocusTransitionProvider);
+      _eewFocusSession = transition
+          .sync(
+            previous: _eewFocusSession,
+            eventIds: eews.map((eew) => eew.eventId).toSet(),
+          )
+          .session;
+      final decision = transition.refocus(previous: _eewFocusSession);
+      _eewFocusSession = decision.session;
+      if (!decision.shouldFocus) {
+        return;
+      }
+      final focusSession = decision.session;
+      state = state.copyWith(isAtHome: false, isEewFocusActive: true);
+      final isAtHome = await ref
+          .read(homeMapCameraCoordinatorProvider)
+          .handleRealtimeTransition(
+            home: ref.read(homeConfigurationProvider.future),
+            eews: eews,
+            shakes: const [],
+            ignoreAutoZoom: true,
+          );
+      if (!identical(_eewFocusSession, focusSession)) {
+        return;
+      }
+      if (isAtHome != null) {
+        state = state.copyWith(
+          isAtHome: isAtHome,
+          isEewFocusActive: !isAtHome,
+        );
+      } else {
+        state = state.copyWith(isEewFocusActive: false);
+      }
+      return;
+    }
     final isAtHome = await ref
         .read(homeMapCameraCoordinatorProvider)
         .returnToHome(home: ref.read(homeConfigurationProvider.future));
     if (isAtHome != null) {
-      state = state.copyWith(isAtHome: isAtHome);
+      state = state.copyWith(
+        isAtHome: isAtHome,
+        isEewFocusActive: false,
+      );
     }
   }
 }

--- a/app/lib/feature/home/data/provider/map_camera_state_provider.g.dart
+++ b/app/lib/feature/home/data/provider/map_camera_state_provider.g.dart
@@ -44,7 +44,7 @@ final class HomeMapCameraStateProvider
 }
 
 String _$homeMapCameraStateHash() =>
-    r'7f2a208f2f4423611e215ba43f2a3bcaafcaf9b5';
+    r'b86350103a89dc48f85dcd03933c88dd5efac6da';
 
 abstract class _$HomeMapCameraState extends $Notifier<MapCameraState> {
   MapCameraState build();

--- a/app/lib/feature/home/data/provider/map_camera_state_provider.g.dart
+++ b/app/lib/feature/home/data/provider/map_camera_state_provider.g.dart
@@ -44,7 +44,7 @@ final class HomeMapCameraStateProvider
 }
 
 String _$homeMapCameraStateHash() =>
-    r'9d53848d2f711c4e73a8374741944ef1b7056a1e';
+    r'7f2a208f2f4423611e215ba43f2a3bcaafcaf9b5';
 
 abstract class _$HomeMapCameraState extends $Notifier<MapCameraState> {
   MapCameraState build();

--- a/app/lib/feature/home/data/service/home_map_camera_coordinator.dart
+++ b/app/lib/feature/home/data/service/home_map_camera_coordinator.dart
@@ -44,12 +44,16 @@ class HomeMapCameraCoordinator {
     required Future<HomeConfigurationModel> home,
     required List<EewTelegramItem> eews,
     required List<ShakeDetectionEvent> shakes,
+    bool applyInitialFocus = true,
   }) {
     _cameraGeneration += 1;
     _controller = controller;
     _viewportSize = viewportSize;
     _isHomeFocusRequested = false;
     _operationQueue = MapAutomaticFocusOperationQueue();
+    if (!applyInitialFocus) {
+      return Future<bool?>.value();
+    }
     return handleRealtimeTransition(home: home, eews: eews, shakes: shakes);
   }
 
@@ -67,6 +71,7 @@ class HomeMapCameraCoordinator {
     required Future<HomeConfigurationModel> home,
     required List<EewTelegramItem> eews,
     required List<ShakeDetectionEvent> shakes,
+    bool ignoreAutoZoom = false,
   }) {
     final generation = ++_cameraGeneration;
     final targets = const SeismicMapFocusBuilder().realtimeTargetCoordinates(
@@ -82,6 +87,7 @@ class HomeMapCameraCoordinator {
         eews: eews,
         shakes: shakes,
         generation: generation,
+        ignoreAutoZoom: ignoreAutoZoom,
       ),
       .returnToHome => applyHomeFocus(home: home, generation: generation),
       .none => Future<bool?>.value(),
@@ -93,6 +99,7 @@ class HomeMapCameraCoordinator {
     required List<EewTelegramItem> eews,
     required List<ShakeDetectionEvent> shakes,
     required int generation,
+    bool ignoreAutoZoom = false,
   }) async {
     final configuration = await home;
     final controller = _controller;
@@ -104,7 +111,7 @@ class HomeMapCameraCoordinator {
     if (controller == null || viewportSize == null || !isCurrent()) {
       return null;
     }
-    if (!configuration.eew.autoZoom) {
+    if (!configuration.eew.autoZoom && !ignoreAutoZoom) {
       return null;
     }
 
@@ -127,6 +134,10 @@ class HomeMapCameraCoordinator {
 
   Future<bool?> returnToHome({required Future<HomeConfigurationModel> home}) =>
       applyHomeFocus(home: home, generation: ++_cameraGeneration);
+
+  void cancelAutomaticFocus() {
+    _cameraGeneration += 1;
+  }
 
   Future<bool?> applyHomeFocus({
     required Future<HomeConfigurationModel> home,

--- a/app/lib/feature/home/ui/component/map/home_map_controller_card.dart
+++ b/app/lib/feature/home/ui/component/map/home_map_controller_card.dart
@@ -10,12 +10,14 @@ class HomeMapControllerCard extends StatelessWidget {
     super.key,
     this.onLayerButtonTap,
     this.onLocationButtonTap,
+    this.isLocationButtonEnabled = true,
     this.onDebugButtonTap,
     this.onLabelDebugButtonTap,
   });
 
   final void Function()? onLayerButtonTap;
   final void Function()? onLocationButtonTap;
+  final bool isLocationButtonEnabled;
   final void Function()? onDebugButtonTap;
   final void Function()? onLabelDebugButtonTap;
 
@@ -59,12 +61,19 @@ class HomeMapControllerCard extends StatelessWidget {
                     InkWell(
                       child: Padding(
                         padding: EdgeInsets.all(spacing.sm),
-                        child: const Icon(Icons.home_rounded),
+                        child: Icon(
+                          Icons.home_rounded,
+                          color: isLocationButtonEnabled
+                              ? null
+                              : colorTheme.onSurface.withValues(alpha: 0.38),
+                        ),
                       ),
-                      onTap: () async {
-                        await hapticFeedback();
-                        onLocationButtonTap?.call();
-                      },
+                      onTap: isLocationButtonEnabled
+                          ? () async {
+                              await hapticFeedback();
+                              onLocationButtonTap?.call();
+                            }
+                          : null,
                     ),
                     if (onLabelDebugButtonTap != null)
                       InkWell(

--- a/app/lib/feature/home/ui/component/map/home_map_view.dart
+++ b/app/lib/feature/home/ui/component/map/home_map_view.dart
@@ -207,7 +207,15 @@ class _MapLibreMapHost extends HookConsumerWidget {
             await controller.enableLocation();
           }
         },
-        onEvent: (event) => MapLibreEventProvider.maybeOf(context)?.emit(event),
+        onEvent: (event) {
+          MapLibreEventProvider.maybeOf(context)?.emit(event);
+          if (event is MapEventStartMoveCamera &&
+              event.reason == CameraChangeReason.apiGesture) {
+            ref
+                .read(homeMapCameraStateProvider.notifier)
+                .handleUserMapGesture();
+          }
+        },
         children: children,
       ),
     );
@@ -248,8 +256,12 @@ class _MapHeader extends ConsumerWidget {
     );
 
     final isDebug = ref.watch(debugProvider).value ?? false;
+    final isEewFocusActive = ref.watch(
+      homeMapCameraStateProvider.select((state) => state.isEewFocusActive),
+    );
 
     final controllerCard = HomeMapControllerCard(
+      isLocationButtonEnabled: !isEewFocusActive,
       onLayerButtonTap: () async =>
           const HomeMapLayerRoute().push<void>(context),
       onLocationButtonTap: () =>

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -21,32 +21,32 @@ dependency_overrides:
   maplibre:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 55dfdac42e142f31c64a00c9615edf61d3ffb615
+      ref: 7080ae5
       path: packages/maplibre
   maplibre_android:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 55dfdac42e142f31c64a00c9615edf61d3ffb615
+      ref: 7080ae5
       path: packages/maplibre_android
   maplibre_ios:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 55dfdac42e142f31c64a00c9615edf61d3ffb615
+      ref: 7080ae5
       path: packages/maplibre_ios
   maplibre_platform_interface:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 55dfdac42e142f31c64a00c9615edf61d3ffb615
+      ref: 7080ae5
       path: packages/maplibre_platform_interface
   maplibre_web:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 55dfdac42e142f31c64a00c9615edf61d3ffb615
+      ref: 7080ae5
       path: packages/maplibre_web
   maplibre_webview:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
-      ref: 55dfdac42e142f31c64a00c9615edf61d3ffb615
+      ref: 7080ae5
       path: packages/maplibre_webview
 
 dependencies:

--- a/app/test/feature/home/data/logic/home_map_eew_focus_transition_test.dart
+++ b/app/test/feature/home/data/logic/home_map_eew_focus_transition_test.dart
@@ -1,0 +1,53 @@
+import 'package:eqmonitor/feature/home/data/logic/home_map_eew_focus_transition.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const transition = HomeMapEewFocusTransition();
+
+  test('ユーザー解除後は同じEEWの更新でフォーカスを再開しない', () {
+    final initial = transition.sync(
+      previous: HomeMapEewFocusSession.initial,
+      eventIds: const {'event-a'},
+    );
+    final dismissed = transition.dismiss(previous: initial.session);
+
+    final updated = transition.sync(
+      previous: dismissed,
+      eventIds: const {'event-a'},
+    );
+
+    expect(updated.shouldFocus, isFalse);
+    expect(updated.session.isFocused, isFalse);
+  });
+
+  test('ユーザー解除後でも新しいEEWが追加されたらフォーカスを再開する', () {
+    final dismissed = transition.dismiss(
+      previous: const HomeMapEewFocusSession(
+        eventIds: {'event-a'},
+        isFocused: true,
+      ),
+    );
+
+    final updated = transition.sync(
+      previous: dismissed,
+      eventIds: const {'event-a', 'event-b'},
+    );
+
+    expect(updated.shouldFocus, isTrue);
+    expect(updated.session.isFocused, isTrue);
+  });
+
+  test('ホーム操作は生存中のEEWへフォーカスを再開する', () {
+    final dismissed = transition.dismiss(
+      previous: const HomeMapEewFocusSession(
+        eventIds: {'event-a'},
+        isFocused: true,
+      ),
+    );
+
+    final refocused = transition.refocus(previous: dismissed);
+
+    expect(refocused.shouldFocus, isTrue);
+    expect(refocused.session.isFocused, isTrue);
+  });
+}

--- a/app/test/feature/home/data/provider/map_camera_state_provider_test.dart
+++ b/app/test/feature/home/data/provider/map_camera_state_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:eqmonitor/core/model/telegram/telegram_info_type.dart';
 import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
 import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
@@ -50,12 +52,16 @@ class _StubHomeConfiguration extends HomeConfigurationNotifier {
 
 class _RecordingHomeMapCameraCoordinator extends HomeMapCameraCoordinator {
   bool? setControllerResult;
+  Completer<bool?>? setControllerCompleter;
   bool? realtimeTransitionResult;
   bool? returnToHomeResult;
   var setControllerCallCount = 0;
   var realtimeTransitionCallCount = 0;
   var clearControllerCallCount = 0;
+  var cancelAutomaticFocusCallCount = 0;
   var returnToHomeCallCount = 0;
+  bool? receivedIgnoreAutoZoom;
+  bool? receivedApplyInitialFocus;
   MapController? receivedController;
   Size? receivedViewportSize;
   List<EewTelegramItem> receivedEews = const [];
@@ -68,6 +74,7 @@ class _RecordingHomeMapCameraCoordinator extends HomeMapCameraCoordinator {
     required Future<HomeConfigurationModel> home,
     required List<EewTelegramItem> eews,
     required List<ShakeDetectionEvent> shakes,
+    bool applyInitialFocus = true,
   }) async {
     await home;
     setControllerCallCount += 1;
@@ -75,7 +82,9 @@ class _RecordingHomeMapCameraCoordinator extends HomeMapCameraCoordinator {
     receivedViewportSize = viewportSize;
     receivedEews = eews;
     receivedShakes = shakes;
-    return setControllerResult;
+    receivedApplyInitialFocus = applyInitialFocus;
+    final completer = setControllerCompleter;
+    return completer == null ? setControllerResult : completer.future;
   }
 
   @override
@@ -89,11 +98,18 @@ class _RecordingHomeMapCameraCoordinator extends HomeMapCameraCoordinator {
     required Future<HomeConfigurationModel> home,
     required List<EewTelegramItem> eews,
     required List<ShakeDetectionEvent> shakes,
+    bool ignoreAutoZoom = false,
   }) {
     realtimeTransitionCallCount += 1;
     receivedEews = eews;
     receivedShakes = shakes;
+    receivedIgnoreAutoZoom = ignoreAutoZoom;
     return SynchronousFuture(realtimeTransitionResult);
+  }
+
+  @override
+  void cancelAutomaticFocus() {
+    cancelAutomaticFocusCallCount += 1;
   }
 
   @override
@@ -108,22 +124,23 @@ class _RecordingHomeMapCameraCoordinator extends HomeMapCameraCoordinator {
 
 final _now = DateTime.utc(2025, 1, 1, 12);
 
-EewTelegramItem _sampleEew() => EewTelegramItem(
-  eventId: '20250101120000',
-  status: TelegramStatus.normal,
-  infoType: TelegramInfoType.publication,
-  serialNo: 1,
-  isCanceled: false,
-  isLastInfo: false,
-  reportTime: _now,
-  isPlum: false,
-  hypocenter: const EewHypocenterInfo(
-    code: '101',
-    name: '東京都',
-    latitude: 35.5,
-    longitude: 139.5,
-  ),
-);
+EewTelegramItem _sampleEew({String eventId = '20250101120000'}) =>
+    EewTelegramItem(
+      eventId: eventId,
+      status: TelegramStatus.normal,
+      infoType: TelegramInfoType.publication,
+      serialNo: 1,
+      isCanceled: false,
+      isLastInfo: false,
+      reportTime: _now,
+      isPlum: false,
+      hypocenter: const EewHypocenterInfo(
+        code: '101',
+        name: '東京都',
+        latitude: 35.5,
+        longitude: 139.5,
+      ),
+    );
 
 ShakeDetectionEvent _sampleShake() => ShakeDetectionEvent(
   eventId: 'shake',
@@ -245,10 +262,24 @@ void main() {
       expect(coordinator.receivedController, same(controller));
     });
 
-    test('Home復帰をcoordinatorへ委譲し結果を公開する', () async {
+    test('EEWがない場合はHome復帰をcoordinatorへ委譲し結果を公開する', () async {
       final coordinator = _RecordingHomeMapCameraCoordinator()
-        ..setControllerResult = false
         ..returnToHomeResult = true;
+      final container = _container(
+        eews: _MutableEewAliveTelegram(const []),
+        coordinator: coordinator,
+      );
+      final notifier = container.read(homeMapCameraStateProvider.notifier);
+
+      await notifier.returnToHome();
+
+      expect(coordinator.returnToHomeCallCount, 1);
+      expect(container.read(homeMapCameraStateProvider).isAtHome, isTrue);
+    });
+
+    test('EEWフォーカス中のユーザー操作はフォーカスを解除する', () async {
+      final coordinator = _RecordingHomeMapCameraCoordinator()
+        ..setControllerResult = false;
       final container = _container(
         eews: _MutableEewAliveTelegram([_sampleEew()]),
         coordinator: coordinator,
@@ -259,12 +290,134 @@ void main() {
         controller: MockMapController(),
         viewportSize: const Size(375, 667),
       );
-      expect(container.read(homeMapCameraStateProvider).isAtHome, isFalse);
+      expect(
+        container.read(homeMapCameraStateProvider).isEewFocusActive,
+        isTrue,
+      );
+
+      notifier.handleUserMapGesture();
+
+      expect(coordinator.cancelAutomaticFocusCallCount, 1);
+      expect(
+        container.read(homeMapCameraStateProvider).isEewFocusActive,
+        isFalse,
+      );
+    });
+
+    test('EEWフォーカスのカメラ移動中でもユーザー操作で解除できる', () async {
+      final focusCompleter = Completer<bool?>();
+      final coordinator = _RecordingHomeMapCameraCoordinator()
+        ..setControllerCompleter = focusCompleter;
+      final container = _container(
+        eews: _MutableEewAliveTelegram([_sampleEew()]),
+        coordinator: coordinator,
+      );
+      final notifier = container.read(homeMapCameraStateProvider.notifier);
+
+      final focus = notifier.setController(
+        controller: MockMapController(),
+        viewportSize: const Size(375, 667),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        container.read(homeMapCameraStateProvider).isEewFocusActive,
+        isTrue,
+      );
+
+      notifier.handleUserMapGesture();
+      focusCompleter.complete(false);
+      await focus;
+
+      expect(coordinator.cancelAutomaticFocusCallCount, 1);
+      expect(
+        container.read(homeMapCameraStateProvider).isEewFocusActive,
+        isFalse,
+      );
+    });
+
+    test('フォーカス解除後は同じEEW更新を無視し、新規EEWで再開する', () async {
+      final eews = _MutableEewAliveTelegram([_sampleEew()]);
+      final coordinator = _RecordingHomeMapCameraCoordinator()
+        ..setControllerResult = false
+        ..realtimeTransitionResult = false;
+      final container = _container(eews: eews, coordinator: coordinator);
+      final notifier = container.read(homeMapCameraStateProvider.notifier);
+      await notifier.setController(
+        controller: MockMapController(),
+        viewportSize: const Size(375, 667),
+      );
+      notifier.handleUserMapGesture();
+
+      eews.replace([_sampleEew()]);
+      await container.pump();
+      expect(coordinator.realtimeTransitionCallCount, 0);
+      expect(
+        container.read(homeMapCameraStateProvider).isEewFocusActive,
+        isFalse,
+      );
+
+      eews.replace([_sampleEew(), _sampleEew(eventId: 'new-event')]);
+      await container.pump();
+      expect(coordinator.realtimeTransitionCallCount, 1);
+      expect(
+        container.read(homeMapCameraStateProvider).isEewFocusActive,
+        isTrue,
+      );
+    });
+
+    test('フォーカス解除後のMap remountでは初期カメラ移動を要求しない', () async {
+      final coordinator = _RecordingHomeMapCameraCoordinator()
+        ..setControllerResult = false;
+      final container = _container(
+        eews: _MutableEewAliveTelegram([_sampleEew()]),
+        coordinator: coordinator,
+      );
+      final notifier = container.read(homeMapCameraStateProvider.notifier);
+      await notifier.setController(
+        controller: MockMapController(),
+        viewportSize: const Size(375, 667),
+      );
+      notifier.handleUserMapGesture();
+
+      await notifier.setController(
+        controller: MockMapController(),
+        viewportSize: const Size(667, 375),
+      );
+
+      expect(coordinator.receivedApplyInitialFocus, isFalse);
+      expect(
+        container.read(homeMapCameraStateProvider).isEewFocusActive,
+        isFalse,
+      );
+    });
+
+    test('フォーカス解除後のHome操作はautoZoomを無視してEEWへ再フォーカスする', () async {
+      final coordinator = _RecordingHomeMapCameraCoordinator()
+        ..setControllerResult = false
+        ..realtimeTransitionResult = false;
+      final container = _container(
+        eews: _MutableEewAliveTelegram([_sampleEew()]),
+        coordinator: coordinator,
+      );
+      final notifier = container.read(homeMapCameraStateProvider.notifier);
+      await notifier.setController(
+        controller: MockMapController(),
+        viewportSize: const Size(375, 667),
+      );
+      container.read(_testShakesProvider.notifier).replace([_sampleShake()]);
+      container.read(shakeDetectionVisibleProvider);
+      await container.pump();
+      notifier.handleUserMapGesture();
 
       await notifier.returnToHome();
 
-      expect(coordinator.returnToHomeCallCount, 1);
-      expect(container.read(homeMapCameraStateProvider).isAtHome, isTrue);
+      expect(coordinator.returnToHomeCallCount, 0);
+      expect(coordinator.receivedIgnoreAutoZoom, isTrue);
+      expect(coordinator.receivedShakes, isEmpty);
+      expect(
+        container.read(homeMapCameraStateProvider).isEewFocusActive,
+        isTrue,
+      );
     });
   });
 }

--- a/app/test/feature/home/data/service/home_map_camera_coordinator_test.dart
+++ b/app/test/feature/home/data/service/home_map_camera_coordinator_test.dart
@@ -154,6 +154,91 @@ void main() {
       verifyNoMoreInteractions(controller);
     });
 
+    test('autoZoom無効でも明示EEW再フォーカスはcamera命令を出す', () async {
+      final coordinator = HomeMapCameraCoordinator();
+      final controller = MockMapController();
+      const home = HomeConfigurationModel(
+        eew: HomeEewSettings(autoZoom: false),
+      );
+
+      await coordinator.setController(
+        controller: controller,
+        viewportSize: const Size(375, 667),
+        home: Future.value(home),
+        eews: [_sampleEew()],
+        shakes: const [],
+      );
+      stubCameraAnimations(controller: controller, animate: () async {});
+
+      final result = await coordinator.handleRealtimeTransition(
+        home: Future.value(home),
+        eews: [_sampleEew()],
+        shakes: const [],
+        ignoreAutoZoom: true,
+      );
+
+      expect(result, isFalse);
+      verify(
+        controller.animateCamera(
+          center: anyNamed('center'),
+          zoom: anyNamed('zoom'),
+          bearing: 0,
+          pitch: 0,
+        ),
+      ).called(1);
+      verifyNoMoreInteractions(controller);
+    });
+
+    test('初期フォーカス無効のcontroller登録はcamera命令を出さない', () async {
+      final coordinator = HomeMapCameraCoordinator();
+      final controller = MockMapController();
+
+      final result = await coordinator.setController(
+        controller: controller,
+        viewportSize: const Size(375, 667),
+        home: Future.value(const HomeConfigurationModel()),
+        eews: [_sampleEew()],
+        shakes: const [],
+        applyInitialFocus: false,
+      );
+
+      expect(result, isNull);
+      verifyNoMoreInteractions(controller);
+    });
+
+    test('フォーカスcancel後は進行中のcamera結果を適用しない', () async {
+      final coordinator = HomeMapCameraCoordinator();
+      final controller = MockMapController();
+      final animation = Completer<void>();
+      stubCameraAnimations(
+        controller: controller,
+        animate: () => animation.future,
+      );
+
+      final focus = coordinator.setController(
+        controller: controller,
+        viewportSize: const Size(375, 667),
+        home: Future.value(const HomeConfigurationModel()),
+        eews: [_sampleEew()],
+        shakes: const [],
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      coordinator.cancelAutomaticFocus();
+      animation.complete();
+
+      expect(await focus, isNull);
+      verify(
+        controller.animateCamera(
+          center: anyNamed('center'),
+          zoom: anyNamed('zoom'),
+          bearing: 0,
+          pitch: 0,
+        ),
+      ).called(1);
+      verifyNoMoreInteractions(controller);
+    });
+
     test('controller切替後は新controllerへactual viewportでfocusする', () async {
       final coordinator = HomeMapCameraCoordinator();
       final oldController = MockMapController();

--- a/app/test/feature/home/ui/home_map_controller_card_test.dart
+++ b/app/test/feature/home/ui/home_map_controller_card_test.dart
@@ -1,0 +1,28 @@
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/feature/home/ui/component/map/home_map_controller_card.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('無効なホームボタンはタップを受け付けない', (tester) async {
+    var tapCount = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          extensions: [DesignSystemThemeExtension.light()],
+        ),
+        home: Scaffold(
+          body: HomeMapControllerCard(
+            isLocationButtonEnabled: false,
+            onLocationButtonTap: () => tapCount += 1,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.home_rounded));
+    await tester.pump();
+
+    expect(tapCount, 0);
+  });
+}

--- a/docs/knowledge/20260824_eew_map_focus_gesture.md
+++ b/docs/knowledge/20260824_eew_map_focus_gesture.md
@@ -1,0 +1,24 @@
+# EEW地図フォーカスとユーザージェスチャ
+
+ホーム地図のEEW自動フォーカスは、MapLibreの
+`MapEventStartMoveCamera` が `CameraChangeReason.apiGesture` を通知した場合だけ
+解除する。`developerAnimation` や `apiAnimation` は自動カメラ移動なので解除しない。
+
+iOSの`MLNCameraChangeReason`はbitmaskであり、pinchとrotateなど複数理由が同時に
+立つ。flutter-maplibre側ではgesture bitのいずれかを含むか判定し、
+`TransitionCancelled`単独をgestureとして扱わないこと。
+
+- 解除後は同じEEWの更新で自動フォーカスを再開しない。
+- 新しいEEWのイベントIDが追加された場合は自動フォーカスを再開する。
+- EEW発表中にホームボタンを押した場合は、`autoZoom` 設定に関係なくEEWだけへ再フォーカスする。
+- カメラアニメーション中のジェスチャでも解除できるよう、フォーカス状態はアニメーション開始前に公開し、完了時はセッションの同一性を確認する。
+
+関連テスト:
+
+```sh
+mise exec -- flutter test \
+  app/test/feature/home/data/logic/home_map_eew_focus_transition_test.dart \
+  app/test/feature/home/data/provider/map_camera_state_provider_test.dart \
+  app/test/feature/home/data/service/home_map_camera_coordinator_test.dart \
+  app/test/feature/home/ui/home_map_controller_card_test.dart
+```

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1503,8 +1503,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre"
-      ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
-      resolved-ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
+      ref: "7080ae5"
+      resolved-ref: "7080ae5676cae4fd6a722ee67a55f64488e20940"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1512,8 +1512,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_android"
-      ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
-      resolved-ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
+      ref: "7080ae5"
+      resolved-ref: "7080ae5676cae4fd6a722ee67a55f64488e20940"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1521,8 +1521,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_ios"
-      ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
-      resolved-ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
+      ref: "7080ae5"
+      resolved-ref: "7080ae5676cae4fd6a722ee67a55f64488e20940"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1530,8 +1530,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_platform_interface"
-      ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
-      resolved-ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
+      ref: "7080ae5"
+      resolved-ref: "7080ae5676cae4fd6a722ee67a55f64488e20940"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1539,8 +1539,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_web"
-      ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
-      resolved-ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
+      ref: "7080ae5"
+      resolved-ref: "7080ae5676cae4fd6a722ee67a55f64488e20940"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"
@@ -1548,8 +1548,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/maplibre_webview"
-      ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
-      resolved-ref: "55dfdac42e142f31c64a00c9615edf61d3ffb615"
+      ref: "7080ae5"
+      resolved-ref: "7080ae5676cae4fd6a722ee67a55f64488e20940"
       url: "https://github.com/YumNumm/flutter-maplibre.git"
     source: git
     version: "0.3.5"


### PR DESCRIPTION
## 概要

- EEWフォーカス中のユーザー地図操作でフォーカスを解除
- フォーカス中はホームボタンを無効化し、解除後は有効化
- 同一EEWの更新では解除状態を維持し、新規EEWではフォーカスを再開
- 解除後のホーム操作では生存中のEEWへ明示的に再フォーカス
- iOSの複合カメラ変更理由を正しく分類するflutter-maplibre修正を参照

## 依存PR

- YumNumm/flutter-maplibre#7

## 検証

- `mise exec -- flutter analyze`（変更対象10ファイル）: 成功
- 関連テスト26件: 成功
- `mise exec -- dart run build_runner build --delete-conflicting-outputs`: 成功
- 全体`flutter test`: 1,937件成功、今回の変更外の既存テスト23件が失敗
- 全体`flutter analyze`: 今回の変更外の既存警告1件（`test/core/provider/clock/app_clock_test.dart:21`）