### PR TITLE
docs: Flutter GPU地図移行ロードマップを策定

### DIFF
--- a/docs/superpowers/specs/2026-08-24-earthquake-map-hypocenter-observation-parity-design.md
+++ b/docs/superpowers/specs/2026-08-24-earthquake-map-hypocenter-observation-parity-design.md
@@ -1,0 +1,479 @@
+# Earthquake Map Hypocenter and Observation Parity Design
+
+## 1. Goal
+
+Flutter Scene / GPU のデバッグ地図で、一つの実地震について次を同じ camera 上へ
+表示する。
+
+- base map
+- 地域または市区町村の震度 Fill
+- 震度観測点
+- 震源 sprite
+
+対象地震へ確実に移動でき、zoom 6 の地域 / 市区町村 / 観測点境界、pan / pinch、
+background / foreground、source switch、coverage を runtime で検証できる状態を
+完成条件とする。
+
+本仕様は
+`docs/superpowers/specs/2026-08-24-flutter-gpu-map-migration-roadmap-design.md`
+の最初の subproject である。
+
+## 2. Existing Inputs
+
+### 2.1 App earthquake model
+
+`Earthquake` は event ID、telegram metadata、intensity、hypocenter を持つ。
+震源を描画できるのは `EarthquakeHypocenter.coordinates` が緯度経度を持つ場合だけ
+である。座標が欠損、description、unknown の場合に既定位置へ置かない。
+
+### 2.2 Existing overlay
+
+現行`EarthquakeMapOverlaySnapshot`はsource ID、単一revision、地域 / 市区町村
+style、観測点を保持する。本subprojectで単一revisionを3.4のversion stampへ置換
+する。観測点はMercator座標、premultiplied color、logical-pixel radiusを28-byte
+instance streamへ変換し、一geometry / 一nodeで描画する。
+
+### 2.3 Existing icons
+
+app は次を持つ。
+
+- `app/assets/images/map/normal_hypocenter.png`
+- `app/assets/images/map/low_precise_hypocenter.png`
+
+地震履歴では normal icon を使用する。低精度 icon は同じ generic sprite foundation
+を将来 EEW から再利用できることを確認する fixture とするが、本 subproject の
+地震履歴 data builder は normal icon だけを出力する。
+
+## 3. Public Contracts
+
+### 3.1 Sprite atlas
+
+`eqmonitor_map` は app asset path を受け取らない。app が asset bytes を decode し、
+次の immutable descriptor を構築する。
+
+```dart
+final class MapSpriteAtlas {
+  MapSourceIdentity identity;
+  int width;
+  int height;
+  Uint8List rgbaBytes;
+  List<MapSpriteRegion> regions;
+}
+
+final class MapSpriteAtlasLimits {
+  int maxWidth;
+  int maxHeight;
+  int maxPixelBytes;
+  int maxRegions;
+}
+
+final class MapSpriteRegion {
+  String id;
+  Rect normalizedUv;
+  Size logicalSize;
+}
+```
+
+実際の Dart 宣言は既存 naming、const / factory validation 規約に合わせる。公開
+factory は caller 必須の `MapSpriteAtlasLimits` を受け、defensive copy と次の検証を
+行う。package に暗黙の上限を置かない。
+
+- identity が空でない
+- width / height / byte count が一致する
+- atlas byte / region count / dimension の明示上限
+- UV が finite かつ 0..1
+- logical size が finite かつ正
+- region ID が非空・重複なし
+
+atlas は content digest を identity に含める。theme / DPR は atlas identity に
+含めず、必要なら別 material / uniform generation として扱う。
+
+pixel ABI は次に固定する。
+
+- top-left origin
+- row-major、tight stride `width * 4`
+- RGBA8888、straight alpha、sRGB encoded color
+- shader で alpha をちょうど一回掛けて premultiplied output にする
+- manual gamma conversion を行わない
+- sampler は linear filter / clamp-to-edge
+- 各 region は上下左右に 2 physical pixel の extruded edge padding を持つ
+- normalized UV は padding を除く texel center を指す
+
+2x2 の向き確認fixture、alpha 0.5 fixture、atlas端regionを使い、上下反転、二重
+premultiply、neighbor bleed がないことを shader / iOS / Android で確認する。
+
+### 3.2 Zoom scalar policy
+
+地震固有の size / fade を renderer に hardcode しない。本subprojectのGPU ABIは、
+必要なMapLibre表現へ絞った次の二型に固定する。
+
+```dart
+final class MapZoomLinearRange {
+  double startZoom;
+  double startValue;
+  double endZoom;
+  double endValue;
+}
+
+final class MapZoomStep {
+  double thresholdZoom;
+  double belowValue;
+  double atOrAboveValue;
+}
+```
+
+linear rangeは範囲外を端点clampし、`startZoom < endZoom`を必須とする。stepは
+`zoom < thresholdZoom`でbelow、`zoom >= thresholdZoom`でatOrAboveを返す。全値は
+finite、size値は正、opacity値は0..1をfactoryで検証する。
+
+size / opacity policy pairはbatch-level immutable dataであり、canonical digestを
+batch keyへ含める。instance ABIへ任意長stopやpolicy indexを入れない。同じpolicy
+pairのfeatureを一batchへまとめ、異なるpolicy pairは別batchへ分ける。caller必須の
+`maxSpritePolicyBatches`でbatch数を制限し、packageに暗黙上限を置かない。
+
+### 3.3 Sprite feature
+
+```dart
+final class MapPointSpriteFeature {
+  String id;
+  double longitude;
+  double latitude;
+  String spriteRegionId;
+  MapZoomLinearRange sizeScale;
+  MapZoomStep opacity;
+  int priority;
+}
+```
+
+longitude / latitude と policy を factory で検証する。feature ID は一 snapshot
+内で一意とする。
+
+地震履歴の震源 feature は安定 ID `hypocenter:<eventId>`、normal region、既存
+MapLibre parameter と同じ zoom 3 -> 20 の linear size と、設定された fade zoom
+での step opacity を使用する。既存設定を app builder が generic policy へ変換し、
+package は地震固有設定へ依存しない。zoom 3、fade zoom の直前 / 一致 / 直後、zoom
+20 の値を既存 MapLibre fixture と比較する。
+
+### 3.4 Earthquake overlay
+
+`EarthquakeMapOverlaySnapshot` に次を追加する。
+
+```dart
+MapSpriteAtlas? spriteAtlas;
+List<MapPointSpriteFeature> sprites;
+```
+
+atlas が null で sprites が非空、未知 region ID、重複 feature ID は factory で
+拒否する。
+
+snapshot は full replacement で、roadmap の data / render version を持つ。既存の
+単一 `revision` は本subproject内でdata sequenceへ置換し、compatibility aliasを残さ
+ない。
+
+- data sequence: app provider が canonical earthquake data 変更時に進める
+- data digest: region / city / station / hypocenter の canonical digest
+- render generation: theme、atlas、display setting 変更時に進める
+- render digest: data version と全 render policy の digest
+
+同じ data sequence / 異なる data digest は拒否する。theme / atlas / setting だけの
+変更は data version を維持し render generation を進めて受理する。同じ render
+generation / 異なる render digest も拒否する。
+
+commit、coverage callback、debug presentationは共通のimmutable
+`MapOverlayVersionStamp`を使用する。
+
+```dart
+final class MapOverlayVersionStamp {
+  MapSourceIdentity sourceIdentity;
+  MapSourceIncarnation sourceIncarnation;
+  int dataSequence;
+  String dataDigest;
+  int renderGeneration;
+  String renderDigest;
+}
+```
+
+`MapSourceIncarnation`は非空のopaque文字列をfactoryで検証する専用value typeとし、
+`Object` identityやprocess-local hashを公開契約に使わない。
+
+旧`sourceId / revision`だけのcoverage identityは削除する。app provider、controller、
+frame owner、coverage equality、debug banner、testsを同じcommit範囲でversion stampへ
+移行し、部分的なcompatibility stateを作らない。
+
+### 3.5 Camera controller
+
+`BaseMapView` はSceneやtile内部状態を公開せず、camera commandとcommit済みcamera
+stateだけを扱う`MapViewCameraController`を任意引数として受け取る。
+
+controller は caller が所有し、同時に一つの `BaseMapView` だけへ attach できる。
+view dispose で detach し、その後の別 view への再attachは許可する。attach 前、
+detach 中、二重attachのcommandはtyped failureを返し、queueしない。
+
+controllerは最後にcommitされた`MapCamera`を保持し、同期getterと
+`ValueListenable<MapCamera>`でcallerへ公開する。再attach時は保持cameraを使い、保持値
+がない最初のattachだけ`BaseMapView.initialCamera`を使う。source switchはcameraを
+暗黙resetしない。callerがcontrollerをdisposeした後のattach / commandはfailureと
+する。
+
+最低限の command は次とする。
+
+- `Future<MapCameraCommandResult> moveTo({required MapCamera camera})`
+- `Future<MapCameraCommandResult> fitBounds({required MapCameraBounds bounds,
+  required EdgeInsets padding})`
+
+`MapCameraCommandResult` は success receipt と sealed failure を持つ。success は camera
+state が受理され次 frame がscheduleされた時点を意味し、tile load完了は意味しない。
+failure は invalid input、not attached、already attached、disposed、superseded を区別
+する。
+
+command は非 finite input を typed failure として返し、例外を unawaited にしない。
+新 command は未commitの前 commandを generation で supersede する。gesture と
+command は同じ camera clamp / tile cover 経路を使う。`fitBounds` は antimeridian、
+padding、DPR、viewport resize、min / max zoom clamp を扱う。
+
+MapLibre parity fixtureでは、同一viewport / padding / boundsに対しzoom絶対誤差
+`1e-6`以下、中心点のprojected logical-pixel誤差`0.5 px`以下を合格条件とする。
+
+本 subproject の debug page は overlay source が変わったとき、震源座標があるなら
+一度だけ震源へ移動できる UI action を表示する。座標がない場合は action を表示
+しない。自動で毎 rebuild camera を戻さない。
+
+## 4. Renderer Design
+
+### 4.1 Geometry and instance layout
+
+sprite は一つの quad topology と、全 feature の instance stream を使用する。
+instance は少なくとも次を含む。
+
+- normalized Mercator center
+- atlas UV rect
+- logical size / scale
+- opacity
+- feature priority
+
+size / opacity policyはinstance streamへ格納せずbatch uniformで評価する。byte
+stride、attribute offset、endiannessはpublic constantsとtest fixtureで固定する。
+入力listはimmutableに所有し、caller buffer aliasを残さない。
+
+同じbatch dataでcameraだけが変わる場合、instance bytes、texture、geometryを
+再生成しない。cameraとzoom policy評価用uniformだけを更新する。
+
+### 4.2 Shader contract
+
+vertex shader は normalized Mercator、nearest date-line wrap、camera center、zoom、
+viewport logical size から quad position を算出する。DPR を logical size に二重適用
+しない。
+
+fragment shader は straight-alpha atlas sample のRGBへsample alphaとfeature
+opacityを一度だけ適用し、premultiplied RGBA を出力する。material は alpha
+blending、depth write off、culling none、opaque false とする。texture row origin、
+UV orientation、linear / clamp sampler は 3.1 のABIと一致させる。
+
+shader symbol、uniform block size、instance stride / offset、texture binding type を
+Scene mutation 前に reflection preflight する。
+
+### 4.3 Phase and batching
+
+地震 Fill、観測点、震源の順序は次とする。
+
+```text
+base < earthquake Fill < observation point < hypocenter sprite < label
+```
+
+震源は観測点より前面に置く。feature数に関係なく同じatlas / material / zoom policy
+pairのspriteは一geometry / 一nodeとする。本subprojectの地震履歴震源は一policy
+pairなので一geometry / 一nodeである。
+
+### 4.4 Resource ownership
+
+texture、static topology、instance geometry、node は別々に所有する。
+
+- texture: `(contextGeneration, atlasDigest)`
+- quad topology: `(contextGeneration, ABI version, material version)`
+- instance: `(contextGeneration, batchGeneration)`
+- node: committed frame
+
+次の場合に旧 resource を Scene から外し、renderer completion fence 後に一度だけ
+retire する。
+
+- overlay source / full snapshot replacementで不要になったinstance / node
+- atlas identity changeで不要になったtexture pin
+- context recreation
+- background
+- widget dispose
+
+submit / reflection / texture upload が失敗した場合、new earthquake candidate を
+commit せず base-only へ fail closed する。旧 source の震源や観測点を残さない。
+同atlasを二つのlogical overlayが共有する場合、一方の更新 / 削除でtextureを再upload
+せず、他方のpinがある限りretireしない。failed candidateはcommitted texture /
+topology / instanceをretireしない。
+
+transaction順序を次に固定する。
+
+1. candidate resourceをprepareしcandidate pinを取得
+2. preflight / submit失敗時はcandidate pinだけをrelease
+3. base-onlyをatomic commitし旧nodeをSceneから除去
+4. completion fence後に旧instance / node pinと、旧consumerが保持していたtexture /
+   topology pinをrelease
+5. shared atlas / topologyは他pinがなくなった時だけretire
+
+candidate失敗そのものはcommitted resourceへ触れず、その後のbase-only atomic commit
+が旧ownerのpin releaseを担う。
+
+同atlas digestならrender generation、station、sprite instanceの変更後もtexture upload
+は0とする。同batch digestならinstanceを再利用し、camera-onlyではuniformだけを更新
+する。異batch digestではinstanceだけを更新し、texture / topologyを再利用する。
+
+## 5. Coverage Semantics
+
+### 5.1 User-facing status
+
+利用者向け earthquake coverage は、要求された style code と表示可能 component の
+結果を表す。
+
+- complete: source が提供すると宣言した required visible code / component が解決
+- loading: exact tile または material / texture の準備中
+- incomplete: required visible code、station input、hypocenter input の実欠損
+- hidden: overlay null、source switch、fail-closed
+
+震源座標や観測点が API 上で提供されない telegram は「正常にcomponentなし」で
+あり、overlay 全体を incomplete にしない。source が座標 / 観測点を提供したのに
+変換・sprite input・atlasが不正な場合は incomplete または failure とする。
+
+### 5.2 Diagnostic status
+
+debug diagnostic は別に次を保持できる。
+
+- visible canonical tile count
+- authoritative empty tile count
+- source layer absent tile count
+- missing / invalid property feature count
+- decode / schema failure
+- required code unresolved count
+- station count
+- sprite count
+
+Asset Pack行政区域overlayでは、signed semantic sidecar等のverified evidenceが空を
+明示した場合だけauthoritative emptyとする。tile内に対象source layerが存在しない
+だけでは空を証明できないためincompleteを維持する。required codeが未解決、required
+propertyが不正、decode / schema failureもincompleteとする。explicit empty layer、
+absent layer、corrupt layerを別fixtureで検証する。
+
+`EarthquakeOverlayCoverageSnapshot` はcommit済み`MapOverlayVersionStamp`とcoverageを
+atomicに通知する。data / render versionのいずれかが一致しないcoverageをappへ適用
+しない。必要ならdiagnosticを同snapshotへ追加する。
+
+## 6. App Data Flow
+
+```text
+latest earthquake list
+  -> event detail
+  -> EarthquakeMapOverlayBuilder
+       -> region / city maximum intensity styles
+       -> deduplicated station observations
+       -> validated hypocenter sprite feature
+  -> asset atlas provider
+  -> full earthquake overlay snapshot
+  -> BaseMapView
+```
+
+loading、event switch、error、no intensity では旧 overlay を null にする。event A の
+detail / asset / material が event B switch 後に完了しても A を publish しない。
+
+atlas decode は provider で一度だけ行い、widget build 内で行わない。例外や stack
+trace を banner に直接表示しない。
+
+## 7. Debug UI
+
+デバッグ地図は最低限次を表示する。
+
+- current event ID / data sequence / render generation
+- region / city / station / sprite counts
+- coverage state
+- `震源へ移動` action
+- current zoom
+
+長い diagnostic は折り返し可能な developer detail とし、地図操作を妨げる固定高を
+置かない。
+
+Simulator / emulator を agent が操作する前にユーザーへ通知する。ユーザーが操作中
+なら agent は入力せず、ユーザー操作後に screenshot / log を read-only 採取する。
+
+## 8. Testing
+
+### 8.1 Package tests
+
+- atlas validation、defensive copy、bounds / byte limits
+- sprite feature validation、duplicate / unknown region rejection
+- exact instance bytes、stride、offset、premultiply
+- atlas top-left / RGBA / straight-alpha / sRGB / padding / sampler ABI
+- zoom linear clamp / step equalityと既存MapLibre size / fade fixture
+- policy batch digest、同policy grouping、caller上限超過拒否
+- nearest date-line wrap、logical pixel size、zoom fade
+- zero sprite、one batch / one geometry / one node
+- same version / digestのidempotent camera-only reuse
+- same data sequence / different data digest rejection
+- same data version / higher render generationのtheme・atlas replacement
+- same render generation / different render digest rejection
+- material / texture reflection fail-closed
+- source / context / background / dispose fence retirement
+- shared atlasの片方更新 / 削除、candidate失敗時のresource pin維持
+- command camera clamp、supersede、pre-attach / post-dispose failure
+- controller attach / detach / reattach / double attach
+- committed camera getter / listenableと再attach時restoration
+- antimeridian fit、padding、DPR、viewport resizeの数値fixture
+- authoritative empty と実欠損 coverage の区別
+
+### 8.2 App tests
+
+- hypocenter `CoordinateLatLng` だけを feature 化
+- coordinate missing / description / unknown で固定位置を作らない
+- event switch / late completion / asset failure
+- existing station maximum / deterministic order regressions
+- banner が committed version stamp だけを表示
+- camera action visibility と一度だけの command
+
+### 8.3 Runtime gate
+
+verified Asset Pack と実 API event を使用する。固定の fake event を成功根拠にしない。
+
+iOS Simulator と Android emulator / device で次を確認する。
+
+- Impeller / Flutter GPU backend log
+- base + region Fill + station + hypocenter
+- zoom 5.999 は region、station hidden
+- zoom 6 は city、station visible
+- pan / pinch 追従
+- 震源へ移動
+- MapLibre基準とのcenter / zoom / projected pixel tolerance
+- antimeridian、viewport resize、state restoration
+- event switch
+- background 30 秒 / foreground
+- Scene / GPU exception が連続しない
+- source switch / dispose 後の resource 上限
+
+市区町村、観測点、震源の画面確認ができない場合、本 subproject は完成扱いにしない。
+
+## 9. Migration Gate
+
+本 subproject ではデバッグ地図へ実装する。地震詳細 MapLibre の削除は行わない。
+
+本番地震詳細への切替は、別 task で次を確認後に行う。
+
+- existing normal hypocenter size / fade parity
+- station display mode / label setting parity
+- hypocenter below-stations mode
+- hypocenter error rectangle
+- fit bounds / focus behavior
+- Light / Dark theme
+- iOS / Android profile performance
+
+## 10. Out of Scope
+
+- low-precision EEW hypocenter consumer
+- hypocenter error rectangle renderer
+- estimated intensity remote PMTiles
+- EEW P/S wave
+- KMON live points
+- station labels
+- production MapLibre removal

