### PR TITLE
refactor: 地震overlayをversion stampへ完全移行

### DIFF
--- a/app/lib/feature/earthquake_history/data/logic/earthquake_map_overlay_builder.dart
+++ b/app/lib/feature/earthquake_history/data/logic/earthquake_map_overlay_builder.dart
@@ -5,6 +5,9 @@ import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_inten
 import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
 import 'package:eqmonitor_map/eqmonitor_map.dart';
 
+const earthquakeOverlayRegionToCityZoom = 6.0;
+const earthquakeOverlayStationMinZoom = 6.0;
+
 enum EarthquakeMapOverlayUnavailableReason {
   noIntensity,
   missingTelegramMetadata,
@@ -28,168 +31,190 @@ final class EarthquakeMapOverlayUnavailable
   final EarthquakeMapOverlayUnavailableReason reason;
 }
 
-class EarthquakeMapOverlayBuilder {
+typedef EarthquakeStationObservation = ({
+  EarthquakeParameterStationItem station,
+  JmaIntensity intensity,
+});
+
+final class EarthquakeMapOverlayBuilder {
   const new();
 
   EarthquakeMapOverlayBuildResult build({
     required Earthquake earthquake,
     required IntensityColors colorModel,
+    required MapOverlayVersionStamp versionStamp,
   }) {
-    final intensity = earthquake.intensity;
-    if (intensity == null) {
-      return const EarthquakeMapOverlayUnavailable(
-        reason: .noIntensity,
-      );
+    final reason = unavailableReason(earthquake);
+    if (reason != null) {
+      return EarthquakeMapOverlayUnavailable(reason: reason);
     }
-    if (earthquake.telegramMetadata.isEmpty) {
-      return const EarthquakeMapOverlayUnavailable(
-        reason: .missingTelegramMetadata,
+    final intensity = earthquake.intensity as EarthquakeIntensity;
+    if (versionStamp.sourceIdentity.value != earthquake.eventId) {
+      throw ArgumentError.value(
+        versionStamp.sourceIdentity.value,
+        'versionStamp.sourceIdentity',
+        'must match earthquake.eventId',
       );
     }
     return EarthquakeMapOverlayAvailable(
       snapshot: createEarthquakeMapOverlaySnapshot(
-        sourceId: earthquake.eventId,
-        revision: latestEarthquakeOverlayRevision(earthquake),
-        regionToCityZoom: 6,
-        stationMinZoom: 6,
-        regionStyles: earthquakeRegionStyles(
+        versionStamp: versionStamp,
+        regionToCityZoom: earthquakeOverlayRegionToCityZoom,
+        stationMinZoom: earthquakeOverlayStationMinZoom,
+        regionStyles: regionStyles(
           intensity: intensity,
           colorModel: colorModel,
         ),
-        cityStyles: earthquakeCityStyles(
+        cityStyles: cityStyles(
           intensity: intensity,
           colorModel: colorModel,
         ),
-        stations: earthquakeObservationPoints(
+        stations: observationPoints(
           intensity: intensity,
           colorModel: colorModel,
         ),
       ),
     );
   }
-}
 
-int latestEarthquakeOverlayRevision(Earthquake earthquake) {
-  final metadata = earthquake.telegramMetadata;
-  var latest = metadata.first.reportedAt.toUtc().microsecondsSinceEpoch;
-  for (final item in metadata.skip(1)) {
-    final revision = item.reportedAt.toUtc().microsecondsSinceEpoch;
-    if (revision > latest) {
-      latest = revision;
+  EarthquakeMapOverlayUnavailableReason? unavailableReason(
+    Earthquake earthquake,
+  ) {
+    if (earthquake.intensity == null) {
+      return EarthquakeMapOverlayUnavailableReason.noIntensity;
     }
-  }
-  return latest;
-}
-
-List<EarthquakeAreaStyle> earthquakeRegionStyles({
-  required EarthquakeIntensity intensity,
-  required IntensityColors colorModel,
-}) {
-  final levels = <String, JmaIntensity>{};
-  for (final nodes in intensity.regions.values) {
-    for (final node in nodes) {
-      final level = node.maxIntensity;
-      if (level != null) {
-        recordMaximumIntensity(
-          levels: levels,
-          code: node.region.code,
-          intensity: level,
-        );
-      }
+    if (earthquake.telegramMetadata.isEmpty) {
+      return EarthquakeMapOverlayUnavailableReason.missingTelegramMetadata;
     }
+    return null;
   }
-  return earthquakeAreaStyles(levels: levels, colorModel: colorModel);
-}
 
-List<EarthquakeAreaStyle> earthquakeCityStyles({
-  required EarthquakeIntensity intensity,
-  required IntensityColors colorModel,
-}) {
-  final levels = <String, JmaIntensity>{};
-  for (final prefectures in intensity.intensityTree.values) {
-    for (final prefecture in prefectures) {
-      for (final city in prefecture.cities) {
-        final level = city.maxIntensity;
+  List<EarthquakeAreaStyle> regionStyles({
+    required EarthquakeIntensity intensity,
+    required IntensityColors colorModel,
+  }) => areaStyles(
+    levels: regionIntensityLevels(intensity: intensity),
+    colorModel: colorModel,
+  );
+
+  Map<String, JmaIntensity> regionIntensityLevels({
+    required EarthquakeIntensity intensity,
+  }) {
+    final levels = <String, JmaIntensity>{};
+    for (final nodes in intensity.regions.values) {
+      for (final node in nodes) {
+        final level = node.maxIntensity;
         if (level != null) {
           recordMaximumIntensity(
             levels: levels,
-            code: city.city.code,
+            code: node.region.code,
             intensity: level,
           );
         }
       }
     }
+    return levels;
   }
-  return earthquakeAreaStyles(levels: levels, colorModel: colorModel);
-}
 
-void recordMaximumIntensity({
-  required Map<String, JmaIntensity> levels,
-  required String code,
-  required JmaIntensity intensity,
-}) {
-  final current = levels[code];
-  if (current == null || intensity.orderIndex > current.orderIndex) {
-    levels[code] = intensity;
-  }
-}
+  List<EarthquakeAreaStyle> cityStyles({
+    required EarthquakeIntensity intensity,
+    required IntensityColors colorModel,
+  }) => areaStyles(
+    levels: cityIntensityLevels(intensity: intensity),
+    colorModel: colorModel,
+  );
 
-List<EarthquakeAreaStyle> earthquakeAreaStyles({
-  required Map<String, JmaIntensity> levels,
-  required IntensityColors colorModel,
-}) {
-  final entries = levels.entries.toList()
-    ..sort((first, second) => first.key.compareTo(second.key));
-  return [
-    for (final entry in entries)
-      EarthquakeAreaStyle(
-        code: entry.key,
-        color: colorModel.fromJmaIntensity(entry.value).background,
-        opacity: 0.6,
-      ),
-  ];
-}
-
-typedef EarthquakeStationObservation = ({
-  EarthquakeParameterStationItem station,
-  JmaIntensity intensity,
-});
-
-List<EarthquakeObservationPoint> earthquakeObservationPoints({
-  required EarthquakeIntensity intensity,
-  required IntensityColors colorModel,
-}) {
-  final observations = <String, EarthquakeStationObservation>{};
-  for (final prefectures in intensity.intensityTree.values) {
-    for (final prefecture in prefectures) {
-      for (final city in prefecture.cities) {
-        for (final node in city.stations) {
-          final level = node.intensity?.maxIntensity;
-          if (level == null) {
-            continue;
-          }
-          final code = node.station.code;
-          final current = observations[code];
-          if (current == null ||
-              level.orderIndex > current.intensity.orderIndex) {
-            observations[code] = (station: node.station, intensity: level);
+  Map<String, JmaIntensity> cityIntensityLevels({
+    required EarthquakeIntensity intensity,
+  }) {
+    final levels = <String, JmaIntensity>{};
+    for (final prefectures in intensity.intensityTree.values) {
+      for (final prefecture in prefectures) {
+        for (final city in prefecture.cities) {
+          final level = city.maxIntensity;
+          if (level != null) {
+            recordMaximumIntensity(
+              levels: levels,
+              code: city.city.code,
+              intensity: level,
+            );
           }
         }
       }
     }
+    return levels;
   }
-  final entries = observations.entries.toList()
-    ..sort((first, second) => first.key.compareTo(second.key));
-  return [
-    for (final entry in entries)
-      EarthquakeObservationPoint(
-        id: entry.key,
-        longitude: entry.value.station.location.lon,
-        latitude: entry.value.station.location.lat,
-        color: colorModel.fromJmaIntensity(entry.value.intensity).background,
-        radiusLogicalPixels: entry.value.intensity == intensity.maxIntensity
-            ? 6.7
-            : 4.0,
-      ),
-  ];
+
+  void recordMaximumIntensity({
+    required Map<String, JmaIntensity> levels,
+    required String code,
+    required JmaIntensity intensity,
+  }) {
+    final current = levels[code];
+    if (current == null || intensity.orderIndex > current.orderIndex) {
+      levels[code] = intensity;
+    }
+  }
+
+  List<EarthquakeAreaStyle> areaStyles({
+    required Map<String, JmaIntensity> levels,
+    required IntensityColors colorModel,
+  }) {
+    final entries = levels.entries.toList()
+      ..sort((first, second) => first.key.compareTo(second.key));
+    return [
+      for (final entry in entries)
+        EarthquakeAreaStyle(
+          code: entry.key,
+          color: colorModel.fromJmaIntensity(entry.value).background,
+          opacity: 0.6,
+        ),
+    ];
+  }
+
+  List<EarthquakeObservationPoint> observationPoints({
+    required EarthquakeIntensity intensity,
+    required IntensityColors colorModel,
+  }) {
+    final observations = stationObservations(intensity: intensity);
+    final entries = observations.entries.toList()
+      ..sort((first, second) => first.key.compareTo(second.key));
+    return [
+      for (final entry in entries)
+        EarthquakeObservationPoint(
+          id: entry.key,
+          longitude: entry.value.station.location.lon,
+          latitude: entry.value.station.location.lat,
+          color: colorModel.fromJmaIntensity(entry.value.intensity).background,
+          radiusLogicalPixels: entry.value.intensity == intensity.maxIntensity
+              ? 6.7
+              : 4.0,
+        ),
+    ];
+  }
+
+  Map<String, EarthquakeStationObservation> stationObservations({
+    required EarthquakeIntensity intensity,
+  }) {
+    final observations = <String, EarthquakeStationObservation>{};
+    for (final prefectures in intensity.intensityTree.values) {
+      for (final prefecture in prefectures) {
+        for (final city in prefecture.cities) {
+          for (final node in city.stations) {
+            final level = node.intensity?.maxIntensity;
+            if (level == null) {
+              continue;
+            }
+            final code = node.station.code;
+            final current = observations[code];
+            if (current == null ||
+                level.orderIndex > current.intensity.orderIndex) {
+              observations[code] = (station: node.station, intensity: level);
+            }
+          }
+        }
+      }
+    }
+    return observations;
+  }
 }

--- a/app/lib/feature/earthquake_history/data/logic/earthquake_map_overlay_digest_builder.dart
+++ b/app/lib/feature/earthquake_history/data/logic/earthquake_map_overlay_digest_builder.dart
@@ -1,0 +1,249 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+
+enum EarthquakeMapOverlayHypocenterState {
+  earthquakeAbsent,
+  coordinateAbsent,
+  unknown,
+  latLng,
+}
+
+typedef EarthquakeOverlayHypocenterInput = ({
+  EarthquakeMapOverlayHypocenterState state,
+  double? longitude,
+  double? latitude,
+});
+
+final class CanonicalOverlayRecord {
+  new({
+    required this.recordType,
+    required this.stableId,
+    required Map<String, String> fields,
+  }) : fields = Map.unmodifiable(fields);
+
+  final String recordType;
+  final String stableId;
+  final Map<String, String> fields;
+}
+
+final class EarthquakeMapOverlayDigestBuilder {
+  const new();
+
+  String buildDataDigest({
+    required List<({String stableId, int intensityOrder})> regions,
+    required List<({String stableId, int intensityOrder})> cities,
+    required List<
+      ({
+        String stableId,
+        double longitude,
+        double latitude,
+        int intensityOrder,
+        bool isMaximum,
+      })
+    >
+    stations,
+    required EarthquakeMapOverlayHypocenterState hypocenterState,
+    required double? hypocenterLongitude,
+    required double? hypocenterLatitude,
+  }) {
+    final records = <CanonicalOverlayRecord>[
+      for (final region in regions)
+        CanonicalOverlayRecord(
+          recordType: 'region',
+          stableId: region.stableId,
+          fields: {'intensityOrder': region.intensityOrder.toString()},
+        ),
+      for (final city in cities)
+        CanonicalOverlayRecord(
+          recordType: 'city',
+          stableId: city.stableId,
+          fields: {'intensityOrder': city.intensityOrder.toString()},
+        ),
+      for (final station in stations)
+        CanonicalOverlayRecord(
+          recordType: 'station',
+          stableId: station.stableId,
+          fields: {
+            'intensityOrder': station.intensityOrder.toString(),
+            'isMaximum': station.isMaximum.toString(),
+            'latitude': canonicalDouble(station.latitude),
+            'longitude': canonicalDouble(station.longitude),
+          },
+        ),
+      CanonicalOverlayRecord(
+        recordType: 'hypocenter',
+        stableId: 'hypocenter',
+        fields: {
+          if (hypocenterLatitude != null)
+            'latitude': canonicalDouble(hypocenterLatitude),
+          if (hypocenterLongitude != null)
+            'longitude': canonicalDouble(hypocenterLongitude),
+          'state': hypocenterState.name,
+        },
+      ),
+    ];
+    return canonicalDigest(
+      format: 'earthquake-overlay-data-v1',
+      headerFields: const {},
+      records: records,
+    );
+  }
+
+  String buildRenderDigest({
+    required int dataSequence,
+    required String dataDigest,
+    required double regionToCityZoom,
+    required double stationMinZoom,
+    required List<EarthquakeAreaStyle> regionStyles,
+    required List<EarthquakeAreaStyle> cityStyles,
+    required List<EarthquakeObservationPoint> stations,
+  }) {
+    final records = <CanonicalOverlayRecord>[
+      CanonicalOverlayRecord(
+        recordType: 'policy',
+        stableId: 'overlay',
+        fields: {
+          'regionToCityZoom': canonicalDouble(regionToCityZoom),
+          'stationMinZoom': canonicalDouble(stationMinZoom),
+        },
+      ),
+      for (final style in regionStyles)
+        areaStyleRecord(recordType: 'regionStyle', style: style),
+      for (final style in cityStyles)
+        areaStyleRecord(recordType: 'cityStyle', style: style),
+      for (final station in stations)
+        CanonicalOverlayRecord(
+          recordType: 'stationStyle',
+          stableId: station.id,
+          fields: {
+            'colorArgb': station.color.toARGB32().toString(),
+            'latitude': canonicalDouble(station.latitude),
+            'longitude': canonicalDouble(station.longitude),
+            'radiusLogicalPixels': canonicalDouble(
+              station.radiusLogicalPixels,
+            ),
+          },
+        ),
+    ];
+    return canonicalDigest(
+      format: 'earthquake-overlay-render-v1',
+      headerFields: {
+        'dataDigest': dataDigest,
+        'dataSequence': dataSequence.toString(),
+      },
+      records: records,
+    );
+  }
+
+  EarthquakeOverlayHypocenterInput hypocenterInput(Earthquake earthquake) {
+    final hypocenter = earthquake.hypocenter;
+    if (hypocenter == null) {
+      return (
+        state: EarthquakeMapOverlayHypocenterState.earthquakeAbsent,
+        longitude: null,
+        latitude: null,
+      );
+    }
+    return switch (hypocenter.coordinates) {
+      null => (
+        state: EarthquakeMapOverlayHypocenterState.coordinateAbsent,
+        longitude: null,
+        latitude: null,
+      ),
+      CoordinateUnknown() => (
+        state: EarthquakeMapOverlayHypocenterState.unknown,
+        longitude: null,
+        latitude: null,
+      ),
+      CoordinateLatLng(:final longitude, :final latitude) => (
+        state: EarthquakeMapOverlayHypocenterState.latLng,
+        longitude: longitude,
+        latitude: latitude,
+      ),
+    };
+  }
+
+  CanonicalOverlayRecord areaStyleRecord({
+    required String recordType,
+    required EarthquakeAreaStyle style,
+  }) => CanonicalOverlayRecord(
+    recordType: recordType,
+    stableId: style.code,
+    fields: {
+      'colorArgb': style.color.toARGB32().toString(),
+      'opacity': canonicalDouble(style.opacity),
+    },
+  );
+
+  String canonicalDouble(double value) => value == 0 ? '0' : '$value';
+
+  String canonicalDigest({
+    required String format,
+    required Map<String, String> headerFields,
+    required List<CanonicalOverlayRecord> records,
+  }) {
+    final bytes = <int>[];
+    appendField(bytes: bytes, tag: 'format', value: format);
+    final headerEntries = headerFields.entries.toList()
+      ..sort((first, second) => first.key.compareTo(second.key));
+    for (final field in headerEntries) {
+      appendField(bytes: bytes, tag: field.key, value: field.value);
+    }
+    final sortedRecords = records.toList()
+      ..sort((first, second) {
+        final typeOrder = first.recordType.compareTo(second.recordType);
+        return typeOrder != 0
+            ? typeOrder
+            : first.stableId.compareTo(second.stableId);
+      });
+    appendField(
+      bytes: bytes,
+      tag: 'recordCount',
+      value: sortedRecords.length.toString(),
+    );
+    for (final record in sortedRecords) {
+      appendRecord(bytes: bytes, record: record);
+    }
+    return sha256.convert(bytes).toString();
+  }
+
+  void appendRecord({
+    required List<int> bytes,
+    required CanonicalOverlayRecord record,
+  }) {
+    appendField(
+      bytes: bytes,
+      tag: 'recordType',
+      value: record.recordType,
+    );
+    appendField(bytes: bytes, tag: 'stableId', value: record.stableId);
+    appendField(
+      bytes: bytes,
+      tag: 'fieldCount',
+      value: record.fields.length.toString(),
+    );
+    final fields = record.fields.entries.toList()
+      ..sort((first, second) => first.key.compareTo(second.key));
+    for (final field in fields) {
+      appendField(bytes: bytes, tag: field.key, value: field.value);
+    }
+  }
+
+  void appendField({
+    required List<int> bytes,
+    required String tag,
+    required String value,
+  }) {
+    final tagBytes = utf8.encode(tag);
+    final valueBytes = utf8.encode(value);
+    bytes
+      ..addAll(ascii.encode('${tagBytes.length}:'))
+      ..addAll(tagBytes)
+      ..addAll(ascii.encode('${valueBytes.length}:'))
+      ..addAll(valueBytes);
+  }
+}

--- a/app/lib/feature/earthquake_history/data/provider/earthquake_overlay_source_incarnation_provider.dart
+++ b/app/lib/feature/earthquake_history/data/provider/earthquake_overlay_source_incarnation_provider.dart
@@ -1,0 +1,17 @@
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:uuid/uuid.dart';
+
+part 'earthquake_overlay_source_incarnation_provider.g.dart';
+
+typedef EarthquakeOverlaySourceIncarnationFactory =
+    MapSourceIncarnation Function();
+
+@riverpod
+EarthquakeOverlaySourceIncarnationFactory
+earthquakeOverlaySourceIncarnationFactory(Ref ref) =>
+    () => createMapSourceIncarnation(value: const Uuid().v7());
+
+@riverpod
+MapSourceIncarnation earthquakeOverlaySourceIncarnation(Ref ref) =>
+    ref.watch(earthquakeOverlaySourceIncarnationFactoryProvider)();

--- a/app/lib/feature/earthquake_history/data/provider/earthquake_overlay_source_incarnation_provider.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/earthquake_overlay_source_incarnation_provider.g.dart
@@ -1,0 +1,113 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'earthquake_overlay_source_incarnation_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(earthquakeOverlaySourceIncarnationFactory)
+final earthquakeOverlaySourceIncarnationFactoryProvider =
+    EarthquakeOverlaySourceIncarnationFactoryProvider._();
+
+final class EarthquakeOverlaySourceIncarnationFactoryProvider
+    extends
+        $FunctionalProvider<
+          EarthquakeOverlaySourceIncarnationFactory,
+          EarthquakeOverlaySourceIncarnationFactory,
+          EarthquakeOverlaySourceIncarnationFactory
+        >
+    with $Provider<EarthquakeOverlaySourceIncarnationFactory> {
+  EarthquakeOverlaySourceIncarnationFactoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'earthquakeOverlaySourceIncarnationFactoryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$earthquakeOverlaySourceIncarnationFactoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<EarthquakeOverlaySourceIncarnationFactory> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EarthquakeOverlaySourceIncarnationFactory create(Ref ref) {
+    return earthquakeOverlaySourceIncarnationFactory(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EarthquakeOverlaySourceIncarnationFactory value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride:
+          $SyncValueProvider<EarthquakeOverlaySourceIncarnationFactory>(value),
+    );
+  }
+}
+
+String _$earthquakeOverlaySourceIncarnationFactoryHash() =>
+    r'079d91b261c603919b70ff65ccb051437274af64';
+
+@ProviderFor(earthquakeOverlaySourceIncarnation)
+final earthquakeOverlaySourceIncarnationProvider =
+    EarthquakeOverlaySourceIncarnationProvider._();
+
+final class EarthquakeOverlaySourceIncarnationProvider
+    extends
+        $FunctionalProvider<
+          MapSourceIncarnation,
+          MapSourceIncarnation,
+          MapSourceIncarnation
+        >
+    with $Provider<MapSourceIncarnation> {
+  EarthquakeOverlaySourceIncarnationProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'earthquakeOverlaySourceIncarnationProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$earthquakeOverlaySourceIncarnationHash();
+
+  @$internal
+  @override
+  $ProviderElement<MapSourceIncarnation> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  MapSourceIncarnation create(Ref ref) {
+    return earthquakeOverlaySourceIncarnation(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(MapSourceIncarnation value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<MapSourceIncarnation>(value),
+    );
+  }
+}
+
+String _$earthquakeOverlaySourceIncarnationHash() =>
+    r'6c3d566e70b5f06f3d40d427ce76de0335f72041';

--- a/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.dart
+++ b/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.dart
@@ -2,12 +2,14 @@ import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
 import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_map_overlay_builder.dart';
-import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_map_overlay_digest_builder.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_details_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/earthquake_overlay_source_incarnation_provider.dart';
 import 'package:eqmonitor/feature/live_monitor/data/logic/live_monitor_latest_earthquake_selector.dart';
 import 'package:eqmonitor_map/eqmonitor_map.dart';
 import 'package:flutter/foundation.dart';
@@ -24,6 +26,10 @@ const latestEarthquakeOverlayParameter = EarthquakeHistoryParameter.all(
 @riverpod
 EarthquakeMapOverlayBuilder earthquakeMapOverlayBuilder(Ref ref) =>
     const EarthquakeMapOverlayBuilder();
+
+@riverpod
+EarthquakeMapOverlayDigestBuilder earthquakeMapOverlayDigestBuilder(Ref ref) =>
+    const EarthquakeMapOverlayDigestBuilder();
 
 enum LatestEarthquakeOverlayAvailability {
   available,
@@ -54,37 +60,18 @@ final class LatestEarthquakeOverlayData {
   final EarthquakeMapOverlaySnapshot? overlay;
 }
 
-LatestEarthquakeOverlayData latestEarthquakeOverlayDataFor({
-  required Earthquake earthquake,
-  required EarthquakeMapOverlayBuildResult result,
-}) => switch (result) {
-  EarthquakeMapOverlayAvailable(:final snapshot) => LatestEarthquakeOverlayData(
-    eventId: earthquake.eventId,
-    originTime: earthquake.originTime,
-    telegramStatus: earthquake.status,
-    availability: .available,
-    overlay: snapshot,
-  ),
-  EarthquakeMapOverlayUnavailable(:final reason) => LatestEarthquakeOverlayData(
-    eventId: earthquake.eventId,
-    originTime: earthquake.originTime,
-    telegramStatus: earthquake.status,
-    availability: switch (reason) {
-      EarthquakeMapOverlayUnavailableReason.noIntensity => .noIntensity,
-      EarthquakeMapOverlayUnavailableReason.missingTelegramMetadata =>
-        .missingTelegramMetadata,
-    },
-    overlay: null,
-  ),
-};
-
 @riverpod
 class LatestEarthquakeOverlay extends _$LatestEarthquakeOverlay {
-  var _generation = 0;
+  final _versionOwner = EarthquakeOverlayVersionOwner();
 
   @override
   Future<LatestEarthquakeOverlayData> build() async {
-    final generation = ++_generation;
+    final asyncGenerationOwner = AsyncGenerationOwner();
+    ref.onDispose(asyncGenerationOwner.dispose);
+    final asyncGeneration = asyncGenerationOwner.begin();
+    final sourceIncarnation = ref.watch(
+      earthquakeOverlaySourceIncarnationProvider,
+    );
     final colorModel = ref.watch(activeColorSetProvider).intensity;
     final page = await ref.watch(
       earthquakeHistoryProvider(latestEarthquakeOverlayParameter).future,
@@ -104,7 +91,7 @@ class LatestEarthquakeOverlay extends _$LatestEarthquakeOverlay {
     final earthquake = await ref.watch(
       earthquakeHistoryDetailsProvider(eventId).future,
     );
-    if (generation != _generation || earthquake.eventId != eventId) {
+    if (!asyncGeneration.isCurrent || earthquake.eventId != eventId) {
       return LatestEarthquakeOverlayData(
         eventId: eventId,
         originTime: null,
@@ -114,12 +101,156 @@ class LatestEarthquakeOverlay extends _$LatestEarthquakeOverlay {
       );
     }
     final overlayBuilder = ref.watch(earthquakeMapOverlayBuilderProvider);
-    return latestEarthquakeOverlayDataFor(
-      earthquake: earthquake,
-      result: overlayBuilder.build(
-        earthquake: earthquake,
-        colorModel: colorModel,
+    final unavailableReason = overlayBuilder.unavailableReason(earthquake);
+    if (unavailableReason != null) {
+      return LatestEarthquakeOverlayData(
+        eventId: earthquake.eventId,
+        originTime: earthquake.originTime,
+        telegramStatus: earthquake.status,
+        availability: switch (unavailableReason) {
+          EarthquakeMapOverlayUnavailableReason.noIntensity => .noIntensity,
+          EarthquakeMapOverlayUnavailableReason.missingTelegramMetadata =>
+            .missingTelegramMetadata,
+        },
+        overlay: null,
+      );
+    }
+    final intensity = earthquake.intensity as EarthquakeIntensity;
+    final regionLevels = overlayBuilder.regionIntensityLevels(
+      intensity: intensity,
+    );
+    final cityLevels = overlayBuilder.cityIntensityLevels(intensity: intensity);
+    final stationObservations = overlayBuilder.stationObservations(
+      intensity: intensity,
+    );
+    final regionStyles = overlayBuilder.areaStyles(
+      levels: regionLevels,
+      colorModel: colorModel,
+    );
+    final cityStyles = overlayBuilder.areaStyles(
+      levels: cityLevels,
+      colorModel: colorModel,
+    );
+    final stations = overlayBuilder.observationPoints(
+      intensity: intensity,
+      colorModel: colorModel,
+    );
+    final digestBuilder = ref.watch(earthquakeMapOverlayDigestBuilderProvider);
+    final hypocenterInput = digestBuilder.hypocenterInput(earthquake);
+    final dataDigest = digestBuilder.buildDataDigest(
+      regions: [
+        for (final entry in regionLevels.entries)
+          (stableId: entry.key, intensityOrder: entry.value.orderIndex),
+      ],
+      cities: [
+        for (final entry in cityLevels.entries)
+          (stableId: entry.key, intensityOrder: entry.value.orderIndex),
+      ],
+      stations: [
+        for (final entry in stationObservations.entries)
+          (
+            stableId: entry.key,
+            longitude: entry.value.station.location.lon,
+            latitude: entry.value.station.location.lat,
+            intensityOrder: entry.value.intensity.orderIndex,
+            isMaximum: entry.value.intensity == intensity.maxIntensity,
+          ),
+      ],
+      hypocenterState: hypocenterInput.state,
+      hypocenterLongitude: hypocenterInput.longitude,
+      hypocenterLatitude: hypocenterInput.latitude,
+    );
+    final versionStamp = _versionOwner.next(
+      sourceIdentity: createMapSourceIdentity(value: eventId),
+      sourceIncarnation: sourceIncarnation,
+      dataDigest: dataDigest,
+      renderDigestFor: (dataSequence) => digestBuilder.buildRenderDigest(
+        dataSequence: dataSequence,
+        dataDigest: dataDigest,
+        regionToCityZoom: earthquakeOverlayRegionToCityZoom,
+        stationMinZoom: earthquakeOverlayStationMinZoom,
+        regionStyles: regionStyles,
+        cityStyles: cityStyles,
+        stations: stations,
       ),
     );
+    if (!asyncGeneration.isCurrent) {
+      return LatestEarthquakeOverlayData(
+        eventId: eventId,
+        originTime: null,
+        telegramStatus: null,
+        availability: .superseded,
+        overlay: null,
+      );
+    }
+    final result = overlayBuilder.build(
+      earthquake: earthquake,
+      colorModel: colorModel,
+      versionStamp: versionStamp,
+    );
+    return switch (result) {
+      EarthquakeMapOverlayAvailable(:final snapshot) =>
+        LatestEarthquakeOverlayData(
+          eventId: earthquake.eventId,
+          originTime: earthquake.originTime,
+          telegramStatus: earthquake.status,
+          availability: .available,
+          overlay: snapshot,
+        ),
+      EarthquakeMapOverlayUnavailable(:final reason) =>
+        LatestEarthquakeOverlayData(
+          eventId: earthquake.eventId,
+          originTime: earthquake.originTime,
+          telegramStatus: earthquake.status,
+          availability: switch (reason) {
+            EarthquakeMapOverlayUnavailableReason.noIntensity => .noIntensity,
+            EarthquakeMapOverlayUnavailableReason.missingTelegramMetadata =>
+              .missingTelegramMetadata,
+          },
+          overlay: null,
+        ),
+    };
+  }
+}
+
+final class EarthquakeOverlayVersionOwner {
+  MapOverlayVersionStamp? _current;
+
+  MapOverlayVersionStamp next({
+    required MapSourceIdentity sourceIdentity,
+    required MapSourceIncarnation sourceIncarnation,
+    required String dataDigest,
+    required String Function(int dataSequence) renderDigestFor,
+  }) {
+    final current = _current;
+    final isSameSource =
+        current != null &&
+        current.sourceIdentity == sourceIdentity &&
+        current.sourceIncarnation == sourceIncarnation;
+    final dataSequence = !isSameSource
+        ? 0
+        : current.dataDigest == dataDigest
+        ? current.dataSequence
+        : current.dataSequence + 1;
+    final renderDigest = renderDigestFor(dataSequence);
+    final renderGeneration = !isSameSource
+        ? 0
+        : current.renderDigest == renderDigest
+        ? current.renderGeneration
+        : current.renderGeneration + 1;
+    final next = createMapOverlayVersionStamp(
+      sourceIdentity: sourceIdentity,
+      sourceIncarnation: sourceIncarnation,
+      dataSequence: dataSequence,
+      dataDigest: dataDigest,
+      renderGeneration: renderGeneration,
+      renderDigest: renderDigest,
+    );
+    if (current != null &&
+        !canAdvanceMapOverlayVersionStamp(current: current, next: next)) {
+      throw StateError('Invalid earthquake overlay version transition.');
+    }
+    _current = next;
+    return next;
   }
 }

--- a/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.g.dart
@@ -60,6 +60,58 @@ final class EarthquakeMapOverlayBuilderProvider
 String _$earthquakeMapOverlayBuilderHash() =>
     r'0156dba1aee5af4ffb66390c488d261b26f1ae5a';
 
+@ProviderFor(earthquakeMapOverlayDigestBuilder)
+final earthquakeMapOverlayDigestBuilderProvider =
+    EarthquakeMapOverlayDigestBuilderProvider._();
+
+final class EarthquakeMapOverlayDigestBuilderProvider
+    extends
+        $FunctionalProvider<
+          EarthquakeMapOverlayDigestBuilder,
+          EarthquakeMapOverlayDigestBuilder,
+          EarthquakeMapOverlayDigestBuilder
+        >
+    with $Provider<EarthquakeMapOverlayDigestBuilder> {
+  EarthquakeMapOverlayDigestBuilderProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'earthquakeMapOverlayDigestBuilderProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$earthquakeMapOverlayDigestBuilderHash();
+
+  @$internal
+  @override
+  $ProviderElement<EarthquakeMapOverlayDigestBuilder> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EarthquakeMapOverlayDigestBuilder create(Ref ref) {
+    return earthquakeMapOverlayDigestBuilder(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EarthquakeMapOverlayDigestBuilder value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EarthquakeMapOverlayDigestBuilder>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$earthquakeMapOverlayDigestBuilderHash() =>
+    r'acf123b9b4bdceb13ea98e9ca2d8e2f67929722e';
+
 @ProviderFor(LatestEarthquakeOverlay)
 final latestEarthquakeOverlayProvider = LatestEarthquakeOverlayProvider._();
 
@@ -89,7 +141,7 @@ final class LatestEarthquakeOverlayProvider
 }
 
 String _$latestEarthquakeOverlayHash() =>
-    r'19419441db4839464bb424ede192d8e9b99ef964';
+    r'0ded90547bb5f30ad2a844814f62f4d0190f1641';
 
 abstract class _$LatestEarthquakeOverlay
     extends $AsyncNotifier<LatestEarthquakeOverlayData> {

--- a/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.g.dart
@@ -141,7 +141,7 @@ final class LatestEarthquakeOverlayProvider
 }
 
 String _$latestEarthquakeOverlayHash() =>
-    r'0ded90547bb5f30ad2a844814f62f4d0190f1641';
+    r'a63806c016e4a2740eda30bd3aabedd57621ce9c';
 
 abstract class _$LatestEarthquakeOverlay
     extends $AsyncNotifier<LatestEarthquakeOverlayData> {

--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_banner.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_banner.dart
@@ -18,7 +18,7 @@ final class EqmonitorMapOverlayPresentation {
   factory from({
     required AsyncValue<LatestEarthquakeOverlayData> overlayState,
     required EarthquakeOverlayCoverageSnapshot? coverageSnapshot,
-  }) => createEqmonitorMapOverlayPresentation(
+  }) => const EqmonitorMapOverlayPresentationBuilder().build(
     overlayState: overlayState,
     coverageSnapshot: coverageSnapshot,
   );
@@ -31,96 +31,100 @@ final class EqmonitorMapOverlayPresentation {
   final bool isError;
 }
 
-EqmonitorMapOverlayPresentation createEqmonitorMapOverlayPresentation({
-  required AsyncValue<LatestEarthquakeOverlayData> overlayState,
-  required EarthquakeOverlayCoverageSnapshot? coverageSnapshot,
-}) {
-  if (overlayState.isLoading) {
-    return const EqmonitorMapOverlayPresentation(
-      eventIdLabel: '取得中',
-      originTimeLabel: '取得中',
-      statusLabel: '取得中',
-      message: '最新の地震情報を取得中です',
-      overlay: null,
+final class EqmonitorMapOverlayPresentationBuilder {
+  const new();
+
+  EqmonitorMapOverlayPresentation build({
+    required AsyncValue<LatestEarthquakeOverlayData> overlayState,
+    required EarthquakeOverlayCoverageSnapshot? coverageSnapshot,
+  }) {
+    if (overlayState.isLoading) {
+      return const EqmonitorMapOverlayPresentation(
+        eventIdLabel: '取得中',
+        originTimeLabel: '取得中',
+        statusLabel: '取得中',
+        message: '最新の地震情報を取得中です',
+        overlay: null,
+        isError: false,
+      );
+    }
+    if (overlayState.hasError) {
+      return const EqmonitorMapOverlayPresentation(
+        eventIdLabel: '取得失敗',
+        originTimeLabel: '取得失敗',
+        statusLabel: '取得失敗',
+        message: '最新の地震情報を取得できませんでした',
+        overlay: null,
+        isError: true,
+      );
+    }
+    return switch (overlayState) {
+      AsyncData(:final value) => buildData(
+        data: value,
+        coverageSnapshot: coverageSnapshot,
+      ),
+      _ => const EqmonitorMapOverlayPresentation(
+        eventIdLabel: '取得中',
+        originTimeLabel: '取得中',
+        statusLabel: '取得中',
+        message: '最新の地震情報を取得中です',
+        overlay: null,
+        isError: false,
+      ),
+    };
+  }
+
+  EqmonitorMapOverlayPresentation buildData({
+    required LatestEarthquakeOverlayData data,
+    required EarthquakeOverlayCoverageSnapshot? coverageSnapshot,
+  }) {
+    final originTime = data.originTime;
+    final overlay = data.overlay;
+    final coverage =
+        overlay == null ||
+            coverageSnapshot == null ||
+            coverageSnapshot.versionStamp != overlay.versionStamp
+        ? const EarthquakeOverlayCoverage.hidden()
+        : coverageSnapshot.coverage;
+    return EqmonitorMapOverlayPresentation(
+      eventIdLabel: data.eventId ?? '対象なし',
+      originTimeLabel: originTime == null
+          ? '不明'
+          : DateFormat('yyyy/MM/dd HH:mm:ss').format(originTime.toLocal()),
+      statusLabel: statusLabel(data.telegramStatus),
+      message: message(
+        availability: data.availability,
+        coverage: coverage,
+      ),
+      overlay: overlay,
       isError: false,
     );
   }
-  if (overlayState.hasError) {
-    return const EqmonitorMapOverlayPresentation(
-      eventIdLabel: '取得失敗',
-      originTimeLabel: '取得失敗',
-      statusLabel: '取得失敗',
-      message: '最新の地震情報を取得できませんでした',
-      overlay: null,
-      isError: true,
-    );
-  }
-  return switch (overlayState) {
-    AsyncData(:final value) => createEqmonitorMapOverlayDataPresentation(
-      data: value,
-      coverageSnapshot: coverageSnapshot,
-    ),
-    _ => const EqmonitorMapOverlayPresentation(
-      eventIdLabel: '取得中',
-      originTimeLabel: '取得中',
-      statusLabel: '取得中',
-      message: '最新の地震情報を取得中です',
-      overlay: null,
-      isError: false,
-    ),
+
+  String statusLabel(TelegramStatus? status) => switch (status) {
+    TelegramStatus.normal => '通常',
+    TelegramStatus.training => '訓練',
+    TelegramStatus.test => '試験',
+    null => '不明',
+  };
+
+  String message({
+    required LatestEarthquakeOverlayAvailability availability,
+    required EarthquakeOverlayCoverage coverage,
+  }) => switch (availability) {
+    LatestEarthquakeOverlayAvailability.available => switch (coverage) {
+      EarthquakeOverlayIncomplete() => '表示範囲の震度情報は不完全です',
+      EarthquakeOverlayComplete() => '表示範囲の震度情報を表示中です',
+      EarthquakeOverlayHidden() ||
+      EarthquakeOverlayLoading() => '表示範囲の震度情報を準備中です',
+    },
+    LatestEarthquakeOverlayAvailability.noEarthquake => '震度1以上の地震はありません',
+    LatestEarthquakeOverlayAvailability.noIntensity => '震度データがありません',
+    LatestEarthquakeOverlayAvailability.missingTelegramMetadata =>
+      '電文の更新時刻を確認できないため表示できません',
+    LatestEarthquakeOverlayAvailability.superseded => '地震情報を切り替え中です',
   };
 }
-
-EqmonitorMapOverlayPresentation createEqmonitorMapOverlayDataPresentation({
-  required LatestEarthquakeOverlayData data,
-  required EarthquakeOverlayCoverageSnapshot? coverageSnapshot,
-}) {
-  final originTime = data.originTime;
-  final overlay = data.overlay;
-  final coverage =
-      overlay == null ||
-          coverageSnapshot == null ||
-          coverageSnapshot.sourceId != overlay.sourceId ||
-          coverageSnapshot.revision != overlay.revision
-      ? const EarthquakeOverlayCoverage.hidden()
-      : coverageSnapshot.coverage;
-  return EqmonitorMapOverlayPresentation(
-    eventIdLabel: data.eventId ?? '対象なし',
-    originTimeLabel: originTime == null
-        ? '不明'
-        : DateFormat('yyyy/MM/dd HH:mm:ss').format(originTime.toLocal()),
-    statusLabel: telegramStatusLabel(data.telegramStatus),
-    message: latestEarthquakeOverlayMessage(
-      availability: data.availability,
-      coverage: coverage,
-    ),
-    overlay: overlay,
-    isError: false,
-  );
-}
-
-String telegramStatusLabel(TelegramStatus? status) => switch (status) {
-  TelegramStatus.normal => '通常',
-  TelegramStatus.training => '訓練',
-  TelegramStatus.test => '試験',
-  null => '不明',
-};
-
-String latestEarthquakeOverlayMessage({
-  required LatestEarthquakeOverlayAvailability availability,
-  required EarthquakeOverlayCoverage coverage,
-}) => switch (availability) {
-  LatestEarthquakeOverlayAvailability.available => switch (coverage) {
-    EarthquakeOverlayIncomplete() => '表示範囲の震度情報は不完全です',
-    EarthquakeOverlayComplete() => '表示範囲の震度情報を表示中です',
-    EarthquakeOverlayHidden() => '表示範囲の震度情報を準備中です',
-  },
-  LatestEarthquakeOverlayAvailability.noEarthquake => '震度1以上の地震はありません',
-  LatestEarthquakeOverlayAvailability.noIntensity => '震度データがありません',
-  LatestEarthquakeOverlayAvailability.missingTelegramMetadata =>
-    '電文の更新時刻を確認できないため表示できません',
-  LatestEarthquakeOverlayAvailability.superseded => '地震情報を切り替え中です',
-};
 
 class EqmonitorMapOverlayBanner extends StatelessWidget {
   const new({

--- a/app/test/feature/earthquake_history/data/earthquake_map_overlay_builder_test.dart
+++ b/app/test/feature/earthquake_history/data/earthquake_map_overlay_builder_test.dart
@@ -10,6 +10,7 @@ import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_statio
 import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_tree.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
 import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lat_lng/lat_lng.dart';
@@ -154,6 +155,17 @@ void main() {
       .intensity;
   const builder = EarthquakeMapOverlayBuilder();
 
+  MapOverlayVersionStamp versionStamp({
+    String sourceIdentity = '20260823123456',
+  }) => createMapOverlayVersionStamp(
+    sourceIdentity: createMapSourceIdentity(value: sourceIdentity),
+    sourceIncarnation: createMapSourceIncarnation(value: 'incarnation-a'),
+    dataSequence: 0,
+    dataDigest: 'data-a',
+    renderGeneration: 0,
+    renderDigest: 'render-a',
+  );
+
   test('同一region/city codeを最大震度styleだけへ正規化する', () {
     final result = builder.build(
       earthquake: _earthquake(
@@ -166,6 +178,7 @@ void main() {
         ],
       ),
       colorModel: colors,
+      versionStamp: versionStamp(),
     );
 
     expect(result, isA<EarthquakeMapOverlayAvailable>());
@@ -192,6 +205,7 @@ void main() {
         ],
       ),
       colorModel: colors,
+      versionStamp: versionStamp(),
     ) as EarthquakeMapOverlayAvailable;
     final snapshot = result.snapshot;
     final max = snapshot.stations.singleWhere((point) => point.id == 'ST-MAX');
@@ -217,8 +231,9 @@ void main() {
     expect(snapshot.cityStyles.single.opacity, 0.6);
   });
 
-  test('sourceIdはeventId、revisionは最大reportedAtのUTC microsecondsにする', () {
+  test('providerが発行したversion stampをsnapshotへ保持する', () {
     final latest = DateTime.parse('2026-08-23T21:00:00.123456+09:00');
+    final stamp = versionStamp();
     final result = builder.build(
       earthquake: _earthquake(
         intensity: _intensity(),
@@ -234,12 +249,28 @@ void main() {
         ],
       ),
       colorModel: colors,
+      versionStamp: stamp,
     ) as EarthquakeMapOverlayAvailable;
 
-    expect(result.snapshot.sourceId, '20260823123456');
+    expect(result.snapshot.versionStamp, same(stamp));
+  });
+
+  test('event IDと異なるsource identityを拒否する', () {
     expect(
-      result.snapshot.revision,
-      latest.toUtc().microsecondsSinceEpoch,
+      () => builder.build(
+        earthquake: _earthquake(
+          intensity: _intensity(),
+          metadata: [
+            EarthquakeTelegramMetadata(
+              type: EarthquakeTelegramType.vxse53,
+              reportedAt: DateTime.utc(2026, 8, 23, 12, 35),
+            ),
+          ],
+        ),
+        colorModel: colors,
+        versionStamp: versionStamp(sourceIdentity: 'another-event'),
+      ),
+      throwsArgumentError,
     );
   });
 
@@ -247,6 +278,7 @@ void main() {
     final result = builder.build(
       earthquake: _earthquake(intensity: _intensity(), metadata: const []),
       colorModel: colors,
+      versionStamp: versionStamp(),
     );
 
     expect(result, isA<EarthquakeMapOverlayUnavailable>());
@@ -260,6 +292,7 @@ void main() {
     final result = builder.build(
       earthquake: _earthquake(intensity: null, metadata: const []),
       colorModel: colors,
+      versionStamp: versionStamp(),
     );
 
     expect(result, isA<EarthquakeMapOverlayUnavailable>());

--- a/app/test/feature/earthquake_history/data/earthquake_map_overlay_digest_builder_test.dart
+++ b/app/test/feature/earthquake_history/data/earthquake_map_overlay_digest_builder_test.dart
@@ -1,0 +1,126 @@
+import 'dart:ui';
+
+import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_map_overlay_digest_builder.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const builder = EarthquakeMapOverlayDigestBuilder();
+  const regionA = (stableId: 'R-A', intensityOrder: 4);
+  const regionB = (stableId: 'R-B', intensityOrder: 3);
+  const cityA = (stableId: 'C-A', intensityOrder: 3);
+  const stationA = (
+    stableId: 'S-A',
+    longitude: 139.75,
+    latitude: 35.25,
+    intensityOrder: 4,
+    isMaximum: true,
+  );
+
+  String dataDigest({
+    List<({String stableId, int intensityOrder})> regions = const [
+      regionA,
+    ],
+    List<({String stableId, int intensityOrder})> cities = const [cityA],
+    List<
+      ({
+        String stableId,
+        double longitude,
+        double latitude,
+        int intensityOrder,
+        bool isMaximum,
+      })
+    >
+    stations = const [
+      stationA,
+    ],
+  }) => builder.buildDataDigest(
+    regions: regions,
+    cities: cities,
+    stations: stations,
+    hypocenterState: .latLng,
+    hypocenterLongitude: 140,
+    hypocenterLatitude: 36,
+  );
+
+  test('canonical UTF-8 records produce the known SHA-256 digest', () {
+    expect(
+      dataDigest(),
+      '231122c122f035a97707f693a880a148b57ffc8e03e246606cacb2475716e546',
+    );
+  });
+
+  test('region city and station input order does not affect data digest', () {
+    final forward = dataDigest(
+      regions: const [regionA, regionB],
+      cities: const [cityA, (stableId: 'C-B', intensityOrder: 2)],
+      stations: const [
+        stationA,
+        (
+          stableId: 'S-B',
+          longitude: 141,
+          latitude: 37,
+          intensityOrder: 2,
+          isMaximum: false,
+        ),
+      ],
+    );
+    final reversed = dataDigest(
+      regions: const [regionB, regionA],
+      cities: const [(stableId: 'C-B', intensityOrder: 2), cityA],
+      stations: const [
+        (
+          stableId: 'S-B',
+          longitude: 141,
+          latitude: 37,
+          intensityOrder: 2,
+          isMaximum: false,
+        ),
+        stationA,
+      ],
+    );
+
+    expect(reversed, forward);
+    expect(
+      dataDigest(regions: const [(stableId: 'R-A', intensityOrder: 5)]),
+      isNot(forward),
+    );
+  });
+
+  test('theme-only color change affects render digest but not data digest', () {
+    final data = dataDigest();
+    final red = builder.buildRenderDigest(
+      dataSequence: 0,
+      dataDigest: data,
+      regionToCityZoom: 6,
+      stationMinZoom: 6,
+      regionStyles: const [
+        EarthquakeAreaStyle(
+          code: 'R-A',
+          color: Color(0xFFFF0000),
+          opacity: 0.6,
+        ),
+      ],
+      cityStyles: const [],
+      stations: const [],
+    );
+    final blue = builder.buildRenderDigest(
+      dataSequence: 0,
+      dataDigest: data,
+      regionToCityZoom: 6,
+      stationMinZoom: 6,
+      regionStyles: const [
+        EarthquakeAreaStyle(
+          code: 'R-A',
+          color: Color(0xFF0000FF),
+          opacity: 0.6,
+        ),
+      ],
+      cityStyles: const [],
+      stations: const [],
+    );
+
+    expect(blue, isNot(red));
+    expect(dataDigest(), data);
+  });
+}

--- a/app/test/feature/earthquake_history/data/latest_earthquake_overlay_provider_test.dart
+++ b/app/test/feature/earthquake_history/data/latest_earthquake_overlay_provider_test.dart
@@ -5,13 +5,20 @@ import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
 import 'package:eqmonitor/core/theme/model/app_theme.dart';
 import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_search_response.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_metadata.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_type.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_tree.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_details_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/earthquake_overlay_source_incarnation_provider.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.dart';
+import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -45,6 +52,26 @@ class _PendingDetailsNotifier extends EarthquakeHistoryDetailsNotifier {
   }
 }
 
+class _MutableDetailsNotifier extends EarthquakeHistoryDetailsNotifier {
+  new(this.initial);
+
+  final Earthquake initial;
+
+  @override
+  Future<Earthquake> build(String eventId) async => initial;
+
+  void publish(Earthquake earthquake) {
+    state = AsyncData(earthquake);
+  }
+}
+
+const _region = EarthquakeParameterRegionItem(
+  code: 'R-A',
+  name: LocalizedName(ja: '地域A'),
+  kana: null,
+  cities: [],
+);
+
 EarthquakePartial _partial(String eventId) => EarthquakePartial.normal(
   eventId: eventId,
   status: TelegramStatus.normal,
@@ -75,6 +102,45 @@ Earthquake _earthquake(String eventId) => Earthquake(
   intensity: null,
   estimatedIntensityTileUrl: null,
 );
+
+Earthquake _availableEarthquake({
+  String eventId = 'A',
+  JmaIntensity intensity = JmaIntensity.three,
+}) => Earthquake(
+  eventId: eventId,
+  status: TelegramStatus.normal,
+  originTime: DateTime.utc(2026, 8, 23),
+  originTimePrecision: OriginTimePrecision.second,
+  arrivalTime: null,
+  dataSources: const [],
+  telegramTypes: const [EarthquakeTelegramType.vxse53],
+  telegramMetadata: [
+    EarthquakeTelegramMetadata(
+      type: EarthquakeTelegramType.vxse53,
+      reportedAt: DateTime.utc(2026, 8, 23, 0, 1),
+    ),
+  ],
+  hypocenter: null,
+  intensity: EarthquakeIntensity(
+    maxIntensity: intensity,
+    maxLpgmIntensity: null,
+    regions: {
+      intensity: [IntensityRegion(region: _region, maxIntensity: intensity)],
+    },
+    intensityTree: const {},
+    lpgmIntensityTree: const {},
+  ),
+  estimatedIntensityTileUrl: null,
+);
+
+MapSourceIncarnation _incarnation(String value) =>
+    createMapSourceIncarnation(value: value);
+
+MapOverlayVersionStamp _stamp(LatestEarthquakeOverlayData data) {
+  final overlay = data.overlay;
+  expect(overlay, isNotNull);
+  return (overlay as EarthquakeMapOverlaySnapshot).versionStamp;
+}
 
 void main() {
   test('一覧はevent ID降順かつ震度1以上の専用parameterを使う', () {
@@ -140,5 +206,199 @@ void main() {
       result.availability,
       LatestEarthquakeOverlayAvailability.noIntensity,
     );
+  });
+
+  test('reportedAtが同一でもcanonical data変更でdata sequenceが進む', () async {
+    final earthquake = _availableEarthquake();
+    final details = _MutableDetailsNotifier(earthquake);
+    final colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
+    final container = ProviderContainer(
+      overrides: [
+        activeColorSetProvider.overrideWithValue(colorSet),
+        earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
+          () => _incarnation('incarnation-a'),
+        ),
+        earthquakeHistoryProvider(
+          latestEarthquakeOverlayParameter,
+        ).overrideWith(() => _MutableHistoryNotifier(_page('A'))),
+        earthquakeHistoryDetailsProvider(
+          'A',
+        ).overrideWith(() => details),
+      ],
+    );
+    addTearDown(container.dispose);
+    final detailsSubscription = container.listen(
+      earthquakeHistoryDetailsProvider('A'),
+      (_, _) {},
+    );
+    addTearDown(detailsSubscription.close);
+    final overlaySubscription = container.listen(
+      latestEarthquakeOverlayProvider,
+      (_, _) {},
+    );
+    addTearDown(overlaySubscription.close);
+
+    final first = _stamp(
+      await container.read(latestEarthquakeOverlayProvider.future),
+    );
+    details.publish(
+      _availableEarthquake(intensity: JmaIntensity.four),
+    );
+    await pumpEventQueue();
+    final second = _stamp(
+      await container.read(latestEarthquakeOverlayProvider.future),
+    );
+
+    expect(first.dataSequence, 0);
+    expect(second.sourceIncarnation, first.sourceIncarnation);
+    expect(second.dataSequence, 1);
+    expect(second.dataDigest, isNot(first.dataDigest));
+    expect(second.renderGeneration, greaterThan(first.renderGeneration));
+  });
+
+  test('theme色だけの変更はdata versionを維持してrender generationを進める', () async {
+    var colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
+    final details = _MutableDetailsNotifier(_availableEarthquake());
+    final container = ProviderContainer(
+      overrides: [
+        activeColorSetProvider.overrideWith((ref) => colorSet),
+        earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
+          () => _incarnation('incarnation-a'),
+        ),
+        earthquakeHistoryProvider(
+          latestEarthquakeOverlayParameter,
+        ).overrideWith(() => _MutableHistoryNotifier(_page('A'))),
+        earthquakeHistoryDetailsProvider(
+          'A',
+        ).overrideWith(() => details),
+      ],
+    );
+    addTearDown(container.dispose);
+    final detailsSubscription = container.listen(
+      earthquakeHistoryDetailsProvider('A'),
+      (_, _) {},
+    );
+    addTearDown(detailsSubscription.close);
+    final overlaySubscription = container.listen(
+      latestEarthquakeOverlayProvider,
+      (_, _) {},
+    );
+    addTearDown(overlaySubscription.close);
+
+    final first = _stamp(
+      await container.read(latestEarthquakeOverlayProvider.future),
+    );
+    colorSet = colorSet.copyWith(
+      intensity: colorSet.intensity.copyWith(
+        three: colorSet.intensity.three.copyWith(
+          background: const Color(0xFF123456),
+        ),
+      ),
+    );
+    container.invalidate(activeColorSetProvider);
+    await pumpEventQueue();
+    final second = _stamp(
+      await container.read(latestEarthquakeOverlayProvider.future),
+    );
+
+    expect(second.sourceIncarnation, first.sourceIncarnation);
+    expect(second.dataSequence, first.dataSequence);
+    expect(second.dataDigest, first.dataDigest);
+    expect(second.renderGeneration, first.renderGeneration + 1);
+    expect(second.renderDigest, isNot(first.renderDigest));
+  });
+
+  test('provider再生成時は同じeventを新incarnationのsequence 0にする', () async {
+    Future<MapOverlayVersionStamp> readStamp(String incarnation) async {
+      final colorSet = AppTheme.eqmonitorDefault().colorSetFor(
+        Brightness.light,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          activeColorSetProvider.overrideWithValue(colorSet),
+          earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
+            () => _incarnation(incarnation),
+          ),
+          earthquakeHistoryProvider(
+            latestEarthquakeOverlayParameter,
+          ).overrideWith(() => _MutableHistoryNotifier(_page('A'))),
+          earthquakeHistoryDetailsProvider('A').overrideWith(
+            () => _MutableDetailsNotifier(_availableEarthquake()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      return _stamp(
+        await container.read(latestEarthquakeOverlayProvider.future),
+      );
+    }
+
+    final first = await readStamp('incarnation-a');
+    final second = await readStamp('incarnation-b');
+
+    expect(first.dataSequence, 0);
+    expect(second.dataSequence, 0);
+    expect(second.sourceIdentity, first.sourceIdentity);
+    expect(second.sourceIncarnation, isNot(first.sourceIncarnation));
+  });
+
+  test('incarnation変更後は旧incarnationのdetail完了を公開しない', () async {
+    final detail = Completer<Earthquake>();
+    final requested = Completer<void>();
+    final incarnations = [
+      _incarnation('incarnation-a'),
+      _incarnation('incarnation-b'),
+    ].iterator;
+    final colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
+    final container = ProviderContainer(
+      overrides: [
+        activeColorSetProvider.overrideWithValue(colorSet),
+        earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
+          () {
+            if (!incarnations.moveNext()) {
+              throw StateError('unexpected incarnation request');
+            }
+            return incarnations.current;
+          },
+        ),
+        earthquakeHistoryProvider(
+          latestEarthquakeOverlayParameter,
+        ).overrideWith(() => _MutableHistoryNotifier(_page('A'))),
+        earthquakeHistoryDetailsProvider('A').overrideWith(
+          () => _PendingDetailsNotifier(
+            completer: detail,
+            requested: requested,
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final publishedIncarnations = <MapSourceIncarnation>[];
+    final subscription = container.listen(
+      latestEarthquakeOverlayProvider,
+      (_, next) {
+        if (next case AsyncData(:final value)) {
+          final overlay = value.overlay;
+          if (overlay != null) {
+            publishedIncarnations.add(overlay.versionStamp.sourceIncarnation);
+          }
+        }
+      },
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+
+    await requested.future;
+    container.invalidate(earthquakeOverlaySourceIncarnationProvider);
+    await pumpEventQueue();
+    detail.complete(_availableEarthquake());
+    final result = await container.read(latestEarthquakeOverlayProvider.future);
+
+    expect(
+      publishedIncarnations,
+      isNot(contains(_incarnation('incarnation-a'))),
+    );
+    expect(_stamp(result).sourceIncarnation, _incarnation('incarnation-b'));
+    expect(_stamp(result).dataSequence, 0);
   });
 }

--- a/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_presentation_test.dart
+++ b/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_presentation_test.dart
@@ -7,10 +7,25 @@ import 'package:eqmonitor_map/eqmonitor_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-EarthquakeMapOverlaySnapshot _snapshot(String sourceId) =>
+MapOverlayVersionStamp _versionStamp({
+  required String sourceIdentity,
+  String sourceIncarnation = 'incarnation-a',
+  int dataSequence = 0,
+  String dataDigest = 'data-a',
+  int renderGeneration = 0,
+  String renderDigest = 'render-a',
+}) => createMapOverlayVersionStamp(
+  sourceIdentity: createMapSourceIdentity(value: sourceIdentity),
+  sourceIncarnation: createMapSourceIncarnation(value: sourceIncarnation),
+  dataSequence: dataSequence,
+  dataDigest: dataDigest,
+  renderGeneration: renderGeneration,
+  renderDigest: renderDigest,
+);
+
+EarthquakeMapOverlaySnapshot _snapshot(MapOverlayVersionStamp versionStamp) =>
     createEarthquakeMapOverlaySnapshot(
-      sourceId: sourceId,
-      revision: 12,
+      versionStamp: versionStamp,
       regionToCityZoom: 6,
       stationMinZoom: 6,
       regionStyles: const [],
@@ -18,14 +33,18 @@ EarthquakeMapOverlaySnapshot _snapshot(String sourceId) =>
       stations: const [],
     );
 
-LatestEarthquakeOverlayData _available(String eventId) =>
-    LatestEarthquakeOverlayData(
-      eventId: eventId,
-      originTime: DateTime.utc(2026, 8, 23, 12, 34),
-      telegramStatus: TelegramStatus.normal,
-      availability: LatestEarthquakeOverlayAvailability.available,
-      overlay: _snapshot(eventId),
-    );
+LatestEarthquakeOverlayData _available(
+  String eventId, {
+  MapOverlayVersionStamp? versionStamp,
+}) => LatestEarthquakeOverlayData(
+  eventId: eventId,
+  originTime: DateTime.utc(2026, 8, 23, 12, 34),
+  telegramStatus: TelegramStatus.normal,
+  availability: LatestEarthquakeOverlayAvailability.available,
+  overlay: _snapshot(
+    versionStamp ?? _versionStamp(sourceIdentity: eventId),
+  ),
+);
 
 void main() {
   test('previous overlayを持つloadingでもoverlayをnullにして切替中を示す', () {
@@ -76,12 +95,12 @@ void main() {
 
   test('current overlayのcoverage不完全をbannerへ明示する', () {
     final data = _available('A');
+    final overlay = data.overlay as EarthquakeMapOverlaySnapshot;
     final presentation = EqmonitorMapOverlayPresentation.from(
       overlayState: AsyncData(data),
-      coverageSnapshot: const EarthquakeOverlayCoverageSnapshot(
-        sourceId: 'A',
-        revision: 12,
-        coverage: EarthquakeOverlayCoverage.incomplete(
+      coverageSnapshot: EarthquakeOverlayCoverageSnapshot(
+        versionStamp: overlay.versionStamp,
+        coverage: const EarthquakeOverlayCoverage.incomplete(
           requestedTileCount: 4,
           readyTileCount: 3,
           missingOrInvalidCodeCount: 1,
@@ -96,12 +115,63 @@ void main() {
   test('旧sourceのcoverageをcurrent overlayへ適用しない', () {
     final presentation = EqmonitorMapOverlayPresentation.from(
       overlayState: AsyncData(_available('B')),
-      coverageSnapshot: const EarthquakeOverlayCoverageSnapshot(
-        sourceId: 'A',
-        revision: 12,
-        coverage: EarthquakeOverlayCoverage.complete(
+      coverageSnapshot: EarthquakeOverlayCoverageSnapshot(
+        versionStamp: _versionStamp(sourceIdentity: 'A'),
+        coverage: const EarthquakeOverlayCoverage.complete(
           requestedTileCount: 4,
         ),
+      ),
+    );
+
+    expect(presentation.message, '表示範囲の震度情報を準備中です');
+  });
+
+  test('同じsourceでもdata stampが異なるcoverageを適用しない', () {
+    final presentation = EqmonitorMapOverlayPresentation.from(
+      overlayState: AsyncData(_available('A')),
+      coverageSnapshot: EarthquakeOverlayCoverageSnapshot(
+        versionStamp: _versionStamp(
+          sourceIdentity: 'A',
+          dataSequence: 1,
+          dataDigest: 'data-b',
+          renderGeneration: 1,
+          renderDigest: 'render-b',
+        ),
+        coverage: const EarthquakeOverlayCoverage.complete(
+          requestedTileCount: 4,
+        ),
+      ),
+    );
+
+    expect(presentation.message, '表示範囲の震度情報を準備中です');
+  });
+
+  test('同じdataでもrender stampが異なるcoverageを適用しない', () {
+    final presentation = EqmonitorMapOverlayPresentation.from(
+      overlayState: AsyncData(_available('A')),
+      coverageSnapshot: EarthquakeOverlayCoverageSnapshot(
+        versionStamp: _versionStamp(
+          sourceIdentity: 'A',
+          renderGeneration: 1,
+          renderDigest: 'render-b',
+        ),
+        coverage: const EarthquakeOverlayCoverage.complete(
+          requestedTileCount: 4,
+        ),
+      ),
+    );
+
+    expect(presentation.message, '表示範囲の震度情報を準備中です');
+  });
+
+  test('current overlayのloading coverageを準備中として扱う', () {
+    final data = _available('A');
+    final overlay = data.overlay as EarthquakeMapOverlaySnapshot;
+    final presentation = EqmonitorMapOverlayPresentation.from(
+      overlayState: AsyncData(data),
+      coverageSnapshot: EarthquakeOverlayCoverageSnapshot(
+        versionStamp: overlay.versionStamp,
+        coverage: const EarthquakeOverlayCoverage.loading(),
       ),
     );
 

--- a/packages/eqmonitor_map/lib/eqmonitor_map.dart
+++ b/packages/eqmonitor_map/lib/eqmonitor_map.dart
@@ -45,6 +45,7 @@ export 'src/mesh/line_mesh_builder_limits.dart';
 export 'src/overlay/earthquake_map_overlay_snapshot.dart';
 export 'src/overlay/earthquake_overlay_controller.dart';
 export 'src/overlay/earthquake_overlay_coverage.dart';
+export 'src/overlay/map_overlay_version_stamp.dart';
 export 'src/renderer/eqmonitor_orthographic_projection.dart';
 export 'src/renderer/map_render_batch_adapter.dart';
 export 'src/renderer/map_scene_renderer_adapter.dart';

--- a/packages/eqmonitor_map/lib/eqmonitor_map.dart
+++ b/packages/eqmonitor_map/lib/eqmonitor_map.dart
@@ -11,6 +11,7 @@ export 'package:pmtiles_v3/pmtiles_v3.dart'
 
 export 'src/eqmonitor_map_library.dart';
 export 'src/flutter_scene/base_map_material_preflight_view.dart';
+export 'src/foundation/async_generation_token.dart';
 export 'src/foundation/frame/map_clock.dart';
 export 'src/foundation/frame/map_frame_revision.dart';
 export 'src/foundation/frame/map_frame_snapshot.dart';

--- a/packages/eqmonitor_map/lib/src/foundation/revision/map_source_identity.dart
+++ b/packages/eqmonitor_map/lib/src/foundation/revision/map_source_identity.dart
@@ -2,6 +2,10 @@ extension type MapSourceInstanceId._(String value);
 
 extension type MapContentDigest._(String value);
 
+extension type MapSourceIdentity._(String value);
+
+extension type MapSourceIncarnation._(String value);
+
 MapSourceInstanceId createMapSourceInstanceId({required String value}) {
   final normalizedValue = value.trim();
   if (normalizedValue.isEmpty) {
@@ -18,4 +22,18 @@ MapContentDigest createMapContentDigest({required String value}) {
   }
 
   return MapContentDigest._(normalizedValue);
+}
+
+MapSourceIdentity createMapSourceIdentity({required String value}) =>
+    MapSourceIdentity._(_normalizeIdentityValue(value: value));
+
+MapSourceIncarnation createMapSourceIncarnation({required String value}) =>
+    MapSourceIncarnation._(_normalizeIdentityValue(value: value));
+
+String _normalizeIdentityValue({required String value}) {
+  final normalizedValue = value.trim();
+  if (normalizedValue.isEmpty) {
+    throw ArgumentError.value(value, 'value', 'must not be blank');
+  }
+  return normalizedValue;
 }

--- a/packages/eqmonitor_map/lib/src/overlay/earthquake_map_overlay_snapshot.dart
+++ b/packages/eqmonitor_map/lib/src/overlay/earthquake_map_overlay_snapshot.dart
@@ -1,5 +1,7 @@
 import 'dart:ui';
 
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
+
 /// 震度区域の描画style。
 final class EarthquakeAreaStyle {
   const EarthquakeAreaStyle({
@@ -33,8 +35,7 @@ final class EarthquakeObservationPoint {
 /// 一つの地震sourceに対応する完全なoverlay描画入力。
 final class EarthquakeMapOverlaySnapshot {
   const EarthquakeMapOverlaySnapshot._({
-    required this.sourceId,
-    required this.revision,
+    required this.versionStamp,
     required this.regionToCityZoom,
     required this.stationMinZoom,
     required this.regionStyles,
@@ -42,8 +43,7 @@ final class EarthquakeMapOverlaySnapshot {
     required this.stations,
   });
 
-  final String sourceId;
-  final int revision;
+  final MapOverlayVersionStamp versionStamp;
   final double regionToCityZoom;
   final double stationMinZoom;
   final List<EarthquakeAreaStyle> regionStyles;
@@ -53,8 +53,7 @@ final class EarthquakeMapOverlaySnapshot {
 
 /// [EarthquakeMapOverlaySnapshot]を検証済みの不変入力から構築する。
 EarthquakeMapOverlaySnapshot createEarthquakeMapOverlaySnapshot({
-  required String sourceId,
-  required int revision,
+  required MapOverlayVersionStamp versionStamp,
   required double regionToCityZoom,
   required double stationMinZoom,
   required List<EarthquakeAreaStyle> regionStyles,
@@ -62,8 +61,6 @@ EarthquakeMapOverlaySnapshot createEarthquakeMapOverlaySnapshot({
   required List<EarthquakeObservationPoint> stations,
 }) {
   _validateSnapshotValues(
-    sourceId: sourceId,
-    revision: revision,
     regionToCityZoom: regionToCityZoom,
     stationMinZoom: stationMinZoom,
   );
@@ -72,8 +69,7 @@ EarthquakeMapOverlaySnapshot createEarthquakeMapOverlaySnapshot({
   _validateStations(stations: stations);
 
   return EarthquakeMapOverlaySnapshot._(
-    sourceId: sourceId,
-    revision: revision,
+    versionStamp: versionStamp,
     regionToCityZoom: regionToCityZoom,
     stationMinZoom: stationMinZoom,
     regionStyles: List<EarthquakeAreaStyle>.unmodifiable(regionStyles),
@@ -83,17 +79,9 @@ EarthquakeMapOverlaySnapshot createEarthquakeMapOverlaySnapshot({
 }
 
 void _validateSnapshotValues({
-  required String sourceId,
-  required int revision,
   required double regionToCityZoom,
   required double stationMinZoom,
 }) {
-  if (sourceId.trim().isEmpty) {
-    throw ArgumentError.value(sourceId, 'sourceId', 'must not be blank');
-  }
-  if (revision.isNegative) {
-    throw ArgumentError.value(revision, 'revision', 'must not be negative');
-  }
   if (!regionToCityZoom.isFinite) {
     throw ArgumentError.value(
       regionToCityZoom,

--- a/packages/eqmonitor_map/lib/src/overlay/earthquake_overlay_controller.dart
+++ b/packages/eqmonitor_map/lib/src/overlay/earthquake_overlay_controller.dart
@@ -1,4 +1,5 @@
 import 'package:eqmonitor_map/src/overlay/earthquake_map_overlay_snapshot.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
 
 /// snapshot更新を受理した結果。
 sealed class EarthquakeOverlayCommitResult {
@@ -21,14 +22,16 @@ final class EarthquakeOverlayCommitRejected
   final EarthquakeMapOverlaySnapshot current;
 }
 
-/// source/revision規約に従い、次の完全snapshotを判定する。
+/// data/render version規約に従い、次の完全snapshotを判定する。
 EarthquakeOverlayCommitResult commitEarthquakeOverlaySnapshot({
   required EarthquakeMapOverlaySnapshot? current,
   required EarthquakeMapOverlaySnapshot next,
 }) {
   if (current != null &&
-      current.sourceId == next.sourceId &&
-      next.revision < current.revision) {
+      !canAdvanceMapOverlayVersionStamp(
+        current: current.versionStamp,
+        next: next.versionStamp,
+      )) {
     return EarthquakeOverlayCommitRejected(current: current);
   }
   return EarthquakeOverlayCommitAccepted(next: next);

--- a/packages/eqmonitor_map/lib/src/overlay/earthquake_overlay_coverage.dart
+++ b/packages/eqmonitor_map/lib/src/overlay/earthquake_overlay_coverage.dart
@@ -1,3 +1,4 @@
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
 import 'package:flutter/foundation.dart';
 
 /// 可視範囲における地震overlayの準備状況。
@@ -6,6 +7,8 @@ sealed class EarthquakeOverlayCoverage {
   const EarthquakeOverlayCoverage();
 
   const factory EarthquakeOverlayCoverage.hidden() = EarthquakeOverlayHidden;
+
+  const factory EarthquakeOverlayCoverage.loading() = EarthquakeOverlayLoading;
 
   const factory EarthquakeOverlayCoverage.incomplete({
     required int requestedTileCount,
@@ -59,29 +62,25 @@ sealed class EarthquakeOverlayCoverage {
 @immutable
 final class EarthquakeOverlayCoverageSnapshot {
   const EarthquakeOverlayCoverageSnapshot({
-    required String this.sourceId,
-    required int this.revision,
+    required MapOverlayVersionStamp this.versionStamp,
     required this.coverage,
   });
 
   const EarthquakeOverlayCoverageSnapshot.hidden()
-    : sourceId = null,
-      revision = null,
+    : versionStamp = null,
       coverage = const EarthquakeOverlayCoverage.hidden();
 
-  final String? sourceId;
-  final int? revision;
+  final MapOverlayVersionStamp? versionStamp;
   final EarthquakeOverlayCoverage coverage;
 
   @override
   bool operator ==(Object other) =>
       other is EarthquakeOverlayCoverageSnapshot &&
-      other.sourceId == sourceId &&
-      other.revision == revision &&
+      other.versionStamp == versionStamp &&
       other.coverage == coverage;
 
   @override
-  int get hashCode => Object.hash(sourceId, revision, coverage);
+  int get hashCode => Object.hash(versionStamp, coverage);
 }
 
 /// overlayが非表示で、可視tileを要求していない状態。
@@ -90,6 +89,17 @@ final class EarthquakeOverlayHidden extends EarthquakeOverlayCoverage {
 
   @override
   bool operator ==(Object other) => other is EarthquakeOverlayHidden;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+/// commit候補のtile/material/textureを準備している状態。
+final class EarthquakeOverlayLoading extends EarthquakeOverlayCoverage {
+  const EarthquakeOverlayLoading();
+
+  @override
+  bool operator ==(Object other) => other is EarthquakeOverlayLoading;
 
   @override
   int get hashCode => runtimeType.hashCode;

--- a/packages/eqmonitor_map/lib/src/overlay/earthquake_overlay_coverage_owner.dart
+++ b/packages/eqmonitor_map/lib/src/overlay/earthquake_overlay_coverage_owner.dart
@@ -24,8 +24,7 @@ final class EarthquakeOverlayCoverageOwner {
     final next = overlay == null
         ? const EarthquakeOverlayCoverageSnapshot.hidden()
         : EarthquakeOverlayCoverageSnapshot(
-            sourceId: overlay.sourceId,
-            revision: overlay.revision,
+            versionStamp: overlay.versionStamp,
             coverage: coverage,
           );
     if (next == _snapshot) {

--- a/packages/eqmonitor_map/lib/src/overlay/map_overlay_version_stamp.dart
+++ b/packages/eqmonitor_map/lib/src/overlay/map_overlay_version_stamp.dart
@@ -1,0 +1,99 @@
+import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
+import 'package:flutter/foundation.dart';
+
+/// One immutable identity for an earthquake overlay's data and render input.
+@immutable
+final class MapOverlayVersionStamp {
+  const MapOverlayVersionStamp._({
+    required this.sourceIdentity,
+    required this.sourceIncarnation,
+    required this.dataSequence,
+    required this.dataDigest,
+    required this.renderGeneration,
+    required this.renderDigest,
+  });
+
+  final MapSourceIdentity sourceIdentity;
+  final MapSourceIncarnation sourceIncarnation;
+  final int dataSequence;
+  final String dataDigest;
+  final int renderGeneration;
+  final String renderDigest;
+
+  @override
+  bool operator ==(Object other) =>
+      other is MapOverlayVersionStamp &&
+      other.sourceIdentity == sourceIdentity &&
+      other.sourceIncarnation == sourceIncarnation &&
+      other.dataSequence == dataSequence &&
+      other.dataDigest == dataDigest &&
+      other.renderGeneration == renderGeneration &&
+      other.renderDigest == renderDigest;
+
+  @override
+  int get hashCode => Object.hash(
+    sourceIdentity,
+    sourceIncarnation,
+    dataSequence,
+    dataDigest,
+    renderGeneration,
+    renderDigest,
+  );
+}
+
+MapOverlayVersionStamp createMapOverlayVersionStamp({
+  required MapSourceIdentity sourceIdentity,
+  required MapSourceIncarnation sourceIncarnation,
+  required int dataSequence,
+  required String dataDigest,
+  required int renderGeneration,
+  required String renderDigest,
+}) {
+  if (dataSequence.isNegative) {
+    throw ArgumentError.value(dataSequence, 'dataSequence');
+  }
+  if (renderGeneration.isNegative) {
+    throw ArgumentError.value(renderGeneration, 'renderGeneration');
+  }
+  final normalizedDataDigest = dataDigest.trim();
+  final normalizedRenderDigest = renderDigest.trim();
+  if (normalizedDataDigest.isEmpty) {
+    throw ArgumentError.value(dataDigest, 'dataDigest', 'must not be blank');
+  }
+  if (normalizedRenderDigest.isEmpty) {
+    throw ArgumentError.value(
+      renderDigest,
+      'renderDigest',
+      'must not be blank',
+    );
+  }
+  return MapOverlayVersionStamp._(
+    sourceIdentity: sourceIdentity,
+    sourceIncarnation: sourceIncarnation,
+    dataSequence: dataSequence,
+    dataDigest: normalizedDataDigest,
+    renderGeneration: renderGeneration,
+    renderDigest: normalizedRenderDigest,
+  );
+}
+
+/// Whether [next] is a valid full-snapshot transition from [current].
+bool canAdvanceMapOverlayVersionStamp({
+  required MapOverlayVersionStamp current,
+  required MapOverlayVersionStamp next,
+}) {
+  if (current.sourceIdentity != next.sourceIdentity ||
+      current.sourceIncarnation != next.sourceIncarnation) {
+    return true;
+  }
+  if (next.dataSequence < current.dataSequence ||
+      next.renderGeneration < current.renderGeneration) {
+    return false;
+  }
+  if (next.dataSequence == current.dataSequence &&
+      next.dataDigest != current.dataDigest) {
+    return false;
+  }
+  return next.renderGeneration != current.renderGeneration ||
+      next.renderDigest == current.renderDigest;
+}

--- a/packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_builder.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_builder.dart
@@ -187,8 +187,7 @@ ObservationPointBatch? _reusableObservation({
   if (previous == null || overlay == null) {
     return null;
   }
-  return previous.sourceId == overlay.sourceId &&
-          previous.snapshotRevision == overlay.revision &&
+  return previous.versionStamp == overlay.versionStamp &&
           previous.hasStationSnapshotIdentity(overlay.stations)
       ? previous
       : null;

--- a/packages/eqmonitor_map/lib/src/renderer/observation_point_batch.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/observation_point_batch.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
 import 'package:eqmonitor_map/src/renderer/map_scene_frame_submission.dart';
 
 const observationPointInstanceStrideInBytes = 28;
@@ -15,12 +16,11 @@ final class ObservationPointInstanceGeneration {
   ObservationPointInstanceGeneration._();
 }
 
-/// 1 snapshot revision分の観測点instanceとframe固有uniform。
+/// 1 overlay version分の観測点instanceとframe固有uniform。
 final class ObservationPointBatch implements MapSceneObservationBatch {
   const ObservationPointBatch._({
     required this.frame,
-    required this.sourceId,
-    required this.snapshotRevision,
+    required this.versionStamp,
     required this.instanceGeneration,
     required this.instanceData,
     required this.instanceCount,
@@ -33,8 +33,7 @@ final class ObservationPointBatch implements MapSceneObservationBatch {
 
   @override
   final MapFrameSnapshot frame;
-  final String sourceId;
-  final int snapshotRevision;
+  final MapOverlayVersionStamp versionStamp;
   final ObservationPointInstanceGeneration instanceGeneration;
   final Float32List instanceData;
   final int instanceCount;
@@ -68,8 +67,7 @@ final class ObservationPointBatch implements MapSceneObservationBatch {
     );
     return ObservationPointBatch._(
       frame: frame,
-      sourceId: sourceId,
-      snapshotRevision: snapshotRevision,
+      versionStamp: versionStamp,
       instanceGeneration: instanceGeneration,
       instanceData: instanceData,
       instanceCount: instanceCount,
@@ -87,8 +85,7 @@ final class ObservationPointBatch implements MapSceneObservationBatch {
 /// 検証済みbyte列から観測点batchを作る。
 ObservationPointBatch createObservationPointBatch({
   required MapFrameSnapshot frame,
-  required String sourceId,
-  required int snapshotRevision,
+  required MapOverlayVersionStamp versionStamp,
   required Float32List instanceData,
   required int instanceCount,
   required ByteData frameUniform,
@@ -97,16 +94,6 @@ ObservationPointBatch createObservationPointBatch({
   required int translucentSortPriority,
   Object? stationSnapshotIdentity,
 }) {
-  if (sourceId.trim().isEmpty) {
-    throw ArgumentError.value(sourceId, 'sourceId', 'must not be blank');
-  }
-  if (snapshotRevision.isNegative) {
-    throw ArgumentError.value(
-      snapshotRevision,
-      'snapshotRevision',
-      'must not be negative',
-    );
-  }
   if (instanceCount <= 0 ||
       instanceData.lengthInBytes !=
           instanceCount * observationPointInstanceStrideInBytes) {
@@ -133,8 +120,7 @@ ObservationPointBatch createObservationPointBatch({
   );
   return ObservationPointBatch._(
     frame: frame,
-    sourceId: sourceId,
-    snapshotRevision: snapshotRevision,
+    versionStamp: versionStamp,
     instanceGeneration: ObservationPointInstanceGeneration._(),
     instanceData: ownedInstances.asUnmodifiableView(),
     instanceCount: instanceCount,

--- a/packages/eqmonitor_map/lib/src/renderer/observation_point_batch_builder.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/observation_point_batch_builder.dart
@@ -29,12 +29,11 @@ ObservationPointBatch? buildObservationPointBatch({
 
   final canReuse =
       previous != null &&
-      previous.sourceId == snapshot.sourceId &&
-      previous.snapshotRevision == snapshot.revision &&
+      previous.versionStamp == snapshot.versionStamp &&
       previous.hasStationSnapshotIdentity(snapshot.stations);
   if (canReuse && previous.instanceCount != snapshot.stations.length) {
     throw StateError(
-      'Observation station count changed without a snapshot revision change.',
+      'Observation station count changed without a version stamp change.',
     );
   }
   final frameUniform = packObservationFrameUniform(
@@ -54,8 +53,7 @@ ObservationPointBatch? buildObservationPointBatch({
   );
   return createObservationPointBatch(
     frame: frame,
-    sourceId: snapshot.sourceId,
-    snapshotRevision: snapshot.revision,
+    versionStamp: snapshot.versionStamp,
     instanceData: instanceData,
     instanceCount: snapshot.stations.length,
     frameUniform: frameUniform,

--- a/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
@@ -10,10 +10,12 @@ import 'package:eqmonitor_map/src/foundation/render/map_render_batch.dart';
 import 'package:eqmonitor_map/src/foundation/render/map_render_packet.dart';
 import 'package:eqmonitor_map/src/foundation/render/map_render_phase.dart';
 import 'package:eqmonitor_map/src/foundation/render/map_render_sort_key.dart';
+import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
 import 'package:eqmonitor_map/src/geo/map_camera.dart';
 import 'package:eqmonitor_map/src/geo/map_viewport.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_map_overlay_snapshot.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
 import 'package:eqmonitor_map/src/renderer/base_map_packed_mesh.dart';
 import 'package:eqmonitor_map/src/renderer/base_map_render_submission_builder.dart';
 import 'package:eqmonitor_map/src/renderer/earthquake_area_render_submission_builder.dart';
@@ -264,11 +266,17 @@ void main() {
   );
 
   EarthquakeMapOverlaySnapshot observationSnapshot({
-    required int revision,
+    required int dataSequence,
     Color stationColor = const Color(0xFFFF0000),
   }) => createEarthquakeMapOverlaySnapshot(
-    sourceId: 'event-1',
-    revision: revision,
+    versionStamp: createMapOverlayVersionStamp(
+      sourceIdentity: createMapSourceIdentity(value: 'event-1'),
+      sourceIncarnation: createMapSourceIncarnation(value: 'incarnation-1'),
+      dataSequence: dataSequence,
+      dataDigest: 'data-$dataSequence',
+      renderGeneration: dataSequence,
+      renderDigest: 'render-$dataSequence',
+    ),
     regionToCityZoom: 6,
     stationMinZoom: 6,
     regionStyles: const [],
@@ -452,7 +460,7 @@ void main() {
     final batch = _requireObservationPointBatch(
       buildObservationPointBatch(
         frame: observationFrame,
-        snapshot: observationSnapshot(revision: 1),
+        snapshot: observationSnapshot(dataSequence: 1),
       ),
     );
     final sceneGraph = _RecordingSceneGraph();
@@ -483,10 +491,10 @@ void main() {
   });
 
   test(
-    'same revision keeps geometry identity and changes only frame uniform',
+    'same version stamp keeps geometry identity and changes only frame uniform',
     () {
       final firstFrame = observationFrameAt(frameNumber: 0);
-      final snapshot = observationSnapshot(revision: 1);
+      final snapshot = observationSnapshot(dataSequence: 1);
       final firstBatch = _requireObservationPointBatch(
         buildObservationPointBatch(
           frame: firstFrame,
@@ -542,12 +550,12 @@ void main() {
     },
   );
 
-  test('same source and revision with changed color creates new geometry', () {
+  test('same version stamp with changed color creates new geometry', () {
     final firstFrame = observationFrameAt(frameNumber: 0);
     final firstBatch = _requireObservationPointBatch(
       buildObservationPointBatch(
         frame: firstFrame,
-        snapshot: observationSnapshot(revision: 1),
+        snapshot: observationSnapshot(dataSequence: 1),
       ),
     );
     final secondFrame = observationFrameAt(frameNumber: 1);
@@ -555,7 +563,7 @@ void main() {
       buildObservationPointBatch(
         frame: secondFrame,
         snapshot: observationSnapshot(
-          revision: 1,
+          dataSequence: 1,
           stationColor: const Color(0xFF0000FF),
         ),
         previous: firstBatch,
@@ -595,7 +603,7 @@ void main() {
       final batch = _requireObservationPointBatch(
         buildObservationPointBatch(
           frame: observationFrame,
-          snapshot: observationSnapshot(revision: 1),
+          snapshot: observationSnapshot(dataSequence: 1),
         ),
       );
       final sceneGraph = _RecordingSceneGraph();
@@ -631,14 +639,14 @@ void main() {
     final firstBatch = _requireObservationPointBatch(
       buildObservationPointBatch(
         frame: firstFrame,
-        snapshot: observationSnapshot(revision: 1),
+        snapshot: observationSnapshot(dataSequence: 1),
       ),
     );
     final secondFrame = observationFrameAt(frameNumber: 1);
     final secondBatch = _requireObservationPointBatch(
       buildObservationPointBatch(
         frame: secondFrame,
-        snapshot: observationSnapshot(revision: 2),
+        snapshot: observationSnapshot(dataSequence: 2),
       ),
     );
     final sceneGraph = _RecordingSceneGraph();
@@ -683,7 +691,7 @@ void main() {
     'context generation change creates new geometry before retiring old',
     () {
       final firstFrame = observationFrameAt(frameNumber: 0);
-      final snapshot = observationSnapshot(revision: 1);
+      final snapshot = observationSnapshot(dataSequence: 1);
       final firstBatch = _requireObservationPointBatch(
         buildObservationPointBatch(
           frame: firstFrame,
@@ -745,7 +753,7 @@ void main() {
 
   test('context generation change forbids reuse if an old id reappears', () {
     final firstFrame = observationFrameAt(frameNumber: 0);
-    final snapshot = observationSnapshot(revision: 1);
+    final snapshot = observationSnapshot(dataSequence: 1);
     final firstBatch = _requireObservationPointBatch(
       buildObservationPointBatch(
         frame: firstFrame,
@@ -798,7 +806,7 @@ void main() {
       final firstBatch = _requireObservationPointBatch(
         buildObservationPointBatch(
           frame: firstFrame,
-          snapshot: observationSnapshot(revision: 1),
+          snapshot: observationSnapshot(dataSequence: 1),
         ),
       );
       final sceneGraph = _RecordingSceneGraph();
@@ -842,7 +850,7 @@ void main() {
     final firstBatch = _requireObservationPointBatch(
       buildObservationPointBatch(
         frame: firstFrame,
-        snapshot: observationSnapshot(revision: 1),
+        snapshot: observationSnapshot(dataSequence: 1),
       ),
     );
     final sceneGraph = _RecordingSceneGraph();
@@ -882,7 +890,7 @@ void main() {
     final firstBatch = _requireObservationPointBatch(
       buildObservationPointBatch(
         frame: firstFrame,
-        snapshot: observationSnapshot(revision: 1),
+        snapshot: observationSnapshot(dataSequence: 1),
       ),
     );
     final sceneGraph = _RecordingSceneGraph();
@@ -911,7 +919,7 @@ void main() {
 
   test('fails closed when a live cached geometry was already retired', () {
     final firstFrame = observationFrameAt(frameNumber: 0);
-    final snapshot = observationSnapshot(revision: 1);
+    final snapshot = observationSnapshot(dataSequence: 1);
     final firstBatch = _requireObservationPointBatch(
       buildObservationPointBatch(
         frame: firstFrame,

--- a/packages/eqmonitor_map/test/overlay/earthquake_map_overlay_snapshot_test.dart
+++ b/packages/eqmonitor_map/test/overlay/earthquake_map_overlay_snapshot_test.dart
@@ -22,17 +22,31 @@ void main() {
     radiusLogicalPixels: 6.7,
   );
 
+  MapOverlayVersionStamp versionStamp({
+    String sourceIdentity = 'earthquake-20260823',
+    String sourceIncarnation = '019c8f5e-1f00-7000-8000-000000000001',
+    int dataSequence = 42,
+    String dataDigest = 'data-sha256',
+    int renderGeneration = 7,
+    String renderDigest = 'render-sha256',
+  }) => createMapOverlayVersionStamp(
+    sourceIdentity: createMapSourceIdentity(value: sourceIdentity),
+    sourceIncarnation: createMapSourceIncarnation(value: sourceIncarnation),
+    dataSequence: dataSequence,
+    dataDigest: dataDigest,
+    renderGeneration: renderGeneration,
+    renderDigest: renderDigest,
+  );
+
   EarthquakeMapOverlaySnapshot snapshot({
-    String sourceId = 'earthquake-20260823',
-    int revision = 42,
+    MapOverlayVersionStamp? version,
     double regionToCityZoom = 6,
     double stationMinZoom = 6,
     List<EarthquakeAreaStyle> regionStyles = const [regionStyle],
     List<EarthquakeAreaStyle> cityStyles = const [cityStyle],
     List<EarthquakeObservationPoint> stations = const [station],
   }) => createEarthquakeMapOverlaySnapshot(
-    sourceId: sourceId,
-    revision: revision,
+    versionStamp: version ?? versionStamp(),
     regionToCityZoom: regionToCityZoom,
     stationMinZoom: stationMinZoom,
     regionStyles: regionStyles,
@@ -40,12 +54,35 @@ void main() {
     stations: stations,
   );
 
-  test('rejects blank source ID after trimming', () {
-    expect(() => snapshot(sourceId: '  '), throwsArgumentError);
+  test('version stamp rejects blank typed identities and digests', () {
+    expect(() => versionStamp(sourceIdentity: '  '), throwsArgumentError);
+    expect(() => versionStamp(sourceIncarnation: '\n'), throwsArgumentError);
+    expect(() => versionStamp(dataDigest: '\t'), throwsArgumentError);
+    expect(() => versionStamp(renderDigest: ' '), throwsArgumentError);
   });
 
-  test('rejects negative revision', () {
-    expect(() => snapshot(revision: -1), throwsArgumentError);
+  test('version stamp rejects negative sequence and generation', () {
+    expect(() => versionStamp(dataSequence: -1), throwsArgumentError);
+    expect(() => versionStamp(renderGeneration: -1), throwsArgumentError);
+  });
+
+  test('version stamp normalizes values and supports value equality', () {
+    final first = versionStamp(
+      sourceIdentity: ' event-a ',
+      sourceIncarnation: ' incarnation-a ',
+      dataDigest: ' data-a ',
+      renderDigest: ' render-a ',
+    );
+    final second = versionStamp(
+      sourceIdentity: 'event-a',
+      sourceIncarnation: 'incarnation-a',
+      dataDigest: 'data-a',
+      renderDigest: 'render-a',
+    );
+
+    expect(first, second);
+    expect(first.hashCode, second.hashCode);
+    expect(snapshot(version: first).versionStamp, first);
   });
 
   test('rejects non-finite zoom values', () {

--- a/packages/eqmonitor_map/test/overlay/earthquake_overlay_controller_test.dart
+++ b/packages/eqmonitor_map/test/overlay/earthquake_overlay_controller_test.dart
@@ -4,13 +4,27 @@ import 'package:eqmonitor_map/eqmonitor_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  MapOverlayVersionStamp versionStamp({
+    required String sourceIdentity,
+    required int dataSequence,
+    required int renderGeneration,
+    String sourceIncarnation = 'incarnation-a',
+    String dataDigest = 'data-a',
+    String renderDigest = 'render-a',
+  }) => createMapOverlayVersionStamp(
+    sourceIdentity: createMapSourceIdentity(value: sourceIdentity),
+    sourceIncarnation: createMapSourceIncarnation(value: sourceIncarnation),
+    dataSequence: dataSequence,
+    dataDigest: dataDigest,
+    renderGeneration: renderGeneration,
+    renderDigest: renderDigest,
+  );
+
   EarthquakeMapOverlaySnapshot snapshot({
-    required String sourceId,
-    required int revision,
+    required MapOverlayVersionStamp versionStamp,
     required Color color,
   }) => createEarthquakeMapOverlaySnapshot(
-    sourceId: sourceId,
-    revision: revision,
+    versionStamp: versionStamp,
     regionToCityZoom: 6,
     stationMinZoom: 6,
     regionStyles: [
@@ -20,15 +34,21 @@ void main() {
     stations: const [],
   );
 
-  test('rejects a lower revision from the current source', () {
+  test('rejects a lower data sequence from the current source', () {
     final current = snapshot(
-      sourceId: 'event-a',
-      revision: 8,
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        dataSequence: 8,
+        renderGeneration: 8,
+      ),
       color: const Color(0xfff44336),
     );
     final stale = snapshot(
-      sourceId: 'event-a',
-      revision: 7,
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        dataSequence: 7,
+        renderGeneration: 8,
+      ),
       color: const Color(0xffff9800),
     );
 
@@ -41,15 +61,87 @@ void main() {
     expect((result as EarthquakeOverlayCommitRejected).current, same(current));
   });
 
-  test('accepts the same revision to replace the theme', () {
+  test('rejects equal data sequence with a conflicting digest', () {
     final current = snapshot(
-      sourceId: 'event-a',
-      revision: 8,
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        dataSequence: 8,
+        renderGeneration: 8,
+      ),
+      color: const Color(0xfff44336),
+    );
+    final conflicting = snapshot(
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        dataSequence: 8,
+        dataDigest: 'data-b',
+        renderGeneration: 9,
+        renderDigest: 'render-b',
+      ),
+      color: const Color(0xff2196f3),
+    );
+
+    final result = commitEarthquakeOverlaySnapshot(
+      current: current,
+      next: conflicting,
+    );
+
+    expect(result, isA<EarthquakeOverlayCommitRejected>());
+  });
+
+  test('rejects lower or conflicting render generation', () {
+    final current = snapshot(
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        dataSequence: 8,
+        renderGeneration: 8,
+      ),
+      color: const Color(0xfff44336),
+    );
+    final lower = snapshot(
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        dataSequence: 8,
+        renderGeneration: 7,
+      ),
+      color: const Color(0xffff9800),
+    );
+    final conflicting = snapshot(
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        dataSequence: 8,
+        renderGeneration: 8,
+        renderDigest: 'render-b',
+      ),
+      color: const Color(0xff2196f3),
+    );
+
+    expect(
+      commitEarthquakeOverlaySnapshot(current: current, next: lower),
+      isA<EarthquakeOverlayCommitRejected>(),
+    );
+    expect(
+      commitEarthquakeOverlaySnapshot(current: current, next: conflicting),
+      isA<EarthquakeOverlayCommitRejected>(),
+    );
+  });
+
+  test('accepts a higher render generation without changing data version', () {
+    final current = snapshot(
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        dataSequence: 8,
+        renderGeneration: 8,
+      ),
       color: const Color(0xfff44336),
     );
     final themed = snapshot(
-      sourceId: 'event-a',
-      revision: 8,
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        dataSequence: 8,
+        renderGeneration: 9,
+        renderDigest: 'render-b',
+      ),
       color: const Color(0xff2196f3),
     );
 
@@ -62,15 +154,45 @@ void main() {
     expect((result as EarthquakeOverlayCommitAccepted).next, same(themed));
   });
 
+  test('accepts an exactly identical stamp idempotently', () {
+    final stamp = versionStamp(
+      sourceIdentity: 'event-a',
+      dataSequence: 8,
+      renderGeneration: 8,
+    );
+    final current = snapshot(
+      versionStamp: stamp,
+      color: const Color(0xfff44336),
+    );
+    final identicalVersion = snapshot(
+      versionStamp: stamp,
+      color: const Color(0xfff44336),
+    );
+
+    expect(
+      commitEarthquakeOverlaySnapshot(
+        current: current,
+        next: identicalVersion,
+      ),
+      isA<EarthquakeOverlayCommitAccepted>(),
+    );
+  });
+
   test('atomically replaces the current snapshot from another source', () {
     final current = snapshot(
-      sourceId: 'event-a',
-      revision: 100,
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        dataSequence: 100,
+        renderGeneration: 100,
+      ),
       color: const Color(0xfff44336),
     );
     final replacement = snapshot(
-      sourceId: 'event-b',
-      revision: 0,
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-b',
+        dataSequence: 0,
+        renderGeneration: 0,
+      ),
       color: const Color(0xff2196f3),
     );
 
@@ -86,10 +208,38 @@ void main() {
     );
   });
 
+  test('accepts a fresh incarnation of the same source from sequence zero', () {
+    final current = snapshot(
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        dataSequence: 100,
+        renderGeneration: 100,
+      ),
+      color: const Color(0xfff44336),
+    );
+    final replacement = snapshot(
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        sourceIncarnation: 'incarnation-b',
+        dataSequence: 0,
+        renderGeneration: 0,
+      ),
+      color: const Color(0xff2196f3),
+    );
+
+    expect(
+      commitEarthquakeOverlaySnapshot(current: current, next: replacement),
+      isA<EarthquakeOverlayCommitAccepted>(),
+    );
+  });
+
   test('accepts an initial snapshot', () {
     final initial = snapshot(
-      sourceId: 'event-a',
-      revision: 0,
+      versionStamp: versionStamp(
+        sourceIdentity: 'event-a',
+        dataSequence: 0,
+        renderGeneration: 0,
+      ),
       color: const Color(0xfff44336),
     );
 

--- a/packages/eqmonitor_map/test/overlay/earthquake_overlay_coverage_test.dart
+++ b/packages/eqmonitor_map/test/overlay/earthquake_overlay_coverage_test.dart
@@ -1,7 +1,31 @@
+import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_overlay_coverage.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  final versionStamp = createMapOverlayVersionStamp(
+    sourceIdentity: createMapSourceIdentity(value: 'event-a'),
+    sourceIncarnation: createMapSourceIncarnation(value: 'incarnation-a'),
+    dataSequence: 3,
+    dataDigest: 'data-a',
+    renderGeneration: 5,
+    renderDigest: 'render-a',
+  );
+
+  test('only the hidden snapshot omits a committed version stamp', () {
+    const hidden = EarthquakeOverlayCoverageSnapshot.hidden();
+    final loading = EarthquakeOverlayCoverageSnapshot(
+      versionStamp: versionStamp,
+      coverage: const EarthquakeOverlayCoverage.loading(),
+    );
+
+    expect(hidden.versionStamp, isNull);
+    expect(hidden.coverage, isA<EarthquakeOverlayHidden>());
+    expect(loading.versionStamp, versionStamp);
+    expect(loading.coverage, isA<EarthquakeOverlayLoading>());
+  });
+
   test('is hidden when no tiles are requested', () {
     final coverage = EarthquakeOverlayCoverage.fromCounts(
       requestedTileCount: 0,

--- a/packages/eqmonitor_map/test/overlay/map_overlay_version_stamp_test.dart
+++ b/packages/eqmonitor_map/test/overlay/map_overlay_version_stamp_test.dart
@@ -1,0 +1,105 @@
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+MapOverlayVersionStamp _stamp({
+  String sourceIdentity = 'event-a',
+  String sourceIncarnation = 'incarnation-a',
+  int dataSequence = 3,
+  String dataDigest = 'data-a',
+  int renderGeneration = 5,
+  String renderDigest = 'render-a',
+}) => createMapOverlayVersionStamp(
+  sourceIdentity: createMapSourceIdentity(value: sourceIdentity),
+  sourceIncarnation: createMapSourceIncarnation(value: sourceIncarnation),
+  dataSequence: dataSequence,
+  dataDigest: dataDigest,
+  renderGeneration: renderGeneration,
+  renderDigest: renderDigest,
+);
+
+void main() {
+  test('normalizes every string and provides full value equality', () {
+    final first = _stamp(
+      sourceIdentity: ' event-a ',
+      sourceIncarnation: ' incarnation-a ',
+      dataDigest: ' data-a ',
+      renderDigest: ' render-a ',
+    );
+    final second = _stamp();
+
+    expect(first, second);
+    expect(first.hashCode, second.hashCode);
+  });
+
+  test('rejects blank values and negative counters', () {
+    expect(() => _stamp(sourceIdentity: ' '), throwsArgumentError);
+    expect(() => _stamp(sourceIncarnation: '\n'), throwsArgumentError);
+    expect(() => _stamp(dataDigest: '\t'), throwsArgumentError);
+    expect(() => _stamp(renderDigest: ' '), throwsArgumentError);
+    expect(() => _stamp(dataSequence: -1), throwsArgumentError);
+    expect(() => _stamp(renderGeneration: -1), throwsArgumentError);
+  });
+
+  test('accepts only monotonic, digest-consistent same-source transitions', () {
+    final current = _stamp();
+
+    expect(
+      canAdvanceMapOverlayVersionStamp(
+        current: current,
+        next: _stamp(dataSequence: 2),
+      ),
+      isFalse,
+    );
+    expect(
+      canAdvanceMapOverlayVersionStamp(
+        current: current,
+        next: _stamp(dataDigest: 'data-b'),
+      ),
+      isFalse,
+    );
+    expect(
+      canAdvanceMapOverlayVersionStamp(
+        current: current,
+        next: _stamp(renderGeneration: 4),
+      ),
+      isFalse,
+    );
+    expect(
+      canAdvanceMapOverlayVersionStamp(
+        current: current,
+        next: _stamp(renderDigest: 'render-b'),
+      ),
+      isFalse,
+    );
+    expect(
+      canAdvanceMapOverlayVersionStamp(current: current, next: _stamp()),
+      isTrue,
+    );
+    expect(
+      canAdvanceMapOverlayVersionStamp(
+        current: current,
+        next: _stamp(renderGeneration: 6, renderDigest: 'render-b'),
+      ),
+      isTrue,
+    );
+  });
+
+  test('accepts a new identity or incarnation as full replacement', () {
+    final current = _stamp(dataSequence: 100, renderGeneration: 100);
+
+    expect(
+      canAdvanceMapOverlayVersionStamp(
+        current: current,
+        next: _stamp(sourceIdentity: 'event-b'),
+      ),
+      isTrue,
+    );
+    expect(
+      canAdvanceMapOverlayVersionStamp(
+        current: current,
+        next: _stamp(sourceIncarnation: 'incarnation-b'),
+      ),
+      isTrue,
+    );
+  });
+}

--- a/packages/eqmonitor_map/test/renderer/earthquake_area_render_submission_builder_test.dart
+++ b/packages/eqmonitor_map/test/renderer/earthquake_area_render_submission_builder_test.dart
@@ -3,11 +3,13 @@ import 'dart:ui';
 
 import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
+import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
 import 'package:eqmonitor_map/src/geo/map_camera.dart';
 import 'package:eqmonitor_map/src/geo/map_viewport.dart';
 import 'package:eqmonitor_map/src/geo/tile_id.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_map_overlay_snapshot.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
 import 'package:eqmonitor_map/src/renderer/earthquake_area_packed_mesh_cache.dart';
 import 'package:eqmonitor_map/src/renderer/earthquake_area_render_submission_builder.dart';
 import 'package:eqmonitor_map/src/renderer/map_scene_render_phase_policy.dart';
@@ -39,10 +41,18 @@ void main() {
         contextGeneration: 0,
       );
 
-  EarthquakeMapOverlaySnapshot snapshot({int revision = 3}) =>
+  EarthquakeMapOverlaySnapshot snapshot({int dataSequence = 3}) =>
       createEarthquakeMapOverlaySnapshot(
-        sourceId: 'event-1',
-        revision: revision,
+        versionStamp: createMapOverlayVersionStamp(
+          sourceIdentity: createMapSourceIdentity(value: 'event-1'),
+          sourceIncarnation: createMapSourceIncarnation(
+            value: 'incarnation-1',
+          ),
+          dataSequence: dataSequence,
+          dataDigest: 'data-$dataSequence',
+          renderGeneration: dataSequence,
+          renderDigest: 'render-$dataSequence',
+        ),
         regionToCityZoom: 6,
         stationMinZoom: 6,
         regionStyles: const [
@@ -184,7 +194,7 @@ void main() {
     );
     final second = buildEarthquakeAreaRenderSubmission(
       frame: frameAt(5, frameNumber: 8),
-      snapshot: snapshot(revision: 4),
+      snapshot: snapshot(dataSequence: 4),
       exactTileResults: [exactResult],
       packedMeshFor: packedMeshCache.resolve,
     );

--- a/packages/eqmonitor_map/test/renderer/observation_point_batch_builder_test.dart
+++ b/packages/eqmonitor_map/test/renderer/observation_point_batch_builder_test.dart
@@ -3,9 +3,11 @@ import 'dart:ui';
 
 import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
+import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
 import 'package:eqmonitor_map/src/geo/map_camera.dart';
 import 'package:eqmonitor_map/src/geo/map_viewport.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_map_overlay_snapshot.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -28,6 +30,18 @@ void main() {
     devicePixelRatio: 3,
   );
 
+  MapOverlayVersionStamp versionStamp({int dataSequence = 3}) =>
+      createMapOverlayVersionStamp(
+        sourceIdentity: createMapSourceIdentity(value: 'event-1'),
+        sourceIncarnation: createMapSourceIncarnation(
+          value: 'incarnation-1',
+        ),
+        dataSequence: dataSequence,
+        dataDigest: 'data-$dataSequence',
+        renderGeneration: dataSequence,
+        renderDigest: 'render-$dataSequence',
+      );
+
   MapFrameSnapshot frame({
     int frameNumber = 0,
     double centerLongitude = 139.7,
@@ -48,7 +62,7 @@ void main() {
   );
 
   EarthquakeMapOverlaySnapshot snapshot({
-    int revision = 3,
+    int dataSequence = 3,
     List<EarthquakeObservationPoint> stations = const [
       EarthquakeObservationPoint(
         id: 'tokyo',
@@ -59,8 +73,7 @@ void main() {
       ),
     ],
   }) => createEarthquakeMapOverlaySnapshot(
-    sourceId: 'event-1',
-    revision: revision,
+    versionStamp: versionStamp(dataSequence: dataSequence),
     regionToCityZoom: 6,
     stationMinZoom: 6,
     regionStyles: const [],
@@ -196,7 +209,7 @@ void main() {
   );
 
   test(
-    'same source and revision with changed station color is new generation',
+    'same version stamp with changed station color is new generation',
     () {
       final first = _requireObservationPointBatch(
         buildObservationPointBatch(
@@ -243,8 +256,7 @@ void main() {
       ..setFloat32(0, 0.25, Endian.little);
     final batch = createObservationPointBatch(
       frame: template.frame,
-      sourceId: template.sourceId,
-      snapshotRevision: template.snapshotRevision,
+      versionStamp: template.versionStamp,
       instanceData: callerInstances,
       instanceCount: template.instanceCount,
       frameUniform: callerUniform,

--- a/packages/eqmonitor_map/test/widget/base_map_overlay_frame_builder_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_overlay_frame_builder_test.dart
@@ -6,6 +6,7 @@ import 'package:eqmonitor_map/src/flutter_scene/earthquake_overlay_material_owne
 import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_map_adapter.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
+import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
 import 'package:eqmonitor_map/src/geo/map_camera.dart';
 import 'package:eqmonitor_map/src/geo/map_viewport.dart';
 import 'package:eqmonitor_map/src/geo/tile_id.dart';
@@ -13,6 +14,7 @@ import 'package:eqmonitor_map/src/mesh/fill_mesh.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_map_overlay_snapshot.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_overlay_coverage.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_overlay_coverage_owner.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
 import 'package:eqmonitor_map/src/renderer/base_map_overlay_frame_builder.dart';
 import 'package:eqmonitor_map/src/renderer/base_map_overlay_frame_owner.dart';
 import 'package:eqmonitor_map/src/renderer/earthquake_area_packed_mesh_cache.dart';
@@ -151,15 +153,41 @@ void main() {
     contextGeneration: 0,
   );
 
+  MapOverlayVersionStamp versionStamp({
+    String sourceIdentity = 'event-a',
+    String sourceIncarnation = 'incarnation-a',
+    int dataSequence = 8,
+    String dataDigest = 'data-a',
+    int renderGeneration = 8,
+    String renderDigest = 'render-a',
+  }) => createMapOverlayVersionStamp(
+    sourceIdentity: createMapSourceIdentity(value: sourceIdentity),
+    sourceIncarnation: createMapSourceIncarnation(value: sourceIncarnation),
+    dataSequence: dataSequence,
+    dataDigest: dataDigest,
+    renderGeneration: renderGeneration,
+    renderDigest: renderDigest,
+  );
+
   EarthquakeMapOverlaySnapshot snapshot({
-    String sourceId = 'event-a',
-    int revision = 8,
+    String sourceIdentity = 'event-a',
+    String sourceIncarnation = 'incarnation-a',
+    int dataSequence = 8,
+    String dataDigest = 'data-a',
+    int renderGeneration = 8,
+    String renderDigest = 'render-a',
     String regionCode = '130',
     String cityCode = '13101',
     Color color = const Color(0xFFFF0000),
   }) => createEarthquakeMapOverlaySnapshot(
-    sourceId: sourceId,
-    revision: revision,
+    versionStamp: versionStamp(
+      sourceIdentity: sourceIdentity,
+      sourceIncarnation: sourceIncarnation,
+      dataSequence: dataSequence,
+      dataDigest: dataDigest,
+      renderGeneration: renderGeneration,
+      renderDigest: renderDigest,
+    ),
     regionToCityZoom: 6,
     stationMinZoom: 6,
     regionStyles: [
@@ -282,9 +310,12 @@ void main() {
     expect(result.coverage, const EarthquakeOverlayCoverage.hidden());
   });
 
-  test('same-source revision regression keeps the current full snapshot', () {
+  test('same-source data sequence regression keeps the current snapshot', () {
     final current = snapshot();
-    final stale = snapshot(revision: 7, color: const Color(0xFF0000FF));
+    final stale = snapshot(
+      dataSequence: 7,
+      color: const Color(0xFF0000FF),
+    );
 
     final result = build(
       frame: frameAt(5),
@@ -306,8 +337,9 @@ void main() {
 
   test('another source atomically replaces Fill and station inputs', () {
     final replacement = snapshot(
-      sourceId: 'event-b',
-      revision: 0,
+      sourceIdentity: 'event-b',
+      dataSequence: 0,
+      renderGeneration: 0,
       regionCode: '999',
       cityCode: '99999',
       color: const Color(0xFF0000FF),
@@ -315,7 +347,7 @@ void main() {
 
     final result = build(
       frame: frameAt(6),
-      current: snapshot(revision: 100),
+      current: snapshot(dataSequence: 100, renderGeneration: 100),
       requested: replacement,
     );
 
@@ -454,25 +486,24 @@ void main() {
     owner.hide(overlay: value);
 
     expect(values, [
-      const EarthquakeOverlayCoverageSnapshot(
-        sourceId: 'event-a',
-        revision: 8,
+      EarthquakeOverlayCoverageSnapshot(
+        versionStamp: value.versionStamp,
         coverage: incomplete,
       ),
-      const EarthquakeOverlayCoverageSnapshot(
-        sourceId: 'event-a',
-        revision: 8,
-        coverage: EarthquakeOverlayCoverage.complete(requestedTileCount: 1),
+      EarthquakeOverlayCoverageSnapshot(
+        versionStamp: value.versionStamp,
+        coverage: const EarthquakeOverlayCoverage.complete(
+          requestedTileCount: 1,
+        ),
       ),
-      const EarthquakeOverlayCoverageSnapshot(
-        sourceId: 'event-a',
-        revision: 8,
-        coverage: EarthquakeOverlayCoverage.hidden(),
+      EarthquakeOverlayCoverageSnapshot(
+        versionStamp: value.versionStamp,
+        coverage: const EarthquakeOverlayCoverage.hidden(),
       ),
     ]);
   });
 
-  test('same-source revision regression publishes committed provenance', () {
+  test('same-source data regression publishes committed provenance', () {
     final values = <EarthquakeOverlayCoverageSnapshot>[];
     final frames = BaseMapOverlayFrameOwner(onCoverageChanged: values.add);
     final current = snapshot();
@@ -492,7 +523,7 @@ void main() {
     );
     values.clear();
 
-    final stale = snapshot(revision: 7);
+    final stale = snapshot(dataSequence: 7);
     final candidate = build(
       frame: frameAt(6, frameNumber: 1),
       current: frames.overlay,
@@ -509,8 +540,7 @@ void main() {
     );
 
     expect(candidate.overlay, same(current));
-    expect(values.single.sourceId, 'event-a');
-    expect(values.single.revision, 8);
+    expect(values.single.versionStamp, current.versionStamp);
     expect(values.single.coverage, isA<EarthquakeOverlayIncomplete>());
   });
 
@@ -551,8 +581,7 @@ void main() {
       failClosedResources: () {},
     );
 
-    expect(delayedCallbackValues.single.sourceId, 'event-a');
-    expect(delayedCallbackValues.single.revision, 8);
+    expect(delayedCallbackValues.single.versionStamp, eventA.versionStamp);
     expect(
       delayedCallbackValues.single.coverage,
       isA<EarthquakeOverlayIncomplete>(),
@@ -659,8 +688,9 @@ void main() {
 
       rejectsLoad = true;
       final eventB = snapshot(
-        sourceId: 'event-b',
-        revision: 0,
+        sourceIdentity: 'event-b',
+        dataSequence: 0,
+        renderGeneration: 0,
         color: const Color(0xFF0000FF),
       );
       final failedPreparation = await materials.prepare(
@@ -696,10 +726,11 @@ void main() {
       expect(frames.previousObservationBatch, isNull);
       expect(frames.coverage, const EarthquakeOverlayCoverage.hidden());
       expect(coverages, [
-        const EarthquakeOverlayCoverageSnapshot(
-          sourceId: 'event-a',
-          revision: 8,
-          coverage: EarthquakeOverlayCoverage.complete(requestedTileCount: 1),
+        EarthquakeOverlayCoverageSnapshot(
+          versionStamp: eventA.versionStamp,
+          coverage: const EarthquakeOverlayCoverage.complete(
+            requestedTileCount: 1,
+          ),
         ),
         const EarthquakeOverlayCoverageSnapshot.hidden(),
       ]);
@@ -752,8 +783,9 @@ void main() {
       );
 
       final eventB = snapshot(
-        sourceId: 'event-b',
-        revision: 0,
+        sourceIdentity: 'event-b',
+        dataSequence: 0,
+        renderGeneration: 0,
         regionCode: '999',
         cityCode: '99999',
         color: const Color(0xFF0000FF),
@@ -824,10 +856,11 @@ void main() {
       expect(frames.previousObservationBatch, isNull);
       expect(frames.coverage, const EarthquakeOverlayCoverage.hidden());
       expect(coverages, [
-        const EarthquakeOverlayCoverageSnapshot(
-          sourceId: 'event-a',
-          revision: 8,
-          coverage: EarthquakeOverlayCoverage.complete(requestedTileCount: 1),
+        EarthquakeOverlayCoverageSnapshot(
+          versionStamp: eventA.versionStamp,
+          coverage: const EarthquakeOverlayCoverage.complete(
+            requestedTileCount: 1,
+          ),
         ),
         const EarthquakeOverlayCoverageSnapshot.hidden(),
       ]);
@@ -915,8 +948,9 @@ void main() {
       );
 
       final eventB = snapshot(
-        sourceId: 'event-b',
-        revision: 0,
+        sourceIdentity: 'event-b',
+        dataSequence: 0,
+        renderGeneration: 0,
         color: const Color(0xFF0000FF),
       );
       final eventBStyles = EarthquakeAreaRenderStyleCache();

--- a/packages/eqmonitor_map/test/widget/base_map_view_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_view_test.dart
@@ -2,12 +2,14 @@
 // (Global Constraints「widget testとgolden testは追加しない」)。ここでは
 // gesture callbackから分離したpure関数(`cameraAfterGestureUpdate`/
 // `canonicalZoomFor`)だけを検証する。
+import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
 import 'package:eqmonitor_map/src/geo/map_camera.dart';
 import 'package:eqmonitor_map/src/geo/map_mercator_projection.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh_builder_limits.dart';
 import 'package:eqmonitor_map/src/mesh/line_mesh_builder_limits.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_map_overlay_snapshot.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_overlay_coverage.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
 import 'package:eqmonitor_map/src/tile/base_map_tile_decoder.dart';
 import 'package:eqmonitor_map/src/tile/mvt/mvt_decode_limits.dart';
 import 'package:eqmonitor_map/src/tile/verified_pm_tiles_source.dart';
@@ -19,8 +21,14 @@ import 'package:pmtiles_v3/pmtiles_v3.dart';
 void main() {
   test('exposes nullable earthquake overlay and coverage callback inputs', () {
     final overlay = createEarthquakeMapOverlaySnapshot(
-      sourceId: 'event-a',
-      revision: 1,
+      versionStamp: createMapOverlayVersionStamp(
+        sourceIdentity: createMapSourceIdentity(value: 'event-a'),
+        sourceIncarnation: createMapSourceIncarnation(value: 'incarnation-a'),
+        dataSequence: 1,
+        dataDigest: 'data-a',
+        renderGeneration: 1,
+        renderDigest: 'render-a',
+      ),
       regionToCityZoom: 6,
       stationMinZoom: 6,
       regionStyles: const [],


### PR DESCRIPTION
## 概要

- earthquake overlay固有のsourceId、revision、snapshotRevisionを単一のtyped version stampへ移行します。
- event identity、UUIDv7 source incarnation、canonical SHA-256 data digest、data sequence、render generationを分離します。
- AsyncGenerationOwnerでevent/incarnation切替後のlate completionを拒否し、coverageはoverlayとstampが完全一致する場合だけ表示します。
- MapLibre側など別用途のsource identity契約は変更しません。

## 検証

- package targeted tests 50件成功
- app targeted tests 23件成功
- packageとappのtargeted analyze clean
- build_runner成功
- format 30 files、変更なし
- overlay旧alias 0件
- 独立レビュー Critical、Important、Minor すべて0件

## CI baseline note

Full CIの失敗はTask 1差分外の既知baselineです。

- eqmonitor_map全658 tests、iOS Profile/Release、integration testは成功
- Flutter Analyzeはflutter_hooks_lint_plugin 0.8.0のExhaustiveKeysRule内部RangeError、既存fatal infos、Asset Pack未stageで失敗
- Flutter Testは既存NANKAI、Kyoshin時刻、AppClock、WebView、LiveMonitor、Asset Pack未stageのfailure後に10分timeout
- Android exampleは既存AGP 9 Kotlin DSL非互換でDart/shader build前に失敗
- 既存課題: docs/todo/770_existing_eqmonitor_flutter_test_failures.md、docs/todo/700_flutter_test_ci_10min_timeout.md、docs/todo/880_eqmonitor_map_example_agp9_gradle_dsl.md

## Stack

- Depends on #1754
- Task 2以降はこのPRの上へ追加します。