### PR TITLE
refactor: Scene frameをtyped layer listへ移行

### DIFF
--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_page.dart
@@ -112,6 +112,7 @@ final class EqmonitorMapDebugConfiguration {
     // 余裕を持たせた値。GPU resourceの参照を落とすのは、可視tileから外れて
     // この frame 数ぶん経ってからになる。
     maxFramesInFlight: 3,
+    maxSceneNodeCount: 512,
   );
 }
 

--- a/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_map_adapter.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_map_adapter.dart
@@ -351,6 +351,104 @@ final class FlutterSceneMeshBatchPlan {
   final MapSceneMeshLayerKind kind;
 }
 
+enum FlutterSceneLayerPreflightFailureReason {
+  instanceBatchTypeMismatch,
+  unsupportedInstanceKind,
+}
+
+final class FlutterSceneLayerPreflightFailure implements Exception {
+  const FlutterSceneLayerPreflightFailure({
+    required this.reason,
+    required this.layer,
+  });
+
+  final FlutterSceneLayerPreflightFailureReason reason;
+  final MapSceneInstanceLayerSubmission layer;
+}
+
+sealed class FlutterSceneNodePlan {
+  const FlutterSceneNodePlan({required this.drawRank});
+
+  final int drawRank;
+}
+
+final class FlutterSceneMeshNodePlan extends FlutterSceneNodePlan {
+  const FlutterSceneMeshNodePlan({
+    required super.drawRank,
+    required this.layer,
+    required this.packetIndex,
+  });
+
+  final MapSceneMeshLayerSubmission layer;
+  final int packetIndex;
+}
+
+final class FlutterSceneObservationNodePlan extends FlutterSceneNodePlan {
+  const FlutterSceneObservationNodePlan({
+    required super.drawRank,
+    required this.layer,
+    required this.batch,
+  });
+
+  final MapSceneInstanceLayerSubmission layer;
+  final ObservationPointBatch batch;
+}
+
+List<FlutterSceneNodePlan> buildFlutterSceneNodePlans({
+  required MapSceneFrameSubmission submission,
+}) {
+  final plans = <FlutterSceneNodePlan>[];
+  for (final layer in submission.layers) {
+    switch (layer) {
+      case MapSceneMeshLayerSubmission(:final batch):
+        for (final (packetIndex, _) in batch.packets.indexed) {
+          plans.add(
+            FlutterSceneMeshNodePlan(
+              drawRank: plans.length,
+              layer: layer,
+              packetIndex: packetIndex,
+            ),
+          );
+        }
+      case MapSceneInstanceLayerSubmission():
+        final batch = preflightFlutterSceneInstanceLayer(layer: layer);
+        plans.add(
+          FlutterSceneObservationNodePlan(
+            drawRank: plans.length,
+            layer: layer,
+            batch: batch,
+          ),
+        );
+    }
+  }
+  return List.unmodifiable(plans);
+}
+
+ObservationPointBatch preflightFlutterSceneInstanceLayer({
+  required MapSceneInstanceLayerSubmission layer,
+}) => switch (layer) {
+  MapSceneInstanceLayerSubmission(
+    kind: MapSceneInstanceLayerKind.observationPoint,
+    :final batch,
+  )
+      when batch is ObservationPointBatch =>
+    batch,
+  MapSceneInstanceLayerSubmission(
+    kind: MapSceneInstanceLayerKind.observationPoint,
+  ) =>
+    throw FlutterSceneLayerPreflightFailure(
+      reason: FlutterSceneLayerPreflightFailureReason.instanceBatchTypeMismatch,
+      layer: layer,
+    ),
+  MapSceneInstanceLayerSubmission(
+    kind: MapSceneInstanceLayerKind.pointSprite,
+  ) =>
+    throw FlutterSceneLayerPreflightFailure(
+      reason: FlutterSceneLayerPreflightFailureReason.unsupportedInstanceKind,
+      layer: layer,
+    ),
+};
+
 /// frame submissionをcanonicalなmesh batch planへ変換する。
 List<FlutterSceneMeshBatchPlan> buildFlutterSceneMeshBatchPlans({
   required MapSceneFrameSubmission submission,
@@ -360,21 +458,8 @@ List<FlutterSceneMeshBatchPlan> buildFlutterSceneMeshBatchPlans({
     switch (layer) {
       case MapSceneMeshLayerSubmission(:final batch, :final kind):
         plans.add(FlutterSceneMeshBatchPlan(batch: batch, kind: kind));
-      case MapSceneInstanceLayerSubmission(
-        kind: MapSceneInstanceLayerKind.observationPoint,
-        :final batch,
-      ):
-        if (batch is! ObservationPointBatch) {
-          throw ArgumentError.value(
-            batch,
-            'layer',
-            'observationPoint must contain an ObservationPointBatch',
-          );
-        }
-      case MapSceneInstanceLayerSubmission(
-        kind: MapSceneInstanceLayerKind.pointSprite,
-      ):
-        throw UnsupportedError('pointSprite batch is not implemented');
+      case MapSceneInstanceLayerSubmission():
+        preflightFlutterSceneInstanceLayer(layer: layer);
     }
   }
   return List.unmodifiable(plans);
@@ -388,22 +473,8 @@ ObservationPointBatch? observationPointBatchFrom({
     switch (layer) {
       case MapSceneMeshLayerSubmission():
         continue;
-      case MapSceneInstanceLayerSubmission(
-        kind: MapSceneInstanceLayerKind.observationPoint,
-        :final batch,
-      ):
-        if (batch is! ObservationPointBatch) {
-          throw ArgumentError.value(
-            batch,
-            'layer',
-            'observationPoint must contain an ObservationPointBatch',
-          );
-        }
-        observation = batch;
-      case MapSceneInstanceLayerSubmission(
-        kind: MapSceneInstanceLayerKind.pointSprite,
-      ):
-        throw UnsupportedError('pointSprite batch is not implemented');
+      case MapSceneInstanceLayerSubmission():
+        observation = preflightFlutterSceneInstanceLayer(layer: layer);
     }
   }
   return observation;
@@ -461,6 +532,7 @@ final class FlutterSceneMapAdapter {
       _observationGeometries.liveGeometryCount;
 
   void submitFrame({required MapSceneFrameSubmission submission}) {
+    final nodePlans = buildFlutterSceneNodePlans(submission: submission);
     final plans = buildFlutterSceneMeshBatchPlans(submission: submission);
     preflightFlutterSceneMeshBatchPlans(plans: plans);
     final resolved = resolveFlutterSceneMaterials(
@@ -493,41 +565,57 @@ final class FlutterSceneMapAdapter {
     );
 
     final nodes = <scene.Node>[];
-    var drawRank = 0;
-    for (final entry in resolved) {
-      applyFlutterSceneMeshBatchMaterial(
-        plan: entry.plan,
-        parameters: entry.material.parameters,
-      );
-      for (final (index, packet) in entry.plan.batch.packets.indexed) {
-        final node = scene.Node(
-          localTransform: scene_math.Matrix4.fromList(
-            entry.plan.batch.instanceTransforms[index],
-          ),
-          mesh: scene.Mesh(_geometryFor(packet.mesh), entry.material.material),
-        );
-        applyFlutterSceneDrawRank(
-          node: node,
-          drawRank: drawRank++,
-        );
-        nodes.add(node);
+    final resolvedByBatch = {
+      for (final entry in resolved) entry.plan.batch: entry,
+    };
+    for (final nodePlan in nodePlans) {
+      switch (nodePlan) {
+        case FlutterSceneMeshNodePlan(:final layer, :final packetIndex):
+          final entry = resolvedByBatch[layer.batch];
+          if (entry == null) {
+            throw StateError('A preflighted mesh material was not resolved.');
+          }
+          applyFlutterSceneMeshBatchMaterial(
+            plan: entry.plan,
+            parameters: entry.material.parameters,
+          );
+          final packet = layer.batch.packets[packetIndex];
+          final node = scene.Node(
+            localTransform: scene_math.Matrix4.fromList(
+              layer.batch.instanceTransforms[packetIndex],
+            ),
+            mesh: scene.Mesh(
+              _geometryFor(packet.mesh),
+              entry.material.material,
+            ),
+          );
+          applyFlutterSceneDrawRank(
+            node: node,
+            drawRank: nodePlan.drawRank,
+          );
+          nodes.add(node);
+        case FlutterSceneObservationNodePlan(:final batch):
+          final material = observationMaterial;
+          if (material == null) {
+            throw StateError(
+              'A preflighted observation material was not resolved.',
+            );
+          }
+          final before = _observationGeometries.liveGeometryCount;
+          final geometry = _observationGeometries.geometryFor(batch: batch);
+          if (_observationGeometries.liveGeometryCount > before) {
+            _uploadedObservationGeometryCount++;
+          }
+          material.setFrameUniform(batch.frameUniform);
+          final node = scene.Node(
+            mesh: scene.Mesh(geometry, material.material),
+          );
+          applyFlutterSceneDrawRank(
+            node: node,
+            drawRank: nodePlan.drawRank,
+          );
+          nodes.add(node);
       }
-    }
-    if (observation != null && observationMaterial != null) {
-      final before = _observationGeometries.liveGeometryCount;
-      final geometry = _observationGeometries.geometryFor(batch: observation);
-      if (_observationGeometries.liveGeometryCount > before) {
-        _uploadedObservationGeometryCount++;
-      }
-      observationMaterial.setFrameUniform(observation.frameUniform);
-      final node = scene.Node(
-        mesh: scene.Mesh(geometry, observationMaterial.material),
-      );
-      applyFlutterSceneDrawRank(
-        node: node,
-        drawRank: drawRank,
-      );
-      nodes.add(node);
     }
 
     _sceneGraph

--- a/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_map_adapter.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_map_adapter.dart
@@ -9,7 +9,6 @@ import 'package:eqmonitor_map/src/renderer/base_map_render_submission_builder.da
 import 'package:eqmonitor_map/src/renderer/earthquake_area_render_submission_builder.dart';
 import 'package:eqmonitor_map/src/renderer/map_gpu_resource_ledger.dart';
 import 'package:eqmonitor_map/src/renderer/map_scene_frame_submission.dart';
-import 'package:eqmonitor_map/src/renderer/map_scene_render_phase_policy.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch.dart';
 import 'package:flutter_scene/gpu.dart' as scene_gpu;
 import 'package:flutter_scene/scene.dart' as scene;
@@ -341,53 +340,73 @@ scene.StaticInstanceGeometry createFlutterSceneObservationGeometry({
   );
 }
 
-enum FlutterSceneMeshBatchKind { baseMap, earthquakeAreaFill }
-
 /// GPU呼び出し前に確定するScene mesh nodeのplan。
 final class FlutterSceneMeshBatchPlan {
   const new({
     required this.batch,
     required this.kind,
-    required this.translucentSortPriority,
   });
 
   final MapRenderBatch batch;
-  final FlutterSceneMeshBatchKind kind;
-  final int translucentSortPriority;
+  final MapSceneMeshLayerKind kind;
 }
 
 /// frame submissionをcanonicalなmesh batch planへ変換する。
 List<FlutterSceneMeshBatchPlan> buildFlutterSceneMeshBatchPlans({
   required MapSceneFrameSubmission submission,
 }) {
-  validateMapSceneFrameSubmission(submission: submission);
-  final observation = submission.observationBatch;
-  if (observation != null && observation is! ObservationPointBatch) {
-    throw ArgumentError.value(
-      observation,
-      'observationBatch',
-      'must be an ObservationPointBatch',
-    );
+  final plans = <FlutterSceneMeshBatchPlan>[];
+  for (final layer in submission.layers) {
+    switch (layer) {
+      case MapSceneMeshLayerSubmission(:final batch, :final kind):
+        plans.add(FlutterSceneMeshBatchPlan(batch: batch, kind: kind));
+      case MapSceneInstanceLayerSubmission(
+        kind: MapSceneInstanceLayerKind.observationPoint,
+        :final batch,
+      ):
+        if (batch is! ObservationPointBatch) {
+          throw ArgumentError.value(
+            batch,
+            'layer',
+            'observationPoint must contain an ObservationPointBatch',
+          );
+        }
+      case MapSceneInstanceLayerSubmission(
+        kind: MapSceneInstanceLayerKind.pointSprite,
+      ):
+        throw UnsupportedError('pointSprite batch is not implemented');
+    }
   }
+  return List.unmodifiable(plans);
+}
 
-  return List.unmodifiable([
-    for (final batch in submission.baseMap.batches)
-      FlutterSceneMeshBatchPlan(
-        batch: batch,
-        kind: FlutterSceneMeshBatchKind.baseMap,
-        translucentSortPriority: mapSceneTranslucentSortPriorityFor(
-          phase: batch.compatibility.phase,
-        ),
-      ),
-    for (final batch in submission.earthquakeFill.batches)
-      FlutterSceneMeshBatchPlan(
-        batch: batch,
-        kind: FlutterSceneMeshBatchKind.earthquakeAreaFill,
-        translucentSortPriority: mapSceneTranslucentSortPriorityFor(
-          phase: batch.compatibility.phase,
-        ),
-      ),
-  ]);
+ObservationPointBatch? observationPointBatchFrom({
+  required MapSceneFrameSubmission submission,
+}) {
+  ObservationPointBatch? observation;
+  for (final layer in submission.layers) {
+    switch (layer) {
+      case MapSceneMeshLayerSubmission():
+        continue;
+      case MapSceneInstanceLayerSubmission(
+        kind: MapSceneInstanceLayerKind.observationPoint,
+        :final batch,
+      ):
+        if (batch is! ObservationPointBatch) {
+          throw ArgumentError.value(
+            batch,
+            'layer',
+            'observationPoint must contain an ObservationPointBatch',
+          );
+        }
+        observation = batch;
+      case MapSceneInstanceLayerSubmission(
+        kind: MapSceneInstanceLayerKind.pointSprite,
+      ):
+        throw UnsupportedError('pointSprite batch is not implemented');
+    }
+  }
+  return observation;
 }
 
 /// base mapとoverlayを1つのFlutter Sceneへ送る唯一のowner。
@@ -448,15 +467,7 @@ final class FlutterSceneMapAdapter {
       plans: plans,
       materialFor: _materialFor,
     );
-    final observation = switch (submission.observationBatch) {
-      final ObservationPointBatch batch => batch,
-      null => null,
-      final other => throw ArgumentError.value(
-        other,
-        'observationBatch',
-        'must be an ObservationPointBatch',
-      ),
-    };
+    final observation = observationPointBatchFrom(submission: submission);
     final observationMaterial = switch (observation) {
       null => null,
       _ =>
@@ -482,6 +493,7 @@ final class FlutterSceneMapAdapter {
     );
 
     final nodes = <scene.Node>[];
+    var drawRank = 0;
     for (final entry in resolved) {
       applyFlutterSceneMeshBatchMaterial(
         plan: entry.plan,
@@ -494,10 +506,9 @@ final class FlutterSceneMapAdapter {
           ),
           mesh: scene.Mesh(_geometryFor(packet.mesh), entry.material.material),
         );
-        applyFlutterSceneTranslucentSortPriority(
+        applyFlutterSceneDrawRank(
           node: node,
-          phase: entry.plan.batch.compatibility.phase,
-          priority: entry.plan.translucentSortPriority,
+          drawRank: drawRank++,
         );
         nodes.add(node);
       }
@@ -512,10 +523,9 @@ final class FlutterSceneMapAdapter {
       final node = scene.Node(
         mesh: scene.Mesh(geometry, observationMaterial.material),
       );
-      applyFlutterSceneTranslucentSortPriority(
+      applyFlutterSceneDrawRank(
         node: node,
-        phase: observation.phase,
-        priority: observation.translucentSortPriority,
+        drawRank: drawRank,
       );
       nodes.add(node);
     }
@@ -571,7 +581,7 @@ void preflightFlutterSceneMeshBatchPlans({
     final compatibility = plan.batch.compatibility;
     final parameters = compatibility.materialParameters;
     switch (plan.kind) {
-      case FlutterSceneMeshBatchKind.baseMap:
+      case MapSceneMeshLayerKind.baseMap:
         if (parameters.version != baseMapMaterialParameterVersion) {
           throw ArgumentError.value(
             parameters.version,
@@ -592,7 +602,7 @@ void preflightFlutterSceneMeshBatchPlans({
           'pipeline',
           'is not a supported base map pipeline',
         );
-      case FlutterSceneMeshBatchKind.earthquakeAreaFill:
+      case MapSceneMeshLayerKind.earthquakeAreaFill:
         if (compatibility.pipeline != earthquakeAreaFillPipelineKey ||
             parameters.version != earthquakeAreaMaterialParameterVersion) {
           throw ArgumentError.value(
@@ -606,17 +616,15 @@ void preflightFlutterSceneMeshBatchPlans({
   }
 }
 
-/// 共有phase policyとの一致を検証してから実Nodeへpriorityを設定する。
-void applyFlutterSceneTranslucentSortPriority({
+/// canonical node planで確定した0始まりのdraw rankをNodeへ設定する。
+void applyFlutterSceneDrawRank({
   required scene.Node node,
-  required int phase,
-  required int priority,
+  required int drawRank,
 }) {
-  validateMapSceneTranslucentSortPriority(
-    phase: phase,
-    priority: priority,
-  );
-  node.translucentSortPriority = priority;
+  if (drawRank < 0) {
+    throw ArgumentError.value(drawRank, 'drawRank', 'must not be negative');
+  }
+  node.translucentSortPriority = drawRank;
 }
 
 typedef FlutterSceneResolvedMeshBatch = ({
@@ -682,13 +690,13 @@ void applyFlutterSceneMeshBatchMaterial({
 }) {
   final compatibility = plan.batch.compatibility;
   switch (plan.kind) {
-    case FlutterSceneMeshBatchKind.baseMap:
+    case MapSceneMeshLayerKind.baseMap:
       applyBaseMapMaterialParameters(
         parameters: parameters,
         pipelineKey: compatibility.pipeline.key,
         bytes: compatibility.materialParameters.bytes,
       );
-    case FlutterSceneMeshBatchKind.earthquakeAreaFill:
+    case MapSceneMeshLayerKind.earthquakeAreaFill:
       final values = decodeEarthquakeAreaFillMaterialBytes(
         compatibility.materialParameters.bytes,
       );

--- a/packages/eqmonitor_map/lib/src/foundation/render/map_render_batch.dart
+++ b/packages/eqmonitor_map/lib/src/foundation/render/map_render_batch.dart
@@ -69,7 +69,7 @@ MapRenderBatch createMapRenderBatch({
   final compatibility = mapRenderBatchCompatibilityOf(packet: packets.first);
   for (final (index, packet) in packets.indexed) {
     if (packet.sortKey.phasePolicyVersion != policy.version ||
-        packet.sortKey.phase >= policy.orderedPhases.length) {
+        !policy.containsRank(packet.sortKey.phase)) {
       throw ArgumentError.value(
         packet,
         'packets',

--- a/packages/eqmonitor_map/lib/src/foundation/render/map_render_phase.dart
+++ b/packages/eqmonitor_map/lib/src/foundation/render/map_render_phase.dart
@@ -13,6 +13,8 @@ final class MapRenderPhasePolicy {
   final List<MapRenderPhaseId> orderedPhases;
   final Map<MapRenderPhaseId, int> _rankByPhase;
 
+  bool containsRank(int rank) => _rankByPhase.containsValue(rank);
+
   int rankOf(MapRenderPhaseId phase) {
     final rank = _rankByPhase[phase];
     if (rank == null) {
@@ -34,6 +36,7 @@ MapRenderPhaseId createMapRenderPhaseId({required String value}) {
 MapRenderPhasePolicy createMapRenderPhasePolicy({
   required int version,
   required List<MapRenderPhaseId> orderedPhases,
+  List<int>? phaseRanks,
 }) {
   if (version <= 0) {
     throw ArgumentError.value(version, 'version', 'must be positive');
@@ -42,12 +45,30 @@ MapRenderPhasePolicy createMapRenderPhasePolicy({
     throw ArgumentError.value(orderedPhases, 'orderedPhases');
   }
 
+  if (phaseRanks != null && phaseRanks.length != orderedPhases.length) {
+    throw ArgumentError.value(
+      phaseRanks,
+      'phaseRanks',
+      'must have one rank for each ordered phase',
+    );
+  }
+
   final ranks = <MapRenderPhaseId, int>{};
-  for (final (rank, phase) in orderedPhases.indexed) {
+  var previousRank = -1;
+  for (final (index, phase) in orderedPhases.indexed) {
+    final rank = phaseRanks?[index] ?? index;
+    if (rank <= previousRank) {
+      throw ArgumentError.value(
+        phaseRanks,
+        'phaseRanks',
+        'must be non-negative and strictly increasing',
+      );
+    }
     if (ranks.containsKey(phase)) {
       throw ArgumentError.value(phase.value, 'orderedPhases');
     }
     ranks[phase] = rank;
+    previousRank = rank;
   }
   if (!ranks.containsKey(MapRenderPhaseId.labelForeground)) {
     throw ArgumentError.value(orderedPhases, 'orderedPhases');

--- a/packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_builder.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_builder.dart
@@ -43,6 +43,7 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
   required BaseMapTileCache tileCache,
   required EarthquakeAreaPackedMeshResolver packedMeshFor,
   required EarthquakeAreaRenderStyleCache styleCache,
+  required MapSceneFrameLimits sceneFrameLimits,
 }) {
   if (!identical(baseMap.frame, frame)) {
     throw ArgumentError('baseMap must use the captured frame');
@@ -69,6 +70,7 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
       submission: buildBaseMapOnlyFrameSubmission(
         frame: frame,
         baseMap: baseMap,
+        sceneFrameLimits: sceneFrameLimits,
       ),
       coverage: const EarthquakeOverlayCoverage.hidden(),
       observationBatchForReuse: null,
@@ -111,9 +113,34 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
   return BaseMapOverlayFrameResult(
     overlay: overlay,
     submission: MapSceneFrameSubmission(
-      baseMap: baseMap,
-      earthquakeFill: earthquakeFill,
-      observationBatch: observation,
+      frame: frame,
+      layers: [
+        ...buildBaseMapSceneLayers(frame: frame, baseMap: baseMap),
+        for (final batch in earthquakeFill.batches)
+          MapSceneMeshLayerSubmission(
+            frame: frame,
+            logicalSourceKey: mapSceneEarthquakeHistorySourceKey,
+            componentKey: switch (layerMode) {
+              EarthquakeAreaLayerMode.region => mapSceneRegionFillComponentKey,
+              EarthquakeAreaLayerMode.city => mapSceneCityFillComponentKey,
+            },
+            overlayVersion: overlay.versionStamp,
+            orderWithinPhase:
+                batch.packets.first.sortKey.declarationOrderWithinPhase,
+            batch: batch,
+            kind: MapSceneMeshLayerKind.earthquakeAreaFill,
+          ),
+        if (observation != null)
+          MapSceneInstanceLayerSubmission(
+            logicalSourceKey: mapSceneEarthquakeHistorySourceKey,
+            componentKey: mapSceneObservationPointComponentKey,
+            overlayVersion: overlay.versionStamp,
+            orderWithinPhase: 0,
+            kind: MapSceneInstanceLayerKind.observationPoint,
+            batch: observation,
+          ),
+      ],
+      limits: sceneFrameLimits,
     ),
     coverage: coverage,
     observationBatchForReuse:
@@ -129,19 +156,33 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
 MapSceneFrameSubmission buildBaseMapOnlyFrameSubmission({
   required MapFrameSnapshot frame,
   required MapRenderSubmission baseMap,
+  required MapSceneFrameLimits sceneFrameLimits,
 }) {
   if (!identical(baseMap.frame, frame)) {
     throw ArgumentError('baseMap must use the captured frame');
   }
   return MapSceneFrameSubmission(
-    baseMap: baseMap,
-    earthquakeFill: createMapRenderSubmission(
-      frame: frame,
-      batches: const [],
-    ),
-    observationBatch: null,
+    frame: frame,
+    layers: buildBaseMapSceneLayers(frame: frame, baseMap: baseMap),
+    limits: sceneFrameLimits,
   );
 }
+
+List<MapSceneMeshLayerSubmission> buildBaseMapSceneLayers({
+  required MapFrameSnapshot frame,
+  required MapRenderSubmission baseMap,
+}) => List.unmodifiable([
+  for (final batch in baseMap.batches)
+    MapSceneMeshLayerSubmission(
+      frame: frame,
+      logicalSourceKey: mapSceneBaseSourceKey,
+      componentKey: mapSceneBaseComponentKey,
+      overlayVersion: null,
+      orderWithinPhase: batch.packets.first.sortKey.declarationOrderWithinPhase,
+      batch: batch,
+      kind: MapSceneMeshLayerKind.baseMap,
+    ),
+]);
 
 EarthquakeMapOverlaySnapshot? selectEarthquakeOverlaySnapshot({
   required EarthquakeMapOverlaySnapshot? current,

--- a/packages/eqmonitor_map/lib/src/renderer/base_map_render_submission_builder.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/base_map_render_submission_builder.dart
@@ -27,12 +27,16 @@ const baseMapRenderBatchVersion = 1;
 const baseMapRenderBatchKeyVersion = 1;
 
 /// Fill layer群のpipeline key。`assets/base_map_fill.fmat`に対応する。
-final MapRenderPipelineKey baseMapFillPipelineKey =
-    createMapRenderPipelineKey(version: 1, key: 'base-map-fill');
+final MapRenderPipelineKey baseMapFillPipelineKey = createMapRenderPipelineKey(
+  version: 1,
+  key: 'base-map-fill',
+);
 
 /// Line layer群のpipeline key。`assets/base_map_line.fmat`に対応する。
-final MapRenderPipelineKey baseMapLinePipelineKey =
-    createMapRenderPipelineKey(version: 1, key: 'base-map-line');
+final MapRenderPipelineKey baseMapLinePipelineKey = createMapRenderPipelineKey(
+  version: 1,
+  key: 'base-map-line',
+);
 
 /// base map treeのnode key。
 ///
@@ -46,8 +50,9 @@ final MapNodeKey baseMapRenderNodeKey = createMapNodeKey(value: 'base-map');
 /// 戻り値は`styleLayerId`→segmentごとの[MapPackedMesh]。`BaseMapPackedMeshCache`
 /// をそのまま渡す想定だが、builderがcacheの実装へ依存しないようにfunction型で
 /// 受け取る(builderのtestはcacheを組み立てずにfakeを渡せる)。
-typedef BaseMapPackedMeshResolver =
-    Map<String, List<MapPackedMesh>> Function(BaseMapLayerRenderPlan plan);
+typedef BaseMapPackedMeshResolver = Map<String, List<MapPackedMesh>> Function(
+  BaseMapLayerRenderPlan plan,
+);
 
 /// [plans]から`MapRenderSubmission`を組み立てる。
 ///
@@ -96,7 +101,6 @@ List<MapRenderPacket> buildBaseMapRenderPackets({
   required BaseMapPackedMeshResolver packedMeshesFor,
   required double lineHalfWidthLogicalPixels,
 }) {
-  final phase = mapSceneRenderPhasePolicy.rankOf(mapSceneBasePhaseId);
   final tileOrders = <UnwrappedTileId, int>{};
   for (final plan in plans) {
     tileOrders.putIfAbsent(
@@ -120,6 +124,17 @@ List<MapRenderPacket> buildBaseMapRenderPackets({
     }
     final declarationOrder =
         _baseMapDeclarationOrderByStyleLayerId[styleLayerId]!;
+    final phase = mapSceneRenderPhasePolicy.rankOf(
+      switch (spec.kind) {
+        BaseMapLayerKind.background => throw ArgumentError.value(
+          styleLayerId,
+          'plans',
+          'background is not drawable',
+        ),
+        BaseMapLayerKind.fill => mapSceneBaseLandFillPhaseId,
+        BaseMapLayerKind.line => mapSceneBaseAdministrativeLinePhaseId,
+      },
+    );
     final transformInput = plan.transformInput;
     if (transformInput.zoom != frame.camera.zoom) {
       throw ArgumentError.value(

--- a/packages/eqmonitor_map/lib/src/renderer/earthquake_area_render_submission_builder.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/earthquake_area_render_submission_builder.dart
@@ -59,9 +59,7 @@ MapRenderSubmission buildEarthquakeAreaRenderSubmission({
       : EarthquakeAreaLayerMode.city;
   final styles = regionMode ? snapshot.regionStyles : snapshot.cityStyles;
   final phase = mapSceneRenderPhasePolicy.rankOf(
-    regionMode
-        ? mapSceneEarthquakeRegionPhaseId
-        : mapSceneEarthquakeCityPhaseId,
+    mapSceneOverlayHazardFillPhaseId,
   );
   final packets = buildEarthquakeAreaRenderPackets(
     frame: frame,

--- a/packages/eqmonitor_map/lib/src/renderer/map_scene_frame_submission.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/map_scene_frame_submission.dart
@@ -1,160 +1,430 @@
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
 import 'package:eqmonitor_map/src/foundation/render/map_render_batch.dart';
-import 'package:eqmonitor_map/src/foundation/render/map_render_sort_key.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
+import 'package:eqmonitor_map/src/renderer/base_map_render_submission_builder.dart';
 import 'package:eqmonitor_map/src/renderer/earthquake_area_render_submission_builder.dart';
-import 'package:eqmonitor_map/src/renderer/map_render_batch_adapter.dart';
 import 'package:eqmonitor_map/src/renderer/map_scene_render_phase_policy.dart';
 
-/// Task 7が実装する観測点batchの最小typed contract。
-abstract interface class MapSceneObservationBatch {
-  MapFrameSnapshot get frame;
-  int get phasePolicyVersion;
-  int get phase;
-  int get translucentSortPriority;
+extension type const MapSceneLogicalSourceKey._(String value) {}
+
+extension type const MapSceneComponentKey._(String value) {}
+
+extension type const MapSceneBatchKey._(String value) {}
+
+MapSceneLogicalSourceKey createMapSceneLogicalSourceKey({
+  required String value,
+}) => MapSceneLogicalSourceKey._(
+  normalizeMapSceneKey(value: value, parameterName: 'value'),
+);
+
+MapSceneComponentKey createMapSceneComponentKey({required String value}) =>
+    MapSceneComponentKey._(
+      normalizeMapSceneKey(value: value, parameterName: 'value'),
+    );
+
+MapSceneBatchKey createMapSceneBatchKey({required String value}) =>
+    MapSceneBatchKey._(
+      normalizeMapSceneKey(value: value, parameterName: 'value'),
+    );
+
+String normalizeMapSceneKey({
+  required String value,
+  required String parameterName,
+}) {
+  final normalized = value.trim();
+  if (normalized.isEmpty) {
+    throw ArgumentError.value(value, parameterName, 'must not be blank');
+  }
+  return normalized;
 }
 
-/// 1 frameで同じSceneへ送るbase、震度Fill、観測点batch。
+final MapSceneLogicalSourceKey mapSceneBaseSourceKey =
+    createMapSceneLogicalSourceKey(
+      value: 'base-map',
+    );
+final MapSceneLogicalSourceKey mapSceneEarthquakeHistorySourceKey =
+    createMapSceneLogicalSourceKey(
+      value: 'earthquake-history',
+    );
+final MapSceneComponentKey mapSceneBaseComponentKey =
+    createMapSceneComponentKey(value: 'base');
+final MapSceneComponentKey mapSceneRegionFillComponentKey =
+    createMapSceneComponentKey(
+      value: 'region-fill',
+    );
+final MapSceneComponentKey mapSceneCityFillComponentKey =
+    createMapSceneComponentKey(
+      value: 'city-fill',
+    );
+final MapSceneComponentKey mapSceneObservationPointComponentKey =
+    createMapSceneComponentKey(
+      value: 'observation-point',
+    );
+final MapSceneComponentKey mapSceneHypocenterSpriteComponentKey =
+    createMapSceneComponentKey(
+      value: 'hypocenter-sprite',
+    );
+final MapSceneBatchKey mapSceneObservationBatchKey = createMapSceneBatchKey(
+  value: 'observation-point',
+);
+
+enum MapSceneMeshLayerKind { baseMap, earthquakeAreaFill }
+
+enum MapSceneInstanceLayerKind { observationPoint, pointSprite }
+
+abstract interface class MapSceneInstanceBatch {
+  MapFrameSnapshot get frame;
+  MapSceneBatchKey get batchKey;
+  int get phasePolicyVersion;
+  int get phase;
+}
+
+sealed class MapSceneLayerSubmission {
+  const MapSceneLayerSubmission();
+
+  MapFrameSnapshot get frame;
+  MapSceneLogicalSourceKey get logicalSourceKey;
+  MapSceneComponentKey get componentKey;
+  MapSceneBatchKey get batchKey;
+  MapOverlayVersionStamp? get overlayVersion;
+  int get phasePolicyVersion;
+  int get phase;
+  int get orderWithinPhase;
+}
+
+final class MapSceneMeshLayerSubmission extends MapSceneLayerSubmission {
+  factory MapSceneMeshLayerSubmission({
+    required MapFrameSnapshot frame,
+    required MapSceneLogicalSourceKey logicalSourceKey,
+    required MapSceneComponentKey componentKey,
+    required MapOverlayVersionStamp? overlayVersion,
+    required int orderWithinPhase,
+    required MapRenderBatch batch,
+    required MapSceneMeshLayerKind kind,
+  }) {
+    validateMapSceneLayerOrder(orderWithinPhase);
+    return MapSceneMeshLayerSubmission._(
+      frame: frame,
+      logicalSourceKey: logicalSourceKey,
+      componentKey: componentKey,
+      overlayVersion: overlayVersion,
+      orderWithinPhase: orderWithinPhase,
+      batch: batch,
+      kind: kind,
+      batchKey: mapSceneBatchKeyFor(batch: batch),
+    );
+  }
+
+  const MapSceneMeshLayerSubmission._({
+    required this.frame,
+    required this.logicalSourceKey,
+    required this.componentKey,
+    required this.overlayVersion,
+    required this.orderWithinPhase,
+    required this.batch,
+    required this.kind,
+    required this.batchKey,
+  });
+
+  @override
+  final MapFrameSnapshot frame;
+  @override
+  final MapSceneLogicalSourceKey logicalSourceKey;
+  @override
+  final MapSceneComponentKey componentKey;
+  @override
+  final MapOverlayVersionStamp? overlayVersion;
+  @override
+  final int orderWithinPhase;
+  final MapRenderBatch batch;
+  final MapSceneMeshLayerKind kind;
+  @override
+  final MapSceneBatchKey batchKey;
+
+  @override
+  int get phasePolicyVersion => batch.compatibility.phasePolicyVersion;
+
+  @override
+  int get phase => batch.compatibility.phase;
+}
+
+final class MapSceneInstanceLayerSubmission extends MapSceneLayerSubmission {
+  factory MapSceneInstanceLayerSubmission({
+    required MapSceneLogicalSourceKey logicalSourceKey,
+    required MapSceneComponentKey componentKey,
+    required MapOverlayVersionStamp? overlayVersion,
+    required int orderWithinPhase,
+    required MapSceneInstanceLayerKind kind,
+    required MapSceneInstanceBatch batch,
+  }) {
+    validateMapSceneLayerOrder(orderWithinPhase);
+    return MapSceneInstanceLayerSubmission._(
+      logicalSourceKey: logicalSourceKey,
+      componentKey: componentKey,
+      overlayVersion: overlayVersion,
+      orderWithinPhase: orderWithinPhase,
+      kind: kind,
+      batch: batch,
+    );
+  }
+
+  const MapSceneInstanceLayerSubmission._({
+    required this.logicalSourceKey,
+    required this.componentKey,
+    required this.overlayVersion,
+    required this.orderWithinPhase,
+    required this.kind,
+    required this.batch,
+  });
+
+  @override
+  MapFrameSnapshot get frame => batch.frame;
+  @override
+  final MapSceneLogicalSourceKey logicalSourceKey;
+  @override
+  final MapSceneComponentKey componentKey;
+  @override
+  final MapOverlayVersionStamp? overlayVersion;
+  @override
+  final int orderWithinPhase;
+  final MapSceneInstanceLayerKind kind;
+  final MapSceneInstanceBatch batch;
+
+  @override
+  MapSceneBatchKey get batchKey => batch.batchKey;
+
+  @override
+  int get phasePolicyVersion => batch.phasePolicyVersion;
+
+  @override
+  int get phase => batch.phase;
+}
+
+final class MapSceneFrameLimits {
+  new({required this.maxNodeCount}) {
+    if (maxNodeCount <= 0) {
+      throw ArgumentError.value(
+        maxNodeCount,
+        'maxNodeCount',
+        'must be positive',
+      );
+    }
+  }
+
+  final int maxNodeCount;
+}
+
 final class MapSceneFrameSubmission {
   factory MapSceneFrameSubmission({
-    required MapRenderSubmission baseMap,
-    required MapRenderSubmission earthquakeFill,
-    required MapSceneObservationBatch? observationBatch,
+    required MapFrameSnapshot frame,
+    required List<MapSceneLayerSubmission> layers,
+    required MapSceneFrameLimits limits,
   }) {
-    final submission = MapSceneFrameSubmission._(
-      baseMap: baseMap,
-      earthquakeFill: earthquakeFill,
-      observationBatch: observationBatch,
+    final canonical = List<MapSceneLayerSubmission>.of(layers)
+      ..sort(compareMapSceneLayerSubmissions);
+    validateMapSceneFrameLayers(
+      frame: frame,
+      layers: canonical,
+      limits: limits,
     );
-    validateMapSceneFrameSubmission(submission: submission);
-    return submission;
+    return MapSceneFrameSubmission._(
+      frame: frame,
+      layers: List.unmodifiable(canonical),
+    );
   }
 
   const MapSceneFrameSubmission._({
-    required this.baseMap,
-    required this.earthquakeFill,
-    required this.observationBatch,
+    required this.frame,
+    required this.layers,
   });
 
-  final MapRenderSubmission baseMap;
-  final MapRenderSubmission earthquakeFill;
-  final MapSceneObservationBatch? observationBatch;
-
-  MapFrameSnapshot get frame => baseMap.frame;
+  final MapFrameSnapshot frame;
+  final List<MapSceneLayerSubmission> layers;
 }
 
-/// frame identity、共有phase policy、submission用途をsubmit前に検証する。
-void validateMapSceneFrameSubmission({
-  required MapSceneFrameSubmission submission,
-}) {
-  validateMapRenderSubmission(submission: submission.baseMap);
-  validateMapRenderSubmission(submission: submission.earthquakeFill);
-  if (!identical(submission.baseMap.frame, submission.earthquakeFill.frame)) {
-    throw ArgumentError('baseMap and earthquakeFill must share one frame');
-  }
-
-  validateMapSceneBatches(
-    batches: submission.baseMap.batches,
-    expectedPhases: {
-      mapSceneRenderPhasePolicy.rankOf(mapSceneBaseLandFillPhaseId),
-      mapSceneRenderPhasePolicy.rankOf(
-        mapSceneBaseAdministrativeLinePhaseId,
-      ),
-    },
-    parameterName: 'baseMap',
-  );
-  validateMapSceneBatches(
-    batches: submission.earthquakeFill.batches,
-    expectedPhases: {
-      mapSceneRenderPhasePolicy.rankOf(mapSceneOverlayHazardFillPhaseId),
-    },
-    parameterName: 'earthquakeFill',
-  );
-  validateEarthquakeFillBatches(batches: submission.earthquakeFill.batches);
-  validateCombinedBatchOrder(submission: submission);
-
-  final observation = submission.observationBatch;
-  if (observation == null) {
-    return;
-  }
-  if (!identical(observation.frame, submission.frame)) {
-    throw ArgumentError('observationBatch must share the Scene frame');
-  }
-  final observationPhase = mapSceneRenderPhasePolicy.rankOf(
-    mapSceneLivePointPhaseId,
-  );
-  if (observation.phasePolicyVersion != mapSceneRenderPhasePolicy.version ||
-      observation.phase != observationPhase) {
-    throw ArgumentError.value(
-      observation.phase,
-      'observationBatch',
-      'must use the shared observation phase',
-    );
-  }
-  validateMapSceneTranslucentSortPriority(
-    phase: observation.phase,
-    priority: observation.translucentSortPriority,
-  );
-}
-
-void validateMapSceneBatches({
-  required List<MapRenderBatch> batches,
-  required Set<int> expectedPhases,
-  required String parameterName,
-}) {
-  for (final batch in batches) {
-    if (batch.compatibility.phasePolicyVersion !=
-            mapSceneRenderPhasePolicy.version ||
-        !expectedPhases.contains(batch.compatibility.phase)) {
-      throw ArgumentError.value(
-        batch,
-        parameterName,
-        'contains an unknown phase or policy version',
-      );
-    }
-  }
-}
-
-void validateEarthquakeFillBatches({required List<MapRenderBatch> batches}) {
-  final phases = <int>{};
-  for (final batch in batches) {
-    phases.add(batch.compatibility.phase);
-    if (batch.compatibility.batchKey.materialKey !=
-            earthquakeAreaFillMaterialKey ||
-        batch.compatibility.pipeline != earthquakeAreaFillPipelineKey) {
-      throw ArgumentError.value(
-        batch,
-        'earthquakeFill',
-        'contains an unknown material or pipeline',
-      );
-    }
-  }
-  if (phases.length > 1) {
-    throw ArgumentError.value(
-      batches,
-      'earthquakeFill',
-      'must contain either region or city Fill, never both',
-    );
-  }
-}
-
-void validateCombinedBatchOrder({
-  required MapSceneFrameSubmission submission,
-}) {
-  final batches = [
-    ...submission.baseMap.batches,
-    ...submission.earthquakeFill.batches,
+MapSceneBatchKey mapSceneBatchKeyFor({required MapRenderBatch batch}) {
+  final key = batch.compatibility.batchKey;
+  final fields = [
+    key.version.toString(),
+    key.nodeKey.value,
+    key.scopeKey,
+    key.materialKey,
+    key.phasePolicyVersion.toString(),
+    key.phase.toString(),
   ];
-  for (var index = 1; index < batches.length; index++) {
-    if (compareMapRenderSortKeys(
-          batches[index - 1].packets.last.sortKey,
-          batches[index].packets.first.sortKey,
-        ) >
-        0) {
+  return createMapSceneBatchKey(
+    value: fields.map((field) => '${field.length}:$field').join('|'),
+  );
+}
+
+int compareMapSceneLayerSubmissions(
+  MapSceneLayerSubmission left,
+  MapSceneLayerSubmission right,
+) => left.phase != right.phase
+    ? left.phase.compareTo(right.phase)
+    : left.orderWithinPhase != right.orderWithinPhase
+    ? left.orderWithinPhase.compareTo(right.orderWithinPhase)
+    : left.logicalSourceKey.value != right.logicalSourceKey.value
+    ? left.logicalSourceKey.value.compareTo(right.logicalSourceKey.value)
+    : left.componentKey.value != right.componentKey.value
+    ? left.componentKey.value.compareTo(right.componentKey.value)
+    : left.batchKey.value.compareTo(right.batchKey.value);
+
+void validateMapSceneLayerOrder(int orderWithinPhase) {
+  if (orderWithinPhase < 0) {
+    throw ArgumentError.value(
+      orderWithinPhase,
+      'orderWithinPhase',
+      'must not be negative',
+    );
+  }
+}
+
+void validateMapSceneFrameLayers({
+  required MapFrameSnapshot frame,
+  required List<MapSceneLayerSubmission> layers,
+  required MapSceneFrameLimits limits,
+}) {
+  final identities = <String>{};
+  final overlayVersions = <MapSceneLogicalSourceKey, MapOverlayVersionStamp?>{};
+  var hasRegion = false;
+  var hasCity = false;
+  var nodeCount = 0;
+
+  for (final layer in layers) {
+    if (!identical(layer.frame, frame)) {
       throw ArgumentError.value(
-        batches[index],
-        'submission',
-        'is not in canonical Scene order',
+        layer,
+        'layers',
+        'must share the captured frame',
       );
     }
+    if (layer.phasePolicyVersion != mapSceneRenderPhasePolicy.version ||
+        !mapSceneRenderPhasePolicy.containsRank(layer.phase)) {
+      throw ArgumentError.value(
+        layer,
+        'layers',
+        'has an unknown phase policy',
+      );
+    }
+    validateMapSceneLayerCompatibility(layer);
+
+    final identity =
+        '${layer.logicalSourceKey.value.length}:'
+        '${layer.logicalSourceKey.value}|${layer.componentKey.value.length}:'
+        '${layer.componentKey.value}|${layer.batchKey.value.length}:'
+        '${layer.batchKey.value}';
+    if (!identities.add(identity)) {
+      throw ArgumentError.value(
+        layer,
+        'layers',
+        'has a duplicate identity tuple',
+      );
+    }
+
+    if (overlayVersions.containsKey(layer.logicalSourceKey) &&
+        overlayVersions[layer.logicalSourceKey] != layer.overlayVersion) {
+      throw ArgumentError.value(
+        layer,
+        'layers',
+        'mixes overlay version stamps',
+      );
+    }
+    overlayVersions[layer.logicalSourceKey] = layer.overlayVersion;
+
+    if (layer.logicalSourceKey == mapSceneEarthquakeHistorySourceKey) {
+      hasRegion =
+          hasRegion || layer.componentKey == mapSceneRegionFillComponentKey;
+      hasCity = hasCity || layer.componentKey == mapSceneCityFillComponentKey;
+    }
+    nodeCount += switch (layer) {
+      MapSceneMeshLayerSubmission(:final batch) => batch.packets.length,
+      MapSceneInstanceLayerSubmission() => 1,
+    };
+  }
+
+  if (hasRegion && hasCity) {
+    throw ArgumentError.value(
+      layers,
+      'layers',
+      'must not mix region and city Fill',
+    );
+  }
+  if (nodeCount > limits.maxNodeCount) {
+    throw ArgumentError.value(nodeCount, 'layers', 'exceeds maxNodeCount');
+  }
+}
+
+void validateMapSceneLayerCompatibility(MapSceneLayerSubmission layer) {
+  switch (layer) {
+    case MapSceneMeshLayerSubmission(:final kind, :final batch):
+      final pipeline = batch.compatibility.pipeline;
+      final expectedPhase = switch (kind) {
+        MapSceneMeshLayerKind.baseMap when pipeline == baseMapFillPipelineKey =>
+          mapSceneRenderPhasePolicy.rankOf(mapSceneBaseLandFillPhaseId),
+        MapSceneMeshLayerKind.baseMap when pipeline == baseMapLinePipelineKey =>
+          mapSceneRenderPhasePolicy.rankOf(
+            mapSceneBaseAdministrativeLinePhaseId,
+          ),
+        MapSceneMeshLayerKind.earthquakeAreaFill
+            when pipeline == earthquakeAreaFillPipelineKey =>
+          mapSceneRenderPhasePolicy.rankOf(mapSceneOverlayHazardFillPhaseId),
+        _ => throw ArgumentError.value(
+          pipeline,
+          'layer',
+          'is not supported by the mesh layer kind',
+        ),
+      };
+      if (layer.phase != expectedPhase) {
+        throw ArgumentError.value(
+          layer.phase,
+          'layer',
+          'has a phase mismatch',
+        );
+      }
+      switch (kind) {
+        case MapSceneMeshLayerKind.baseMap:
+          if (layer.logicalSourceKey != mapSceneBaseSourceKey ||
+              layer.componentKey != mapSceneBaseComponentKey ||
+              layer.overlayVersion != null) {
+            throw ArgumentError.value(
+              layer,
+              'layer',
+              'has invalid base identity',
+            );
+          }
+        case MapSceneMeshLayerKind.earthquakeAreaFill:
+          if (layer.logicalSourceKey != mapSceneEarthquakeHistorySourceKey ||
+              (layer.componentKey != mapSceneRegionFillComponentKey &&
+                  layer.componentKey != mapSceneCityFillComponentKey) ||
+              layer.overlayVersion == null) {
+            throw ArgumentError.value(
+              layer,
+              'layer',
+              'has invalid earthquake Fill identity',
+            );
+          }
+      }
+    case MapSceneInstanceLayerSubmission(:final kind):
+      final expected = switch (kind) {
+        MapSceneInstanceLayerKind.observationPoint => (
+          phase: mapSceneRenderPhasePolicy.rankOf(mapSceneLivePointPhaseId),
+          component: mapSceneObservationPointComponentKey,
+        ),
+        MapSceneInstanceLayerKind.pointSprite => (
+          phase: mapSceneRenderPhasePolicy.rankOf(mapSceneSpritePhaseId),
+          component: mapSceneHypocenterSpriteComponentKey,
+        ),
+      };
+      if (layer.phase != expected.phase ||
+          layer.logicalSourceKey != mapSceneEarthquakeHistorySourceKey ||
+          layer.componentKey != expected.component ||
+          layer.overlayVersion == null) {
+        throw ArgumentError.value(
+          layer,
+          'layer',
+          'has an instance mismatch',
+        );
+      }
   }
 }

--- a/packages/eqmonitor_map/lib/src/renderer/map_scene_frame_submission.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/map_scene_frame_submission.dart
@@ -52,21 +52,21 @@ void validateMapSceneFrameSubmission({
     throw ArgumentError('baseMap and earthquakeFill must share one frame');
   }
 
-  final basePhase = mapSceneRenderPhasePolicy.rankOf(mapSceneBasePhaseId);
   validateMapSceneBatches(
     batches: submission.baseMap.batches,
-    expectedPhases: {basePhase},
+    expectedPhases: {
+      mapSceneRenderPhasePolicy.rankOf(mapSceneBaseLandFillPhaseId),
+      mapSceneRenderPhasePolicy.rankOf(
+        mapSceneBaseAdministrativeLinePhaseId,
+      ),
+    },
     parameterName: 'baseMap',
-  );
-  final regionPhase = mapSceneRenderPhasePolicy.rankOf(
-    mapSceneEarthquakeRegionPhaseId,
-  );
-  final cityPhase = mapSceneRenderPhasePolicy.rankOf(
-    mapSceneEarthquakeCityPhaseId,
   );
   validateMapSceneBatches(
     batches: submission.earthquakeFill.batches,
-    expectedPhases: {regionPhase, cityPhase},
+    expectedPhases: {
+      mapSceneRenderPhasePolicy.rankOf(mapSceneOverlayHazardFillPhaseId),
+    },
     parameterName: 'earthquakeFill',
   );
   validateEarthquakeFillBatches(batches: submission.earthquakeFill.batches);
@@ -80,7 +80,7 @@ void validateMapSceneFrameSubmission({
     throw ArgumentError('observationBatch must share the Scene frame');
   }
   final observationPhase = mapSceneRenderPhasePolicy.rankOf(
-    mapSceneObservationPointPhaseId,
+    mapSceneLivePointPhaseId,
   );
   if (observation.phasePolicyVersion != mapSceneRenderPhasePolicy.version ||
       observation.phase != observationPhase) {

--- a/packages/eqmonitor_map/lib/src/renderer/map_scene_frame_submission.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/map_scene_frame_submission.dart
@@ -1,5 +1,6 @@
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
 import 'package:eqmonitor_map/src/foundation/render/map_render_batch.dart';
+import 'package:eqmonitor_map/src/foundation/render/map_render_packet.dart';
 import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
 import 'package:eqmonitor_map/src/renderer/base_map_render_submission_builder.dart';
 import 'package:eqmonitor_map/src/renderer/earthquake_area_render_submission_builder.dart';
@@ -69,6 +70,16 @@ final MapSceneBatchKey mapSceneObservationBatchKey = createMapSceneBatchKey(
 );
 
 enum MapSceneMeshLayerKind { baseMap, earthquakeAreaFill }
+
+final class MapSceneMeshPipelineMismatch implements Exception {
+  const MapSceneMeshPipelineMismatch({
+    required this.kind,
+    required this.pipeline,
+  });
+
+  final MapSceneMeshLayerKind kind;
+  final MapRenderPipelineKey pipeline;
+}
 
 enum MapSceneInstanceLayerKind { observationPoint, pointSprite }
 
@@ -369,10 +380,9 @@ void validateMapSceneLayerCompatibility(MapSceneLayerSubmission layer) {
         MapSceneMeshLayerKind.earthquakeAreaFill
             when pipeline == earthquakeAreaFillPipelineKey =>
           mapSceneRenderPhasePolicy.rankOf(mapSceneOverlayHazardFillPhaseId),
-        _ => throw ArgumentError.value(
-          pipeline,
-          'layer',
-          'is not supported by the mesh layer kind',
+        _ => throw MapSceneMeshPipelineMismatch(
+          kind: kind,
+          pipeline: pipeline,
         ),
       };
       if (layer.phase != expectedPhase) {

--- a/packages/eqmonitor_map/lib/src/renderer/map_scene_render_phase_policy.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/map_scene_render_phase_policy.dart
@@ -1,60 +1,71 @@
 import 'package:eqmonitor_map/src/foundation/render/map_render_phase.dart';
 
-/// base mapを描画するphase。
-final MapRenderPhaseId mapSceneBasePhaseId = createMapRenderPhaseId(
-  value: 'base',
+final MapRenderPhaseId mapSceneBaseLandFillPhaseId = createMapRenderPhaseId(
+  value: 'baseLandFill',
 );
 
-/// 予報区Fillを描画するphase。
-final MapRenderPhaseId mapSceneEarthquakeRegionPhaseId = createMapRenderPhaseId(
-  value: 'earthquakeRegion',
+final MapRenderPhaseId mapSceneUnderlayHazardFillPhaseId =
+    createMapRenderPhaseId(value: 'underlayHazardFill');
+
+final MapRenderPhaseId mapSceneUnderlayHazardLinePhaseId =
+    createMapRenderPhaseId(value: 'underlayHazardLine');
+
+final MapRenderPhaseId mapSceneBaseAdministrativeLinePhaseId =
+    createMapRenderPhaseId(value: 'baseAdministrativeLine');
+
+final MapRenderPhaseId mapSceneOverlayHazardFillPhaseId =
+    createMapRenderPhaseId(
+      value: 'overlayHazardFill',
+    );
+
+final MapRenderPhaseId mapSceneOverlayHazardLinePhaseId =
+    createMapRenderPhaseId(
+      value: 'overlayHazardLine',
+    );
+
+final MapRenderPhaseId mapSceneDynamicWaveFillPhaseId = createMapRenderPhaseId(
+  value: 'dynamicWaveFill',
 );
 
-/// 市区町村Fillを描画するphase。
-final MapRenderPhaseId mapSceneEarthquakeCityPhaseId = createMapRenderPhaseId(
-  value: 'earthquakeCity',
+final MapRenderPhaseId mapSceneDynamicWaveLinePhaseId = createMapRenderPhaseId(
+  value: 'dynamicWaveLine',
 );
 
-/// 観測点を描画するphase。
-final MapRenderPhaseId mapSceneObservationPointPhaseId = createMapRenderPhaseId(
-  value: 'observationPoint',
+final MapRenderPhaseId mapSceneLivePointPhaseId = createMapRenderPhaseId(
+  value: 'livePoint',
 );
 
-/// 1つのSceneへ送る全描画要素が共有するphase policy。
-///
-/// v1のbase/label専用policyへ地震overlay phaseを追加したためversionを2へ上げる。
+final MapRenderPhaseId mapSceneSpritePhaseId = createMapRenderPhaseId(
+  value: 'sprite',
+);
+
+final MapRenderPhaseId mapSceneForegroundLabelPhaseId =
+    MapRenderPhaseId.labelForeground;
+
+/// package-neutralな全描画要素が共有する疎なphase policy。
 final MapRenderPhasePolicy mapSceneRenderPhasePolicy =
     createMapRenderPhasePolicy(
-      version: 2,
+      version: 3,
       orderedPhases: [
-        mapSceneBasePhaseId,
-        mapSceneEarthquakeRegionPhaseId,
-        mapSceneEarthquakeCityPhaseId,
-        mapSceneObservationPointPhaseId,
-        MapRenderPhaseId.labelForeground,
+        mapSceneBaseLandFillPhaseId,
+        mapSceneUnderlayHazardFillPhaseId,
+        mapSceneUnderlayHazardLinePhaseId,
+        mapSceneBaseAdministrativeLinePhaseId,
+        mapSceneOverlayHazardFillPhaseId,
+        mapSceneOverlayHazardLinePhaseId,
+        mapSceneDynamicWaveFillPhaseId,
+        mapSceneDynamicWaveLinePhaseId,
+        mapSceneLivePointPhaseId,
+        mapSceneSpritePhaseId,
+        mapSceneForegroundLabelPhaseId,
       ],
+      phaseRanks: const [0, 20, 30, 40, 100, 110, 200, 210, 300, 350, 400],
     );
 
 /// phaseごとのFlutter Scene translucent sort priority。
 int mapSceneTranslucentSortPriorityFor({required int phase}) {
-  if (phase == mapSceneRenderPhasePolicy.rankOf(mapSceneBasePhaseId)) {
-    return 0;
-  }
-  if (phase ==
-      mapSceneRenderPhasePolicy.rankOf(mapSceneEarthquakeRegionPhaseId)) {
-    return 100;
-  }
-  if (phase ==
-      mapSceneRenderPhasePolicy.rankOf(mapSceneEarthquakeCityPhaseId)) {
-    return 200;
-  }
-  if (phase ==
-      mapSceneRenderPhasePolicy.rankOf(mapSceneObservationPointPhaseId)) {
-    return 300;
-  }
-  if (phase ==
-      mapSceneRenderPhasePolicy.rankOf(MapRenderPhaseId.labelForeground)) {
-    return 400;
+  if (mapSceneRenderPhasePolicy.containsRank(phase)) {
+    return phase;
   }
   throw ArgumentError.value(phase, 'phase', 'is not in the Scene policy');
 }

--- a/packages/eqmonitor_map/lib/src/renderer/map_scene_render_phase_policy.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/map_scene_render_phase_policy.dart
@@ -39,7 +39,7 @@ final MapRenderPhaseId mapSceneSpritePhaseId = createMapRenderPhaseId(
   value: 'sprite',
 );
 
-final MapRenderPhaseId mapSceneForegroundLabelPhaseId =
+const MapRenderPhaseId mapSceneForegroundLabelPhaseId =
     MapRenderPhaseId.labelForeground;
 
 /// package-neutralな全描画要素が共有する疎なphase policy。
@@ -61,26 +61,3 @@ final MapRenderPhasePolicy mapSceneRenderPhasePolicy =
       ],
       phaseRanks: const [0, 20, 30, 40, 100, 110, 200, 210, 300, 350, 400],
     );
-
-/// phaseごとのFlutter Scene translucent sort priority。
-int mapSceneTranslucentSortPriorityFor({required int phase}) {
-  if (mapSceneRenderPhasePolicy.containsRank(phase)) {
-    return phase;
-  }
-  throw ArgumentError.value(phase, 'phase', 'is not in the Scene policy');
-}
-
-/// [priority]が[phase]に割り当てられた値と一致することを検証する。
-void validateMapSceneTranslucentSortPriority({
-  required int phase,
-  required int priority,
-}) {
-  final expected = mapSceneTranslucentSortPriorityFor(phase: phase);
-  if (priority != expected) {
-    throw ArgumentError.value(
-      priority,
-      'priority',
-      'must be $expected for phase $phase',
-    );
-  }
-}

--- a/packages/eqmonitor_map/lib/src/renderer/observation_point_batch.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/observation_point_batch.dart
@@ -17,7 +17,7 @@ final class ObservationPointInstanceGeneration {
 }
 
 /// 1 overlay version分の観測点instanceとframe固有uniform。
-final class ObservationPointBatch implements MapSceneObservationBatch {
+final class ObservationPointBatch implements MapSceneInstanceBatch {
   const ObservationPointBatch._({
     required this.frame,
     required this.versionStamp,
@@ -25,9 +25,9 @@ final class ObservationPointBatch implements MapSceneObservationBatch {
     required this.instanceData,
     required this.instanceCount,
     required this.frameUniform,
+    required this.batchKey,
     required this.phasePolicyVersion,
     required this.phase,
-    required this.translucentSortPriority,
     required Object stationSnapshotIdentity,
   }) : _stationSnapshotToken = stationSnapshotIdentity;
 
@@ -40,13 +40,13 @@ final class ObservationPointBatch implements MapSceneObservationBatch {
   final ByteData frameUniform;
 
   @override
+  final MapSceneBatchKey batchKey;
+
+  @override
   final int phasePolicyVersion;
 
   @override
   final int phase;
-
-  @override
-  final int translucentSortPriority;
 
   final Object _stationSnapshotToken;
 
@@ -74,9 +74,9 @@ final class ObservationPointBatch implements MapSceneObservationBatch {
       frameUniform: ByteData.sublistView(
         ownedUniformBytes,
       ).asUnmodifiableView(),
+      batchKey: batchKey,
       phasePolicyVersion: phasePolicyVersion,
       phase: phase,
-      translucentSortPriority: translucentSortPriority,
       stationSnapshotIdentity: _stationSnapshotToken,
     );
   }
@@ -89,9 +89,9 @@ ObservationPointBatch createObservationPointBatch({
   required Float32List instanceData,
   required int instanceCount,
   required ByteData frameUniform,
+  required MapSceneBatchKey batchKey,
   required int phasePolicyVersion,
   required int phase,
-  required int translucentSortPriority,
   Object? stationSnapshotIdentity,
 }) {
   if (instanceCount <= 0 ||
@@ -127,9 +127,9 @@ ObservationPointBatch createObservationPointBatch({
     frameUniform: ByteData.sublistView(
       ownedUniformBytes,
     ).asUnmodifiableView(),
+    batchKey: batchKey,
     phasePolicyVersion: phasePolicyVersion,
     phase: phase,
-    translucentSortPriority: translucentSortPriority,
     stationSnapshotIdentity: stationSnapshotIdentity ?? Object(),
   );
 }

--- a/packages/eqmonitor_map/lib/src/renderer/observation_point_batch_builder.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/observation_point_batch_builder.dart
@@ -4,6 +4,7 @@ import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
 import 'package:eqmonitor_map/src/geo/map_mercator_projection.dart';
 import 'package:eqmonitor_map/src/geo/map_viewport.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_map_overlay_snapshot.dart';
+import 'package:eqmonitor_map/src/renderer/map_scene_frame_submission.dart';
 import 'package:eqmonitor_map/src/renderer/map_scene_render_phase_policy.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch.dart';
 
@@ -57,9 +58,9 @@ ObservationPointBatch? buildObservationPointBatch({
     instanceData: instanceData,
     instanceCount: snapshot.stations.length,
     frameUniform: frameUniform,
+    batchKey: mapSceneObservationBatchKey,
     phasePolicyVersion: mapSceneRenderPhasePolicy.version,
     phase: phase,
-    translucentSortPriority: mapSceneTranslucentSortPriorityFor(phase: phase),
     stationSnapshotIdentity: snapshot.stations,
   );
 }

--- a/packages/eqmonitor_map/lib/src/renderer/observation_point_batch_builder.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/observation_point_batch_builder.dart
@@ -49,7 +49,7 @@ ObservationPointBatch? buildObservationPointBatch({
     projection: projection,
   );
   final phase = mapSceneRenderPhasePolicy.rankOf(
-    mapSceneObservationPointPhaseId,
+    mapSceneLivePointPhaseId,
   );
   return createObservationPointBatch(
     frame: frame,

--- a/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
+++ b/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
@@ -23,6 +23,7 @@ import 'package:eqmonitor_map/src/renderer/earthquake_area_packed_mesh_cache.dar
 import 'package:eqmonitor_map/src/renderer/earthquake_area_render_resources.dart';
 import 'package:eqmonitor_map/src/renderer/earthquake_area_render_submission_builder.dart';
 import 'package:eqmonitor_map/src/renderer/map_render_lifecycle_policy.dart';
+import 'package:eqmonitor_map/src/renderer/map_scene_frame_submission.dart';
 import 'package:eqmonitor_map/src/tile/base_map_render_plan_builder.dart';
 import 'package:eqmonitor_map/src/tile/base_map_tile_cache.dart';
 import 'package:eqmonitor_map/src/tile/base_map_tile_decode_failure_owner.dart';
@@ -105,6 +106,9 @@ abstract class MapBaseLayerLimits with _$MapBaseLayerLimits {
     /// 落とすと、まだ in-flight の frame が参照している最中に GC 対象へ
     /// してしまう。この frame 数ぶん未使用が続いた resource だけを手放す。
     required int maxFramesInFlight,
+
+    /// 一つのScene frameへ送るmesh packet / instance batch node総数の上限。
+    required int maxSceneNodeCount,
   }) = _MapBaseLayerLimits;
 }
 
@@ -770,6 +774,9 @@ class _BaseMapController extends ChangeNotifier {
       tileCache: _cache,
       packedMeshFor: _earthquakePackedMeshCache.resolve,
       styleCache: _earthquakeStyleCache,
+      sceneFrameLimits: MapSceneFrameLimits(
+        maxNodeCount: limits.maxSceneNodeCount,
+      ),
     );
     if (result.shouldRetireGpuResources) {
       adapter.retireAllGpuResources();
@@ -784,6 +791,9 @@ class _BaseMapController extends ChangeNotifier {
       baseOnlySubmission: buildBaseMapOnlyFrameSubmission(
         frame: frame,
         baseMap: baseMap,
+        sceneFrameLimits: MapSceneFrameLimits(
+          maxNodeCount: limits.maxSceneNodeCount,
+        ),
       ),
       resources: _requestedMaterialStage,
       submitFrame: (submission) => adapter.submitFrame(

--- a/packages/eqmonitor_map/lib/src/widget/base_map_view.freezed.dart
+++ b/packages/eqmonitor_map/lib/src/widget/base_map_view.freezed.dart
@@ -59,7 +59,8 @@ mixin _$MapBaseLayerLimits {
 /// GPU完了を意味しない」)。可視 tile から外れた geometry の参照を即座に
 /// 落とすと、まだ in-flight の frame が参照している最中に GC 対象へ
 /// してしまう。この frame 数ぶん未使用が続いた resource だけを手放す。
- int get maxFramesInFlight;
+ int get maxFramesInFlight;/// 一つのScene frameへ送るmesh packet / instance batch node総数の上限。
+ int get maxSceneNodeCount;
 /// Create a copy of MapBaseLayerLimits
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -70,16 +71,16 @@ $MapBaseLayerLimitsCopyWith<MapBaseLayerLimits> get copyWith => _$MapBaseLayerLi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MapBaseLayerLimits&&(identical(other.minZoom, minZoom) || other.minZoom == minZoom)&&(identical(other.maxZoom, maxZoom) || other.maxZoom == maxZoom)&&(identical(other.pmTilesLimits, pmTilesLimits) || other.pmTilesLimits == pmTilesLimits)&&(identical(other.decodeLimits, decodeLimits) || other.decodeLimits == decodeLimits)&&(identical(other.maxCachedTileGeometries, maxCachedTileGeometries) || other.maxCachedTileGeometries == maxCachedTileGeometries)&&(identical(other.maxParentFallbackSteps, maxParentFallbackSteps) || other.maxParentFallbackSteps == maxParentFallbackSteps)&&(identical(other.maxInFlightDecodes, maxInFlightDecodes) || other.maxInFlightDecodes == maxInFlightDecodes)&&(identical(other.maxFramesInFlight, maxFramesInFlight) || other.maxFramesInFlight == maxFramesInFlight));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MapBaseLayerLimits&&(identical(other.minZoom, minZoom) || other.minZoom == minZoom)&&(identical(other.maxZoom, maxZoom) || other.maxZoom == maxZoom)&&(identical(other.pmTilesLimits, pmTilesLimits) || other.pmTilesLimits == pmTilesLimits)&&(identical(other.decodeLimits, decodeLimits) || other.decodeLimits == decodeLimits)&&(identical(other.maxCachedTileGeometries, maxCachedTileGeometries) || other.maxCachedTileGeometries == maxCachedTileGeometries)&&(identical(other.maxParentFallbackSteps, maxParentFallbackSteps) || other.maxParentFallbackSteps == maxParentFallbackSteps)&&(identical(other.maxInFlightDecodes, maxInFlightDecodes) || other.maxInFlightDecodes == maxInFlightDecodes)&&(identical(other.maxFramesInFlight, maxFramesInFlight) || other.maxFramesInFlight == maxFramesInFlight)&&(identical(other.maxSceneNodeCount, maxSceneNodeCount) || other.maxSceneNodeCount == maxSceneNodeCount));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,minZoom,maxZoom,pmTilesLimits,decodeLimits,maxCachedTileGeometries,maxParentFallbackSteps,maxInFlightDecodes,maxFramesInFlight);
+int get hashCode => Object.hash(runtimeType,minZoom,maxZoom,pmTilesLimits,decodeLimits,maxCachedTileGeometries,maxParentFallbackSteps,maxInFlightDecodes,maxFramesInFlight,maxSceneNodeCount);
 
 @override
 String toString() {
-  return 'MapBaseLayerLimits(minZoom: $minZoom, maxZoom: $maxZoom, pmTilesLimits: $pmTilesLimits, decodeLimits: $decodeLimits, maxCachedTileGeometries: $maxCachedTileGeometries, maxParentFallbackSteps: $maxParentFallbackSteps, maxInFlightDecodes: $maxInFlightDecodes, maxFramesInFlight: $maxFramesInFlight)';
+  return 'MapBaseLayerLimits(minZoom: $minZoom, maxZoom: $maxZoom, pmTilesLimits: $pmTilesLimits, decodeLimits: $decodeLimits, maxCachedTileGeometries: $maxCachedTileGeometries, maxParentFallbackSteps: $maxParentFallbackSteps, maxInFlightDecodes: $maxInFlightDecodes, maxFramesInFlight: $maxFramesInFlight, maxSceneNodeCount: $maxSceneNodeCount)';
 }
 
 
@@ -90,7 +91,7 @@ abstract mixin class $MapBaseLayerLimitsCopyWith<$Res>  {
   factory $MapBaseLayerLimitsCopyWith(MapBaseLayerLimits value, $Res Function(MapBaseLayerLimits) _then) = _$MapBaseLayerLimitsCopyWithImpl;
 @useResult
 $Res call({
- int minZoom, int maxZoom, PmTilesV3Limits pmTilesLimits, BaseMapTileDecodeLimits decodeLimits, int maxCachedTileGeometries, int maxParentFallbackSteps, int maxInFlightDecodes, int maxFramesInFlight
+ int minZoom, int maxZoom, PmTilesV3Limits pmTilesLimits, BaseMapTileDecodeLimits decodeLimits, int maxCachedTileGeometries, int maxParentFallbackSteps, int maxInFlightDecodes, int maxFramesInFlight, int maxSceneNodeCount
 });
 
 
@@ -107,7 +108,7 @@ class _$MapBaseLayerLimitsCopyWithImpl<$Res>
 
 /// Create a copy of MapBaseLayerLimits
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? minZoom = null,Object? maxZoom = null,Object? pmTilesLimits = null,Object? decodeLimits = null,Object? maxCachedTileGeometries = null,Object? maxParentFallbackSteps = null,Object? maxInFlightDecodes = null,Object? maxFramesInFlight = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? minZoom = null,Object? maxZoom = null,Object? pmTilesLimits = null,Object? decodeLimits = null,Object? maxCachedTileGeometries = null,Object? maxParentFallbackSteps = null,Object? maxInFlightDecodes = null,Object? maxFramesInFlight = null,Object? maxSceneNodeCount = null,}) {
   return _then(MapBaseLayerLimits(
 minZoom: null == minZoom ? _self.minZoom : minZoom // ignore: cast_nullable_to_non_nullable
 as int,maxZoom: null == maxZoom ? _self.maxZoom : maxZoom // ignore: cast_nullable_to_non_nullable
@@ -117,6 +118,7 @@ as BaseMapTileDecodeLimits,maxCachedTileGeometries: null == maxCachedTileGeometr
 as int,maxParentFallbackSteps: null == maxParentFallbackSteps ? _self.maxParentFallbackSteps : maxParentFallbackSteps // ignore: cast_nullable_to_non_nullable
 as int,maxInFlightDecodes: null == maxInFlightDecodes ? _self.maxInFlightDecodes : maxInFlightDecodes // ignore: cast_nullable_to_non_nullable
 as int,maxFramesInFlight: null == maxFramesInFlight ? _self.maxFramesInFlight : maxFramesInFlight // ignore: cast_nullable_to_non_nullable
+as int,maxSceneNodeCount: null == maxSceneNodeCount ? _self.maxSceneNodeCount : maxSceneNodeCount // ignore: cast_nullable_to_non_nullable
 as int,
   ));
 }
@@ -220,10 +222,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int minZoom,  int maxZoom,  PmTilesV3Limits pmTilesLimits,  BaseMapTileDecodeLimits decodeLimits,  int maxCachedTileGeometries,  int maxParentFallbackSteps,  int maxInFlightDecodes,  int maxFramesInFlight)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int minZoom,  int maxZoom,  PmTilesV3Limits pmTilesLimits,  BaseMapTileDecodeLimits decodeLimits,  int maxCachedTileGeometries,  int maxParentFallbackSteps,  int maxInFlightDecodes,  int maxFramesInFlight,  int maxSceneNodeCount)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _MapBaseLayerLimits() when $default != null:
-return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimits,_that.maxCachedTileGeometries,_that.maxParentFallbackSteps,_that.maxInFlightDecodes,_that.maxFramesInFlight);case _:
+return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimits,_that.maxCachedTileGeometries,_that.maxParentFallbackSteps,_that.maxInFlightDecodes,_that.maxFramesInFlight,_that.maxSceneNodeCount);case _:
   return orElse();
 
 }
@@ -241,10 +243,10 @@ return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimi
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int minZoom,  int maxZoom,  PmTilesV3Limits pmTilesLimits,  BaseMapTileDecodeLimits decodeLimits,  int maxCachedTileGeometries,  int maxParentFallbackSteps,  int maxInFlightDecodes,  int maxFramesInFlight)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int minZoom,  int maxZoom,  PmTilesV3Limits pmTilesLimits,  BaseMapTileDecodeLimits decodeLimits,  int maxCachedTileGeometries,  int maxParentFallbackSteps,  int maxInFlightDecodes,  int maxFramesInFlight,  int maxSceneNodeCount)  $default,) {final _that = this;
 switch (_that) {
 case _MapBaseLayerLimits():
-return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimits,_that.maxCachedTileGeometries,_that.maxParentFallbackSteps,_that.maxInFlightDecodes,_that.maxFramesInFlight);case _:
+return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimits,_that.maxCachedTileGeometries,_that.maxParentFallbackSteps,_that.maxInFlightDecodes,_that.maxFramesInFlight,_that.maxSceneNodeCount);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -261,10 +263,10 @@ return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimi
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int minZoom,  int maxZoom,  PmTilesV3Limits pmTilesLimits,  BaseMapTileDecodeLimits decodeLimits,  int maxCachedTileGeometries,  int maxParentFallbackSteps,  int maxInFlightDecodes,  int maxFramesInFlight)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int minZoom,  int maxZoom,  PmTilesV3Limits pmTilesLimits,  BaseMapTileDecodeLimits decodeLimits,  int maxCachedTileGeometries,  int maxParentFallbackSteps,  int maxInFlightDecodes,  int maxFramesInFlight,  int maxSceneNodeCount)?  $default,) {final _that = this;
 switch (_that) {
 case _MapBaseLayerLimits() when $default != null:
-return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimits,_that.maxCachedTileGeometries,_that.maxParentFallbackSteps,_that.maxInFlightDecodes,_that.maxFramesInFlight);case _:
+return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimits,_that.maxCachedTileGeometries,_that.maxParentFallbackSteps,_that.maxInFlightDecodes,_that.maxFramesInFlight,_that.maxSceneNodeCount);case _:
   return null;
 
 }
@@ -276,7 +278,7 @@ return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimi
 
 
 class _MapBaseLayerLimits implements MapBaseLayerLimits {
-  const _MapBaseLayerLimits({required this.minZoom, required this.maxZoom, required this.pmTilesLimits, required this.decodeLimits, required this.maxCachedTileGeometries, required this.maxParentFallbackSteps, required this.maxInFlightDecodes, required this.maxFramesInFlight});
+  const _MapBaseLayerLimits({required this.minZoom, required this.maxZoom, required this.pmTilesLimits, required this.decodeLimits, required this.maxCachedTileGeometries, required this.maxParentFallbackSteps, required this.maxInFlightDecodes, required this.maxFramesInFlight, required this.maxSceneNodeCount});
   
 
 /// pan/pinch zoom gestureが許すcamera zoomの下限、および
@@ -331,6 +333,8 @@ class _MapBaseLayerLimits implements MapBaseLayerLimits {
 /// 落とすと、まだ in-flight の frame が参照している最中に GC 対象へ
 /// してしまう。この frame 数ぶん未使用が続いた resource だけを手放す。
 @override final  int maxFramesInFlight;
+/// 一つのScene frameへ送るmesh packet / instance batch node総数の上限。
+@override final  int maxSceneNodeCount;
 
 /// Create a copy of MapBaseLayerLimits
 /// with the given fields replaced by the non-null parameter values.
@@ -342,16 +346,16 @@ _$MapBaseLayerLimitsCopyWith<_MapBaseLayerLimits> get copyWith => __$MapBaseLaye
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MapBaseLayerLimits&&(identical(other.minZoom, minZoom) || other.minZoom == minZoom)&&(identical(other.maxZoom, maxZoom) || other.maxZoom == maxZoom)&&(identical(other.pmTilesLimits, pmTilesLimits) || other.pmTilesLimits == pmTilesLimits)&&(identical(other.decodeLimits, decodeLimits) || other.decodeLimits == decodeLimits)&&(identical(other.maxCachedTileGeometries, maxCachedTileGeometries) || other.maxCachedTileGeometries == maxCachedTileGeometries)&&(identical(other.maxParentFallbackSteps, maxParentFallbackSteps) || other.maxParentFallbackSteps == maxParentFallbackSteps)&&(identical(other.maxInFlightDecodes, maxInFlightDecodes) || other.maxInFlightDecodes == maxInFlightDecodes)&&(identical(other.maxFramesInFlight, maxFramesInFlight) || other.maxFramesInFlight == maxFramesInFlight));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MapBaseLayerLimits&&(identical(other.minZoom, minZoom) || other.minZoom == minZoom)&&(identical(other.maxZoom, maxZoom) || other.maxZoom == maxZoom)&&(identical(other.pmTilesLimits, pmTilesLimits) || other.pmTilesLimits == pmTilesLimits)&&(identical(other.decodeLimits, decodeLimits) || other.decodeLimits == decodeLimits)&&(identical(other.maxCachedTileGeometries, maxCachedTileGeometries) || other.maxCachedTileGeometries == maxCachedTileGeometries)&&(identical(other.maxParentFallbackSteps, maxParentFallbackSteps) || other.maxParentFallbackSteps == maxParentFallbackSteps)&&(identical(other.maxInFlightDecodes, maxInFlightDecodes) || other.maxInFlightDecodes == maxInFlightDecodes)&&(identical(other.maxFramesInFlight, maxFramesInFlight) || other.maxFramesInFlight == maxFramesInFlight)&&(identical(other.maxSceneNodeCount, maxSceneNodeCount) || other.maxSceneNodeCount == maxSceneNodeCount));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,minZoom,maxZoom,pmTilesLimits,decodeLimits,maxCachedTileGeometries,maxParentFallbackSteps,maxInFlightDecodes,maxFramesInFlight);
+int get hashCode => Object.hash(runtimeType,minZoom,maxZoom,pmTilesLimits,decodeLimits,maxCachedTileGeometries,maxParentFallbackSteps,maxInFlightDecodes,maxFramesInFlight,maxSceneNodeCount);
 
 @override
 String toString() {
-  return 'MapBaseLayerLimits(minZoom: $minZoom, maxZoom: $maxZoom, pmTilesLimits: $pmTilesLimits, decodeLimits: $decodeLimits, maxCachedTileGeometries: $maxCachedTileGeometries, maxParentFallbackSteps: $maxParentFallbackSteps, maxInFlightDecodes: $maxInFlightDecodes, maxFramesInFlight: $maxFramesInFlight)';
+  return 'MapBaseLayerLimits(minZoom: $minZoom, maxZoom: $maxZoom, pmTilesLimits: $pmTilesLimits, decodeLimits: $decodeLimits, maxCachedTileGeometries: $maxCachedTileGeometries, maxParentFallbackSteps: $maxParentFallbackSteps, maxInFlightDecodes: $maxInFlightDecodes, maxFramesInFlight: $maxFramesInFlight, maxSceneNodeCount: $maxSceneNodeCount)';
 }
 
 
@@ -362,7 +366,7 @@ abstract mixin class _$MapBaseLayerLimitsCopyWith<$Res> implements $MapBaseLayer
   factory _$MapBaseLayerLimitsCopyWith(_MapBaseLayerLimits value, $Res Function(_MapBaseLayerLimits) _then) = __$MapBaseLayerLimitsCopyWithImpl;
 @override @useResult
 $Res call({
- int minZoom, int maxZoom, PmTilesV3Limits pmTilesLimits, BaseMapTileDecodeLimits decodeLimits, int maxCachedTileGeometries, int maxParentFallbackSteps, int maxInFlightDecodes, int maxFramesInFlight
+ int minZoom, int maxZoom, PmTilesV3Limits pmTilesLimits, BaseMapTileDecodeLimits decodeLimits, int maxCachedTileGeometries, int maxParentFallbackSteps, int maxInFlightDecodes, int maxFramesInFlight, int maxSceneNodeCount
 });
 
 
@@ -379,7 +383,7 @@ class __$MapBaseLayerLimitsCopyWithImpl<$Res>
 
 /// Create a copy of MapBaseLayerLimits
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? minZoom = null,Object? maxZoom = null,Object? pmTilesLimits = null,Object? decodeLimits = null,Object? maxCachedTileGeometries = null,Object? maxParentFallbackSteps = null,Object? maxInFlightDecodes = null,Object? maxFramesInFlight = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? minZoom = null,Object? maxZoom = null,Object? pmTilesLimits = null,Object? decodeLimits = null,Object? maxCachedTileGeometries = null,Object? maxParentFallbackSteps = null,Object? maxInFlightDecodes = null,Object? maxFramesInFlight = null,Object? maxSceneNodeCount = null,}) {
   return _then(_MapBaseLayerLimits(
 minZoom: null == minZoom ? _self.minZoom : minZoom // ignore: cast_nullable_to_non_nullable
 as int,maxZoom: null == maxZoom ? _self.maxZoom : maxZoom // ignore: cast_nullable_to_non_nullable
@@ -389,6 +393,7 @@ as BaseMapTileDecodeLimits,maxCachedTileGeometries: null == maxCachedTileGeometr
 as int,maxParentFallbackSteps: null == maxParentFallbackSteps ? _self.maxParentFallbackSteps : maxParentFallbackSteps // ignore: cast_nullable_to_non_nullable
 as int,maxInFlightDecodes: null == maxInFlightDecodes ? _self.maxInFlightDecodes : maxInFlightDecodes // ignore: cast_nullable_to_non_nullable
 as int,maxFramesInFlight: null == maxFramesInFlight ? _self.maxFramesInFlight : maxFramesInFlight // ignore: cast_nullable_to_non_nullable
+as int,maxSceneNodeCount: null == maxSceneNodeCount ? _self.maxSceneNodeCount : maxSceneNodeCount // ignore: cast_nullable_to_non_nullable
 as int,
   ));
 }

--- a/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
@@ -25,6 +25,7 @@ import 'package:eqmonitor_map/src/renderer/map_scene_render_phase_policy.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch_builder.dart';
 import 'package:flutter_scene/scene.dart' as scene;
+import 'package:flutter_scene/src/scene_encoder.dart' as scene_encoder;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math.dart';
 
@@ -713,7 +714,7 @@ void main() {
   });
 
   test(
-    'preplans same-phase layers and packet nodes with strict draw ranks',
+    'preserves same-phase multi-packet ranks through the Scene comparator',
     () {
       final first = submission(
         policy: mapSceneRenderPhasePolicy,
@@ -738,15 +739,26 @@ void main() {
       final plans = buildFlutterSceneNodePlans(submission: value);
       expect(plans.map((plan) => plan.drawRank), [0, 1, 2]);
 
-      final nodes = [for (final _ in plans) scene.Node()];
-      for (final (index, plan) in plans.indexed) {
-        applyFlutterSceneDrawRank(node: nodes[index], drawRank: plan.drawRank);
-      }
-
-      expect(
-        nodes.map((node) => node.translucentSortPriority),
-        [0, 1, 2],
+      final encodedOrder = scene_encoder.sortSceneTranslucentRecordsForTesting(
+        [
+          for (final index in const [2, 0, 1])
+            (
+              priority: plans[index].drawRank,
+              depth: 42.0,
+              id: switch (plans[index]) {
+                FlutterSceneMeshNodePlan(:final layer, :final packetIndex) =>
+                  '${layer.batch.compatibility.batchKey.materialKey}:'
+                      '$packetIndex',
+                FlutterSceneObservationNodePlan() => 'observation',
+              },
+            ),
+        ],
       );
+      expect(encodedOrder.map((record) => record.id), [
+        'a-fill:0',
+        'a-fill:1',
+        'b-fill:0',
+      ]);
     },
   );
 

--- a/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
@@ -162,54 +162,64 @@ void main() {
     required int phase,
     required String materialKey,
     required String pipelineKey,
+    int packetCount = 1,
   }) {
-    final packet = createMapRenderPacket(
-      contractVersion: 1,
-      sortKey: MapRenderSortKey(
-        phasePolicyVersion: policy.version,
-        phase: phase,
-        declarationOrderWithinPhase: 0,
-        sourceOrder: 0,
-        overscaledTileOrder: 0,
-        featureOrder: 0,
-      ),
-      batchKey: createMapRenderBatchKey(
-        version: 1,
-        nodeKey: createMapNodeKey(value: 'test-node'),
-        scopeKey: 'test-scope',
-        materialKey: materialKey,
-        phasePolicyVersion: policy.version,
-        phase: phase,
-      ),
-      pipeline: createMapRenderPipelineKey(version: 1, key: pipelineKey),
-      mesh: packedMesh,
-      modelTransform: Float64List.fromList([
-        1,
-        0,
-        0,
-        0,
-        0,
-        1,
-        0,
-        0,
-        0,
-        0,
-        1,
-        0,
-        0,
-        0,
-        0,
-        1,
-      ]),
-      materialParameters: createMapMaterialParameterBlock(
-        version: 1,
-        bytes: Uint8List(16),
-      ),
-    );
     return createMapRenderSubmission(
       frame: frame,
       batches: [
-        createMapRenderBatch(version: 1, policy: policy, packets: [packet]),
+        createMapRenderBatch(
+          version: 1,
+          policy: policy,
+          packets: [
+            for (var index = 0; index < packetCount; index++)
+              createMapRenderPacket(
+                contractVersion: 1,
+                sortKey: MapRenderSortKey(
+                  phasePolicyVersion: policy.version,
+                  phase: phase,
+                  declarationOrderWithinPhase: 0,
+                  sourceOrder: 0,
+                  overscaledTileOrder: 0,
+                  featureOrder: index,
+                ),
+                batchKey: createMapRenderBatchKey(
+                  version: 1,
+                  nodeKey: createMapNodeKey(value: 'test-node'),
+                  scopeKey: 'test-scope',
+                  materialKey: materialKey,
+                  phasePolicyVersion: policy.version,
+                  phase: phase,
+                ),
+                pipeline: createMapRenderPipelineKey(
+                  version: 1,
+                  key: pipelineKey,
+                ),
+                mesh: packedMesh,
+                modelTransform: Float64List.fromList([
+                  1,
+                  0,
+                  0,
+                  0,
+                  0,
+                  1,
+                  0,
+                  0,
+                  0,
+                  0,
+                  1,
+                  0,
+                  0,
+                  0,
+                  0,
+                  1,
+                ]),
+                materialParameters: createMapMaterialParameterBlock(
+                  version: 1,
+                  bytes: Uint8List(16),
+                ),
+              ),
+          ],
+        ),
       ],
     );
   }
@@ -702,6 +712,44 @@ void main() {
     expect(plans.last.batch.compatibility.phase, 100);
   });
 
+  test(
+    'preplans same-phase layers and packet nodes with strict draw ranks',
+    () {
+      final first = submission(
+        policy: mapSceneRenderPhasePolicy,
+        phase: 0,
+        materialKey: 'a-fill',
+        pipelineKey: baseMapFillPipelineKey.key,
+        packetCount: 2,
+      );
+      final second = submission(
+        policy: mapSceneRenderPhasePolicy,
+        phase: 0,
+        materialKey: 'b-fill',
+        pipelineKey: baseMapFillPipelineKey.key,
+      );
+      final value = sceneSubmission(
+        baseMap: createMapRenderSubmission(
+          frame: frame,
+          batches: [...first.batches, ...second.batches],
+        ),
+      );
+
+      final plans = buildFlutterSceneNodePlans(submission: value);
+      expect(plans.map((plan) => plan.drawRank), [0, 1, 2]);
+
+      final nodes = [for (final _ in plans) scene.Node()];
+      for (final (index, plan) in plans.indexed) {
+        applyFlutterSceneDrawRank(node: nodes[index], drawRank: plan.drawRank);
+      }
+
+      expect(
+        nodes.map((node) => node.translucentSortPriority),
+        [0, 1, 2],
+      );
+    },
+  );
+
   test('rejects a phase not permitted for the base submission', () {
     final foreignPhase = createMapRenderPhaseId(value: 'foreign');
     final foreignPolicy = createMapRenderPhasePolicy(
@@ -749,7 +797,7 @@ void main() {
         baseMap: baseSubmission(),
         earthquakeFill: unknown,
       ),
-      throwsArgumentError,
+      throwsA(isA<MapSceneMeshPipelineMismatch>()),
     );
   });
 
@@ -777,9 +825,66 @@ void main() {
       limits: MapSceneFrameLimits(maxNodeCount: 1),
     );
 
+    final sceneGraph = _RecordingSceneGraph()..add(scene.Node());
+    var materialLookups = 0;
+    final adapter = FlutterSceneMapAdapter(
+      sceneGraph: sceneGraph,
+      materialFor: (_) {
+        materialLookups++;
+        return null;
+      },
+      maxFramesInFlight: 2,
+    );
+
     expect(
-      () => buildFlutterSceneMeshBatchPlans(submission: value),
-      throwsArgumentError,
+      () => adapter.submitFrame(submission: value),
+      throwsA(
+        isA<FlutterSceneLayerPreflightFailure>().having(
+          (error) => error.reason,
+          'reason',
+          FlutterSceneLayerPreflightFailureReason.instanceBatchTypeMismatch,
+        ),
+      ),
+    );
+    expect(materialLookups, 0);
+    expect(sceneGraph.children, hasLength(1));
+    expect(adapter.uploadedGeometryCount, 0);
+    expect(adapter.liveGeometryCount, 0);
+  });
+
+  test('rejects an unimplemented point sprite kind with a typed failure', () {
+    final spritePhase = mapSceneRenderPhasePolicy.rankOf(
+      mapSceneSpritePhaseId,
+    );
+    final value = MapSceneFrameSubmission(
+      frame: frame,
+      layers: [
+        MapSceneInstanceLayerSubmission(
+          logicalSourceKey: mapSceneEarthquakeHistorySourceKey,
+          componentKey: mapSceneHypocenterSpriteComponentKey,
+          overlayVersion: stampOf(1),
+          orderWithinPhase: 0,
+          kind: MapSceneInstanceLayerKind.pointSprite,
+          batch: _TestInstanceBatch(
+            frame: frame,
+            batchKey: createMapSceneBatchKey(value: 'future-sprite'),
+            phasePolicyVersion: mapSceneRenderPhasePolicy.version,
+            phase: spritePhase,
+          ),
+        ),
+      ],
+      limits: MapSceneFrameLimits(maxNodeCount: 1),
+    );
+
+    expect(
+      () => buildFlutterSceneNodePlans(submission: value),
+      throwsA(
+        isA<FlutterSceneLayerPreflightFailure>().having(
+          (error) => error.reason,
+          'reason',
+          FlutterSceneLayerPreflightFailureReason.unsupportedInstanceKind,
+        ),
+      ),
     );
   });
 
@@ -1334,7 +1439,7 @@ void main() {
 
       expect(
         () => sceneSubmission(baseMap: invalidBase),
-        throwsArgumentError,
+        throwsA(isA<MapSceneMeshPipelineMismatch>()),
       );
       expect(materialLookups, 0);
       expect(existingMaterialParameter, const Color(0xFF123456));

--- a/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
@@ -216,7 +216,7 @@ void main() {
 
   MapRenderSubmission baseSubmission() => submission(
     policy: mapSceneRenderPhasePolicy,
-    phase: mapSceneRenderPhasePolicy.rankOf(mapSceneBasePhaseId),
+    phase: mapSceneRenderPhasePolicy.rankOf(mapSceneBaseLandFillPhaseId),
     materialKey: 'countriesFill',
     pipelineKey: baseMapFillPipelineKey.key,
   );
@@ -225,14 +225,14 @@ void main() {
     String materialKey = earthquakeAreaFillMaterialKey,
   }) => submission(
     policy: mapSceneRenderPhasePolicy,
-    phase: mapSceneRenderPhasePolicy.rankOf(mapSceneEarthquakeRegionPhaseId),
+    phase: mapSceneRenderPhasePolicy.rankOf(mapSceneOverlayHazardFillPhaseId),
     materialKey: materialKey,
     pipelineKey: earthquakeAreaFillPipelineKey.key,
   );
 
   MapRenderSubmission citySubmission() => submission(
     policy: mapSceneRenderPhasePolicy,
-    phase: mapSceneRenderPhasePolicy.rankOf(mapSceneEarthquakeCityPhaseId),
+    phase: mapSceneRenderPhasePolicy.rankOf(mapSceneOverlayHazardFillPhaseId),
     materialKey: earthquakeAreaFillMaterialKey,
     pipelineKey: earthquakeAreaFillPipelineKey.key,
   );
@@ -316,11 +316,11 @@ void main() {
 
     final plans = buildFlutterSceneMeshBatchPlans(submission: value);
 
-    expect(plans.map((plan) => plan.batch.compatibility.phase), [0, 1]);
+    expect(plans.map((plan) => plan.batch.compatibility.phase), [0, 100]);
     expect(plans.map((plan) => plan.translucentSortPriority), [0, 100]);
   });
 
-  test('assigns city Fill priority 200', () {
+  test('assigns city Fill to the overlay hazard phase', () {
     final value = MapSceneFrameSubmission(
       baseMap: baseSubmission(),
       earthquakeFill: citySubmission(),
@@ -329,7 +329,7 @@ void main() {
 
     final plans = buildFlutterSceneMeshBatchPlans(submission: value);
 
-    expect(plans.last.translucentSortPriority, 200);
+    expect(plans.last.translucentSortPriority, 100);
   });
 
   test('writes the phase priority to an actual Flutter Scene node', () {
@@ -338,7 +338,7 @@ void main() {
     applyFlutterSceneTranslucentSortPriority(
       node: node,
       phase: mapSceneRenderPhasePolicy.rankOf(
-        mapSceneEarthquakeRegionPhaseId,
+        mapSceneOverlayHazardFillPhaseId,
       ),
       priority: 100,
     );
@@ -346,37 +346,25 @@ void main() {
     expect(node.translucentSortPriority, 100);
   });
 
-  test('rejects region and city Fill phases in the same frame', () {
-    final bothFillPhases = createMapRenderSubmission(
-      frame: frame,
-      batches: [
-        ...regionSubmission().batches,
-        ...citySubmission().batches,
-      ],
-    );
-
-    expect(
-      () => MapSceneFrameSubmission(
-        baseMap: baseSubmission(),
-        earthquakeFill: bothFillPhases,
-        observationBatch: null,
-      ),
-      throwsArgumentError,
-    );
-  });
-
   test('rejects a phase not permitted for the base submission', () {
     final foreignPhase = createMapRenderPhaseId(value: 'foreign');
     final foreignPolicy = createMapRenderPhasePolicy(
       version: mapSceneRenderPhasePolicy.version,
       orderedPhases: [
-        mapSceneBasePhaseId,
-        mapSceneEarthquakeRegionPhaseId,
-        mapSceneEarthquakeCityPhaseId,
-        mapSceneObservationPointPhaseId,
+        mapSceneBaseLandFillPhaseId,
+        mapSceneUnderlayHazardFillPhaseId,
+        mapSceneUnderlayHazardLinePhaseId,
+        mapSceneBaseAdministrativeLinePhaseId,
+        mapSceneOverlayHazardFillPhaseId,
+        mapSceneOverlayHazardLinePhaseId,
+        mapSceneDynamicWaveFillPhaseId,
+        mapSceneDynamicWaveLinePhaseId,
+        mapSceneLivePointPhaseId,
+        mapSceneSpritePhaseId,
+        mapSceneForegroundLabelPhaseId,
         foreignPhase,
-        MapRenderPhaseId.labelForeground,
       ],
+      phaseRanks: const [0, 20, 30, 40, 100, 110, 200, 210, 300, 350, 400, 500],
     );
     final invalidBase = submission(
       policy: foreignPolicy,
@@ -408,7 +396,7 @@ void main() {
 
   test('rejects an observation batch whose priority disagrees with phase', () {
     final observationPhase = mapSceneRenderPhasePolicy.rankOf(
-      mapSceneObservationPointPhaseId,
+      mapSceneLivePointPhaseId,
     );
 
     expect(
@@ -428,7 +416,7 @@ void main() {
 
   test('rejects a non-typed observation batch before Scene mutation', () {
     final observationPhase = mapSceneRenderPhasePolicy.rankOf(
-      mapSceneObservationPointPhaseId,
+      mapSceneLivePointPhaseId,
     );
     final value = MapSceneFrameSubmission(
       baseMap: baseSubmission(),
@@ -973,7 +961,9 @@ void main() {
           ...baseSubmission().batches,
           ...submission(
             policy: mapSceneRenderPhasePolicy,
-            phase: mapSceneRenderPhasePolicy.rankOf(mapSceneBasePhaseId),
+            phase: mapSceneRenderPhasePolicy.rankOf(
+              mapSceneBaseLandFillPhaseId,
+            ),
             materialKey: 'unknownPipeline',
             pipelineKey: 'unknown-base-pipeline',
           ).batches,
@@ -1044,7 +1034,9 @@ void main() {
           ...baseSubmission().batches,
           ...submission(
             policy: mapSceneRenderPhasePolicy,
-            phase: mapSceneRenderPhasePolicy.rankOf(mapSceneBasePhaseId),
+            phase: mapSceneRenderPhasePolicy.rankOf(
+              mapSceneBaseLandFillPhaseId,
+            ),
             materialKey: 'wrongTypedFill',
             pipelineKey: baseMapFillPipelineKey.key,
           ).batches,

--- a/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
@@ -28,25 +28,25 @@ import 'package:flutter_scene/scene.dart' as scene;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math.dart';
 
-final class _ObservationBatch implements MapSceneObservationBatch {
-  const _ObservationBatch({
+final class _TestInstanceBatch implements MapSceneInstanceBatch {
+  const _TestInstanceBatch({
     required this.frame,
+    required this.batchKey,
     required this.phasePolicyVersion,
     required this.phase,
-    required this.translucentSortPriority,
   });
 
   @override
   final MapFrameSnapshot frame;
 
   @override
+  final MapSceneBatchKey batchKey;
+
+  @override
   final int phasePolicyVersion;
 
   @override
   final int phase;
-
-  @override
-  final int translucentSortPriority;
 }
 
 final class _RecordingSceneGraph with scene.SceneGraph {
@@ -240,6 +240,56 @@ void main() {
   MapRenderSubmission emptySubmission() =>
       createMapRenderSubmission(frame: frame, batches: const []);
 
+  MapOverlayVersionStamp stampOf(int sequence) => createMapOverlayVersionStamp(
+    sourceIdentity: createMapSourceIdentity(value: 'event-1'),
+    sourceIncarnation: createMapSourceIncarnation(value: 'incarnation-1'),
+    dataSequence: sequence,
+    dataDigest: 'data-$sequence',
+    renderGeneration: sequence,
+    renderDigest: 'render-$sequence',
+  );
+
+  MapSceneMeshLayerSubmission meshLayer({
+    required MapSceneComponentKey componentKey,
+    required MapRenderSubmission submission,
+    MapOverlayVersionStamp? overlayVersion,
+    MapSceneLogicalSourceKey? logicalSourceKey,
+    int orderWithinPhase = 0,
+  }) => MapSceneMeshLayerSubmission(
+    frame: submission.frame,
+    logicalSourceKey: logicalSourceKey ?? mapSceneEarthquakeHistorySourceKey,
+    componentKey: componentKey,
+    overlayVersion: overlayVersion,
+    orderWithinPhase: orderWithinPhase,
+    batch: submission.batches.single,
+    kind: componentKey == mapSceneBaseComponentKey
+        ? MapSceneMeshLayerKind.baseMap
+        : MapSceneMeshLayerKind.earthquakeAreaFill,
+  );
+
+  MapSceneInstanceLayerSubmission instanceLayer({
+    required MapFrameSnapshot layerFrame,
+    required MapSceneComponentKey componentKey,
+    required MapSceneBatchKey batchKey,
+    required MapOverlayVersionStamp overlayVersion,
+    required MapSceneInstanceLayerKind kind,
+    required int phase,
+    int phasePolicyVersion = 3,
+    int orderWithinPhase = 0,
+  }) => MapSceneInstanceLayerSubmission(
+    logicalSourceKey: mapSceneEarthquakeHistorySourceKey,
+    componentKey: componentKey,
+    overlayVersion: overlayVersion,
+    orderWithinPhase: orderWithinPhase,
+    kind: kind,
+    batch: _TestInstanceBatch(
+      frame: layerFrame,
+      batchKey: batchKey,
+      phasePolicyVersion: phasePolicyVersion,
+      phase: phase,
+    ),
+  );
+
   final observationClock = SystemMapClock.start(
     domain: createMapClockDomainId(value: 'observation-adapter-test'),
   );
@@ -299,51 +349,357 @@ void main() {
     required MapFrameSnapshot frame,
     required ObservationPointBatch? batch,
   }) => MapSceneFrameSubmission(
-    baseMap: createMapRenderSubmission(frame: frame, batches: const []),
-    earthquakeFill: createMapRenderSubmission(
-      frame: frame,
-      batches: const [],
-    ),
-    observationBatch: batch,
+    frame: frame,
+    layers: [
+      if (batch != null)
+        MapSceneInstanceLayerSubmission(
+          logicalSourceKey: mapSceneEarthquakeHistorySourceKey,
+          componentKey: mapSceneObservationPointComponentKey,
+          overlayVersion: batch.versionStamp,
+          orderWithinPhase: 0,
+          kind: MapSceneInstanceLayerKind.observationPoint,
+          batch: batch,
+        ),
+    ],
+    limits: MapSceneFrameLimits(maxNodeCount: 1),
   );
 
-  test('builds one canonical base then region plan with phase priorities', () {
-    final value = MapSceneFrameSubmission(
+  MapSceneFrameSubmission sceneSubmission({
+    MapRenderSubmission? baseMap,
+    MapRenderSubmission? earthquakeFill,
+    MapSceneComponentKey? earthquakeComponent,
+  }) {
+    final base = baseMap ?? emptySubmission();
+    final earthquake = earthquakeFill ?? emptySubmission();
+    return MapSceneFrameSubmission(
+      frame: frame,
+      layers: [
+        for (final batch in base.batches)
+          MapSceneMeshLayerSubmission(
+            frame: frame,
+            logicalSourceKey: mapSceneBaseSourceKey,
+            componentKey: mapSceneBaseComponentKey,
+            overlayVersion: null,
+            orderWithinPhase:
+                batch.packets.first.sortKey.declarationOrderWithinPhase,
+            batch: batch,
+            kind: MapSceneMeshLayerKind.baseMap,
+          ),
+        for (final batch in earthquake.batches)
+          MapSceneMeshLayerSubmission(
+            frame: frame,
+            logicalSourceKey: mapSceneEarthquakeHistorySourceKey,
+            componentKey: earthquakeComponent ?? mapSceneRegionFillComponentKey,
+            overlayVersion: stampOf(1),
+            orderWithinPhase:
+                batch.packets.first.sortKey.declarationOrderWithinPhase,
+            batch: batch,
+            kind: MapSceneMeshLayerKind.earthquakeAreaFill,
+          ),
+      ],
+      limits: MapSceneFrameLimits(maxNodeCount: 64),
+    );
+  }
+
+  group('typed Scene layer submission', () {
+    final stamp1 = observationSnapshot(dataSequence: 1).versionStamp;
+    final stamp2 = observationSnapshot(dataSequence: 2).versionStamp;
+
+    test('rejects blank logical source, component, and batch keys', () {
+      expect(
+        () => createMapSceneLogicalSourceKey(value: ' '),
+        throwsArgumentError,
+      );
+      expect(() => createMapSceneComponentKey(value: ''), throwsArgumentError);
+      expect(() => createMapSceneBatchKey(value: '\n'), throwsArgumentError);
+    });
+
+    test('owns an immutable canonical layer list', () {
+      final layers = <MapSceneLayerSubmission>[
+        instanceLayer(
+          layerFrame: frame,
+          componentKey: mapSceneHypocenterSpriteComponentKey,
+          batchKey: createMapSceneBatchKey(value: 'sprite'),
+          overlayVersion: stamp1,
+          kind: MapSceneInstanceLayerKind.pointSprite,
+          phase: 350,
+        ),
+        meshLayer(
+          componentKey: mapSceneBaseComponentKey,
+          submission: baseSubmission(),
+          logicalSourceKey: mapSceneBaseSourceKey,
+        ),
+        instanceLayer(
+          layerFrame: frame,
+          componentKey: mapSceneObservationPointComponentKey,
+          batchKey: createMapSceneBatchKey(value: 'observation'),
+          overlayVersion: stamp1,
+          kind: MapSceneInstanceLayerKind.observationPoint,
+          phase: 300,
+        ),
+      ];
+
+      final value = MapSceneFrameSubmission(
+        frame: frame,
+        layers: layers,
+        limits: MapSceneFrameLimits(maxNodeCount: 3),
+      );
+      layers.clear();
+
+      expect(value.layers.map((layer) => layer.phase), [0, 300, 350]);
+      expect(value.layers.clear, throwsUnsupportedError);
+    });
+
+    test('rejects frame mismatch and negative order', () {
+      final otherFrame = observationFrameAt(frameNumber: 99);
+      expect(
+        () => MapSceneFrameSubmission(
+          frame: otherFrame,
+          layers: [
+            meshLayer(
+              componentKey: mapSceneBaseComponentKey,
+              submission: baseSubmission(),
+              logicalSourceKey: mapSceneBaseSourceKey,
+            ),
+          ],
+          limits: MapSceneFrameLimits(maxNodeCount: 1),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => meshLayer(
+          componentKey: mapSceneBaseComponentKey,
+          submission: baseSubmission(),
+          logicalSourceKey: mapSceneBaseSourceKey,
+          orderWithinPhase: -1,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects mixed overlay stamps and duplicate identity tuples', () {
+      final observation = instanceLayer(
+        layerFrame: frame,
+        componentKey: mapSceneObservationPointComponentKey,
+        batchKey: createMapSceneBatchKey(value: 'observation'),
+        overlayVersion: stamp1,
+        kind: MapSceneInstanceLayerKind.observationPoint,
+        phase: 300,
+      );
+      final sprite = instanceLayer(
+        layerFrame: frame,
+        componentKey: mapSceneHypocenterSpriteComponentKey,
+        batchKey: createMapSceneBatchKey(value: 'sprite'),
+        overlayVersion: stamp2,
+        kind: MapSceneInstanceLayerKind.pointSprite,
+        phase: 350,
+      );
+      expect(
+        () => MapSceneFrameSubmission(
+          frame: frame,
+          layers: [observation, sprite],
+          limits: MapSceneFrameLimits(maxNodeCount: 2),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => MapSceneFrameSubmission(
+          frame: frame,
+          layers: [observation, observation],
+          limits: MapSceneFrameLimits(maxNodeCount: 2),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('allows distinct batch keys for one component', () {
+      final layers = [
+        for (final key in ['policy-a', 'policy-b'])
+          instanceLayer(
+            layerFrame: frame,
+            componentKey: mapSceneHypocenterSpriteComponentKey,
+            batchKey: createMapSceneBatchKey(value: key),
+            overlayVersion: stamp1,
+            kind: MapSceneInstanceLayerKind.pointSprite,
+            phase: 350,
+          ),
+      ];
+
+      expect(
+        MapSceneFrameSubmission(
+          frame: frame,
+          layers: layers,
+          limits: MapSceneFrameLimits(maxNodeCount: 2),
+        ).layers,
+        hasLength(2),
+      );
+    });
+
+    test(
+      'compares phase, order, logical source, component, then batch key',
+      () {
+        MapSceneInstanceLayerSubmission layer({
+          required String source,
+          required String component,
+          required String batch,
+          required int phase,
+          required int order,
+        }) => MapSceneInstanceLayerSubmission(
+          logicalSourceKey: createMapSceneLogicalSourceKey(value: source),
+          componentKey: createMapSceneComponentKey(value: component),
+          overlayVersion: stamp1,
+          orderWithinPhase: order,
+          kind: MapSceneInstanceLayerKind.pointSprite,
+          batch: _TestInstanceBatch(
+            frame: frame,
+            batchKey: createMapSceneBatchKey(value: batch),
+            phasePolicyVersion: 3,
+            phase: phase,
+          ),
+        );
+        final values = [
+          layer(source: 'b', component: 'a', batch: 'a', phase: 350, order: 0),
+          layer(source: 'a', component: 'b', batch: 'a', phase: 350, order: 0),
+          layer(source: 'a', component: 'a', batch: 'b', phase: 350, order: 0),
+          layer(source: 'a', component: 'a', batch: 'a', phase: 350, order: 1),
+          layer(source: 'a', component: 'a', batch: 'a', phase: 300, order: 9),
+          layer(source: 'a', component: 'a', batch: 'a', phase: 350, order: 0),
+        ]..sort(compareMapSceneLayerSubmissions);
+
+        expect(
+          values.map(
+            (value) => (
+              value.phase,
+              value.orderWithinPhase,
+              value.logicalSourceKey.value,
+              value.componentKey.value,
+              value.batchKey.value,
+            ),
+          ),
+          [
+            (300, 9, 'a', 'a', 'a'),
+            (350, 0, 'a', 'a', 'a'),
+            (350, 0, 'a', 'a', 'b'),
+            (350, 0, 'a', 'b', 'a'),
+            (350, 0, 'b', 'a', 'a'),
+            (350, 1, 'a', 'a', 'a'),
+          ],
+        );
+      },
+    );
+
+    test(
+      'rejects region and city together, phase mismatch, and node overflow',
+      () {
+        final region = meshLayer(
+          componentKey: mapSceneRegionFillComponentKey,
+          submission: regionSubmission(),
+          overlayVersion: stamp1,
+        );
+        final city = meshLayer(
+          componentKey: mapSceneCityFillComponentKey,
+          submission: citySubmission(),
+          overlayVersion: stamp1,
+        );
+        expect(
+          () => MapSceneFrameSubmission(
+            frame: frame,
+            layers: [region, city],
+            limits: MapSceneFrameLimits(maxNodeCount: 2),
+          ),
+          throwsArgumentError,
+        );
+        expect(
+          () => MapSceneFrameSubmission(
+            frame: frame,
+            layers: [
+              instanceLayer(
+                layerFrame: frame,
+                componentKey: mapSceneObservationPointComponentKey,
+                batchKey: createMapSceneBatchKey(value: 'wrong-phase'),
+                overlayVersion: stamp1,
+                kind: MapSceneInstanceLayerKind.observationPoint,
+                phase: 350,
+              ),
+            ],
+            limits: MapSceneFrameLimits(maxNodeCount: 1),
+          ),
+          throwsArgumentError,
+        );
+        expect(
+          () => MapSceneFrameSubmission(
+            frame: frame,
+            layers: [
+              instanceLayer(
+                layerFrame: frame,
+                componentKey: mapSceneObservationPointComponentKey,
+                batchKey: createMapSceneBatchKey(value: 'wrong-policy'),
+                overlayVersion: stamp1,
+                kind: MapSceneInstanceLayerKind.observationPoint,
+                phase: 300,
+                phasePolicyVersion: 2,
+              ),
+            ],
+            limits: MapSceneFrameLimits(maxNodeCount: 1),
+          ),
+          throwsArgumentError,
+        );
+        expect(
+          () => MapSceneFrameSubmission(
+            frame: frame,
+            layers: [
+              meshLayer(
+                componentKey: mapSceneBaseComponentKey,
+                submission: baseSubmission(),
+                logicalSourceKey: mapSceneBaseSourceKey,
+              ),
+              region,
+            ],
+            limits: MapSceneFrameLimits(maxNodeCount: 1),
+          ),
+          throwsArgumentError,
+        );
+      },
+    );
+
+    test('allows a base-only submission', () {
+      final value = MapSceneFrameSubmission(
+        frame: frame,
+        layers: [
+          meshLayer(
+            componentKey: mapSceneBaseComponentKey,
+            submission: baseSubmission(),
+            logicalSourceKey: mapSceneBaseSourceKey,
+          ),
+        ],
+        limits: MapSceneFrameLimits(maxNodeCount: 1),
+      );
+
+      expect(value.layers.single.componentKey, mapSceneBaseComponentKey);
+    });
+  });
+
+  test('builds one canonical base then region mesh plan', () {
+    final value = sceneSubmission(
       baseMap: baseSubmission(),
       earthquakeFill: regionSubmission(),
-      observationBatch: null,
     );
 
     final plans = buildFlutterSceneMeshBatchPlans(submission: value);
 
     expect(plans.map((plan) => plan.batch.compatibility.phase), [0, 100]);
-    expect(plans.map((plan) => plan.translucentSortPriority), [0, 100]);
   });
 
-  test('assigns city Fill to the overlay hazard phase', () {
-    final value = MapSceneFrameSubmission(
+  test('assigns city Fill to the overlay hazard mesh plan', () {
+    final value = sceneSubmission(
       baseMap: baseSubmission(),
       earthquakeFill: citySubmission(),
-      observationBatch: null,
+      earthquakeComponent: mapSceneCityFillComponentKey,
     );
 
     final plans = buildFlutterSceneMeshBatchPlans(submission: value);
 
-    expect(plans.last.translucentSortPriority, 100);
-  });
-
-  test('writes the phase priority to an actual Flutter Scene node', () {
-    final node = scene.Node();
-
-    applyFlutterSceneTranslucentSortPriority(
-      node: node,
-      phase: mapSceneRenderPhasePolicy.rankOf(
-        mapSceneOverlayHazardFillPhaseId,
-      ),
-      priority: 100,
-    );
-
-    expect(node.translucentSortPriority, 100);
+    expect(plans.last.batch.compatibility.phase, 100);
   });
 
   test('rejects a phase not permitted for the base submission', () {
@@ -374,41 +730,24 @@ void main() {
     );
 
     expect(
-      () => MapSceneFrameSubmission(
-        baseMap: invalidBase,
-        earthquakeFill: emptySubmission(),
-        observationBatch: null,
-      ),
+      () => sceneSubmission(baseMap: invalidBase),
       throwsArgumentError,
     );
   });
 
-  test('rejects an unknown earthquake material before node creation', () {
-    expect(
-      () => MapSceneFrameSubmission(
-        baseMap: baseSubmission(),
-        earthquakeFill: regionSubmission(materialKey: 'unknown'),
-        observationBatch: null,
+  test('rejects an unknown earthquake pipeline before node creation', () {
+    final unknown = submission(
+      policy: mapSceneRenderPhasePolicy,
+      phase: mapSceneRenderPhasePolicy.rankOf(
+        mapSceneOverlayHazardFillPhaseId,
       ),
-      throwsArgumentError,
+      materialKey: earthquakeAreaFillMaterialKey,
+      pipelineKey: 'unknown-earthquake-pipeline',
     );
-  });
-
-  test('rejects an observation batch whose priority disagrees with phase', () {
-    final observationPhase = mapSceneRenderPhasePolicy.rankOf(
-      mapSceneLivePointPhaseId,
-    );
-
     expect(
-      () => MapSceneFrameSubmission(
+      () => sceneSubmission(
         baseMap: baseSubmission(),
-        earthquakeFill: emptySubmission(),
-        observationBatch: _ObservationBatch(
-          frame: frame,
-          phasePolicyVersion: mapSceneRenderPhasePolicy.version,
-          phase: observationPhase,
-          translucentSortPriority: 999,
-        ),
+        earthquakeFill: unknown,
       ),
       throwsArgumentError,
     );
@@ -419,14 +758,23 @@ void main() {
       mapSceneLivePointPhaseId,
     );
     final value = MapSceneFrameSubmission(
-      baseMap: baseSubmission(),
-      earthquakeFill: emptySubmission(),
-      observationBatch: _ObservationBatch(
-        frame: frame,
-        phasePolicyVersion: mapSceneRenderPhasePolicy.version,
-        phase: observationPhase,
-        translucentSortPriority: 300,
-      ),
+      frame: frame,
+      layers: [
+        MapSceneInstanceLayerSubmission(
+          logicalSourceKey: mapSceneEarthquakeHistorySourceKey,
+          componentKey: mapSceneObservationPointComponentKey,
+          overlayVersion: stampOf(1),
+          orderWithinPhase: 0,
+          kind: MapSceneInstanceLayerKind.observationPoint,
+          batch: _TestInstanceBatch(
+            frame: frame,
+            batchKey: createMapSceneBatchKey(value: 'untyped-observation'),
+            phasePolicyVersion: mapSceneRenderPhasePolicy.version,
+            phase: observationPhase,
+          ),
+        ),
+      ],
+      limits: MapSceneFrameLimits(maxNodeCount: 1),
     );
 
     expect(
@@ -446,7 +794,7 @@ void main() {
     );
   });
 
-  test('adds exactly one observation geometry and node at priority 300', () {
+  test('adds exactly one observation geometry and node at draw rank zero', () {
     final observationFrame = observationFrameAt(frameNumber: 0);
     final batch = _requireObservationPointBatch(
       buildObservationPointBatch(
@@ -471,7 +819,7 @@ void main() {
     );
 
     expect(sceneGraph.children, hasLength(1));
-    expect(sceneGraph.children.single.translucentSortPriority, 300);
+    expect(sceneGraph.children.single.translucentSortPriority, 0);
     expect(
       sceneGraph.children.single.mesh?.primitives.single.geometry,
       isA<scene.StaticInstanceGeometry>(),
@@ -969,11 +1317,6 @@ void main() {
           ).batches,
         ],
       );
-      final value = MapSceneFrameSubmission(
-        baseMap: invalidBase,
-        earthquakeFill: emptySubmission(),
-        observationBatch: null,
-      );
       final sceneGraph = _RecordingSceneGraph();
       final existingNode = scene.Node();
       sceneGraph.add(existingNode);
@@ -990,7 +1333,7 @@ void main() {
       );
 
       expect(
-        () => adapter.submitFrame(submission: value),
+        () => sceneSubmission(baseMap: invalidBase),
         throwsArgumentError,
       );
       expect(materialLookups, 0);
@@ -1042,11 +1385,7 @@ void main() {
           ).batches,
         ],
       );
-      final value = MapSceneFrameSubmission(
-        baseMap: invalidBase,
-        earthquakeFill: emptySubmission(),
-        observationBatch: null,
-      );
+      final value = sceneSubmission(baseMap: invalidBase);
       final sceneGraph = _RecordingSceneGraph();
       final existingNode = scene.Node();
       sceneGraph.add(existingNode);

--- a/packages/eqmonitor_map/test/renderer/base_map_render_submission_builder_test.dart
+++ b/packages/eqmonitor_map/test/renderer/base_map_render_submission_builder_test.dart
@@ -127,9 +127,40 @@ void main() {
   );
 
   group('phase policy', () {
-    test('base map draws in the first phase and declares labelForeground', () {
-      expect(mapSceneRenderPhasePolicy.rankOf(mapSceneBasePhaseId), 0);
-      expect(mapSceneRenderPhasePolicy.orderedPhases.length, 5);
+    test('uses the generic sparse phase taxonomy v3', () {
+      expect(mapSceneRenderPhasePolicy.version, 3);
+      expect(
+        [
+          mapSceneRenderPhasePolicy.rankOf(mapSceneBaseLandFillPhaseId),
+          mapSceneRenderPhasePolicy.rankOf(mapSceneUnderlayHazardFillPhaseId),
+          mapSceneRenderPhasePolicy.rankOf(mapSceneUnderlayHazardLinePhaseId),
+          mapSceneRenderPhasePolicy.rankOf(
+            mapSceneBaseAdministrativeLinePhaseId,
+          ),
+          mapSceneRenderPhasePolicy.rankOf(mapSceneOverlayHazardFillPhaseId),
+          mapSceneRenderPhasePolicy.rankOf(mapSceneOverlayHazardLinePhaseId),
+          mapSceneRenderPhasePolicy.rankOf(mapSceneDynamicWaveFillPhaseId),
+          mapSceneRenderPhasePolicy.rankOf(mapSceneDynamicWaveLinePhaseId),
+          mapSceneRenderPhasePolicy.rankOf(mapSceneLivePointPhaseId),
+          mapSceneRenderPhasePolicy.rankOf(mapSceneSpritePhaseId),
+          mapSceneRenderPhasePolicy.rankOf(mapSceneForegroundLabelPhaseId),
+        ],
+        [0, 20, 30, 40, 100, 110, 200, 210, 300, 350, 400],
+      );
+    });
+
+    test('places base Fill before the administrative Line phase', () {
+      final submission = submissionOf(
+        plans: [
+          planOf(styleLayerId: 'countriesLine', tileId: tile(28, 12)),
+          planOf(styleLayerId: 'countriesFill', tileId: tile(28, 12)),
+        ],
+      );
+
+      expect(
+        submission.batches.map((batch) => batch.compatibility.phase),
+        [0, 40],
+      );
     });
   });
 

--- a/packages/eqmonitor_map/test/renderer/earthquake_area_render_submission_builder_test.dart
+++ b/packages/eqmonitor_map/test/renderer/earthquake_area_render_submission_builder_test.dart
@@ -152,13 +152,13 @@ void main() {
     expect(region.batches, hasLength(1));
     expect(
       region.batches.single.compatibility.phase,
-      mapSceneRenderPhasePolicy.rankOf(mapSceneEarthquakeRegionPhaseId),
+      100,
     );
     expect(region.batches.single.packets.single.sortKey.featureOrder, 0);
     expect(city.batches, hasLength(1));
     expect(
       city.batches.single.compatibility.phase,
-      mapSceneRenderPhasePolicy.rankOf(mapSceneEarthquakeCityPhaseId),
+      100,
     );
     expect(city.batches.single.packets.single.sortKey.featureOrder, 0);
   });

--- a/packages/eqmonitor_map/test/renderer/observation_point_batch_builder_test.dart
+++ b/packages/eqmonitor_map/test/renderer/observation_point_batch_builder_test.dart
@@ -263,9 +263,9 @@ void main() {
       instanceData: callerInstances,
       instanceCount: template.instanceCount,
       frameUniform: callerUniform,
+      batchKey: template.batchKey,
       phasePolicyVersion: template.phasePolicyVersion,
       phase: template.phase,
-      translucentSortPriority: template.translucentSortPriority,
     );
 
     callerInstances[0] = 99;

--- a/packages/eqmonitor_map/test/widget/base_map_overlay_frame_builder_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_overlay_frame_builder_test.dart
@@ -6,6 +6,7 @@ import 'package:eqmonitor_map/src/flutter_scene/earthquake_overlay_material_owne
 import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_map_adapter.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
+import 'package:eqmonitor_map/src/foundation/render/map_render_batch.dart';
 import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
 import 'package:eqmonitor_map/src/geo/map_camera.dart';
 import 'package:eqmonitor_map/src/geo/map_viewport.dart';
@@ -93,12 +94,32 @@ final class _RecordingSceneGraph with scene.SceneGraph {
 }
 
 ObservationPointBatch _requireObservationPointBatch(
-  MapSceneObservationBatch? batch,
+  MapSceneFrameSubmission? submission,
 ) {
+  final batch = submission?.layers
+      .whereType<MapSceneInstanceLayerSubmission>()
+      .where(
+        (layer) => layer.kind == MapSceneInstanceLayerKind.observationPoint,
+      )
+      .map((layer) => layer.batch)
+      .firstOrNull;
   if (batch is! ObservationPointBatch) {
     fail('Expected an ObservationPointBatch.');
   }
   return batch;
+}
+
+MapRenderBatch _requireEarthquakeFillBatch(
+  MapSceneFrameSubmission? submission,
+) {
+  final layer = submission?.layers
+      .whereType<MapSceneMeshLayerSubmission>()
+      .where((layer) => layer.kind == MapSceneMeshLayerKind.earthquakeAreaFill)
+      .firstOrNull;
+  if (layer == null) {
+    fail('Expected an earthquake Fill batch.');
+  }
+  return layer.batch;
 }
 
 scene.StaticInstanceGeometry _requireStaticInstanceGeometry(
@@ -278,6 +299,7 @@ void main() {
       tileCache: cache ?? cacheWith(geometry()),
       packedMeshFor: packed.resolve,
       styleCache: styleCache ?? EarthquakeAreaRenderStyleCache(),
+      sceneFrameLimits: MapSceneFrameLimits(maxNodeCount: 64),
     );
   }
 
@@ -285,8 +307,10 @@ void main() {
     final result = build(frame: frameAt(5.999), requested: snapshot());
 
     expect(result.submission, isNotNull);
-    expect(result.submission?.earthquakeFill.batches, hasLength(1));
-    expect(result.submission?.observationBatch, isNull);
+    expect(
+      result.submission?.layers.map((layer) => layer.componentKey),
+      [mapSceneRegionFillComponentKey],
+    );
     expect(
       result.coverage,
       const EarthquakeOverlayCoverage.complete(requestedTileCount: 1),
@@ -296,8 +320,10 @@ void main() {
   test('zoom 6 submits city Fill and one station batch', () {
     final result = build(frame: frameAt(6), requested: snapshot());
 
-    expect(result.submission?.earthquakeFill.batches, hasLength(1));
-    expect(result.submission?.observationBatch, isA<ObservationPointBatch>());
+    expect(
+      result.submission?.layers.map((layer) => layer.componentKey),
+      [mapSceneCityFillComponentKey, mapSceneObservationPointComponentKey],
+    );
   });
 
   test('null snapshot atomically hides the previous overlay', () {
@@ -308,8 +334,7 @@ void main() {
     );
 
     expect(result.overlay, isNull);
-    expect(result.submission?.earthquakeFill.batches, isEmpty);
-    expect(result.submission?.observationBatch, isNull);
+    expect(result.submission?.layers, isEmpty);
     expect(result.coverage, const EarthquakeOverlayCoverage.hidden());
   });
 
@@ -327,15 +352,10 @@ void main() {
     );
 
     expect(result.overlay, same(current));
-    final bytes = result
-        .submission
-        ?.earthquakeFill
-        .batches
-        .single
-        .compatibility
-        .materialParameters
-        .bytes;
-    expect(ByteData.sublistView(bytes!).getFloat32(0, Endian.little), 1);
+    final bytes = _requireEarthquakeFillBatch(
+      result.submission,
+    ).compatibility.materialParameters.bytes;
+    expect(ByteData.sublistView(bytes).getFloat32(0, Endian.little), 1);
   });
 
   test('another source atomically replaces Fill and station inputs', () {
@@ -355,17 +375,11 @@ void main() {
     );
 
     expect(result.overlay, same(replacement));
-    expect(result.submission?.earthquakeFill.batches, hasLength(1));
-    expect(result.submission?.observationBatch, isA<ObservationPointBatch>());
-    final bytes = result
-        .submission
-        ?.earthquakeFill
-        .batches
-        .single
-        .compatibility
-        .materialParameters
-        .bytes;
-    expect(ByteData.sublistView(bytes!).getFloat32(8, Endian.little), 1);
+    expect(_requireObservationPointBatch(result.submission), isNotNull);
+    final bytes = _requireEarthquakeFillBatch(
+      result.submission,
+    ).compatibility.materialParameters.bytes;
+    expect(ByteData.sublistView(bytes).getFloat32(8, Endian.little), 1);
   });
 
   test('background schedules retirement without a Scene submission', () {
@@ -439,31 +453,23 @@ void main() {
     );
 
     final firstObservation = _requireObservationPointBatch(
-      first.submission?.observationBatch,
+      first.submission,
     );
     final secondObservation = _requireObservationPointBatch(
-      second.submission?.observationBatch,
+      second.submission,
     );
     expect(
       secondObservation.instanceGeneration,
       same(firstObservation.instanceGeneration),
     );
     expect(
-      second
-          .submission
-          ?.earthquakeFill
-          .batches
-          .single
-          .compatibility
-          .materialParameters,
+      _requireEarthquakeFillBatch(
+        second.submission,
+      ).compatibility.materialParameters,
       same(
-        first
-            .submission
-            ?.earthquakeFill
-            .batches
-            .single
-            .compatibility
-            .materialParameters,
+        _requireEarthquakeFillBatch(
+          first.submission,
+        ).compatibility.materialParameters,
       ),
     );
   });
@@ -632,8 +638,8 @@ void main() {
         requested: value,
         styleCache: styles,
       );
-      final batch = result.submission?.earthquakeFill.batches.single;
-      expect(owner.materialFor(batch!), same(bindings.single));
+      final batch = _requireEarthquakeFillBatch(result.submission);
+      expect(owner.materialFor(batch), same(bindings.single));
     },
   );
 
@@ -908,15 +914,11 @@ void main() {
         styleCache: eventAStyles,
       );
       final initialSubmission = MapSceneFrameSubmission(
-        baseMap: createMapRenderSubmission(
-          frame: first.submission!.frame,
-          batches: const [],
-        ),
-        earthquakeFill: createMapRenderSubmission(
-          frame: first.submission!.frame,
-          batches: const [],
-        ),
-        observationBatch: first.submission!.observationBatch,
+        frame: first.submission!.frame,
+        layers: first.submission!.layers
+            .whereType<MapSceneInstanceLayerSubmission>()
+            .toList(),
+        limits: MapSceneFrameLimits(maxNodeCount: 1),
       );
       final initialCandidate = BaseMapOverlayFrameResult(
         overlay: first.overlay,

--- a/packages/eqmonitor_map/test/widget/base_map_view_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_view_test.dart
@@ -84,6 +84,7 @@ void main() {
         maxParentFallbackSteps: 4,
         maxInFlightDecodes: 2,
         maxFramesInFlight: 3,
+        maxSceneNodeCount: 32,
       ),
       earthquakeOverlay: overlay,
       onEarthquakeOverlayCoverageChanged: callback,


### PR DESCRIPTION
## 概要

- Scene frameを固定fieldからtyped immutable layer listへ移行します。
- package-neutralなphase taxonomy v3へ更新し、base Fillと行政境界Line、地震Fill、live point、sprite、labelの順序を固定します。
- logical source、component、batch key、overlay stamp、phase、node countをfail-fastで検証します。
- canonical node planを全preflight後にsubmitし、全nodeへ0始まりstrict draw rankを割り当てます。
- Flutter Scene実encoder comparatorへ同depthのshuffle recordsを通す回帰testを追加します。

## 検証

- Task 3 targeted tests 73件成功
- base map view tests 14件成功
- targeted analyze clean
- formatとdiff check成功
- independent review round 1でAPPROVED

## Stack

- Depends on #1757
- Stack #1756 の第5層です。