### PR TITLE
fix: 市区町村別最大震度マップの初回描画を修正

### DIFF
--- a/app/lib/core/component/error/error_card.dart
+++ b/app/lib/core/component/error/error_card.dart
@@ -16,6 +16,7 @@ class ErrorCard extends ConsumerWidget {
     this.stackTrace,
     this.showDetails = true,
     this.showContact = true,
+    this.showLoadingOverlayOnReload = true,
     this.onDioExceptionStatusOverride,
   });
 
@@ -26,6 +27,7 @@ class ErrorCard extends ConsumerWidget {
   final StackTrace? stackTrace;
   final bool showDetails;
   final bool showContact;
+  final bool showLoadingOverlayOnReload;
 
   /// DioExceptionで、StatusCodeがある時にエラーメッセージを上書きする
   final String? Function(int statusCode)? onDioExceptionStatusOverride;
@@ -76,11 +78,14 @@ class ErrorCard extends ConsumerWidget {
               children: [
                 if (onReload case final reload?)
                   FilledButton.tonalIcon(
-                    onPressed: () =>
-                        FullScreenCircularProgressIndicator.showUntil(
-                          context,
-                          reload,
-                        ),
+                    onPressed: showLoadingOverlayOnReload
+                        ? () => FullScreenCircularProgressIndicator.showUntil(
+                            context,
+                            reload,
+                          )
+                        : () async {
+                            await reload();
+                          },
                     icon: const Icon(Icons.refresh_rounded, size: 18),
                     label: const Text('再試行'),
                   ),

--- a/app/lib/feature/intensity_history/ui/action/intensity_history_page_action.dart
+++ b/app/lib/feature/intensity_history/ui/action/intensity_history_page_action.dart
@@ -1,0 +1,19 @@
+import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final intensityHistoryPageActionProvider = Provider(
+  (_) => const IntensityHistoryPageAction(),
+);
+
+class IntensityHistoryPageAction {
+  const new();
+
+  Future<void> retryMapConfiguration(WidgetRef ref) async {
+    try {
+      ref.invalidate(mapConfigurationProvider, asReload: true);
+      await ref.read(mapConfigurationProvider.future);
+    } on Object {
+      // provider のエラー状態を画面に反映するため、Future の例外は伝播させない。
+    }
+  }
+}

--- a/app/lib/feature/intensity_history/ui/components/intensity_history_error_overlay.dart
+++ b/app/lib/feature/intensity_history/ui/components/intensity_history_error_overlay.dart
@@ -1,3 +1,4 @@
+import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/component/error/error_details_sheet.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/feature/intensity_history/data/notifier/city_max_intensity_provider.dart';
@@ -11,6 +12,15 @@ final intensityHistoryErrorOverlayActionProvider =
 
 class IntensityHistoryErrorOverlayAction {
   const new();
+
+  Future<void> retry(WidgetRef ref) async {
+    try {
+      ref.invalidate(cityMaxIntensityProvider, asReload: true);
+      await ref.read(cityMaxIntensityProvider.future);
+    } on Object {
+      // provider のエラー状態を画面に反映するため、Future の例外は伝播させない。
+    }
+  }
 
   Future<void> showDetails({
     required WidgetRef ref,
@@ -41,6 +51,23 @@ class IntensityHistoryErrorOverlay extends ConsumerWidget {
     final designSystem = context.designSystem;
     final action = ref.read(intensityHistoryErrorOverlayActionProvider);
 
+    if (!cityMaxIntensityAsync.hasValue) {
+      return Positioned.fill(
+        child: SafeArea(
+          child: Center(
+            child: ErrorCard(
+              error: error,
+              stackTrace: stackTrace,
+              title: '震度情報を取得できません',
+              onReload: () => action.retry(ref),
+              showContact: false,
+              showLoadingOverlayOnReload: false,
+            ),
+          ),
+        ),
+      );
+    }
+
     return Positioned(
       left: 12,
       right: 12,
@@ -53,40 +80,50 @@ class IntensityHistoryErrorOverlay extends ConsumerWidget {
           borderRadius: BorderRadius.circular(8),
           child: Padding(
             padding: const EdgeInsets.all(12),
-            child: Row(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
               children: [
-                Icon(Icons.error_outline, color: designSystem.colorTheme.error),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        '震度情報を取得できません',
+                Row(
+                  children: [
+                    Icon(
+                      Icons.error_outline,
+                      color: designSystem.colorTheme.error,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        '震度情報を更新できません',
                         style: theme.textTheme.titleSmall?.copyWith(
                           color: designSystem.colorTheme.onErrorContainer,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
+                    ),
+                  ],
+                ),
+                Align(
+                  alignment: AlignmentDirectional.centerEnd,
+                  child: Wrap(
+                    spacing: 4,
+                    children: [
+                      TextButton(
+                        onPressed: () async {
+                          await action.retry(ref);
+                        },
+                        child: const Text('再試行'),
+                      ),
+                      TextButton(
+                        onPressed: () => action.showDetails(
+                          ref: ref,
+                          context: context,
+                          error: error,
+                          stackTrace: stackTrace,
+                        ),
+                        child: const Text('詳細を見る'),
+                      ),
                     ],
                   ),
-                ),
-                const SizedBox(width: 8),
-                TextButton(
-                  style: TextButton.styleFrom(
-                    minimumSize: const Size(0, 36),
-                    padding: const EdgeInsets.symmetric(horizontal: 8),
-                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    visualDensity: VisualDensity.compact,
-                  ),
-                  onPressed: () => action.showDetails(
-                    ref: ref,
-                    context: context,
-                    error: error,
-                    stackTrace: stackTrace,
-                  ),
-                  child: const Text('詳細を見る'),
                 ),
               ],
             ),

--- a/app/lib/feature/intensity_history/ui/components/intensity_history_loading_overlay.dart
+++ b/app/lib/feature/intensity_history/ui/components/intensity_history_loading_overlay.dart
@@ -1,0 +1,21 @@
+import 'package:eqmonitor/feature/intensity_history/data/notifier/city_max_intensity_provider.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class IntensityHistoryLoadingOverlay extends ConsumerWidget {
+  const new({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final value = ref.watch(cityMaxIntensityProvider);
+    if (!value.isLoading || value.hasValue) {
+      return const SizedBox.shrink();
+    }
+
+    return const Positioned.fill(
+      child: IgnorePointer(
+        child: Center(child: CircularProgressIndicator.adaptive()),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/intensity_history/ui/intensity_history_page.dart
+++ b/app/lib/feature/intensity_history/ui/intensity_history_page.dart
@@ -5,11 +5,13 @@ import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/extension/async_value.dart';
 import 'package:eqmonitor/feature/intensity_history/data/notifier/city_max_intensity_provider.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/action/intensity_history_map_action.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/action/intensity_history_page_action.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/components/intensity_history_error_overlay.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/components/intensity_history_legend.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/components/intensity_history_loading_overlay.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/components/intensity_history_navigation_back_button.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/components/region_floating_panel.dart';
-import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_fill_layer.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_history_map_layers.dart';
 import 'package:eqmonitor/feature/location/data/jma_map_isolate.dart';
 import 'package:eqmonitor/feature/map/data/model/map_configuration.dart';
 import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
@@ -37,6 +39,7 @@ class IntensityHistoryPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final action = ref.watch(intensityHistoryPageActionProvider);
     return switch (ref.watch(mapConfigurationProvider)) {
       AsyncData(value: MapConfiguration(:final styleString?)) => _MapContent(
         styleString: styleString,
@@ -45,10 +48,25 @@ class IntensityHistoryPage extends ConsumerWidget {
       ),
       AsyncError(:final error) => Scaffold(
         appBar: AppBar(title: const Text('市区町村別 最大震度')),
-        body: Center(child: ErrorCard(error: error)),
+        body: Center(
+          child: ErrorCard(
+            error: error,
+            onReload: () => action.retryMapConfiguration(ref),
+            showLoadingOverlayOnReload: false,
+          ),
+        ),
       ),
       _ => const Scaffold(
-        body: Center(child: CircularProgressIndicator.adaptive()),
+        body: Stack(
+          children: [
+            Center(child: CircularProgressIndicator.adaptive()),
+            Positioned(
+              top: 0,
+              left: 0,
+              child: IntensityHistoryNavigationBackButton(),
+            ),
+          ],
+        ),
       ),
     };
   }
@@ -133,7 +151,7 @@ class _MapContent extends HookConsumerWidget {
                   point: point,
                 );
               },
-              children: const [IntensityFillLayer()],
+              children: const [IntensityHistoryMapLayers()],
             ),
           ),
 
@@ -167,13 +185,14 @@ class _MapContent extends HookConsumerWidget {
             child: SafeArea(child: IntensityHistoryLegend()),
           ),
 
+          const IntensityHistoryLoadingOverlay(),
+          const IntensityHistoryErrorOverlay(),
+
           const Positioned(
             top: 0,
             left: 0,
             child: IntensityHistoryNavigationBackButton(),
           ),
-
-          const IntensityHistoryErrorOverlay(),
         ],
       ),
     );

--- a/app/lib/feature/intensity_history/ui/layer/intensity_fill_layer.dart
+++ b/app/lib/feature/intensity_history/ui/layer/intensity_fill_layer.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
 
-import 'package:eqmonitor/core/extension/async_value.dart';
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
 import 'package:eqmonitor/core/util/converter/color_converter.dart';
 import 'package:eqmonitor/core/util/map/replace_map_style_layers.dart';
 import 'package:eqmonitor/feature/intensity_history/data/model/city_max_intensity_entry.dart';
-import 'package:eqmonitor/feature/intensity_history/data/notifier/city_max_intensity_provider.dart';
 import 'package:eqmonitor/feature/intensity_history/data/notifier/intensity_history_controller.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_fill_layer_builder.dart';
 import 'package:material_ui/material_ui.dart';
@@ -27,7 +25,9 @@ import 'package:maplibre/maplibre.dart';
 /// 作り直すと塗りが消えたように見える。相対順序はアンカー（細分区域の境界線の
 /// 下 / 上）で決まるので、effect を分けても順序は入れ替わらない。
 class IntensityFillLayer extends HookConsumerWidget {
-  const new({super.key});
+  const new({required this.items, super.key});
+
+  final List<CityMaxIntensityEntry> items;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -36,11 +36,6 @@ class IntensityFillLayer extends HookConsumerWidget {
     final colorModel = colorSet.intensity;
     final isDarkMode = Theme.brightnessOf(context) == Brightness.dark;
 
-    final items = ref.watch(
-      cityMaxIntensityProvider.select(
-        (value) => value.valueOrPrevious?.items,
-      ),
-    );
     final selectedCityCode = ref.watch(
       intensityHistoryControllerProvider.select(
         (state) => state.selectedCity?.code,
@@ -75,7 +70,7 @@ class IntensityFillLayer extends HookConsumerWidget {
         }
 
         final layers = builder.buildFill(
-          cityMaxIntensities: latestItems.value ?? const [],
+          cityMaxIntensities: latestItems.value,
           colorModel: colorModel,
         );
 

--- a/app/lib/feature/intensity_history/ui/layer/intensity_history_map_layers.dart
+++ b/app/lib/feature/intensity_history/ui/layer/intensity_history_map_layers.dart
@@ -1,0 +1,22 @@
+import 'package:eqmonitor/core/extension/async_value.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/city_max_intensity_provider.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_fill_layer.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 市区町村別最大震度の取得状態に応じて MapLibre レイヤーを構成する。
+///
+/// 初回取得前は空のレイヤー更新を行わない。再取得中や再取得失敗時は
+/// [AsyncValue] の previous value を使い、表示済みの塗りを維持する。
+class IntensityHistoryMapLayers extends ConsumerWidget {
+  const new({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final items = ref.watch(cityMaxIntensityProvider).valueOrPrevious?.items;
+    if (items == null) {
+      return const SizedBox.shrink();
+    }
+    return IntensityFillLayer(items: items);
+  }
+}

--- a/app/test/feature/intensity_history/intensity_history_error_overlay_test.dart
+++ b/app/test/feature/intensity_history/intensity_history_error_overlay_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
 import 'package:eqmonitor/core/provider/package_info.dart';
 import 'package:eqmonitor/feature/intensity_history/data/model/city_max_intensity.dart';
@@ -26,6 +28,7 @@ void main() {
   ) async {
     await tester.pumpWidget(
       ProviderScope(
+        retry: (_, _) => null,
         overrides: [
           cityMaxIntensityProvider.overrideWith(
             () => _FakeCityMaxIntensity(
@@ -53,8 +56,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('震度情報を取得できません'), findsOneWidget);
-    expect(find.text('詳細を見る'), findsOneWidget);
-    expect(find.textContaining('地図は操作できます'), findsNothing);
+    expect(find.text('再試行'), findsOneWidget);
+    expect(find.text('詳細'), findsOneWidget);
   });
 
   testWidgets('詳細を見るで詳細シートを開く', (tester) async {
@@ -72,6 +75,7 @@ void main() {
 
     await tester.pumpWidget(
       ProviderScope(
+        retry: (_, _) => null,
         overrides: [
           cityMaxIntensityProvider.overrideWith(
             () => _FakeCityMaxIntensity(
@@ -102,7 +106,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    await tester.tap(find.text('詳細を見る'));
+    await tester.tap(find.text('詳細'));
     await tester.pumpAndSettle();
     expect(find.textContaining('まとめてコピー'), findsOneWidget);
   });
@@ -112,6 +116,7 @@ void main() {
   ) async {
     await tester.pumpWidget(
       ProviderScope(
+        retry: (_, _) => null,
         overrides: [
           cityMaxIntensityProvider.overrideWith(
             () => _FakeCityMaxIntensity(
@@ -140,5 +145,105 @@ void main() {
 
     expect(find.text('震度情報を取得できません'), findsNothing);
     expect(find.text('詳細を見る'), findsNothing);
+  });
+
+  testWidgets('再取得失敗時は取得済みデータを覆わずエラーを表示する', (tester) async {
+    const cached = CityMaxIntensity(aggregatedAt: null, items: []);
+    final refresh = Completer<CityMaxIntensity>();
+    var buildCount = 0;
+    final container = ProviderContainer(
+      retry: (_, _) => null,
+      overrides: [
+        cityMaxIntensityProvider.overrideWith(
+          () => _FakeCityMaxIntensity(() {
+            buildCount++;
+            return buildCount == 1 ? Future.value(cached) : refresh.future;
+          }),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: ThemeData.light().copyWith(
+            extensions: <ThemeExtension<dynamic>>[
+              DesignSystemThemeExtension.light(),
+            ],
+          ),
+          home: const Scaffold(
+            body: Stack(
+              children: [SizedBox.expand(), IntensityHistoryErrorOverlay()],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    container.invalidate(cityMaxIntensityProvider);
+    await tester.pump();
+    refresh.completeError(
+      Exception('refresh failed'),
+      StackTrace.current,
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('震度情報を更新できません'), findsOneWidget);
+    expect(find.text('再試行'), findsOneWidget);
+    expect(find.text('詳細を見る'), findsOneWidget);
+  });
+
+  testWidgets('再試行が再度失敗しても未処理例外にせずエラー表示を維持する', (
+    tester,
+  ) async {
+    const cached = CityMaxIntensity(aggregatedAt: null, items: []);
+    var buildCount = 0;
+    final container = ProviderContainer(
+      retry: (_, _) => null,
+      overrides: [
+        cityMaxIntensityProvider.overrideWith(
+          () => _FakeCityMaxIntensity(() {
+            buildCount++;
+            if (buildCount == 1) {
+              return Future.value(cached);
+            }
+            return Future.error(Exception('refresh failed'));
+          }),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: ThemeData.light().copyWith(
+            extensions: <ThemeExtension<dynamic>>[
+              DesignSystemThemeExtension.light(),
+            ],
+          ),
+          home: const Scaffold(
+            body: Stack(
+              children: [SizedBox.expand(), IntensityHistoryErrorOverlay()],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    container.invalidate(cityMaxIntensityProvider);
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.text('再試行'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('震度情報を更新できません'), findsOneWidget);
   });
 }

--- a/app/test/feature/intensity_history/intensity_history_loading_overlay_test.dart
+++ b/app/test/feature/intensity_history/intensity_history_loading_overlay_test.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:eqmonitor/feature/intensity_history/data/model/city_max_intensity.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/city_max_intensity_provider.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/components/intensity_history_loading_overlay.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class _ControllableCityMaxIntensityNotifier extends CityMaxIntensityNotifier {
+  final requests = <Completer<CityMaxIntensity>>[];
+
+  @override
+  Future<CityMaxIntensity> build() {
+    final request = Completer<CityMaxIntensity>();
+    requests.add(request);
+    return request.future;
+  }
+}
+
+void main() {
+  testWidgets('初回取得中だけ adaptive の進捗表示を出す', (tester) async {
+    final container = ProviderContainer(
+      overrides: [
+        cityMaxIntensityProvider.overrideWith(
+          _ControllableCityMaxIntensityNotifier.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: Stack(children: [IntensityHistoryLoadingOverlay()]),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    final notifier = container.read(
+      cityMaxIntensityProvider.notifier,
+    ) as _ControllableCityMaxIntensityNotifier;
+    notifier.requests.last.complete(
+      const CityMaxIntensity(aggregatedAt: null, items: []),
+    );
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('取得済みデータの再読み込み中は進捗表示でマップを覆わない', (
+    tester,
+  ) async {
+    const value = CityMaxIntensity(aggregatedAt: null, items: []);
+    final container = ProviderContainer(
+      overrides: [
+        cityMaxIntensityProvider.overrideWith(
+          _ControllableCityMaxIntensityNotifier.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: Stack(children: [IntensityHistoryLoadingOverlay()]),
+          ),
+        ),
+      ),
+    );
+    final notifier = container.read(
+      cityMaxIntensityProvider.notifier,
+    ) as _ControllableCityMaxIntensityNotifier;
+    notifier.requests.last.complete(value);
+    await tester.pump();
+    container.invalidate(cityMaxIntensityProvider);
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+}

--- a/app/test/feature/intensity_history/intensity_history_map_layers_test.dart
+++ b/app/test/feature/intensity_history/intensity_history_map_layers_test.dart
@@ -1,0 +1,135 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/city_max_intensity.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/city_max_intensity_entry.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/city_max_intensity_provider.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_fill_layer.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_history_map_layers.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class _ControllableCityMaxIntensityNotifier extends CityMaxIntensityNotifier {
+  final requests = <Completer<CityMaxIntensity>>[];
+
+  @override
+  Future<CityMaxIntensity> build() {
+    final request = Completer<CityMaxIntensity>();
+    requests.add(request);
+    return request.future;
+  }
+}
+
+void main() {
+  testWidgets('初回データ取得後に塗りレイヤーをマウントする', (tester) async {
+    final container = ProviderContainer(
+      retry: (_, _) => null,
+      overrides: [
+        cityMaxIntensityProvider.overrideWith(
+          _ControllableCityMaxIntensityNotifier.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: IntensityHistoryMapLayers()),
+      ),
+    );
+
+    expect(find.byType(IntensityFillLayer), findsNothing);
+
+    final notifier = container.read(
+      cityMaxIntensityProvider.notifier,
+    ) as _ControllableCityMaxIntensityNotifier;
+    notifier.requests.last.complete(
+      const CityMaxIntensity(
+        aggregatedAt: null,
+        items: [
+          CityMaxIntensityEntry(
+            cityCode: '0110110',
+            intensity: JmaIntensity.fiveLower,
+          ),
+        ],
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(IntensityFillLayer), findsOneWidget);
+  });
+
+  testWidgets('取得済みデータは再読み込み中と再読み込み失敗時にも保持する', (
+    tester,
+  ) async {
+    const initial = CityMaxIntensity(
+      aggregatedAt: null,
+      items: [
+        CityMaxIntensityEntry(
+          cityCode: '0110110',
+          intensity: JmaIntensity.fiveLower,
+        ),
+      ],
+    );
+    const refreshed = CityMaxIntensity(
+      aggregatedAt: null,
+      items: [
+        CityMaxIntensityEntry(
+          cityCode: '0110110',
+          intensity: JmaIntensity.sixLower,
+        ),
+      ],
+    );
+    final container = ProviderContainer(
+      retry: (_, _) => null,
+      overrides: [
+        cityMaxIntensityProvider.overrideWith(
+          _ControllableCityMaxIntensityNotifier.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: IntensityHistoryMapLayers()),
+      ),
+    );
+    final notifier = container.read(
+      cityMaxIntensityProvider.notifier,
+    ) as _ControllableCityMaxIntensityNotifier;
+    notifier.requests.last.complete(initial);
+    await tester.pump();
+
+    container.invalidate(cityMaxIntensityProvider);
+    await tester.pump();
+    expect(
+      tester.widget<IntensityFillLayer>(find.byType(IntensityFillLayer)).items,
+      initial.items,
+    );
+
+    notifier.requests.last.complete(refreshed);
+    await tester.pump();
+    await tester.pump();
+    expect(
+      tester.widget<IntensityFillLayer>(find.byType(IntensityFillLayer)).items,
+      refreshed.items,
+    );
+
+    container.invalidate(cityMaxIntensityProvider);
+    await tester.pump();
+    notifier.requests.last.completeError(
+      Exception('refresh failed'),
+      StackTrace.current,
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(
+      tester.widget<IntensityFillLayer>(find.byType(IntensityFillLayer)).items,
+      refreshed.items,
+    );
+  });
+}

--- a/app/test/feature/intensity_history/intensity_history_page_state_test.dart
+++ b/app/test/feature/intensity_history/intensity_history_page_state_test.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/intensity_history_page.dart';
+import 'package:eqmonitor/feature/map/data/model/map_configuration.dart';
+import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class _FakeMapConfigurationNotifier extends MapConfigurationNotifier {
+  new(this._build);
+
+  final Future<MapConfiguration> Function() _build;
+
+  @override
+  Future<MapConfiguration> build() => _build();
+}
+
+void main() {
+  testWidgets('地図設定の初回読み込み中も戻ることができる', (tester) async {
+    final pending = Completer<MapConfiguration>();
+    await tester.pumpWidget(
+      ProviderScope(
+        retry: (_, _) => null,
+        overrides: [
+          mapConfigurationProvider.overrideWith(
+            () => _FakeMapConfigurationNotifier(() => pending.future),
+          ),
+        ],
+        child: _TestApp(page: const IntensityHistoryPage()),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byTooltip('戻る'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('戻る'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('home'), findsOneWidget);
+  });
+
+  testWidgets('地図設定エラーを表示して再試行できる', (
+    tester,
+  ) async {
+    final retryPending = Completer<MapConfiguration>();
+    var buildCount = 0;
+    await tester.pumpWidget(
+      ProviderScope(
+        retry: (_, _) => null,
+        overrides: [
+          mapConfigurationProvider.overrideWith(
+            () => _FakeMapConfigurationNotifier(() {
+              buildCount++;
+              if (buildCount == 1) {
+                throw Exception('map configuration failed');
+              }
+              return retryPending.future;
+            }),
+          ),
+        ],
+        child: _TestApp(page: const IntensityHistoryPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('再試行'), findsOneWidget);
+    expect(find.byType(BackButton), findsOneWidget);
+
+    await tester.tap(find.text('再試行'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('再試行'), findsNothing);
+
+    await tester.tap(find.byTooltip('戻る'));
+    await tester.pumpAndSettle();
+    expect(find.text('home'), findsOneWidget);
+
+    retryPending.complete(
+      const MapConfiguration(theme: MapTheme.light),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+  });
+}
+
+class _TestApp extends StatelessWidget {
+  const new({required this.page});
+
+  final Widget page;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData.light().copyWith(
+        extensions: <ThemeExtension<dynamic>>[
+          DesignSystemThemeExtension.light(),
+        ],
+      ),
+      initialRoute: '/detail',
+      routes: {
+        '/': (_) => const Scaffold(body: Text('home')),
+        '/detail': (_) => page,
+      },
+    );
+  }
+}

--- a/docs/knowledge/20260824_async_map_layer_lifecycle.md
+++ b/docs/knowledge/20260824_async_map_layer_lifecycle.md
@@ -1,0 +1,26 @@
+# 非同期データを使う MapLibre レイヤーのライフサイクル
+
+## ルール
+
+- 初回取得前の空データで MapLibre の source / layer 置換を実行しない。
+- `AsyncValue.valueOrPrevious` にデータがある場合だけレイヤー Widget をマウントする。
+- provider の `invalidate` による再取得中と再取得失敗時は previous value を使い、表示済みレイヤーを維持する。
+- 再取得成功時はデータの実体が変化した場合だけレイヤーを更新する。
+- 読み込み表示は `CircularProgressIndicator.adaptive()` を使い、`IgnorePointer` または非モーダルな配置で戻る操作を遮らない。
+- 再試行で provider の Future が失敗しても、画面は provider のエラー状態を表示するため、ボタンの Future から例外を再伝播させない。
+
+## 理由
+
+初回データがない段階で空のレイヤー置換を予約すると、MapLibre の style 初期化とデータ取得の順序によって空の更新だけが反映されることがある。一方、再取得のたびにレイヤーをアンマウントすると、取得中のちらつきや取得失敗時の表示消失につながる。
+
+## 回帰確認
+
+初回取得、実際の `invalidate`、再取得成功、再取得失敗を同じテストで確認する。
+
+```sh
+mise exec -- flutter test \
+  test/feature/intensity_history/intensity_history_map_layers_test.dart \
+  test/feature/intensity_history/intensity_history_loading_overlay_test.dart \
+  test/feature/intensity_history/intensity_history_error_overlay_test.dart \
+  test/feature/intensity_history/intensity_history_page_state_test.dart
+```

--- a/docs/todo/650_onboarding_notification_preset_build_update.md
+++ b/docs/todo/650_onboarding_notification_preset_build_update.md
@@ -1,0 +1,25 @@
+# オンボーディングの通知プリセット初期化で build 中に状態更新される
+
+## 現象
+
+iOS 26.4 シミュレーターで新規インストール後のオンボーディングを進めると、
+通知設定画面の初期表示時に次の Flutter エラーが記録される。
+
+```text
+setState() or markNeedsBuild() called during build.
+```
+
+`NotificationPresetSelector` の `useEffect` から
+`_NewUserNotificationSettingsStepPage` が保持する `ValueNotifier` を同期更新しており、
+親 Widget の build 中に再ビルドを要求している。
+
+## 該当箇所
+
+- `app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart`
+- `app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart`
+
+## 対応案
+
+- 初期プリセットの導出を build 前の状態初期化へ移す。
+- コールバック通知が必要な場合は、初期 build 完了後に一度だけ実行する。
+- 新規インストール相当の Widget テストまたは iOS シミュレーターで再発しないことを確認する。


### PR DESCRIPTION
## 概要

- 市区町村別最大震度の初回取得後に MapLibre の塗りレイヤーをマウントするよう修正
- provider が外部から invalidate された再取得中・再取得失敗時も取得済みレイヤーを維持
- 初回読み込み中に adaptive の進捗表示を出し、戻る操作を妨げないよう修正
- 初回取得エラーとバックグラウンド更新エラーを分け、再試行と詳細表示を追加

## 確認内容

- 関連 Flutter テスト 28件成功
- 対象範囲の flutter analyze 成功
- dart format / git diff --check 成功
- iOS 26.4 シミュレーターのコールド状態で、市区町村別最大震度 API の初回取得直後から塗り潰しが表示されることを確認
- コードレビューで重要指摘なし

## 補足

- 全体 flutter test では今回の差分外にある Widget テストなどで失敗を確認したため、関連テストを個別に完走して回帰確認しています。
- シミュレーター検証中に見つかったオンボーディングの build 中状態更新エラーは docs/todo/650_onboarding_notification_preset_build_update.md に記録しています。
