### PR TITLE
feat: GPU地図のsprite batchとshader契約を追加

### DIFF
--- a/packages/eqmonitor_map/assets/earthquake_sprite.frag
+++ b/packages/eqmonitor_map/assets/earthquake_sprite.frag
@@ -1,0 +1,12 @@
+uniform sampler2D spriteAtlas;
+
+in vec2 v_uv;
+in float v_opacity;
+
+out vec4 frag_color;
+
+void main() {
+  vec4 straight_sample = texture(spriteAtlas, v_uv);
+  float alpha = straight_sample.a * v_opacity;
+  frag_color = vec4(straight_sample.rgb * alpha, alpha);
+}

--- a/packages/eqmonitor_map/assets/earthquake_sprite.vert
+++ b/packages/eqmonitor_map/assets/earthquake_sprite.vert
@@ -1,0 +1,49 @@
+uniform SpriteFrame {
+  vec4 cameraWorld;
+  vec4 viewportZoom;
+  vec4 sizePolicy;
+  vec4 opacityPolicy;
+}
+spriteFrame;
+
+in vec2 corner;
+in vec2 centerMercator;
+in vec4 uvRect;
+in vec2 logicalSize;
+in float opacity;
+in float priority;
+
+out vec2 v_uv;
+out float v_opacity;
+
+void main() {
+  vec2 world_delta = centerMercator - spriteFrame.cameraWorld.xy;
+  world_delta.x -= round(world_delta.x);
+  vec2 logical_delta = world_delta * spriteFrame.cameraWorld.z;
+  vec2 viewport = spriteFrame.viewportZoom.xy;
+  float zoom = spriteFrame.viewportZoom.z;
+  float size_progress = clamp(
+    (zoom - spriteFrame.sizePolicy.x) /
+      (spriteFrame.sizePolicy.z - spriteFrame.sizePolicy.x),
+    0.0,
+    1.0
+  );
+  float size_scale = mix(
+    spriteFrame.sizePolicy.y,
+    spriteFrame.sizePolicy.w,
+    size_progress
+  );
+  float policy_opacity = zoom < spriteFrame.opacityPolicy.x
+    ? spriteFrame.opacityPolicy.y
+    : spriteFrame.opacityPolicy.z;
+  vec2 center_ndc = vec2(
+    logical_delta.x * 2.0 / viewport.x,
+    -logical_delta.y * 2.0 / viewport.y
+  );
+  vec2 corner_ndc = corner * logicalSize * size_scale / viewport;
+  vec2 uv_mix = vec2(corner.x * 0.5 + 0.5, 0.5 - corner.y * 0.5);
+
+  gl_Position = vec4(center_ndc + corner_ndc, 0.0, 1.0);
+  v_uv = mix(uvRect.xy, uvRect.zw, uv_mix);
+  v_opacity = opacity * policy_opacity * step(-1.0, priority);
+}

--- a/packages/eqmonitor_map/hook/build.dart
+++ b/packages/eqmonitor_map/hook/build.dart
@@ -18,6 +18,8 @@ Future<void> main(List<String> args) async {
         buildInput: config,
         buildOutput: output,
         manifestFileName: 'shaders/earthquake_overlay.shaderbundle.json',
+        interfaceManifestFileName:
+            'shaders/earthquake_overlay.shaderinterface.json',
         assetMode: TargetShaderBundleAssetMode.dataAssetsRequired,
         glesLanguageVersion: 300,
       );

