### PR TITLE
ci: beta版TestFlightノートにRelease Pleaseの変更履歴を使う

### DIFF
--- a/docs/knowledge/20260824_beta_testflight_release_notes.md
+++ b/docs/knowledge/20260824_beta_testflight_release_notes.md
@@ -1,0 +1,28 @@
+# Beta Release Please の TestFlight リリースノート
+
+## ルール
+
+- `v*-beta.*` タグから iOS を配布する場合、TestFlight の「テスト内容」は
+  `CHANGELOG.beta.md` の同じバージョンの節から生成する。
+- 対象節の比較リンクは、直前の beta release から現在の beta release までを表す。
+- 見出しと箇条書きは TestFlight 向けのプレーンテキストへ変換し、コミットリンクは除去する。
+- TestFlight の上限に合わせて 4,000 文字以内に収め、末尾の `rev: <commit SHA>` は維持する。
+- beta タグ以外の iOS 配布は、従来どおり App Store Connect の直前ビルドにある
+  `rev:` を起点にする。Android の生成方法も変更しない。
+
+## ローカル確認
+
+```bash
+GITHUB_REF_TYPE=tag \
+GITHUB_REF_NAME=v3.0.0-beta.12 \
+PLATFORM=ios \
+OUTPUT_PATH=/tmp/release-notes-ios.txt \
+bash scripts/ci/generate_release_note.sh
+
+wc -m /tmp/release-notes-ios.txt
+bash scripts/ci/test_generate_release_note.sh
+```
+
+対象タグと同名の節が `CHANGELOG.beta.md` に存在しない場合は、古い配布ノートへ
+フォールバックせずジョブを失敗させる。Release Please の changelog 生成漏れを
+そのまま TestFlight 配布へ持ち込まないためである。

--- a/scripts/ci/generate_release_note.sh
+++ b/scripts/ci/generate_release_note.sh
@@ -13,6 +13,9 @@
 #   LOOKBACK          遡るビルド数 (既定 5、ios のみ)
 #   ASC_BIN           asc CLI のパス (任意)
 #
+# GitHub Actions の beta タグ (v*-beta.*) では、CHANGELOG.beta.md の
+# 対象リリース節を TestFlight 用のプレーンテキストへ変換する。
+#
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -25,6 +28,9 @@ ASC_APP_ID="${ASC_APP_ID:-6447546703}"
 TESTFLIGHT_LOCALE="${TESTFLIGHT_LOCALE:-ja}"
 LOOKBACK="${LOOKBACK:-5}"
 ASC_BIN="${ASC_BIN:-}"
+GITHUB_REF_TYPE="${GITHUB_REF_TYPE:-}"
+GITHUB_REF_NAME="${GITHUB_REF_NAME:-}"
+BETA_CHANGELOG_PATH="${BETA_CHANGELOG_PATH:-$REPO_ROOT/CHANGELOG.beta.md}"
 
 log() { printf '\033[1;34m==>\033[0m %s\n' "$*" >&2; }
 die() {
@@ -154,6 +160,28 @@ resolve_base_sha_for_platform() {
 	esac
 }
 
+generate_beta_release_note() {
+	local body
+	[ -f "$BETA_CHANGELOG_PATH" ] ||
+		die "beta changelog が見つかりません: $BETA_CHANGELOG_PATH"
+
+	if ! body="$(
+		python3 "$SCRIPT_DIR/render_release_please_changelog.py" \
+			--changelog-path "$BETA_CHANGELOG_PATH" \
+			--version "$GITHUB_REF_NAME"
+	)"; then
+		die "beta changelog の変換に失敗しました: $GITHUB_REF_NAME"
+	fi
+
+	mkdir -p "$(dirname "$OUTPUT_PATH")"
+	printf '%s\n\nrev: %s\n' "$body" "$HEAD_SHA" |
+		python3 "$SCRIPT_DIR/truncate_release_note.py" --max-chars "$MAX_LENGTH" \
+			>"$OUTPUT_PATH"
+
+	log "beta changelog から変更履歴を書き出しました: $OUTPUT_PATH ($GITHUB_REF_NAME)"
+	cat "$OUTPUT_PATH" >&2
+}
+
 [ -n "$PLATFORM" ] || die "PLATFORM を指定してください (ios | android)"
 case "$PLATFORM" in
 ios | android) ;;