--- a/docs/superpowers/specs/2026-08-24-flutter-gpu-map-migration-roadmap-design.md
+++ b/docs/superpowers/specs/2026-08-24-flutter-gpu-map-migration-roadmap-design.md
@@ -1,0 +1,363 @@
+# Flutter GPU Map Migration Roadmap Design
+
+## 1. Purpose
+
+EQMonitor の既存 MapLibre レイヤーを、段階的に Flutter Scene / Flutter GPU
+ベースの地図へ置換する。
+
+移行中は既存 MapLibre 実装を正本として残し、デバッグ地図で同一データを
+並行表示して parity を確認する。iOS / Android の profile runtime gate を
+通過した surface だけを本番画面へ切り替え、未確認の MapLibre レイヤーを
+先に削除しない。
+
+本ロードマップは次の利用者向け完成順を固定する。
+
+1. 地震履歴の震度 Fill、震源、観測点
+2. event `20260823020050` の推計震度分布図
+3. 緊急地震速報の予想震度、警報範囲、震源、P/S 波
+4. 強震モニタ観測点
+5. 強震モニタ観測点ラベル
+6. surface ごとの MapLibre 削除
+
+## 2. Current Baseline
+
+2026-08-24 時点の作業ブランチでは、次の経路が実装済みである。
+
+```text
+signed Asset Pack
+  -> verified PMTiles
+  -> bounded MVT decode
+  -> Fill / Line mesh
+  -> packed geometry cache
+  -> Flutter Scene / GPU
+```
+
+地震 overlay は、地域・市区町村の震度 Fill と、単一 GPU instance batch の
+観測点まで接続済みである。実 API event の地域 Fill と pan 追従は iOS
+Simulator / Metal で確認した。市区町村 Fill、観測点、zoom 6 境界、
+background / foreground は未確認であり、完成扱いにしない。
+
+現行 `MapSceneFrameSubmission` は base map、地震 Fill、観測点に固定されて
+いる。EEW、推計震度、強震モニタを domain 固有 field として追加し続けず、
+本ロードマップで package-neutral な overlay submission へ一般化する。
+
+## 3. Architectural Direction
+
+### 3.1 Package boundary
+
+`packages/eqmonitor_map` は EQMonitor app の API model、Riverpod provider、
+MapLibre、GeoJSON、app asset path に依存しない。
+
+app は外部データを検証し、次の package-neutral primitive へ変換する。
+
+- coded polygon Fill / Line
+- static circle point
+- texture-atlas sprite
+- live updatable point batch
+- geodesic ring / dynamic Line / Fill
+- foreground text label candidate
+- camera command
+- component coverage / freshness
+
+app asset を使う sprite は、app が decode した immutable atlas descriptor と
+pixel data を package へ渡す。package から asset path を参照しない。
+
+### 3.2 Frame contract
+
+一つの画面 frame は、一つの camera / viewport / clock capture と、canonical
+phase 順に並んだ typed overlay submission list から構築する。list は logical
+source と component key を持ち、同じ phase の複数 batch を安定順で保持できる。
+
+```text
+base background / land Fill
+  -> underlay hazard Fill
+  -> underlay hazard Line
+  -> base administrative Line
+  -> overlay hazard Fill / Line
+  -> dynamic wave Fill / Line
+  -> live point
+  -> sprite
+  -> foreground label
+```
+
+material reflection、ABI、geometry、uniform、resource ownership を Scene mutation
+前に検証する。全 preflight と submit が成功した場合だけ、描画状態、coverage、
+previous batch、active material を一括 commit する。
+
+同一logical sourceの一部componentだけが新version stampになり、他componentが
+古いversion stampのまま残るmixed frameを禁止する。
+
+各domain specはunderlay / overlayのどちらを使うかMapLibre正本から固定する。
+推計震度のFillとLineはともにunderlayで、行政境界線より下へ置く。EEW warning等の
+overlay phaseは各subprojectで既存layer順をfixture化して決める。
+
+### 3.3 Identity and version acceptance
+
+各 full snapshot は data version と render version を分離して持つ。
+
+- source identity: event ID、verified content digest、catalog digest 等
+- source incarnation: provider / pipeline の再生成を区別する token
+- data sequence: incarnation 内で canonical source data が変わるたび app が進める
+  単調値
+- data digest: canonical source data 全体の digest
+- render generation: theme、atlas、setting 等、data を変えない render 入力の単調値
+- render digest: data version と全 render 入力から作る canonical digest
+- async generation: source、replay、background 復帰を含む非同期処理世代
+
+次は Scene mutation 前に拒否する。
+
+- 古い generation
+- 低い data sequence / render generation
+- 同じ data sequence で異なる data digest
+- 同じ render generation で異なる render digest
+- source switch 後に完了した旧 request
+- context generation の異なる GPU resource
+
+同一 version / digest は idempotent とする。theme-only 変更は data sequence / data
+digest を変えず、render generation を進める。同一 upstream reportedAt でも source
+data が置換された場合は app が新しい data sequence を発行する。reportedAt や EEW
+serialNo を単独で受理 sequence に使用しない。
+
+時刻 tick だけで version を増やさない。連続 animation は immutable timeline と
+frame clock から renderer が補間する。
+
+### 3.4 Clock boundary
+
+`BaseMapView` は内部で wall clock を生成せず、package-neutral `MapClock` を必須入力
+として受け取る。app は `AppClock` の NTP / time-shift / replay 時刻と、単調経過時間
+を一つの adapter へ渡す。
+
+- wall time: EEW timeline、freshness、KMON target time の評価に使う
+- monotonic time: animation delta、timeout、performance 計測に使う
+- 一 frame で各時刻を一度だけ capture し全 component が共有する
+- replay seek / clock source switch は source incarnation と async generation を進める
+- replay pause は continuous frame を停止する
+- background は tick を停止し、foreground で wall time と expiry を再評価する
+
+### 3.5 Coverage and failure
+
+coverage は component ごとに、少なくとも次を区別する。
+
+- complete
+- loading
+- authoritative empty
+- incomplete
+- stale
+- expired
+- disabled
+- invalid input / schema
+- source / decode / Scene failure
+
+正常な空 tile と、source layer / schema / required property の欠損を混同しない。
+debug 診断と利用者向け banner を分け、表示内容を欠損させる問題だけを利用者向け
+`incomplete` とする。
+
+`authoritative empty` は source 固有の verified evidence がある場合だけ使う。
+
+- PMTiles directory に canonical tile entry がない: authoritative empty
+- tile entry があり必須 source layer がない: invalid schema
+- signed semantic sidecar が tile / layer の空を明示する: authoritative empty
+- evidence のない source layer 不在: incomplete
+
+Asset Pack v0.0.9 には per-tile semantic empty attestation がないため、単なる layer
+不在を complete へ緩和しない。debug diagnostic では水域等の可能性を表示できるが、
+利用者向け complete を推測しない。
+
+固定値、ランダム値、異なるsource / version stampのlast-good geometryへfallback
+しない。base map の視覚的親 tile fallback は維持できるが、hazard overlay は
+exact canonical tile だけを使用する。
+
+### 3.6 GPU resource lifecycle
+
+GPU resource は `(contextGeneration, resourceGeneration)` で所有する。
+
+- camera-only update は uniform だけを更新する
+- static topology は ABI / material version 変更時だけ再生成する
+- live value は bounded ring buffer へ更新する
+- background では request、decode、upload、continuous frame を停止する
+- resource は renderer completion fence 後に一度だけ retire する
+- foreground では freshness と source identity を再評価してから再構築する
+
+Flutter Scene の self-instancing 制約により、一つの self-instanced geometry を
+複数 node から参照しない。一 batch / 一 geometry / 一 node を維持する。
+
+texture、quad topology、instance、node の寿命を分離する。
+
+- texture key: `(contextGeneration, atlasDigest)`
+- topology key: `(contextGeneration, ABI version, material version)`
+- instance key: `(contextGeneration, batchGeneration)`
+- node ownership: committed frame
+
+共有 texture / topology は pin または参照数で所有し、一 consumer の更新 / 削除で
+他 consumer が使用中の resource を retire しない。failed candidate は committed
+resource の pin を解放しない。
+
+## 4. Subprojects
+
+### 4.1 Earthquake history parity
+
+既存地震 overlay に texture sprite の震源を追加し、観測点を runtime で確認する。
+programmatic camera command、coverage の user-facing / diagnostic 分離もこの段階で
+実装する。
+
+### 4.2 Estimated intensity PMTiles
+
+観測震度 overlay と独立した remote PMTiles source として実装する。
+
+- API の完全 URL を source of truth とする
+- HTTPS、host allowlist、event path、URL digest を検証し、redirect を拒否する
+- caller 指定の byte 上限内で archive 全体を一時領域へ download する
+- download 完了後に SHA-256 を URL digest と照合する
+- digest 一致した local bytes だけを `VerifiedPmTilesSource` として open する
+- `seismic_intensity` Polygon と既知の `name` class だけを受理する
+- 既知 class は app theme 色を使う
+- visible source coverage が揃うまで部分表示しない
+
+現行 range reader の digest field は cache identity であり、content attestation では
+ないため、初回描画前の全体 download / hash を省略しない。将来 backend が署名済み
+size と per-chunk digest / Merkle proof を提供した場合だけ range 検証へ置換できる。
+
+content identity は `estimated:<eventId>:<verifiedSha256>` とする。hash 変更は同一
+event でも source switch とし、旧 overlay を即時 clear する。theme 変更は content
+identity / data sequence を変えず render generation を進める。
+
+estimated display mode は既存 MapLibre と同じく観測震度 Fill と観測点を隠し、
+推計震度 Fill / Line と同じ event の震源 sprite を残す。app は observed / estimated
+を一つの full display candidate として選び、frame compositor は mode 間の混在を
+禁止する。
+
+base source と event source は header 由来の独立 zoom range、bounds、canonical
+tile cover、repository、cache、scheduler を持つ。同じ camera / viewport transform
+へ合成し、event source は z14 超で z14 を明示 overscale する。event bounds 外は
+directory / bounds evidence に基づく authoritative empty とする。viewport 変更で
+新 event cover が揃うまでは推計震度を一枚も表示しない。
+
+event `20260823020050` の archive は実データで SHA-256 と URL digest の一致、
+PMTiles v3 / MVT / gzip、`seismic_intensity` Polygon、class 4 / 5- / 5+ を
+確認済みである。
+
+### 4.3 EEW
+
+REST latest と WebSocket upsert を event ごとの canonical record へ集約し、active
+event 集合全体を一つの full snapshot にする。
+
+- `areaForecastLocalE.code` の予想震度 Fill
+- `areaForecastLocalEew.code` の警報 Fill
+- normal / low-precision hypocenter sprite
+- AppClock による geodesic P/S wave
+- cancel 時の即時 geometry 除去
+- freshness / expiry / oneHz / unlimited scheduler
+
+clock adapter、replay seek / pause、time shift、background 復帰は 3.4 の契約を使う。
+
+最初の slice はデバッグ地図だけへ接続し、Home MapLibre を残す。
+
+### 4.4 Kyoshin Monitor live points
+
+Asset Pack の station catalog と NIED GIF parser を structured fixed-slot frame へ
+変換する。
+
+- catalog digest と stable slot order
+- typed pixel availability / failure
+- source / data type / layer / target time generation
+- 1 Hz update 用 bounded `UpdatableInstanceGeometry`
+- camera update 時 upload 0
+- value update 時 geometry generation 0 / buffer update 1
+- 1634 points を原則一 draw
+
+GeoJSON encode / decode を GPU 経路に持ち込まない。
+
+KMON subproject は必須の versioned `KyoshinMonitorFreshnessPolicy` を app から渡す。
+policy は fetch interval、`staleAfter`、`expireAfter` を持ち、package に既定値を置か
+ない。`staleAfter >= fetchInterval`、`expireAfter > staleAfter` を検証する。
+
+- fixed slot の availability と frame coverage を別々に保持する
+- known-empty と parser failure を区別する
+- available point は degraded frame でも描画できるが coverage を complete にしない
+- last-good は `staleAfter` 以後 stale、`expireAfter` で全点を除去する
+- 同 target retry は同 digest なら no-op、異 digest なら新 value generation とする
+- 古い target time、旧 source / setting / replay generation を拒否する
+
+### 4.5 Station labels
+
+Flutter foreground `CustomPainter` と `TextPainter` LRU を使用する。GPU glyph atlas、
+MapLibre glyph PBF に依存しない。
+
+- bounded text layout cache
+- right / left / up / down candidates
+- deterministic collision
+- placement hysteresis
+- viewport edge handling
+- DPR / theme / locale / font generation invalidation
+- accessibility semantics
+
+station label の min zoom、表示可否、priority は app から渡す。初期 consumer は
+高 zoom 限定とし、全 1600 点の同時配置を要求しない。
+
+label candidate は catalog 座標を独自投影せず、committed live point frame と同じ
+projected point set、world-wrap identity、camera capture を共有する。point が同frame
+で hidden / unavailable になった場合、対応 label も同時に除去する。
+
+## 5. Parallel Work Graph
+
+利用者向け integration gate は順番を守るが、次の foundation は並行可能である。
+
+```text
+A compositor / camera / clock / coverage ----┐
+B sprite atlas -------------------------------+--> earthquake history gate
+C verified remote PMTiles --------------------┐
+H estimated decoder / renderer / app mode ----+--> A + C + H -> estimated gate
+D freshness / geodesic ring -----------------┐
+I EEW warning coded geometry / app builder --+--> A + B + D + I -> EEW gate
+E structured KMON parser --------------------┐
+F updatable instance / projected-point set --+--> A + E + F -> KMON point gate
+G label placement foundation ----------------+--> A + E + F + G -> station label gate
+```
+
+同じ worktree の同じ file を複数 agent が同時編集しない。並列 agent は独立した
+file ownership または read-only audit に限定し、integration owner が順に統合する。
+
+各 implementation task は fresh implementer、task-scoped reviewer、必要な fix round、
+最終 whole-branch reviewer を持つ。
+
+## 6. Migration Gates
+
+各 subproject は次を満たすまで本番 surface へ切り替えない。
+
+- pure boundary / conversion / lifecycle の自動テスト
+- package と app の関連 full test
+- `dart analyze --fatal-infos`
+- shader / material reflection の DataAssets 経路検証
+- iOS / Android profile mode の画面確認
+- pan / pinch / zoom boundary
+- source switch / late completion / failure injection
+- background / foreground / context recreation
+- GPU resource、upload、node / batch 数の上限確認
+- 連続 Scene / GPU error がないこと
+
+推計震度 gate はさらに次を必須とする。
+
+- non-allowlist host、redirect、event / path / URL hash mismatch を描画前に拒否
+- byte 上限超過、SHA mismatch、同一 validator の内容差替えを拒否
+- absent tile と present-but-layer-missing を区別
+- 全 visible canonical tile 完了前は一枚も表示しない
+- event A -> B、同一 event hash 変更、late download / decode を巻き戻さない
+- target event の 4 / 5- / 5+ を theme 色で表示し、焼き込み色へ fallback しない
+- z0、z14、z14 超 overscale、event bounds 端を確認
+- estimated mode で観測 Fill / station を隠し、同eventの震源を残す
+- iOS / Android profile で event `20260823020050` を確認
+
+Simulator や emulator の操作を agent が行う場合は、ユーザー操作と競合しないよう
+開始前に通知し、終了時に入力を解放する。
+
+MapLibre layer の削除は、同一 surface の全表示 mode と error / loading / lifecycle
+parity を iOS / Android で確認した別 task として行う。
+
+## 7. Out of Scope for the First Subproject
+
+- 推計震度の renderer 実装
+- EEW renderer 実装
+- KMON live buffer 実装
+- label foundation 実装
+- Home / earthquake details の MapLibre 削除
+- backend API / Asset Pack schema の変更


### PR DESCRIPTION
## 概要

- 既存MapLibre layerを段階的にFlutter GPU Mapへ置換する全体ロードマップを追加します。
- 震度区域、震源、観測点、推計震度分布、緊急地震速報、強震モニタ、ラベルの移行順とparity gateを定義します。
- 生命に関わる情報として、固定値や推測geometryへfallbackしないfail-closed方針を明記します。

## 検証

- 設計レビュー承認済み
- git diff --check clean

## Stack

- Stack #1756 の第1層です。
- 次: #1754