--- a/packages/eqmonitor_map/lib/src/flutter_scene/map_shader_interface_manifest.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/map_shader_interface_manifest.dart
@@ -1,0 +1,424 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+enum MapShaderInterfaceStage { vertex, fragment, compute }
+
+enum MapShaderScalarType {
+  boolean,
+  signedByte,
+  unsignedByte,
+  signedShort,
+  unsignedShort,
+  signedInt,
+  unsignedInt,
+  signedInt64,
+  unsignedInt64,
+  halfFloat,
+  float,
+  double,
+  sampledImage,
+}
+
+final class MapShaderInputInterface {
+  const MapShaderInputInterface({
+    required this.name,
+    required this.location,
+    required this.set,
+    required this.binding,
+    required this.type,
+    required this.bitWidth,
+    required this.vecSize,
+    required this.columns,
+    required this.offset,
+  });
+
+  final String name;
+  final int location;
+  final int set;
+  final int binding;
+  final MapShaderScalarType type;
+  final int bitWidth;
+  final int vecSize;
+  final int columns;
+  final int offset;
+}
+
+final class MapShaderUniformFieldInterface {
+  const MapShaderUniformFieldInterface({
+    required this.name,
+    required this.type,
+    required this.offsetInBytes,
+    required this.elementSizeInBytes,
+    required this.totalSizeInBytes,
+    required this.arrayElements,
+    required this.vecSize,
+    required this.columns,
+  });
+
+  final String name;
+  final MapShaderScalarType type;
+  final int offsetInBytes;
+  final int elementSizeInBytes;
+  final int totalSizeInBytes;
+  final int arrayElements;
+  final int vecSize;
+  final int columns;
+}
+
+final class MapShaderUniformBlockInterface {
+  const MapShaderUniformBlockInterface({
+    required this.name,
+    required this.set,
+    required this.binding,
+    required this.sizeInBytes,
+    required this.fields,
+  });
+
+  final String name;
+  final int set;
+  final int binding;
+  final int sizeInBytes;
+  final List<MapShaderUniformFieldInterface> fields;
+}
+
+/// Sampled-image reflection intentionally contains no sampler dimension.
+///
+/// `sampler2D` is guaranteed by the checked-in source declaration test and
+/// compiler success, not by unavailable runtime or bundle reflection.
+final class MapShaderSampledImageInterface {
+  const MapShaderSampledImageInterface({
+    required this.name,
+    required this.set,
+    required this.binding,
+  });
+
+  final String name;
+  final int set;
+  final int binding;
+}
+
+final class MapShaderInterface {
+  const MapShaderInterface({
+    required this.stage,
+    required this.inputs,
+    required this.uniformBlocks,
+    required this.sampledImages,
+  });
+
+  final MapShaderInterfaceStage stage;
+  final List<MapShaderInputInterface> inputs;
+  final List<MapShaderUniformBlockInterface> uniformBlocks;
+  final List<MapShaderSampledImageInterface> sampledImages;
+}
+
+final class MapShaderInterfaceManifest {
+  const MapShaderInterfaceManifest._({required this.shaders});
+
+  factory MapShaderInterfaceManifest.parse({required Uint8List jsonBytes}) =>
+      parseMapShaderInterfaceManifest(jsonBytes: jsonBytes);
+
+  final Map<String, MapShaderInterface> shaders;
+
+  MapShaderInterface shaderNamed(String name) {
+    final shader = shaders[name];
+    if (shader == null) {
+      throw ArgumentError.value(name, 'name', 'is not declared');
+    }
+    return shader;
+  }
+}
+
+MapShaderInterfaceManifest parseMapShaderInterfaceManifest({
+  required Uint8List jsonBytes,
+}) {
+  final decoded = jsonDecode(utf8.decode(jsonBytes, allowMalformed: false));
+  if (decoded is! Map<String, dynamic>) {
+    throw const FormatException('Shader interface manifest must be an object.');
+  }
+  _expectKeys(decoded, const {'version', 'shaders'}, 'manifest');
+  if (decoded['version'] != 1) {
+    throw const FormatException('Shader interface manifest version must be 1.');
+  }
+  final shaderValues = _mapField(decoded, 'shaders', 'shaders');
+  if (shaderValues.isEmpty) {
+    throw const FormatException(
+      'Shader interface manifest must declare at least one shader.',
+    );
+  }
+  final shaders = <String, MapShaderInterface>{};
+  for (final entry in shaderValues.entries) {
+    _nonBlank(entry.key, 'shaders.name');
+    final shaderValue = entry.value;
+    if (shaderValue is! Map<String, dynamic>) {
+      throw FormatException('${entry.key} must be an object.');
+    }
+    shaders[entry.key] = _parseShader(shaderValue);
+  }
+  return MapShaderInterfaceManifest._(
+    shaders: Map<String, MapShaderInterface>.unmodifiable(shaders),
+  );
+}
+
+MapShaderInterface _parseShader(Map<String, dynamic> value) {
+  _expectKeys(
+    value,
+    const {'stage', 'inputs', 'uniformBlocks', 'sampledImages'},
+    'shader',
+  );
+  return MapShaderInterface(
+    stage: _stage(_stringField(value, 'stage', 'stage')),
+    inputs: _parseNamedList(
+      parent: value,
+      key: 'inputs',
+      parameterName: 'inputs',
+      parse: _parseInput,
+      nameOf: (input) => input.name,
+    ),
+    uniformBlocks: _parseNamedList(
+      parent: value,
+      key: 'uniformBlocks',
+      parameterName: 'uniformBlocks',
+      parse: _parseUniformBlock,
+      nameOf: (uniform) => uniform.name,
+    ),
+    sampledImages: _parseNamedList(
+      parent: value,
+      key: 'sampledImages',
+      parameterName: 'sampledImages',
+      parse: _parseSampledImage,
+      nameOf: (image) => image.name,
+    ),
+  );
+}
+
+MapShaderInputInterface _parseInput(Map<String, dynamic> value) {
+  _expectKeys(value, const {
+    'name',
+    'location',
+    'set',
+    'binding',
+    'type',
+    'bitWidth',
+    'vecSize',
+    'columns',
+    'offset',
+  }, 'input');
+  return MapShaderInputInterface(
+    name: _nonBlank(
+      _stringField(value, 'name', 'input.name'),
+      'input.name',
+    ),
+    location: _nonNegativeIntField(value, 'location', 'input.location'),
+    set: _nonNegativeIntField(value, 'set', 'input.set'),
+    binding: _nonNegativeIntField(value, 'binding', 'input.binding'),
+    type: _scalarType(_stringField(value, 'type', 'input.type')),
+    bitWidth: _positiveIntField(value, 'bitWidth', 'input.bitWidth'),
+    vecSize: _positiveIntField(value, 'vecSize', 'input.vecSize'),
+    columns: _positiveIntField(value, 'columns', 'input.columns'),
+    offset: _nonNegativeIntField(value, 'offset', 'input.offset'),
+  );
+}
+
+MapShaderUniformBlockInterface _parseUniformBlock(
+  Map<String, dynamic> value,
+) {
+  _expectKeys(
+    value,
+    const {'name', 'set', 'binding', 'sizeInBytes', 'fields'},
+    'uniformBlock',
+  );
+  return MapShaderUniformBlockInterface(
+    name: _nonBlank(
+      _stringField(value, 'name', 'uniformBlock.name'),
+      'uniformBlock.name',
+    ),
+    set: _nonNegativeIntField(value, 'set', 'uniformBlock.set'),
+    binding: _nonNegativeIntField(value, 'binding', 'uniformBlock.binding'),
+    sizeInBytes: _positiveIntField(
+      value,
+      'sizeInBytes',
+      'uniformBlock.sizeInBytes',
+    ),
+    fields: _parseNamedList(
+      parent: value,
+      key: 'fields',
+      parameterName: 'uniformBlock.fields',
+      parse: _parseUniformField,
+      nameOf: (field) => field.name,
+    ),
+  );
+}
+
+MapShaderUniformFieldInterface _parseUniformField(
+  Map<String, dynamic> value,
+) {
+  _expectKeys(value, const {
+    'name',
+    'type',
+    'offsetInBytes',
+    'elementSizeInBytes',
+    'totalSizeInBytes',
+    'arrayElements',
+    'vecSize',
+    'columns',
+  }, 'uniformField');
+  return MapShaderUniformFieldInterface(
+    name: _nonBlank(
+      _stringField(value, 'name', 'uniformField.name'),
+      'uniformField.name',
+    ),
+    type: _scalarType(_stringField(value, 'type', 'uniformField.type')),
+    offsetInBytes: _nonNegativeIntField(
+      value,
+      'offsetInBytes',
+      'uniformField.offsetInBytes',
+    ),
+    elementSizeInBytes: _positiveIntField(
+      value,
+      'elementSizeInBytes',
+      'uniformField.elementSizeInBytes',
+    ),
+    totalSizeInBytes: _positiveIntField(
+      value,
+      'totalSizeInBytes',
+      'uniformField.totalSizeInBytes',
+    ),
+    arrayElements: _nonNegativeIntField(
+      value,
+      'arrayElements',
+      'uniformField.arrayElements',
+    ),
+    vecSize: _positiveIntField(value, 'vecSize', 'uniformField.vecSize'),
+    columns: _positiveIntField(value, 'columns', 'uniformField.columns'),
+  );
+}
+
+MapShaderSampledImageInterface _parseSampledImage(
+  Map<String, dynamic> value,
+) {
+  _expectKeys(value, const {'name', 'set', 'binding'}, 'sampledImage');
+  return MapShaderSampledImageInterface(
+    name: _nonBlank(
+      _stringField(value, 'name', 'sampledImage.name'),
+      'sampledImage.name',
+    ),
+    set: _nonNegativeIntField(value, 'set', 'sampledImage.set'),
+    binding: _nonNegativeIntField(value, 'binding', 'sampledImage.binding'),
+  );
+}
+
+List<T> _parseNamedList<T>({
+  required Map<String, dynamic> parent,
+  required String key,
+  required String parameterName,
+  required T Function(Map<String, dynamic>) parse,
+  required String Function(T) nameOf,
+}) {
+  final value = parent[key];
+  if (value is! List) {
+    throw FormatException('$parameterName must be a list.');
+  }
+  final result = <T>[];
+  final names = <String>{};
+  for (final item in value) {
+    if (item is! Map<String, dynamic>) {
+      throw FormatException('$parameterName entries must be objects.');
+    }
+    final parsed = parse(item);
+    if (!names.add(nameOf(parsed))) {
+      throw FormatException('$parameterName contains duplicate names.');
+    }
+    result.add(parsed);
+  }
+  return List<T>.unmodifiable(result);
+}
+
+Map<String, dynamic> _mapField(
+  Map<String, dynamic> parent,
+  String key,
+  String parameterName,
+) {
+  final value = parent[key];
+  if (value is! Map<String, dynamic>) {
+    throw FormatException('$parameterName must be an object.');
+  }
+  return value;
+}
+
+String _stringField(
+  Map<String, dynamic> parent,
+  String key,
+  String parameterName,
+) {
+  final value = parent[key];
+  if (value is! String) {
+    throw FormatException('$parameterName must be a string.');
+  }
+  return value;
+}
+
+int _nonNegativeIntField(
+  Map<String, dynamic> parent,
+  String key,
+  String parameterName,
+) {
+  final value = parent[key];
+  if (value is! int || value < 0) {
+    throw FormatException('$parameterName must be a non-negative integer.');
+  }
+  return value;
+}
+
+int _positiveIntField(
+  Map<String, dynamic> parent,
+  String key,
+  String parameterName,
+) {
+  final result = _nonNegativeIntField(parent, key, parameterName);
+  if (result == 0) {
+    throw FormatException('$parameterName must be positive.');
+  }
+  return result;
+}
+
+String _nonBlank(String value, String parameterName) {
+  if (value.trim().isEmpty) {
+    throw FormatException('$parameterName must not be blank.');
+  }
+  return value;
+}
+
+void _expectKeys(
+  Map<String, dynamic> value,
+  Set<String> expected,
+  String parameterName,
+) {
+  if (value.keys.toSet().difference(expected).isNotEmpty ||
+      expected.difference(value.keys.toSet()).isNotEmpty) {
+    throw FormatException('$parameterName has an invalid shape.');
+  }
+}
+
+MapShaderInterfaceStage _stage(String value) => switch (value) {
+  'vertex' => MapShaderInterfaceStage.vertex,
+  'fragment' => MapShaderInterfaceStage.fragment,
+  'compute' => MapShaderInterfaceStage.compute,
+  _ => throw FormatException('Unknown shader stage $value.'),
+};
+
+MapShaderScalarType _scalarType(String value) => switch (value) {
+  'boolean' => MapShaderScalarType.boolean,
+  'signedByte' => MapShaderScalarType.signedByte,
+  'unsignedByte' => MapShaderScalarType.unsignedByte,
+  'signedShort' => MapShaderScalarType.signedShort,
+  'unsignedShort' => MapShaderScalarType.unsignedShort,
+  'signedInt' => MapShaderScalarType.signedInt,
+  'unsignedInt' => MapShaderScalarType.unsignedInt,
+  'signedInt64' => MapShaderScalarType.signedInt64,
+  'unsignedInt64' => MapShaderScalarType.unsignedInt64,
+  'halfFloat' => MapShaderScalarType.halfFloat,
+  'float' => MapShaderScalarType.float,
+  'double' => MapShaderScalarType.double,
+  'sampledImage' => MapShaderScalarType.sampledImage,
+  _ => throw FormatException('Unknown shader scalar type $value.'),
+};

--- a/packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_builder.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_builder.dart
@@ -9,6 +9,8 @@ import 'package:eqmonitor_map/src/renderer/earthquake_area_render_submission_bui
 import 'package:eqmonitor_map/src/renderer/map_render_batch_adapter.dart';
 import 'package:eqmonitor_map/src/renderer/map_render_lifecycle_policy.dart';
 import 'package:eqmonitor_map/src/renderer/map_scene_frame_submission.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch_builder.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch_builder.dart';
 import 'package:eqmonitor_map/src/tile/base_map_tile_cache.dart';
@@ -21,6 +23,7 @@ final class BaseMapOverlayFrameResult {
     required this.submission,
     required this.coverage,
     required this.observationBatchForReuse,
+    required this.spriteBatchesForReuse,
     required this.shouldRetireGpuResources,
   });
 
@@ -28,6 +31,7 @@ final class BaseMapOverlayFrameResult {
   final MapSceneFrameSubmission? submission;
   final EarthquakeOverlayCoverage coverage;
   final ObservationPointBatch? observationBatchForReuse;
+  final List<MapPointSpriteInstanceBatch> spriteBatchesForReuse;
   final bool shouldRetireGpuResources;
 }
 
@@ -44,6 +48,7 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
   required EarthquakeAreaPackedMeshResolver packedMeshFor,
   required EarthquakeAreaRenderStyleCache styleCache,
   required MapSceneFrameLimits sceneFrameLimits,