@@ -163,6 +191,12 @@ esac
 [ -n "$OUTPUT_PATH" ] || die "OUTPUT_PATH を指定してください"
 
 HEAD_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+
+if [ "$PLATFORM" = ios ] && [ "$GITHUB_REF_TYPE" = tag ] &&
+	[[ "$GITHUB_REF_NAME" == v*-beta.* ]]; then
+	generate_beta_release_note
+	exit 0
+fi
 
 if [ -n "$BASE_SHA" ]; then
 	git -C "$REPO_ROOT" cat-file -e "$BASE_SHA^{commit}" 2>/dev/null ||

--- a/scripts/ci/render_release_please_changelog.py
+++ b/scripts/ci/render_release_please_changelog.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Render one Release Please changelog section as TestFlight plain text."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+RELEASE_HEADING_RE = re.compile(r"^## \[([^]]+)]")
+COMMIT_LINK_RE = re.compile(
+    r"\s*\(\[[0-9a-f]{7,40}]\([^)]+\)\)\s*$",
+    re.IGNORECASE,
+)
+MARKDOWN_LINK_RE = re.compile(r"\[([^]]+)]\([^)]+\)")
+BOLD_RE = re.compile(r"\*\*([^*]+)\*\*")
+CODE_RE = re.compile(r"`([^`]+)`")
+
+SECTION_TITLES = {
+    "Features": "新機能",
+    "Bug Fixes": "不具合修正",
+    "Performance Improvements": "パフォーマンス改善",
+    "Reverts": "変更の取り消し",
+    "Documentation": "ドキュメント",
+    "Miscellaneous Chores": "その他",
+}
+
+
+def plain_text(markdown: str) -> str:
+    without_commit = COMMIT_LINK_RE.sub("", markdown)
+    without_links = MARKDOWN_LINK_RE.sub(r"\1", without_commit)
+    without_bold = BOLD_RE.sub(r"\1", without_links)
+    return CODE_RE.sub(r"\1", without_bold).strip()
+
+
+def render_release_section(changelog: str, version: str) -> str:
+    target_version = version.removeprefix("v")
+    in_target = False
+    output: list[str] = []
+
+    for line in changelog.splitlines():
+        release_match = RELEASE_HEADING_RE.match(line)
+        if release_match is not None:
+            if in_target:
+                break
+            in_target = release_match.group(1) == target_version
+            continue
+
+        if not in_target:
+            continue
+
+        if line.startswith("### "):
+            title = line.removeprefix("### ").strip()
+            if output and output[-1] != "":
+                output.append("")
+            output.append(SECTION_TITLES.get(title, plain_text(title)))
+            continue
+
+        if line.startswith("* "):
+            output.append(f"・{plain_text(line.removeprefix('* '))}")
+
+    if not in_target:
+        raise ValueError(f"changelog section was not found: {target_version}")
+
+    rendered = "\n".join(output).strip()
+    if not rendered:
+        raise ValueError(f"changelog section is empty: {target_version}")
+    return f"{rendered}\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--changelog-path", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+
+    try:
+        changelog = args.changelog_path.read_text(encoding="utf-8")
+        print(render_release_section(changelog, args.version), end="")
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test_generate_release_note.sh
+++ b/scripts/ci/test_generate_release_note.sh
@@ -13,6 +13,7 @@ new_repo() {
 	git -C "$repo" init -q
 	git -C "$repo" config user.email t@example.com
 	git -C "$repo" config user.name t
+	git -C "$repo" config commit.gpgSign false
 	echo "$repo"
 }
 
@@ -37,6 +38,47 @@ run_gen "$REPO" ios "$OUT" BASE_SHA="$BASE"
 grep -F '・#42 feat: hello' "$OUT"
 grep -E 'その他 1 件' "$OUT"
 grep -E "^rev: $(git -C "$REPO" rev-parse HEAD)$" "$OUT"