+  List<MapPointSpriteInstanceBatch> previousSpriteBatches = const [],
 }) {
   if (!identical(baseMap.frame, frame)) {
     throw ArgumentError('baseMap must use the captured frame');
@@ -61,6 +66,10 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
         previous: previousObservationBatch,
         overlay: overlay,
       ),
+      spriteBatchesForReuse: _reusableSprites(
+        previous: previousSpriteBatches,
+        overlay: overlay,
+      ),
       shouldRetireGpuResources: true,
     );
   }
@@ -74,6 +83,7 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
       ),
       coverage: const EarthquakeOverlayCoverage.hidden(),
       observationBatchForReuse: null,
+      spriteBatchesForReuse: const [],
       shouldRetireGpuResources: false,
     );
   }
@@ -110,6 +120,14 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
     snapshot: overlay,
     previous: previousObservationBatch,
   );
+  final sprites = buildMapPointSpriteBatches(
+    frame: frame,
+    versionStamp: overlay.versionStamp,
+    atlas: overlay.spriteAtlas,
+    features: overlay.sprites,
+    maxPolicyBatches: overlay.maxSpritePolicyBatches,
+    previous: previousSpriteBatches,
+  );
   return BaseMapOverlayFrameResult(
     overlay: overlay,
     submission: MapSceneFrameSubmission(
@@ -139,6 +157,15 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
             kind: MapSceneInstanceLayerKind.observationPoint,
             batch: observation,
           ),
+        for (final (index, batch) in sprites.indexed)
+          MapSceneInstanceLayerSubmission(
+            logicalSourceKey: mapSceneEarthquakeHistorySourceKey,
+            componentKey: mapSceneHypocenterSpriteComponentKey,
+            overlayVersion: overlay.versionStamp,
+            orderWithinPhase: index,
+            kind: MapSceneInstanceLayerKind.pointSprite,
+            batch: batch,
+          ),
       ],
       limits: sceneFrameLimits,
     ),
@@ -149,6 +176,7 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
           previous: previousObservationBatch,
           overlay: overlay,
         ),
+    spriteBatchesForReuse: sprites,
     shouldRetireGpuResources: false,
   );
 }