+
+# beta Release Please tag -> use only the matching CHANGELOG.beta.md section
+REPO=$(new_repo)
+git -C "$REPO" commit --allow-empty -m 'base' -q
+BASE=$(git -C "$REPO" rev-parse HEAD)
+git -C "$REPO" commit --allow-empty -m 'feat: beta change (#43)' -q
+CHANGELOG="$REPO/CHANGELOG.beta.md"
+cat >"$CHANGELOG" <<'EOF'
+# Changelog (Beta)
+
+## [3.0.0-beta.2](https://example.com/beta.2) (2026-08-24)
+
+### Features
+
+* **map:** 新しい地図表示を追加する ([abcdef0](https://example.com/commit/abcdef0))
+
+### Bug Fixes
+
+* 表示崩れを修正する ([1234567](https://example.com/commit/1234567))
+
+## [3.0.0-beta.1](https://example.com/beta.1) (2026-08-23)
+
+### Features
+
+* 前回 beta の変更は含めない ([7654321](https://example.com/commit/7654321))
+EOF
+
+OUT="$REPO/beta-changelog.txt"
+GITHUB_REF_TYPE=tag \
+	GITHUB_REF_NAME=v3.0.0-beta.2 \
+	run_gen "$REPO" ios "$OUT" BASE_SHA="$BASE"
+
+grep -F '新機能' "$OUT"
+grep -F '・map: 新しい地図表示を追加する' "$OUT"
+grep -F '不具合修正' "$OUT"
+grep -F '・表示崩れを修正する' "$OUT"
+grep -E "^rev: $(git -C "$REPO" rev-parse HEAD)$" "$OUT"
+if grep -F '前回 beta の変更は含めない' "$OUT" || grep -F 'https://example.com' "$OUT"; then
+	echo 'beta release note must contain only the current plain-text changelog section' >&2
+	exit 1
+fi
 
 # BASE_SHA == HEAD -> no changes
 REPO=$(new_repo)

--- a/scripts/ci/test_render_release_please_changelog.py
+++ b/scripts/ci/test_render_release_please_changelog.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+
+from scripts.ci.render_release_please_changelog import render_release_section
+
+
+class RenderReleasePleaseChangelogTest(unittest.TestCase):
+    def test_renders_only_matching_release_as_plain_text(self) -> None:
+        changelog = """\
+## [3.0.0-beta.2](https://example.com/beta.2)
+### Features
+* **map:** 新機能 ([abcdef0](https://example.com/commit/abcdef0))
+### Bug Fixes
+* 不具合修正 ([1234567](https://example.com/commit/1234567))
+## [3.0.0-beta.1](https://example.com/beta.1)
+### Features
+* 前回の変更 ([7654321](https://example.com/commit/7654321))
+"""
+
+        self.assertEqual(
+            render_release_section(changelog, "v3.0.0-beta.2"),
+            "新機能\n・map: 新機能\n\n不具合修正\n・不具合修正\n",
+        )
+
+    def test_rejects_missing_release(self) -> None:
+        with self.assertRaisesRegex(ValueError, "3.0.0-beta.3"):
+            render_release_section("## [3.0.0-beta.2]\n", "v3.0.0-beta.3")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

- betaタグ配信時のiOS TestFlightノートを、Release Pleaseが生成した `CHANGELOG.beta.md` の対象バージョン節から生成
- 直前のbeta releaseとの差分だけをプレーンテキスト化し、4,000文字制限と `rev:` マーカーを維持
- betaタグ以外のiOS配信とAndroid配信は従来方式を維持

## 検証

- `bash scripts/ci/test_generate_release_note.sh`
- `mise exec -- python -m unittest discover -s scripts/ci -p "test_*.py"`
- `bash scripts/ci/test_release_please_dual_track.sh`
- `mise exec -- shellcheck scripts/ci/generate_release_note.sh scripts/ci/test_generate_release_note.sh`
- `mise exec -- actionlint .github/workflows/deploy-app.yaml .github/workflows/release-please.yaml`