@@ -233,3 +261,12 @@ ObservationPointBatch? _reusableObservation({
       ? previous
       : null;
 }
+
+List<MapPointSpriteInstanceBatch> _reusableSprites({
+  required List<MapPointSpriteInstanceBatch> previous,
+  required EarthquakeMapOverlaySnapshot? overlay,
+}) => overlay == null
+    ? const []
+    : List.unmodifiable(
+        previous.where((batch) => batch.versionStamp == overlay.versionStamp),
+      );

--- a/packages/eqmonitor_map/lib/src/renderer/map_sprite_batch.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/map_sprite_batch.dart
@@ -1,0 +1,145 @@
+import 'dart:typed_data';
+
+import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
+import 'package:eqmonitor_map/src/overlay/map_sprite_atlas.dart';
+import 'package:eqmonitor_map/src/overlay/map_zoom_scalar_policy.dart';
+import 'package:eqmonitor_map/src/renderer/map_scene_frame_submission.dart';
+
+const mapSpriteQuadVertexStrideInBytes = 8;
+const mapPointSpriteInstanceStrideInBytes = 40;
+const mapSpriteFrameUniformByteLength = 64;
+const mapSpriteMaterialAbiVersion = 1;
+const mapSpriteFrameUniformBlockName = 'SpriteFrame';
+const mapSpriteVertexShaderSymbol = 'MapSpriteVertex';
+const mapSpriteFragmentShaderSymbol = 'MapSpriteFragment';
+const mapSpriteAtlasUniformName = 'spriteAtlas';
+
+/// StaticInstanceGeometryと1対1で対応するsprite instanceのidentity。
+final class MapSpriteInstanceGeneration {
+  MapSpriteInstanceGeneration._();
+}
+
+/// 同じatlas/material/policyを共有するimmutable sprite instance batch。
+final class MapPointSpriteInstanceBatch implements MapSceneInstanceBatch {
+  const MapPointSpriteInstanceBatch._({
+    required this.frame,
+    required this.versionStamp,
+    required this.atlas,
+    required this.sizePolicy,
+    required this.opacityPolicy,
+    required this.featureIds,
+    required this.instanceGeneration,
+    required this.instanceData,
+    required this.instanceCount,
+    required this.instanceDigest,
+    required this.frameUniform,
+    required this.batchKey,
+    required this.phasePolicyVersion,
+    required this.phase,
+  });
+
+  @override
+  final MapFrameSnapshot frame;
+  final MapOverlayVersionStamp versionStamp;
+  final MapSpriteAtlas atlas;
+  final MapZoomLinearRange sizePolicy;
+  final MapZoomStep opacityPolicy;
+  final List<String> featureIds;
+  final MapSpriteInstanceGeneration instanceGeneration;
+  final Float32List instanceData;
+  final int instanceCount;
+  final String instanceDigest;
+  final ByteData frameUniform;
+
+  @override
+  final MapSceneBatchKey batchKey;
+
+  @override
+  final int phasePolicyVersion;
+
+  @override
+  final int phase;
+
+  int get instanceStrideInBytes => mapPointSpriteInstanceStrideInBytes;
+
+  MapPointSpriteInstanceBatch withFrame({
+    required MapFrameSnapshot frame,
+    required MapOverlayVersionStamp versionStamp,
+    required ByteData frameUniform,
+  }) {
+    final ownedUniform = Uint8List.fromList(
+      frameUniform.buffer.asUint8List(
+        frameUniform.offsetInBytes,
+        frameUniform.lengthInBytes,
+      ),
+    );
+    return MapPointSpriteInstanceBatch._(
+      frame: frame,
+      versionStamp: versionStamp,
+      atlas: atlas,
+      sizePolicy: sizePolicy,
+      opacityPolicy: opacityPolicy,
+      featureIds: featureIds,
+      instanceGeneration: instanceGeneration,
+      instanceData: instanceData,
+      instanceCount: instanceCount,
+      instanceDigest: instanceDigest,
+      frameUniform: ByteData.sublistView(ownedUniform).asUnmodifiableView(),
+      batchKey: batchKey,
+      phasePolicyVersion: phasePolicyVersion,
+      phase: phase,
+    );
+  }
+}
+
+MapPointSpriteInstanceBatch createMapPointSpriteInstanceBatch({
+  required MapFrameSnapshot frame,
+  required MapOverlayVersionStamp versionStamp,
+  required MapSpriteAtlas atlas,
+  required MapZoomLinearRange sizePolicy,
+  required MapZoomStep opacityPolicy,
+  required List<String> featureIds,
+  required Float32List instanceData,
+  required int instanceCount,
+  required String instanceDigest,
+  required ByteData frameUniform,
+  required MapSceneBatchKey batchKey,
+  required int phasePolicyVersion,
+  required int phase,
+}) {
+  if (instanceCount <= 0 ||
+      featureIds.length != instanceCount ||
+      instanceData.lengthInBytes !=
+          instanceCount * mapPointSpriteInstanceStrideInBytes) {
+    throw ArgumentError.value(instanceData, 'instanceData');
+  }
+  if (frameUniform.lengthInBytes != mapSpriteFrameUniformByteLength) {
+    throw ArgumentError.value(frameUniform, 'frameUniform');
+  }
+  if (instanceDigest.trim().isEmpty) {
+    throw ArgumentError.value(instanceDigest, 'instanceDigest');
+  }
+  final ownedUniform = Uint8List.fromList(
+    frameUniform.buffer.asUint8List(
+      frameUniform.offsetInBytes,
+      frameUniform.lengthInBytes,
+    ),
+  );
+  return MapPointSpriteInstanceBatch._(
+    frame: frame,
+    versionStamp: versionStamp,
+    atlas: atlas,
+    sizePolicy: sizePolicy,
+    opacityPolicy: opacityPolicy,
+    featureIds: List<String>.unmodifiable(featureIds),
+    instanceGeneration: MapSpriteInstanceGeneration._(),
+    instanceData: Float32List.fromList(instanceData).asUnmodifiableView(),
+    instanceCount: instanceCount,
+    instanceDigest: instanceDigest,
+    frameUniform: ByteData.sublistView(ownedUniform).asUnmodifiableView(),
+    batchKey: batchKey,
+    phasePolicyVersion: phasePolicyVersion,
+    phase: phase,
+  );
+}

--- a/packages/eqmonitor_map/lib/src/renderer/map_sprite_batch_builder.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/map_sprite_batch_builder.dart
@@ -38,8 +38,10 @@ List<MapPointSpriteInstanceBatch> buildMapPointSpriteBatches({
     if (!ids.add(feature.id) || !regions.containsKey(feature.spriteRegionId)) {
       throw ArgumentError.value(features, 'features');
     }
+    final sizePolicy = _canonicalSizePolicy(feature.sizeScale);
+    final opacityPolicy = _canonicalOpacityPolicy(feature.opacity);
     groups
-        .putIfAbsent((feature.sizeScale, feature.opacity), () => [])
+        .putIfAbsent((sizePolicy, opacityPolicy), () => [])
         .add(
           feature,
         );
@@ -216,6 +218,22 @@ String _policyDigest({
   opacity.belowValue,
   opacity.atOrAboveValue,
 ].map((value) => value.toString()).join(':');
+
+MapZoomLinearRange _canonicalSizePolicy(MapZoomLinearRange policy) =>
+    createMapZoomLinearRange(
+      startZoom: _canonicalPolicyScalar(policy.startZoom),
+      startValue: _canonicalPolicyScalar(policy.startValue),
+      endZoom: _canonicalPolicyScalar(policy.endZoom),
+      endValue: _canonicalPolicyScalar(policy.endValue),
+    );
+
+MapZoomStep _canonicalOpacityPolicy(MapZoomStep policy) => createMapZoomStep(
+  thresholdZoom: _canonicalPolicyScalar(policy.thresholdZoom),
+  belowValue: _canonicalPolicyScalar(policy.belowValue),
+  atOrAboveValue: _canonicalPolicyScalar(policy.atOrAboveValue),
+);
+
+double _canonicalPolicyScalar(double value) => value == 0 ? 0 : value;
 
 double nearestWrappedMapSpriteWorldDelta({
   required double normalizedX,

--- a/packages/eqmonitor_map/lib/src/renderer/map_sprite_batch_builder.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/map_sprite_batch_builder.dart
@@ -1,0 +1,307 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
+import 'package:eqmonitor_map/src/geo/map_mercator_projection.dart';
+import 'package:eqmonitor_map/src/geo/map_viewport.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
+import 'package:eqmonitor_map/src/overlay/map_point_sprite_feature.dart';
+import 'package:eqmonitor_map/src/overlay/map_sprite_atlas.dart';
+import 'package:eqmonitor_map/src/overlay/map_zoom_scalar_policy.dart';
+import 'package:eqmonitor_map/src/renderer/map_scene_frame_submission.dart';
+import 'package:eqmonitor_map/src/renderer/map_scene_render_phase_policy.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
+
+List<MapPointSpriteInstanceBatch> buildMapPointSpriteBatches({
+  required MapFrameSnapshot frame,
+  required MapOverlayVersionStamp versionStamp,
+  required MapSpriteAtlas? atlas,
+  required List<MapPointSpriteFeature> features,
+  required int maxPolicyBatches,
+  List<MapPointSpriteInstanceBatch> previous = const [],
+  MapMercatorProjection projection = const MapMercatorProjection(),
+}) {
+  if (maxPolicyBatches <= 0) {
+    throw ArgumentError.value(maxPolicyBatches, 'maxPolicyBatches');
+  }
+  if (features.isEmpty) {
+    return const [];
+  }
+  if (atlas == null) {
+    throw ArgumentError.value(atlas, 'atlas', 'is required by sprites');
+  }
+  final regions = {for (final region in atlas.regions) region.id: region};
+  final groups =
+      <(MapZoomLinearRange, MapZoomStep), List<MapPointSpriteFeature>>{};
+  final ids = <String>{};
+  for (final feature in features) {
+    if (!ids.add(feature.id) || !regions.containsKey(feature.spriteRegionId)) {
+      throw ArgumentError.value(features, 'features');
+    }
+    groups
+        .putIfAbsent((feature.sizeScale, feature.opacity), () => [])
+        .add(
+          feature,
+        );
+  }
+  if (groups.length > maxPolicyBatches) {
+    throw ArgumentError.value(groups.length, 'features');
+  }
+  final entries = groups.entries.toList()
+    ..sort(
+      (left, right) =>
+          _policyDigest(
+            size: left.key.$1,
+            opacity: left.key.$2,
+          ).compareTo(
+            _policyDigest(size: right.key.$1, opacity: right.key.$2),
+          ),
+    );
+  final previousByDigest = {
+    for (final batch in previous)
+      '${batch.batchKey.value}|${batch.instanceDigest}': batch,
+  };
+  return List.unmodifiable([
+    for (final entry in entries)
+      _buildPolicyBatch(
+        frame: frame,
+        versionStamp: versionStamp,
+        atlas: atlas,
+        regions: regions,
+        sizePolicy: entry.key.$1,
+        opacityPolicy: entry.key.$2,
+        features: entry.value,
+        previousByDigest: previousByDigest,
+        projection: projection,
+      ),
+  ]);
+}
+
+MapPointSpriteInstanceBatch _buildPolicyBatch({
+  required MapFrameSnapshot frame,
+  required MapOverlayVersionStamp versionStamp,
+  required MapSpriteAtlas atlas,
+  required Map<String, MapSpriteRegion> regions,
+  required MapZoomLinearRange sizePolicy,
+  required MapZoomStep opacityPolicy,
+  required List<MapPointSpriteFeature> features,
+  required Map<String, MapPointSpriteInstanceBatch> previousByDigest,
+  required MapMercatorProjection projection,
+}) {
+  features.sort(
+    (left, right) => left.priority != right.priority
+        ? left.priority.compareTo(right.priority)
+        : left.id.compareTo(right.id),
+  );
+  final instanceData = _packMapPointSpriteInstances(
+    features: features,
+    regions: regions,
+    projection: projection,
+  );
+  final policyDigest = _policyDigest(
+    size: sizePolicy,
+    opacity: opacityPolicy,
+  );
+  final batchKey = createMapSceneBatchKey(
+    value:
+        'atlas:${atlas.identity.value}|material:$mapSpriteMaterialAbiVersion|'
+        'policy:$policyDigest',
+  );
+  final instanceDigest = [
+    for (final feature in features) '${feature.id.length}:${feature.id}',
+    base64Encode(instanceData.buffer.asUint8List()),
+  ].join('|');
+  final frameUniform = packMapSpriteFrameUniform(
+    frame: frame,
+    sizePolicy: sizePolicy,
+    opacityPolicy: opacityPolicy,
+    projection: projection,
+  );
+  final reusable = previousByDigest['${batchKey.value}|$instanceDigest'];
+  if (reusable != null) {
+    return reusable.withFrame(
+      frame: frame,
+      versionStamp: versionStamp,
+      frameUniform: frameUniform,
+    );
+  }
+  return createMapPointSpriteInstanceBatch(
+    frame: frame,
+    versionStamp: versionStamp,
+    atlas: atlas,
+    sizePolicy: sizePolicy,
+    opacityPolicy: opacityPolicy,
+    featureIds: [for (final feature in features) feature.id],
+    instanceData: instanceData,
+    instanceCount: features.length,
+    instanceDigest: instanceDigest,
+    frameUniform: frameUniform,
+    batchKey: batchKey,
+    phasePolicyVersion: mapSceneRenderPhasePolicy.version,
+    phase: mapSceneRenderPhasePolicy.rankOf(mapSceneSpritePhaseId),
+  );
+}
+
+Float32List _packMapPointSpriteInstances({
+  required List<MapPointSpriteFeature> features,
+  required Map<String, MapSpriteRegion> regions,
+  required MapMercatorProjection projection,
+}) {
+  final data = Float32List(features.length * 10);
+  final bytes = ByteData.sublistView(data);
+  for (final (index, feature) in features.indexed) {
+    final center = projection.lngLatToNormalized(
+      longitude: feature.longitude,
+      latitude: feature.latitude,
+    );
+    final region = regions[feature.spriteRegionId];
+    if (region == null) {
+      throw StateError('Validated sprite region disappeared.');
+    }
+    final offset = index * mapPointSpriteInstanceStrideInBytes;
+    bytes
+      ..setFloat32(offset, center.x, Endian.little)
+      ..setFloat32(offset + 4, center.y, Endian.little)
+      ..setFloat32(offset + 8, region.normalizedUv.left, Endian.little)
+      ..setFloat32(offset + 12, region.normalizedUv.top, Endian.little)
+      ..setFloat32(offset + 16, region.normalizedUv.right, Endian.little)
+      ..setFloat32(offset + 20, region.normalizedUv.bottom, Endian.little)
+      ..setFloat32(offset + 24, region.logicalSize.width, Endian.little)
+      ..setFloat32(offset + 28, region.logicalSize.height, Endian.little)
+      ..setFloat32(offset + 32, 1, Endian.little)
+      ..setFloat32(offset + 36, feature.priority.toDouble(), Endian.little);
+  }
+  return data;
+}
+
+ByteData packMapSpriteFrameUniform({
+  required MapFrameSnapshot frame,
+  required MapZoomLinearRange sizePolicy,
+  required MapZoomStep opacityPolicy,
+  MapMercatorProjection projection = const MapMercatorProjection(),
+}) {
+  final camera = projection.lngLatToNormalized(
+    longitude: frame.camera.centerLongitude,
+    latitude: frame.camera.centerLatitude,
+  );
+  return ByteData(mapSpriteFrameUniformByteLength)
+    ..setFloat32(0, camera.x, Endian.little)
+    ..setFloat32(4, camera.y, Endian.little)
+    ..setFloat32(
+      8,
+      projection.worldSizeForZoom(frame.camera.zoom),
+      Endian.little,
+    )
+    ..setFloat32(16, frame.viewport.logicalSize.width, Endian.little)
+    ..setFloat32(20, frame.viewport.logicalSize.height, Endian.little)
+    ..setFloat32(24, frame.camera.zoom, Endian.little)
+    ..setFloat32(32, sizePolicy.startZoom, Endian.little)
+    ..setFloat32(36, sizePolicy.startValue, Endian.little)
+    ..setFloat32(40, sizePolicy.endZoom, Endian.little)
+    ..setFloat32(44, sizePolicy.endValue, Endian.little)
+    ..setFloat32(48, opacityPolicy.thresholdZoom, Endian.little)
+    ..setFloat32(52, opacityPolicy.belowValue, Endian.little)
+    ..setFloat32(56, opacityPolicy.atOrAboveValue, Endian.little);
+}
+
+String _policyDigest({
+  required MapZoomLinearRange size,
+  required MapZoomStep opacity,
+}) => [
+  size.startZoom,
+  size.startValue,
+  size.endZoom,
+  size.endValue,
+  opacity.thresholdZoom,
+  opacity.belowValue,
+  opacity.atOrAboveValue,
+].map((value) => value.toString()).join(':');
+
+double nearestWrappedMapSpriteWorldDelta({
+  required double normalizedX,
+  required double cameraNormalizedX,
+}) {
+  if (!normalizedX.isFinite || !cameraNormalizedX.isFinite) {
+    throw ArgumentError('normalized X coordinates must be finite');
+  }
+  final delta = normalizedX - cameraNormalizedX;
+  return delta - delta.round();
+}
+
+({double x, double y}) mapPointSpriteNdc({
+  required double normalizedX,
+  required double normalizedY,
+  required double cameraNormalizedX,
+  required double cameraNormalizedY,
+  required double worldSizeLogicalPixels,
+  required MapViewport viewport,
+  required double cornerX,
+  required double cornerY,
+  required double logicalWidth,
+  required double logicalHeight,
+  required double sizeScale,
+}) {
+  final values = [
+    normalizedY,
+    cameraNormalizedY,
+    worldSizeLogicalPixels,
+    cornerX,
+    cornerY,
+    logicalWidth,
+    logicalHeight,
+    sizeScale,
+  ];
+  if (values.any((value) => !value.isFinite) ||
+      worldSizeLogicalPixels <= 0 ||
+      logicalWidth <= 0 ||
+      logicalHeight <= 0 ||
+      sizeScale <= 0) {
+    throw ArgumentError.value(values, 'sprite projection');
+  }
+  final logicalX =
+      nearestWrappedMapSpriteWorldDelta(
+        normalizedX: normalizedX,
+        cameraNormalizedX: cameraNormalizedX,
+      ) *
+      worldSizeLogicalPixels;
+  final logicalY = (normalizedY - cameraNormalizedY) * worldSizeLogicalPixels;
+  return (
+    x:
+        logicalX * 2 / viewport.logicalSize.width +
+        cornerX * logicalWidth * sizeScale / viewport.logicalSize.width,
+    y:
+        -logicalY * 2 / viewport.logicalSize.height +
+        cornerY * logicalHeight * sizeScale / viewport.logicalSize.height,
+  );
+}
+
+double evaluateMapSpriteSize({
+  required MapZoomLinearRange policy,
+  required double zoom,
+}) => policy.valueAt(zoom: zoom);
+
+double evaluateMapSpriteOpacity({
+  required MapZoomStep policy,
+  required double zoom,
+}) => policy.valueAt(zoom: zoom);
+
+({double red, double green, double blue, double alpha})
+premultiplyMapSpriteSample({
+  required double red,
+  required double green,
+  required double blue,
+  required double sampleAlpha,
+  required double featureOpacity,
+}) {
+  final values = [red, green, blue, sampleAlpha, featureOpacity];
+  if (values.any((value) => !value.isFinite || value < 0 || value > 1)) {
+    throw ArgumentError.value(values, 'sample');
+  }
+  final alpha = sampleAlpha * featureOpacity;
+  return (
+    red: red * alpha,
+    green: green * alpha,
+    blue: blue * alpha,
+    alpha: alpha,
+  );
+}

--- a/packages/eqmonitor_map/pubspec.yaml
+++ b/packages/eqmonitor_map/pubspec.yaml
@@ -35,3 +35,7 @@ dev_dependencies:
 dependency_overrides:
   scene:
     path: ../../third_party/flutter_scene/packages/scene
+
+flutter:
+  assets:
+    - shaders/earthquake_overlay.shaderinterface.json

--- a/packages/eqmonitor_map/shaders/earthquake_overlay.shaderbundle.json
+++ b/packages/eqmonitor_map/shaders/earthquake_overlay.shaderbundle.json
@@ -6,5 +6,13 @@
   "EarthquakeObservationFragment": {
     "type": "fragment",
     "file": "assets/earthquake_observation.frag"
+  },
+  "MapSpriteVertex": {
+    "type": "vertex",
+    "file": "assets/earthquake_sprite.vert"
+  },
+  "MapSpriteFragment": {
+    "type": "fragment",
+    "file": "assets/earthquake_sprite.frag"
   }
 }

--- a/packages/eqmonitor_map/shaders/earthquake_overlay.shaderinterface.json
+++ b/packages/eqmonitor_map/shaders/earthquake_overlay.shaderinterface.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "shaders": {
+    "MapSpriteVertex": {
+      "stage": "vertex",
+      "inputs": [
+        {"name":"centerMercator","location":1,"set":0,"binding":0,"type":"float","bitWidth":32,"vecSize":2,"columns":1,"offset":8},
+        {"name":"corner","location":0,"set":0,"binding":0,"type":"float","bitWidth":32,"vecSize":2,"columns":1,"offset":0},
+        {"name":"logicalSize","location":3,"set":0,"binding":0,"type":"float","bitWidth":32,"vecSize":2,"columns":1,"offset":32},
+        {"name":"uvRect","location":2,"set":0,"binding":0,"type":"float","bitWidth":32,"vecSize":4,"columns":1,"offset":16},
+        {"name":"opacity","location":4,"set":0,"binding":0,"type":"float","bitWidth":32,"vecSize":1,"columns":1,"offset":40},
+        {"name":"priority","location":5,"set":0,"binding":0,"type":"float","bitWidth":32,"vecSize":1,"columns":1,"offset":44}
+      ],
+      "uniformBlocks": [
+        {
+          "name": "SpriteFrame",
+          "set": 0,
+          "binding": 0,
+          "sizeInBytes": 64,
+          "fields": [
+            {"name":"cameraWorld","type":"float","offsetInBytes":0,"elementSizeInBytes":16,"totalSizeInBytes":16,"arrayElements":0,"vecSize":4,"columns":1},
+            {"name":"viewportZoom","type":"float","offsetInBytes":16,"elementSizeInBytes":16,"totalSizeInBytes":16,"arrayElements":0,"vecSize":4,"columns":1},
+            {"name":"sizePolicy","type":"float","offsetInBytes":32,"elementSizeInBytes":16,"totalSizeInBytes":16,"arrayElements":0,"vecSize":4,"columns":1},
+            {"name":"opacityPolicy","type":"float","offsetInBytes":48,"elementSizeInBytes":16,"totalSizeInBytes":16,"arrayElements":0,"vecSize":4,"columns":1}
+          ]
+        }
+      ],
+      "sampledImages": []
+    },
+    "EarthquakeObservationVertex": {
+      "stage": "vertex",
+      "inputs": [
+        {"name":"centerMercator","location":1,"set":0,"binding":0,"type":"float","bitWidth":32,"vecSize":2,"columns":1,"offset":8},
+        {"name":"radiusLogicalPixels","location":3,"set":0,"binding":0,"type":"float","bitWidth":32,"vecSize":1,"columns":1,"offset":32},
+        {"name":"corner","location":0,"set":0,"binding":0,"type":"float","bitWidth":32,"vecSize":2,"columns":1,"offset":0},
+        {"name":"color","location":2,"set":0,"binding":0,"type":"float","bitWidth":32,"vecSize":4,"columns":1,"offset":16}
+      ],
+      "uniformBlocks": [
+        {
+          "name": "ObservationFrame",
+          "set": 0,
+          "binding": 0,
+          "sizeInBytes": 32,
+          "fields": [
+            {"name":"camera_world","type":"float","offsetInBytes":0,"elementSizeInBytes":16,"totalSizeInBytes":16,"arrayElements":0,"vecSize":4,"columns":1},
+            {"name":"viewport_stroke","type":"float","offsetInBytes":16,"elementSizeInBytes":16,"totalSizeInBytes":16,"arrayElements":0,"vecSize":4,"columns":1}
+          ]
+        }
+      ],
+      "sampledImages": []
+    },
+    "MapSpriteFragment": {
+      "stage": "fragment",
+      "inputs": [],
+      "uniformBlocks": [],
+      "sampledImages": [
+        {"name":"spriteAtlas","set":0,"binding":64}
+      ]
+    },
+    "EarthquakeObservationFragment": {
+      "stage": "fragment",
+      "inputs": [],
+      "uniformBlocks": [],
+      "sampledImages": []
+    }
+  }
+}

--- a/packages/eqmonitor_map/test/flutter_scene/map_shader_interface_manifest_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/map_shader_interface_manifest_test.dart
@@ -1,0 +1,134 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:eqmonitor_map/src/flutter_scene/map_shader_interface_manifest.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'defensively parses typed input, uniform, and sampled-image metadata',
+    () {
+      final bytes = Uint8List.fromList(
+        utf8.encode('''
+{
+  "version": 1,
+  "shaders": {
+    "MapSpriteVertex": {
+      "stage": "vertex",
+      "inputs": [
+        {
+          "name": "corner", "location": 0, "set": 0, "binding": 0,
+          "type": "float", "bitWidth": 32, "vecSize": 2,
+          "columns": 1, "offset": 0
+        }
+      ],
+      "uniformBlocks": [
+        {
+          "name": "SpriteFrame", "set": 0, "binding": 0,
+          "sizeInBytes": 64,
+          "fields": [
+            {
+              "name": "cameraWorld", "type": "float",
+              "offsetInBytes": 0, "elementSizeInBytes": 4,
+              "totalSizeInBytes": 16, "arrayElements": 0,
+              "vecSize": 4, "columns": 1
+            }
+          ]
+        }
+      ],
+      "sampledImages": [
+        {"name": "spriteAtlas", "set": 0, "binding": 2}
+      ]
+    }
+  }
+}
+'''),
+      );
+      final manifest = MapShaderInterfaceManifest.parse(jsonBytes: bytes);
+      bytes.fillRange(0, bytes.length, 0);
+
+      final shader = manifest.shaderNamed(mapSpriteVertexShaderSymbol);
+      expect(shader.stage, MapShaderInterfaceStage.vertex);
+      expect(shader.inputs.single.name, 'corner');
+      expect(shader.inputs.single.type, MapShaderScalarType.float);
+      expect(shader.inputs.single.vecSize, 2);
+      expect(shader.uniformBlocks.single.sizeInBytes, 64);
+      expect(shader.uniformBlocks.single.fields.single.offsetInBytes, 0);
+      expect(shader.sampledImages.single.name, mapSpriteAtlasUniformName);
+      expect(shader.sampledImages.single.set, 0);
+      expect(shader.sampledImages.single.binding, 2);
+    },
+  );
+
+  test(
+    'rejects malformed roots, empty manifests, and unknown types',
+    () {
+      for (final source in [
+        '[]',
+        '{"version":2,"shaders":{}}',
+        '{"version":1,"shaders":{}}',
+        '''
+      {"version":1,"shaders":{"a":{
+        "stage":"vertex",
+        "inputs":[{"name":"x","location":0,"set":0,"binding":0,
+          "type":"vec2","bitWidth":32,"vecSize":2,"columns":1,
+          "offset":0}],
+        "uniformBlocks":[],"sampledImages":[]
+      }}}
+      ''',
+      ]) {
+        expect(
+          () => MapShaderInterfaceManifest.parse(
+            jsonBytes: Uint8List.fromList(utf8.encode(source)),
+          ),
+          throwsFormatException,
+        );
+      }
+    },
+  );
+
+  test(
+    'checked-in manifest exposes the sprite ABI without sampler type claims',
+    () {
+      final manifest = MapShaderInterfaceManifest.parse(
+        jsonBytes: File(
+          'shaders/earthquake_overlay.shaderinterface.json',
+        ).readAsBytesSync(),
+      );
+      final vertex = manifest.shaderNamed(mapSpriteVertexShaderSymbol);
+      final fragment = manifest.shaderNamed(mapSpriteFragmentShaderSymbol);
+
+      expect(vertex.uniformBlocks.single.name, mapSpriteFrameUniformBlockName);
+      expect(vertex.uniformBlocks.single.sizeInBytes, 64);
+      expect(
+        {for (final input in vertex.inputs) input.name: input.offset},
+        {
+          'corner': 0,
+          'centerMercator': 8,
+          'uvRect': 16,
+          'logicalSize': 32,
+          'opacity': 40,
+          'priority': 44,
+        },
+      );
+      expect(fragment.sampledImages.single.name, mapSpriteAtlasUniformName);
+      expect(fragment.sampledImages.single.set, 0);
+      expect(fragment.sampledImages.single.binding, 64);
+    },
+  );
+
+  test('fragment source declares exactly one plain sampler2D atlas', () {
+    final source = File('assets/earthquake_sprite.frag').readAsStringSync();
+    final declarations = RegExp(
+      r'^\s*uniform\s+(\w+)\s+spriteAtlas\s*;\s*$',
+      multiLine: true,
+    ).allMatches(source).toList();
+
+    expect(declarations, hasLength(1));
+    expect(declarations.single.group(1), 'sampler2D');
+    expect(source, isNot(contains('samplerCube spriteAtlas')));
+    expect(source, isNot(contains('sampler2DArray spriteAtlas')));
+  });
+}

--- a/packages/eqmonitor_map/test/renderer/map_sprite_batch_builder_test.dart
+++ b/packages/eqmonitor_map/test/renderer/map_sprite_batch_builder_test.dart
@@ -140,6 +140,86 @@ void main() {
     expect(batches.first.batchKey, isNot(batches.last.batchKey));
   });
 
+  test(
+    'canonicalizes equivalent signed-zero policies independent of order',
+    () {
+      final negativeZero = -0.toDouble();
+      final negativeZeroSize = createMapZoomLinearRange(
+        startZoom: negativeZero,
+        startValue: 0.5,
+        endZoom: 20,
+        endValue: 1.5,
+      );
+      final positiveZeroSize = createMapZoomLinearRange(
+        startZoom: 0,
+        startValue: 0.5,
+        endZoom: 20,
+        endValue: 1.5,
+      );
+      final negativeZeroOpacity = createMapZoomStep(
+        thresholdZoom: negativeZero,
+        belowValue: negativeZero,
+        atOrAboveValue: 1,
+      );
+      final positiveZeroOpacity = createMapZoomStep(
+        thresholdZoom: 0,
+        belowValue: 0,
+        atOrAboveValue: 1,
+      );
+      final negativeFirst = buildMapPointSpriteBatches(
+        frame: frame(),
+        versionStamp: versionStamp(),
+        atlas: atlas,
+        features: [
+          feature(
+            id: 'a',
+            priority: 0,
+            size: negativeZeroSize,
+            opacity: negativeZeroOpacity,
+          ),
+          feature(
+            id: 'b',
+            priority: 1,
+            size: positiveZeroSize,
+            opacity: positiveZeroOpacity,
+          ),
+        ],
+        maxPolicyBatches: 1,
+      ).single;
+      final positiveFirst = buildMapPointSpriteBatches(
+        frame: frame(),
+        versionStamp: versionStamp(),
+        atlas: atlas,
+        features: [
+          feature(
+            id: 'b',
+            priority: 1,
+            size: positiveZeroSize,
+            opacity: positiveZeroOpacity,
+          ),
+          feature(
+            id: 'a',
+            priority: 0,
+            size: negativeZeroSize,
+            opacity: negativeZeroOpacity,
+          ),
+        ],
+        maxPolicyBatches: 1,
+        previous: [negativeFirst],
+      ).single;
+
+      expect(negativeFirst.batchKey, positiveFirst.batchKey);
+      expect(
+        positiveFirst.instanceGeneration,
+        same(negativeFirst.instanceGeneration),
+      );
+      expect(
+        negativeFirst.frameUniform.buffer.asUint8List(),
+        positiveFirst.frameUniform.buffer.asUint8List(),
+      );
+    },
+  );
+
   test('rejects caller policy batch overrun', () {
     expect(
       () => buildMapPointSpriteBatches(

--- a/packages/eqmonitor_map/test/renderer/map_sprite_batch_builder_test.dart
+++ b/packages/eqmonitor_map/test/renderer/map_sprite_batch_builder_test.dart
@@ -1,0 +1,335 @@
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
+import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
+import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
+import 'package:eqmonitor_map/src/geo/map_camera.dart';
+import 'package:eqmonitor_map/src/geo/map_viewport.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
+import 'package:eqmonitor_map/src/overlay/map_point_sprite_feature.dart';
+import 'package:eqmonitor_map/src/overlay/map_sprite_atlas.dart';
+import 'package:eqmonitor_map/src/overlay/map_zoom_scalar_policy.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final clock = SystemMapClock.start(
+    domain: createMapClockDomainId(value: 'sprite-batch-test'),
+  );
+  final viewport = MapViewport(
+    logicalSize: const Size(400, 800),
+    devicePixelRatio: 3,
+  );
+  final atlas = createMapSpriteAtlas(
+    identity: createMapSourceIdentity(value: 'sha256:atlas-a'),
+    width: 4,
+    height: 4,
+    rgbaBytes: Uint8List(64),
+    regions: const [
+      MapSpriteRegion(
+        id: 'normal',
+        normalizedUv: Rect.fromLTRB(0.125, 0.125, 0.375, 0.375),
+        logicalSize: Size(24, 32),
+      ),
+      MapSpriteRegion(
+        id: 'low',
+        normalizedUv: Rect.fromLTRB(0.625, 0.125, 0.875, 0.375),
+        logicalSize: Size(20, 28),
+      ),
+    ],
+    limits: const MapSpriteAtlasLimits(
+      maxWidth: 4,
+      maxHeight: 4,
+      maxPixelBytes: 64,
+      maxRegions: 2,
+    ),
+  );
+  final sizeA = createMapZoomLinearRange(
+    startZoom: 3,
+    startValue: 0.5,
+    endZoom: 20,
+    endValue: 1.5,
+  );
+  final sizeB = createMapZoomLinearRange(
+    startZoom: 4,
+    startValue: 0.75,
+    endZoom: 18,
+    endValue: 1.25,
+  );
+  final opacityA = createMapZoomStep(
+    thresholdZoom: 5,
+    belowValue: 0,
+    atOrAboveValue: 1,
+  );
+  final opacityB = createMapZoomStep(
+    thresholdZoom: 7,
+    belowValue: 0.25,
+    atOrAboveValue: 0.75,
+  );
+
+  MapFrameSnapshot frame({
+    int frameNumber = 0,
+    double centerLongitude = 139.7,
+    double zoom = 6,
+  }) => captureMapFrameSnapshot(
+    clock: clock,
+    frameNumber: frameNumber,
+    camera: MapCamera(
+      centerLongitude: centerLongitude,
+      centerLatitude: 35.7,
+      zoom: zoom,
+    ),
+    viewport: viewport,
+    revisions: const [],
+    lifecycle: MapAppLifecycle.active,
+    contextGeneration: 0,
+  );
+
+  MapOverlayVersionStamp versionStamp({int renderGeneration = 1}) =>
+      createMapOverlayVersionStamp(
+        sourceIdentity: createMapSourceIdentity(value: 'event-a'),
+        sourceIncarnation: createMapSourceIncarnation(value: 'incarnation-a'),
+        dataSequence: 1,
+        dataDigest: 'data-a',
+        renderGeneration: renderGeneration,
+        renderDigest: 'render-$renderGeneration',
+      );
+
+  MapPointSpriteFeature feature({
+    required String id,
+    required int priority,
+    String regionId = 'normal',
+    double longitude = 139.6917,
+    double latitude = 35.6895,
+    MapZoomLinearRange? size,
+    MapZoomStep? opacity,
+  }) => createMapPointSpriteFeature(
+    id: id,
+    longitude: longitude,
+    latitude: latitude,
+    spriteRegionId: regionId,
+    sizeScale: size ?? sizeA,
+    opacity: opacity ?? opacityA,
+    priority: priority,
+  );
+
+  test('groups by policy and orders instances by priority then ID', () {
+    final batches = buildMapPointSpriteBatches(
+      frame: frame(),
+      versionStamp: versionStamp(),
+      atlas: atlas,
+      features: [
+        feature(id: 'z', priority: 2),
+        feature(id: 'b', priority: 1),
+        feature(id: 'a', priority: 1),
+        feature(id: 'other', priority: 0, size: sizeB, opacity: opacityB),
+      ],
+      maxPolicyBatches: 2,
+    );
+
+    expect(batches, hasLength(2));
+    expect(batches.first.featureIds, ['a', 'b', 'z']);
+    expect(batches.last.featureIds, ['other']);
+    expect(batches.first.batchKey.value, contains('sha256:atlas-a'));
+    expect(
+      batches.first.batchKey.value,
+      contains('material:$mapSpriteMaterialAbiVersion'),
+    );
+    expect(batches.first.batchKey, isNot(batches.last.batchKey));
+  });
+
+  test('rejects caller policy batch overrun', () {
+    expect(
+      () => buildMapPointSpriteBatches(
+        frame: frame(),
+        versionStamp: versionStamp(),
+        atlas: atlas,
+        features: [
+          feature(id: 'a', priority: 0),
+          feature(id: 'b', priority: 0, size: sizeB, opacity: opacityB),
+        ],
+        maxPolicyBatches: 1,
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('packs exact little-endian 40-byte instance ABI', () {
+    final batch = buildMapPointSpriteBatches(
+      frame: frame(),
+      versionStamp: versionStamp(),
+      atlas: atlas,
+      features: [feature(id: 'tokyo', priority: 7)],
+      maxPolicyBatches: 1,
+    ).single;
+    final bytes = ByteData.sublistView(batch.instanceData);
+
+    expect(batch.instanceStrideInBytes, 40);
+    expect(bytes.lengthInBytes, 40);
+    expect(bytes.getFloat32(0, Endian.little), closeTo(0.8880325, 1e-7));
+    expect(bytes.getFloat32(4, Endian.little), closeTo(0.39374975, 1e-7));
+    expect(bytes.getFloat32(8, Endian.little), 0.125);
+    expect(bytes.getFloat32(12, Endian.little), 0.125);
+    expect(bytes.getFloat32(16, Endian.little), 0.375);
+    expect(bytes.getFloat32(20, Endian.little), 0.375);
+    expect(bytes.getFloat32(24, Endian.little), 24);
+    expect(bytes.getFloat32(28, Endian.little), 32);
+    expect(bytes.getFloat32(32, Endian.little), 1);
+    expect(bytes.getFloat32(36, Endian.little), 7);
+  });
+
+  test('packs exact 64-byte SpriteFrame uniform', () {
+    final uniform = buildMapPointSpriteBatches(
+      frame: frame(),
+      versionStamp: versionStamp(),
+      atlas: atlas,
+      features: [feature(id: 'tokyo', priority: 0)],
+      maxPolicyBatches: 1,
+    ).single.frameUniform;
+
+    expect(uniform.lengthInBytes, 64);
+    expect(uniform.getFloat32(0, Endian.little), closeTo(0.88805556, 1e-7));
+    expect(uniform.getFloat32(4, Endian.little), closeTo(0.39371383, 1e-7));
+    expect(uniform.getFloat32(8, Endian.little), 32768);
+    expect(uniform.getFloat32(12, Endian.little), 0);
+    expect(uniform.getFloat32(16, Endian.little), 400);
+    expect(uniform.getFloat32(20, Endian.little), 800);
+    expect(uniform.getFloat32(24, Endian.little), 6);
+    expect(uniform.getFloat32(28, Endian.little), 0);
+    expect(uniform.getFloat32(32, Endian.little), 3);
+    expect(uniform.getFloat32(36, Endian.little), 0.5);
+    expect(uniform.getFloat32(40, Endian.little), 20);
+    expect(uniform.getFloat32(44, Endian.little), 1.5);
+    expect(uniform.getFloat32(48, Endian.little), 5);
+    expect(uniform.getFloat32(52, Endian.little), 0);
+    expect(uniform.getFloat32(56, Endian.little), 1);
+    expect(uniform.getFloat32(60, Endian.little), 0);
+  });
+
+  test('uses nearest date-line world and logical pixels without DPR', () {
+    expect(
+      nearestWrappedMapSpriteWorldDelta(
+        normalizedX: 0.999,
+        cameraNormalizedX: 0.001,
+      ),
+      closeTo(-0.002, 1e-12),
+    );
+    final vertex = mapPointSpriteNdc(
+      normalizedX: 0.999,
+      normalizedY: 0.5,
+      cameraNormalizedX: 0.001,
+      cameraNormalizedY: 0.499,
+      worldSizeLogicalPixels: 1000,
+      viewport: viewport,
+      cornerX: 1,
+      cornerY: -1,
+      logicalWidth: 20,
+      logicalHeight: 40,
+      sizeScale: 0.5,
+    );
+
+    expect(vertex.x, closeTo(0.015, 1e-12));
+    expect(vertex.y, closeTo(-0.0275, 1e-12));
+  });
+
+  test('matches linear clamp and step equality at shader policy boundary', () {
+    expect(evaluateMapSpriteSize(policy: sizeA, zoom: 2), 0.5);
+    expect(evaluateMapSpriteSize(policy: sizeA, zoom: 20), 1.5);
+    expect(evaluateMapSpriteOpacity(policy: opacityA, zoom: 4.999), 0);
+    expect(evaluateMapSpriteOpacity(policy: opacityA, zoom: 5), 1);
+  });
+
+  test('returns no batches for zero sprites', () {
+    expect(
+      buildMapPointSpriteBatches(
+        frame: frame(),
+        versionStamp: versionStamp(),
+        atlas: null,
+        features: const [],
+        maxPolicyBatches: 1,
+      ),
+      isEmpty,
+    );
+  });
+
+  test('same digest reuses instances while camera-only uniform changes', () {
+    final first = buildMapPointSpriteBatches(
+      frame: frame(),
+      versionStamp: versionStamp(),
+      atlas: atlas,
+      features: [feature(id: 'tokyo', priority: 0)],
+      maxPolicyBatches: 1,
+    ).single;
+    final second = buildMapPointSpriteBatches(
+      frame: frame(frameNumber: 1, centerLongitude: 140),
+      versionStamp: versionStamp(),
+      atlas: atlas,
+      features: [feature(id: 'tokyo', priority: 0)],
+      maxPolicyBatches: 1,
+      previous: [first],
+    ).single;
+
+    expect(second.instanceGeneration, same(first.instanceGeneration));
+    expect(second.instanceData, same(first.instanceData));
+    expect(second.frameUniform, isNot(same(first.frameUniform)));
+  });
+
+  test('different digest replaces instances', () {
+    final first = buildMapPointSpriteBatches(
+      frame: frame(),
+      versionStamp: versionStamp(),
+      atlas: atlas,
+      features: [feature(id: 'tokyo', priority: 0)],
+      maxPolicyBatches: 1,
+    ).single;
+    final second = buildMapPointSpriteBatches(
+      frame: frame(frameNumber: 1),
+      versionStamp: versionStamp(renderGeneration: 2),
+      atlas: atlas,
+      features: [feature(id: 'tokyo', priority: 1)],
+      maxPolicyBatches: 1,
+      previous: [first],
+    ).single;
+
+    expect(second.instanceGeneration, isNot(same(first.instanceGeneration)));
+    expect(second.instanceData, isNot(same(first.instanceData)));
+  });
+
+  test('feature identity participates in the reusable batch digest', () {
+    final first = buildMapPointSpriteBatches(
+      frame: frame(),
+      versionStamp: versionStamp(),
+      atlas: atlas,
+      features: [feature(id: 'old-id', priority: 0)],
+      maxPolicyBatches: 1,
+    ).single;
+    final second = buildMapPointSpriteBatches(
+      frame: frame(frameNumber: 1),
+      versionStamp: versionStamp(renderGeneration: 2),
+      atlas: atlas,
+      features: [feature(id: 'new-id', priority: 0)],
+      maxPolicyBatches: 1,
+      previous: [first],
+    ).single;
+
+    expect(second.instanceGeneration, isNot(same(first.instanceGeneration)));
+    expect(second.featureIds, ['new-id']);
+  });
+
+  test('premultiplies straight atlas alpha and feature opacity once', () {
+    final color = premultiplyMapSpriteSample(
+      red: 0.8,
+      green: 0.4,
+      blue: 0.2,
+      sampleAlpha: 0.5,
+      featureOpacity: 0.25,
+    );
+
+    expect(color.red, closeTo(0.1, 1e-12));
+    expect(color.green, closeTo(0.05, 1e-12));
+    expect(color.blue, closeTo(0.025, 1e-12));
+    expect(color.alpha, 0.125);
+  });
+}

--- a/packages/eqmonitor_map/test/widget/base_map_overlay_frame_builder_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_overlay_frame_builder_test.dart
@@ -16,6 +16,9 @@ import 'package:eqmonitor_map/src/overlay/earthquake_map_overlay_snapshot.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_overlay_coverage.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_overlay_coverage_owner.dart';
 import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
+import 'package:eqmonitor_map/src/overlay/map_point_sprite_feature.dart';
+import 'package:eqmonitor_map/src/overlay/map_sprite_atlas.dart';
+import 'package:eqmonitor_map/src/overlay/map_zoom_scalar_policy.dart';
 import 'package:eqmonitor_map/src/renderer/base_map_overlay_frame_builder.dart';
 import 'package:eqmonitor_map/src/renderer/base_map_overlay_frame_owner.dart';
 import 'package:eqmonitor_map/src/renderer/earthquake_area_packed_mesh_cache.dart';
@@ -23,6 +26,7 @@ import 'package:eqmonitor_map/src/renderer/earthquake_area_render_resources.dart
 import 'package:eqmonitor_map/src/renderer/earthquake_area_render_submission_builder.dart';
 import 'package:eqmonitor_map/src/renderer/map_render_batch_adapter.dart';
 import 'package:eqmonitor_map/src/renderer/map_scene_frame_submission.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch.dart';
 import 'package:eqmonitor_map/src/tile/base_map_tile_cache.dart';
 import 'package:eqmonitor_map/src/tile/base_map_tile_decoder.dart';
@@ -109,6 +113,21 @@ ObservationPointBatch _requireObservationPointBatch(
   return batch;
 }
 
+List<MapPointSpriteInstanceBatch> _requireSpriteBatches(
+  MapSceneFrameSubmission? submission,
+) {
+  final batches = submission?.layers
+      .whereType<MapSceneInstanceLayerSubmission>()
+      .where((layer) => layer.kind == MapSceneInstanceLayerKind.pointSprite)
+      .map((layer) => layer.batch)
+      .whereType<MapPointSpriteInstanceBatch>()
+      .toList();
+  if (batches == null || batches.isEmpty) {
+    fail('Expected point sprite batches.');
+  }
+  return batches;
+}
+
 MapRenderBatch _requireEarthquakeFillBatch(
   MapSceneFrameSubmission? submission,
 ) {
@@ -190,6 +209,46 @@ void main() {
     renderDigest: renderDigest,
   );
 
+  MapSpriteAtlas spriteAtlas() => createMapSpriteAtlas(
+    identity: createMapSourceIdentity(value: 'sha256:sprite-atlas'),
+    width: 1,
+    height: 1,
+    rgbaBytes: Uint8List.fromList([255, 0, 0, 128]),
+    regions: const [
+      MapSpriteRegion(
+        id: 'normal',
+        normalizedUv: Rect.fromLTRB(0.5, 0.5, 0.5, 0.5),
+        logicalSize: Size(24, 24),
+      ),
+    ],
+    limits: const MapSpriteAtlasLimits(
+      maxWidth: 1,
+      maxHeight: 1,
+      maxPixelBytes: 4,
+      maxRegions: 1,
+    ),
+  );
+
+  MapPointSpriteFeature sprite({String id = 'hypocenter:event-a'}) =>
+      createMapPointSpriteFeature(
+        id: id,
+        longitude: 139.6917,
+        latitude: 35.6895,
+        spriteRegionId: 'normal',
+        sizeScale: createMapZoomLinearRange(
+          startZoom: 3,
+          startValue: 0.5,
+          endZoom: 20,
+          endValue: 1.5,
+        ),
+        opacity: createMapZoomStep(
+          thresholdZoom: 5,
+          belowValue: 0,
+          atOrAboveValue: 1,
+        ),
+        priority: 10,
+      );
+
   EarthquakeMapOverlaySnapshot snapshot({
     String sourceIdentity = 'event-a',
     String sourceIncarnation = 'incarnation-a',
@@ -200,6 +259,8 @@ void main() {
     String regionCode = '130',
     String cityCode = '13101',
     Color color = const Color(0xFFFF0000),
+    MapSpriteAtlas? atlas,
+    List<MapPointSpriteFeature> sprites = const [],
   }) => createEarthquakeMapOverlaySnapshot(
     versionStamp: versionStamp(
       sourceIdentity: sourceIdentity,
@@ -226,8 +287,8 @@ void main() {
         radiusLogicalPixels: 6.7,
       ),
     ],
-    spriteAtlas: null,
-    sprites: const [],
+    spriteAtlas: atlas,
+    sprites: sprites,
     maxSpritePolicyBatches: 1,
   );
 
@@ -283,6 +344,7 @@ void main() {
     required EarthquakeMapOverlaySnapshot? requested,
     EarthquakeMapOverlaySnapshot? current,
     ObservationPointBatch? previousObservation,
+    List<MapPointSpriteInstanceBatch> previousSprites = const [],
     BaseMapTileCache? cache,
     EarthquakeAreaRenderStyleCache? styleCache,
   }) {
@@ -294,6 +356,7 @@ void main() {
       currentOverlay: current,
       requestedOverlay: requested,
       previousObservationBatch: previousObservation,
+      previousSpriteBatches: previousSprites,
       requestedCover: cover,
       tileSourceInstanceId: 'archive-a',
       tileCache: cache ?? cacheWith(geometry()),
@@ -325,6 +388,36 @@ void main() {
       [mapSceneCityFillComponentKey, mapSceneObservationPointComponentKey],
     );
   });
+
+  test(
+    'submits sprites after observations and reuses camera-only instances',
+    () {
+      final value = snapshot(atlas: spriteAtlas(), sprites: [sprite()]);
+      final first = build(frame: frameAt(6), requested: value);
+      final firstSprite = _requireSpriteBatches(first.submission).single;
+      final second = build(
+        frame: frameAt(6, frameNumber: 1),
+        current: first.overlay,
+        requested: value,
+        previousSprites: first.spriteBatchesForReuse,
+      );
+      final secondSprite = _requireSpriteBatches(second.submission).single;
+
+      expect(
+        first.submission?.layers.map((layer) => layer.componentKey),
+        [
+          mapSceneCityFillComponentKey,
+          mapSceneObservationPointComponentKey,
+          mapSceneHypocenterSpriteComponentKey,
+        ],
+      );
+      expect(
+        secondSprite.instanceGeneration,
+        same(firstSprite.instanceGeneration),
+      );
+      expect(secondSprite.frameUniform, isNot(same(firstSprite.frameUniform)));
+    },
+  );
 
   test('null snapshot atomically hides the previous overlay', () {
     final result = build(
@@ -925,6 +1018,7 @@ void main() {
         submission: initialSubmission,
         coverage: first.coverage,
         observationBatchForReuse: first.observationBatchForReuse,
+        spriteBatchesForReuse: first.spriteBatchesForReuse,
         shouldRetireGpuResources: false,
       );
       final firstFallback = build(


### PR DESCRIPTION
## 概要
- 震源sprite向け40-byte instance ABIと64-byte frame uniformを追加
- policy単位のdeterministic batch、dateline wrap、camera-only instance reuseを実装
- observation後にsprite layerを合成するtyped Scene frame契約を追加
- DataAssets shader compiler、checked-in interface manifest、strict sampler2D source testを接続
- flutter_scene forkの全5 backend reflection validatorへgitlinkを更新

## Stack
- Depends on #1759
- Stack #1756

## 検証
- Task 4/5統合 tests: 65件成功
- flutter_scene fork tests: 6件成功
- package/fork targeted analyze: No issues
- 実DataAssets compiler: 成功
- format / diff check / submodule remote: clean

## 関連
- YumNumm/flutter_scene#4
- YumNumm/flutter_scene#5
