### PR TITLE
feat: Flutter Scene sprite resource所有とprobeを統合

### DIFF
--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_page.dart
@@ -2,6 +2,7 @@ import 'package:eqmonitor/core/provider/clock/app_clock.dart';
 import 'package:eqmonitor/core/provider/clock/map_clock_source_identity_provider.dart';
 import 'package:eqmonitor/core/util/map/app_map_clock.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_panel.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_source_provider.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_banner.dart';
 import 'package:eqmonitor_map/eqmonitor_map.dart';
@@ -15,8 +16,67 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 /// が実際のarchiveの`PmTilesV3Header`から読んだ値をそのまま使う。固定値を
 /// 転記しない理由は`eqmonitor_map_debug_source_provider.dart`の
 /// `_readHeader`のdoc comment参照。
-class EqmonitorMapDebugPage extends HookConsumerWidget {
+class EqmonitorMapDebugPage extends StatelessWidget {
   const new({super.key});
+
+  @override
+  Widget build(BuildContext context) => switch (mapGpuProbeCompileTimeEnabled) {
+    true => const _EqmonitorMapGpuProbeDebugPage(),
+    false => const _EqmonitorMapDebugContent(probeBindings: null),
+  };
+}
+
+class _EqmonitorMapGpuProbeDebugPage extends HookWidget {
+  const new();
+
+  @override
+  Widget build(BuildContext context) {
+    final atlasFixture = useState(MapSpriteAtlasProbeFixture.production);
+    final faultPoint = useState<MapGpuFaultPoint?>(null);
+    final counterSnapshot = useState<MapGpuResourceCounterSnapshot?>(null);
+    final probeController = useMemoized(MapGpuProbeController.new, const []);
+    final configuration = useMemoized(
+      () => MapGpuProbeConfiguration(
+        faultPoint: faultPoint.value,
+        atlasFixture: atlasFixture.value,
+      ),
+      [faultPoint.value, atlasFixture.value],
+    );
+    final counterCallbackGuard = useMemoized(
+      () => EqmonitorMapDebugGpuCounterCallbackGuard(
+        isMounted: () => context.mounted,
+        onSnapshot: (snapshot) => counterSnapshot.value = snapshot,
+      ),
+      const [],
+    );
+    return _EqmonitorMapDebugContent(
+      probeBindings: _EqmonitorMapGpuProbeBindings(
+        configuration: configuration,
+        controller: probeController,
+        counterSnapshot: counterSnapshot.value,
+        onCounterChanged: counterCallbackGuard.publish,
+        onAtlasFixtureChanged: (value) => atlasFixture.value = value,
+        onFaultPointChanged: (value) => faultPoint.value = value,
+        onInvalidateRendererContextGeneration: () {
+          final didInvalidate = probeController
+              .invalidateRendererContextGeneration();
+          final message = switch (didInvalidate) {
+            true => 'Renderer generation を更新しました',
+            false => '地図の初期化完了後に再試行してください',
+          };
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(SnackBar(content: Text(message)));
+        },
+      ),
+    );
+  }
+}
+
+class _EqmonitorMapDebugContent extends HookConsumerWidget {
+  const new({required this.probeBindings});
+
+  final _EqmonitorMapGpuProbeBindings? probeBindings;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -50,38 +110,91 @@ class EqmonitorMapDebugPage extends HookConsumerWidget {
         );
     return Scaffold(
       appBar: AppBar(title: const Text('EQMonitor Map (Flutter Scene)')),
-      body: source.when(
-        data: (result) => Stack(
-          fit: StackFit.expand,
-          children: [
-            BaseMapView(
-              source: result.source,
-              initialCamera: EqmonitorMapDebugConfiguration.initialCamera,
-              clock: mapClock,
-              cameraController: mapSession.cameraController,
-              limits: EqmonitorMapDebugConfiguration.limitsFor(
-                minZoom: result.minZoom,
-                maxZoom: result.maxZoom,
-              ),
-              earthquakeOverlay: overlay,
-              onEarthquakeOverlayCoverageChanged: onCoverageChanged,
-            ),
-            Positioned(
-              top: 12,
-              left: 12,
-              right: 12,
-              child: SafeArea(
-                child: EqmonitorMapOverlayBanner(
-                  presentation: presentation,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          source.when(
+            data: (result) => Stack(
+              fit: StackFit.expand,
+              children: [
+                BaseMapView(
+                  source: result.source,
+                  initialCamera: EqmonitorMapDebugConfiguration.initialCamera,
+                  clock: mapClock,
+                  cameraController: mapSession.cameraController,
+                  limits: EqmonitorMapDebugConfiguration.limitsFor(
+                    minZoom: result.minZoom,
+                    maxZoom: result.maxZoom,
+                  ),
+                  earthquakeOverlay: overlay,
+                  onEarthquakeOverlayCoverageChanged: onCoverageChanged,
+                  gpuProbeConfiguration: probeBindings?.configuration,
+                  onGpuResourceCounterChanged: probeBindings?.onCounterChanged,
+                  gpuProbeController: probeBindings?.controller,
                 ),
-              ),
+                Positioned(
+                  top: 12,
+                  left: 12,
+                  right: 12,
+                  child: SafeArea(
+                    child: EqmonitorMapOverlayBanner(
+                      presentation: presentation,
+                    ),
+                  ),
+                ),
+              ],
             ),
-          ],
-        ),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, stackTrace) => const _EqmonitorMapDebugSourceError(),
+            loading: () => const Center(
+              child: CircularProgressIndicator.adaptive(),
+            ),
+            error: (error, stackTrace) => const _EqmonitorMapDebugSourceError(),
+          ),
+          if (probeBindings case final bindings?)
+            EqmonitorMapGpuProbePanel(
+              atlasFixture: bindings.configuration.atlasFixture,
+              faultPoint: bindings.configuration.faultPoint,
+              counterSnapshot: bindings.counterSnapshot,
+              onAtlasFixtureChanged: bindings.onAtlasFixtureChanged,
+              onFaultPointChanged: bindings.onFaultPointChanged,
+              onInvalidateRendererContextGeneration:
+                  bindings.onInvalidateRendererContextGeneration,
+            ),
+        ],
       ),
     );
+  }
+}
+
+final class _EqmonitorMapGpuProbeBindings {
+  const new({
+    required this.configuration,
+    required this.controller,
+    required this.counterSnapshot,
+    required this.onCounterChanged,
+    required this.onAtlasFixtureChanged,
+    required this.onFaultPointChanged,
+    required this.onInvalidateRendererContextGeneration,
+  });
+
+  final MapGpuProbeConfiguration configuration;
+  final MapGpuProbeController controller;
+  final MapGpuResourceCounterSnapshot? counterSnapshot;
+  final ValueChanged<MapGpuResourceCounterSnapshot> onCounterChanged;
+  final ValueChanged<MapSpriteAtlasProbeFixture> onAtlasFixtureChanged;
+  final ValueChanged<MapGpuFaultPoint?> onFaultPointChanged;
+  final VoidCallback onInvalidateRendererContextGeneration;
+}
+
+final class EqmonitorMapDebugGpuCounterCallbackGuard {
+  const new({required this.isMounted, required this.onSnapshot});
+
+  final bool Function() isMounted;
+  final ValueChanged<MapGpuResourceCounterSnapshot> onSnapshot;
+
+  void publish(MapGpuResourceCounterSnapshot snapshot) {
+    if (isMounted()) {
+      onSnapshot(snapshot);
+    }
   }
 }
 
@@ -155,6 +268,11 @@ final class EqmonitorMapDebugConfiguration {
     // 余裕を持たせた値。GPU resourceの参照を落とすのは、可視tileから外れて
     // この frame 数ぶん経ってからになる。
     maxFramesInFlight: 3,
+    spriteRendererLimits: const MapSpriteRendererLimits(
+      maxActiveAtlases: 1,
+      maxTopologyVariants: 1,
+      maxPolicyBatches: 1,
+    ),
     maxSceneNodeCount: 512,
   );
 }

--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_panel.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_panel.dart
@@ -1,0 +1,198 @@
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:flutter/material.dart';
+
+const eqmonitorMapGpuProbeAtlasFixtureKey = ValueKey(
+  'eqmonitor-map-gpu-probe-atlas-fixture',
+);
+const eqmonitorMapGpuProbeFaultPointKey = ValueKey(
+  'eqmonitor-map-gpu-probe-fault-point',
+);
+const eqmonitorMapGpuProbeInvalidateGenerationKey = ValueKey(
+  'eqmonitor-map-gpu-probe-invalidate-generation',
+);
+
+enum _MapGpuFaultSelection {
+  none,
+  atlasUpload,
+  shaderInterface,
+  frameSubmit,
+}
+
+/// Compile-timeで有効化したFlutter Scene GPU probeだけが表示する操作面。
+class EqmonitorMapGpuProbePanel extends StatelessWidget {
+  const new({
+    required this.atlasFixture,
+    required this.faultPoint,
+    required this.counterSnapshot,
+    required this.onAtlasFixtureChanged,
+    required this.onFaultPointChanged,
+    required this.onInvalidateRendererContextGeneration,
+    super.key,
+  });
+
+  final MapSpriteAtlasProbeFixture atlasFixture;
+  final MapGpuFaultPoint? faultPoint;
+  final MapGpuResourceCounterSnapshot? counterSnapshot;
+  final ValueChanged<MapSpriteAtlasProbeFixture> onAtlasFixtureChanged;
+  final ValueChanged<MapGpuFaultPoint?> onFaultPointChanged;
+  final VoidCallback onInvalidateRendererContextGeneration;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedFault = switch (faultPoint) {
+      null => _MapGpuFaultSelection.none,
+      MapGpuFaultPoint.atlasUpload => _MapGpuFaultSelection.atlasUpload,
+      MapGpuFaultPoint.shaderInterface => _MapGpuFaultSelection.shaderInterface,
+      MapGpuFaultPoint.frameSubmit => _MapGpuFaultSelection.frameSubmit,
+    };
+    final generationLabel = switch (counterSnapshot) {
+      MapGpuResourceCounterSnapshot(:final rendererContextGeneration) =>
+        'Renderer generation: $rendererContextGeneration',
+      null => 'Renderer generation: 未取得',
+    };
+    final counters = switch (counterSnapshot) {
+      final snapshot? => [
+        (label: 'Texture', counter: snapshot.texture),
+        (label: 'Topology', counter: snapshot.topology),
+        (label: 'Instance', counter: snapshot.instance),
+        (label: 'Node', counter: snapshot.node),
+      ],
+      null => <({String label, MapGpuResourceKindCounter counter})>[],
+    };
+
+    return Align(
+      alignment: Alignment.bottomRight,
+      child: SafeArea(
+        minimum: const EdgeInsets.all(12),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: Card(
+            clipBehavior: Clip.antiAlias,
+            child: ExpansionTile(
+              title: const Text('GPU Probe'),
+              subtitle: Text(generationLabel),
+              childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+              children: [
+                DropdownButtonFormField<MapSpriteAtlasProbeFixture>(
+                  key: eqmonitorMapGpuProbeAtlasFixtureKey,
+                  initialValue: atlasFixture,
+                  decoration: const InputDecoration(
+                    labelText: 'Atlas fixture',
+                  ),
+                  items: MapSpriteAtlasProbeFixture.values
+                      .map(
+                        (fixture) => DropdownMenuItem(
+                          value: fixture,
+                          child: Text(
+                            switch (fixture) {
+                              MapSpriteAtlasProbeFixture.production =>
+                                'Production',
+                              MapSpriteAtlasProbeFixture.orientation2x2 =>
+                                '2x2 向き確認',
+                              MapSpriteAtlasProbeFixture.alphaHalf =>
+                                'Alpha 50%',
+                              MapSpriteAtlasProbeFixture.edgeBleed =>
+                                'Edge bleed',
+                            },
+                          ),
+                        ),
+                      )
+                      .toList(growable: false),
+                  onChanged: (value) {
+                    if (value != null) {
+                      onAtlasFixtureChanged(value);
+                    }
+                  },
+                ),
+                const SizedBox(height: 12),
+                DropdownButtonFormField<_MapGpuFaultSelection>(
+                  key: eqmonitorMapGpuProbeFaultPointKey,
+                  initialValue: selectedFault,
+                  decoration: const InputDecoration(labelText: 'Fault point'),
+                  items: _MapGpuFaultSelection.values
+                      .map(
+                        (selection) => DropdownMenuItem(
+                          value: selection,
+                          child: Text(
+                            switch (selection) {
+                              _MapGpuFaultSelection.none => 'なし',
+                              _MapGpuFaultSelection.atlasUpload =>
+                                'Atlas upload',
+                              _MapGpuFaultSelection.shaderInterface =>
+                                'Shader interface',
+                              _MapGpuFaultSelection.frameSubmit =>
+                                'Frame submit',
+                            },
+                          ),
+                        ),
+                      )
+                      .toList(growable: false),
+                  onChanged: (selection) {
+                    final nextFault = switch (selection) {
+                      null || _MapGpuFaultSelection.none => null,
+                      _MapGpuFaultSelection.atlasUpload =>
+                        MapGpuFaultPoint.atlasUpload,
+                      _MapGpuFaultSelection.shaderInterface =>
+                        MapGpuFaultPoint.shaderInterface,
+                      _MapGpuFaultSelection.frameSubmit =>
+                        MapGpuFaultPoint.frameSubmit,
+                    };
+                    onFaultPointChanged(nextFault);
+                  },
+                ),
+                const SizedBox(height: 12),
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton.icon(
+                    key: eqmonitorMapGpuProbeInvalidateGenerationKey,
+                    onPressed: onInvalidateRendererContextGeneration,
+                    icon: const Icon(Icons.refresh),
+                    label: const Text('Renderer generation を無効化'),
+                  ),
+                ),
+                const Divider(height: 24),
+                if (counters.isEmpty)
+                  const Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text('Resource counter: 未取得'),
+                  )
+                else
+                  ...counters.map(
+                    (entry) => _EqmonitorMapGpuResourceCounterRow(
+                      label: entry.label,
+                      counter: entry.counter,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EqmonitorMapGpuResourceCounterRow extends StatelessWidget {
+  const new({required this.label, required this.counter});
+
+  final String label;
+  final MapGpuResourceKindCounter counter;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.symmetric(vertical: 2),
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(width: 72, child: Text(label)),
+        Expanded(
+          child: Text(
+            'A ${counter.active} / C ${counter.candidate} / '
+            'P ${counter.pendingRetire} / U ${counter.uploads} / '
+            'R ${counter.retires}',
+          ),
+        ),
+      ],
+    ),
+  );
+}

--- a/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_configuration_test.dart
+++ b/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_configuration_test.dart
@@ -1,0 +1,15 @@
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('debug mapはsprite resource上限をcaller側で明示する', () {
+    final limits = EqmonitorMapDebugConfiguration.limitsFor(
+      minZoom: 2,
+      maxZoom: 12,
+    );
+
+    expect(limits.spriteRendererLimits.maxActiveAtlases, 1);
+    expect(limits.spriteRendererLimits.maxTopologyVariants, 1);
+    expect(limits.spriteRendererLimits.maxPolicyBatches, 1);
+  });
+}

--- a/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_callback_test.dart
+++ b/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_callback_test.dart
@@ -1,0 +1,34 @@
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_page.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('dispose後に遅延到達したresource counterを破棄する', () {
+    var isMounted = true;
+    final received = <MapGpuResourceCounterSnapshot>[];
+    final guard = EqmonitorMapDebugGpuCounterCallbackGuard(
+      isMounted: () => isMounted,
+      onSnapshot: received.add,
+    );
+    const beforeDispose = MapGpuResourceCounterSnapshot(
+      texture: MapGpuResourceKindCounter.zero,
+      topology: MapGpuResourceKindCounter.zero,
+      instance: MapGpuResourceKindCounter.zero,
+      node: MapGpuResourceKindCounter.zero,
+      rendererContextGeneration: 1,
+    );
+    const afterDispose = MapGpuResourceCounterSnapshot(
+      texture: MapGpuResourceKindCounter.zero,
+      topology: MapGpuResourceKindCounter.zero,
+      instance: MapGpuResourceKindCounter.zero,
+      node: MapGpuResourceKindCounter.zero,
+      rendererContextGeneration: 2,
+    );
+
+    guard.publish(beforeDispose);
+    isMounted = false;
+    guard.publish(afterDispose);
+
+    expect(received, [same(beforeDispose)]);
+  });
+}

--- a/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_panel_test.dart
+++ b/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_panel_test.dart
@@ -1,0 +1,119 @@
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_panel.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('fixtureとfaultを選択しrenderer generationを無効化できる', (
+    tester,
+  ) async {
+    var atlasFixture = MapSpriteAtlasProbeFixture.production;
+    MapGpuFaultPoint? faultPoint;
+    var invalidationCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) => EqmonitorMapGpuProbePanel(
+              atlasFixture: atlasFixture,
+              faultPoint: faultPoint,
+              counterSnapshot: null,
+              onAtlasFixtureChanged: (value) => setState(
+                () => atlasFixture = value,
+              ),
+              onFaultPointChanged: (value) => setState(
+                () => faultPoint = value,
+              ),
+              onInvalidateRendererContextGeneration: () {
+                invalidationCount += 1;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('GPU Probe'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(eqmonitorMapGpuProbeAtlasFixtureKey));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('2x2 向き確認').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(eqmonitorMapGpuProbeFaultPointKey));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Atlas upload').last);
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(eqmonitorMapGpuProbeInvalidateGenerationKey),
+    );
+
+    expect(atlasFixture, MapSpriteAtlasProbeFixture.orientation2x2);
+    expect(faultPoint, MapGpuFaultPoint.atlasUpload);
+    expect(invalidationCount, 1);
+  });
+
+  testWidgets('resource counterの全状態とrenderer generationを表示する', (
+    tester,
+  ) async {
+    const snapshot = MapGpuResourceCounterSnapshot(
+      texture: MapGpuResourceKindCounter(
+        active: 1,
+        candidate: 2,
+        pendingRetire: 3,
+        uploads: 4,
+        retires: 5,
+      ),
+      topology: MapGpuResourceKindCounter(
+        active: 6,
+        candidate: 7,
+        pendingRetire: 8,
+        uploads: 9,
+        retires: 10,
+      ),
+      instance: MapGpuResourceKindCounter(
+        active: 11,
+        candidate: 12,
+        pendingRetire: 13,
+        uploads: 14,
+        retires: 15,
+      ),
+      node: MapGpuResourceKindCounter(
+        active: 16,
+        candidate: 17,
+        pendingRetire: 18,
+        uploads: 19,
+        retires: 20,
+      ),
+      rendererContextGeneration: 21,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EqmonitorMapGpuProbePanel(
+            atlasFixture: MapSpriteAtlasProbeFixture.alphaHalf,
+            faultPoint: MapGpuFaultPoint.frameSubmit,
+            counterSnapshot: snapshot,
+            onAtlasFixtureChanged: (_) {},
+            onFaultPointChanged: (_) {},
+            onInvalidateRendererContextGeneration: () {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('GPU Probe'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Renderer generation: 21'), findsOneWidget);
+    expect(find.text('Texture'), findsOneWidget);
+    expect(find.text('A 1 / C 2 / P 3 / U 4 / R 5'), findsOneWidget);
+    expect(find.text('Topology'), findsOneWidget);
+    expect(find.text('A 6 / C 7 / P 8 / U 9 / R 10'), findsOneWidget);
+    expect(find.text('Instance'), findsOneWidget);
+    expect(find.text('A 11 / C 12 / P 13 / U 14 / R 15'), findsOneWidget);
+    expect(find.text('Node'), findsOneWidget);
+    expect(find.text('A 16 / C 17 / P 18 / U 19 / R 20'), findsOneWidget);
+  });
+}

--- a/packages/eqmonitor_map/lib/eqmonitor_map.dart
+++ b/packages/eqmonitor_map/lib/eqmonitor_map.dart
@@ -11,6 +11,9 @@ export 'package:pmtiles_v3/pmtiles_v3.dart'
 
 export 'src/eqmonitor_map_library.dart';
 export 'src/flutter_scene/base_map_material_preflight_view.dart';
+export 'src/flutter_scene/flutter_scene_sprite_resource_owner.dart'
+    show MapSpriteRendererLimits;
+export 'src/flutter_scene/map_gpu_probe.dart';
 export 'src/foundation/async_generation_token.dart';
 export 'src/foundation/frame/map_clock.dart';
 export 'src/foundation/frame/map_frame_revision.dart';

--- a/packages/eqmonitor_map/lib/src/flutter_scene/earthquake_overlay_material_owner.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/earthquake_overlay_material_owner.dart
@@ -1,12 +1,22 @@
+import 'dart:typed_data';
+
 import 'package:eqmonitor_map/src/flutter_scene/base_map_material_library.dart';
 import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_map_adapter.dart';
+import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_sprite_resource_owner.dart';
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
+import 'package:eqmonitor_map/src/flutter_scene/map_shader_interface_manifest.dart';
+import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
 import 'package:eqmonitor_map/src/foundation/render/map_render_batch.dart';
 import 'package:eqmonitor_map/src/foundation/render/map_render_packet.dart';
+import 'package:eqmonitor_map/src/overlay/map_sprite_atlas.dart';
 import 'package:eqmonitor_map/src/renderer/base_map_overlay_frame_owner.dart';
 import 'package:eqmonitor_map/src/renderer/earthquake_area_render_resources.dart';
 import 'package:eqmonitor_map/src/renderer/earthquake_area_render_submission_builder.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_scene/gpu.dart' as scene_gpu;
+import 'package:flutter_scene/scene.dart' as scene;
 
 typedef LoadEarthquakeAreaMaterial =
     Future<FlutterSceneMapMaterialBinding> Function();
@@ -14,6 +24,10 @@ typedef LoadEarthquakeAreaMaterial =
 const earthquakeObservationShaderBundleAssetKey =
     'packages/eqmonitor_map/flutter_gpu_shaders/shaderbundles/'
     'earthquake_overlay.shaderbundle';
+
+const earthquakeOverlayShaderInterfaceAssetKey =
+    'packages/eqmonitor_map/shaders/'
+    'earthquake_overlay.shaderinterface.json';
 
 sealed class EarthquakeOverlayMaterialPreparation {
   const EarthquakeOverlayMaterialPreparation();
@@ -165,6 +179,325 @@ final class EarthquakeOverlayMaterialOwner {
   }
 }
 
+const mapSpriteVertexLayout = scene.VertexLayoutDescriptor(
+  buffers: [
+    scene.VertexBufferDescriptor(
+      strideInBytes: mapSpriteQuadVertexStrideInBytes,
+      attributes: [
+        scene.VertexAttributeDescriptor(
+          name: 'corner',
+          format: scene_gpu.VertexFormat.float32x2,
+        ),
+      ],
+    ),
+    scene.VertexBufferDescriptor(
+      strideInBytes: mapPointSpriteInstanceStrideInBytes,
+      stepMode: scene_gpu.VertexStepMode.instance,
+      attributes: [
+        scene.VertexAttributeDescriptor(
+          name: 'centerMercator',
+          format: scene_gpu.VertexFormat.float32x2,
+        ),
+        scene.VertexAttributeDescriptor(
+          name: 'uvRect',
+          format: scene_gpu.VertexFormat.float32x4,
+          offsetInBytes: 8,
+        ),
+        scene.VertexAttributeDescriptor(
+          name: 'logicalSize',
+          format: scene_gpu.VertexFormat.float32x2,
+          offsetInBytes: 24,
+        ),
+        scene.VertexAttributeDescriptor(
+          name: 'opacity',
+          format: scene_gpu.VertexFormat.float32,
+          offsetInBytes: 32,
+        ),
+        scene.VertexAttributeDescriptor(
+          name: 'priority',
+          format: scene_gpu.VertexFormat.float32,
+          offsetInBytes: 36,
+        ),
+      ],
+    ),
+  ],
+);
+
+void validateMapPointSpriteBatchAbi({
+  required MapPointSpriteInstanceBatch batch,
+}) {
+  if (batch.instanceCount <= 0 ||
+      batch.instanceStrideInBytes != mapPointSpriteInstanceStrideInBytes ||
+      batch.instanceData.lengthInBytes !=
+          batch.instanceCount * mapPointSpriteInstanceStrideInBytes ||
+      batch.frameUniform.lengthInBytes != mapSpriteFrameUniformByteLength) {
+    throw ArgumentError.value(batch, 'batch', 'has an invalid sprite ABI');
+  }
+}
+
+void validateMapSpriteShaderManifest({
+  required MapShaderInterfaceManifest manifest,
+}) {
+  final vertex = manifest.shaderNamed(mapSpriteVertexShaderSymbol);
+  final fragment = manifest.shaderNamed(mapSpriteFragmentShaderSymbol);
+  final expectedInputs = <String, (int, int)>{
+    'corner': (2, 0),
+    'centerMercator': (2, 8),
+    'uvRect': (4, 16),
+    'logicalSize': (2, 32),
+    'opacity': (1, 40),
+    'priority': (1, 44),
+  };
+  final actualInputs = <String, (int, int)>{
+    for (final input in vertex.inputs)
+      if (input.type == MapShaderScalarType.float &&
+          input.bitWidth == 32 &&
+          input.columns == 1)
+        input.name: (input.vecSize, input.offset),
+  };
+  final block = vertex.uniformBlocks.singleOrNull;
+  final fields = block == null
+      ? const <String, int>{}
+      : {for (final field in block.fields) field.name: field.offsetInBytes};
+  final sampledImage = fragment.sampledImages.singleOrNull;
+  if (vertex.stage != MapShaderInterfaceStage.vertex ||
+      fragment.stage != MapShaderInterfaceStage.fragment ||
+      !mapEquals(actualInputs, expectedInputs) ||
+      block?.name != mapSpriteFrameUniformBlockName ||
+      block?.set != 0 ||
+      block?.binding != 0 ||
+      block?.sizeInBytes != mapSpriteFrameUniformByteLength ||
+      !mapEquals(fields, const {
+        'cameraWorld': 0,
+        'viewportZoom': 16,
+        'sizePolicy': 32,
+        'opacityPolicy': 48,
+      }) ||
+      sampledImage?.name != mapSpriteAtlasUniformName ||
+      sampledImage?.set != 0 ||
+      sampledImage?.binding != 64) {
+    throw const FormatException('Sprite shader interface ABI mismatch.');
+  }
+  mapSpriteVertexLayout.toGpuLayout();
+}
+
+final class FlutterSceneSpriteInstanceResource {
+  const FlutterSceneSpriteInstanceResource({
+    required this.geometry,
+    required this.material,
+  });
+
+  final scene.StaticInstanceGeometry geometry;
+  final scene.ShaderMaterial material;
+}
+
+final class FlutterSceneProductionSpriteResourceBackend
+    implements
+        FlutterSceneSpriteResourceBackend<
+          scene.Texture2D,
+          scene.StaticInstanceTopology,
+          FlutterSceneSpriteInstanceResource
+        > {
+  factory FlutterSceneProductionSpriteResourceBackend({
+    required scene_gpu.Shader vertexShader,
+    required scene_gpu.Shader fragmentShader,
+    required MapShaderInterfaceManifest manifest,
+  }) => FlutterSceneProductionSpriteResourceBackend._(
+    vertexShader,
+    fragmentShader,
+    manifest,
+  );
+
+  FlutterSceneProductionSpriteResourceBackend._(
+    this._vertexShader,
+    this._fragmentShader,
+    this._manifest,
+  );
+
+  final scene_gpu.Shader _vertexShader;
+  final scene_gpu.Shader _fragmentShader;
+  final MapShaderInterfaceManifest _manifest;
+
+  @override
+  void preflightShaderInterface(MapPointSpriteInstanceBatch batch) {
+    validateMapPointSpriteBatchAbi(batch: batch);
+    validateMapSpriteShaderManifest(manifest: _manifest);
+    final frameSlot = _vertexShader.getUniformSlot(
+      mapSpriteFrameUniformBlockName,
+    );
+    if (frameSlot.sizeInBytes != mapSpriteFrameUniformByteLength ||
+        frameSlot.getMemberOffsetInBytes('cameraWorld') != 0 ||
+        frameSlot.getMemberOffsetInBytes('viewportZoom') != 16 ||
+        frameSlot.getMemberOffsetInBytes('sizePolicy') != 32 ||
+        frameSlot.getMemberOffsetInBytes('opacityPolicy') != 48) {
+      throw StateError('Native SpriteFrame reflection does not match ABI v1.');
+    }
+  }
+
+  @override
+  scene.Texture2D uploadTexture(MapSpriteAtlas atlas) =>
+      scene.Texture2D.fromPixels(
+        atlas.rgbaBytes,
+        atlas.width,
+        atlas.height,
+        sampling: const scene.TextureSampling(
+          mipmaps: false,
+          // Keep atlas filtering explicit even though Scene defaults match.
+          // ignore: avoid_redundant_argument_values
+          minFilter: scene_gpu.MinMagFilter.linear,
+          // Preserve the atlas contract if Scene changes its default filter.
+          // ignore: avoid_redundant_argument_values
+          magFilter: scene_gpu.MinMagFilter.linear,
+          maxAnisotropy: 1,
+          addressMode: scene_gpu.SamplerAddressMode.clampToEdge,
+        ),
+      );
+
+  @override
+  scene.StaticInstanceTopology prepareTopology({
+    required int spriteAbiVersion,
+    required int materialVersion,
+  }) {
+    if (spriteAbiVersion != mapSpriteInstanceAbiVersion ||
+        materialVersion != mapSpriteMaterialAbiVersion) {
+      throw StateError('Unsupported sprite topology ABI.');
+    }
+    final topology = scene.StaticInstanceTopology(
+      vertices: Float32List.fromList(const [-1, -1, 1, -1, 1, 1, -1, 1]),
+      indices: Uint16List.fromList(const [0, 1, 2, 0, 2, 3]),
+      layout: mapSpriteVertexLayout,
+    );
+    topology.prepare();
+    return topology;
+  }
+
+  @override
+  FlutterSceneSpriteInstanceResource prepareInstance({
+    required scene.StaticInstanceTopology topology,
+    required MapPointSpriteInstanceBatch batch,
+  }) {
+    final geometry = scene.StaticInstanceGeometry.withTopology(
+      topology: topology,
+      instanceData: batch.instanceData,
+      instanceCount: batch.instanceCount,
+      layout: mapSpriteVertexLayout,
+    );
+    geometry.prepare();
+    return FlutterSceneSpriteInstanceResource(
+      geometry: geometry,
+      material: scene.ShaderMaterial(
+        vertexShader: _vertexShader,
+        fragmentShader: _fragmentShader,
+        cullingMode: scene_gpu.CullMode.none,
+        isOpaqueOverride: false,
+      ),
+    );
+  }
+
+  @override
+  void retireInstance(FlutterSceneSpriteInstanceResource instance) {
+    instance.geometry.retire();
+  }
+
+  @override
+  void retireTexture(scene.Texture2D texture) {
+    // Texture2D has no explicit retire API. Dropping the owner reference lets
+    // flutter_scene release the native texture after its in-flight pins end.
+  }
+
+  @override
+  void retireTopology(scene.StaticInstanceTopology topology) {
+    topology.retire();
+  }
+}
+
+final class FlutterSceneSpriteSceneResources
+    implements FlutterSceneSpriteFrameResources {
+  FlutterSceneSpriteSceneResources({required this.owner});
+
+  final FlutterSceneSpriteResourceOwner<
+    scene.Texture2D,
+    scene.StaticInstanceTopology,
+    FlutterSceneSpriteInstanceResource
+  >
+  owner;
+
+  MapGpuResourceCounterSnapshot get snapshot => owner.snapshot;
+
+  @override
+  FlutterSceneSpritePreparedSceneFrame prepareFrame({
+    required MapFrameSnapshot frame,
+    required List<MapPointSpriteInstanceBatch> batches,
+  }) {
+    final prepared = owner.prepareFrame(frame: frame, batches: batches);
+    try {
+      final nodes = [
+        for (final entry in prepared.nodes)
+          FlutterSceneSpritePreparedSceneNode(
+            batch: entry.batch,
+            node: scene.Node(
+              mesh: scene.Mesh(
+                entry.instance.geometry,
+                entry.instance.material
+                  ..setUniformBlock(
+                    mapSpriteFrameUniformBlockName,
+                    entry.batch.frameUniform,
+                    stage: scene.ShaderStage.vertex,
+                  )
+                  ..setTexture(mapSpriteAtlasUniformName, entry.texture),
+              ),
+            ),
+          ),
+      ];
+      return _FlutterSceneSpritePreparedSceneFrame(
+        prepared: prepared,
+        nodes: List.unmodifiable(nodes),
+      );
+    } on Exception {
+      prepared.rollback();
+      rethrow;
+      // Synchronous GPU allocation can report StateError during candidate prep.
+      // ignore: avoid_catching_errors
+    } on Error {
+      prepared.rollback();
+      rethrow;
+    }
+  }
+
+  @override
+  void retireAll() {
+    owner.retireAll();
+  }
+}
+
+final class _FlutterSceneSpritePreparedSceneFrame
+    implements FlutterSceneSpritePreparedSceneFrame {
+  const _FlutterSceneSpritePreparedSceneFrame({
+    required this.prepared,
+    required this.nodes,
+  });
+
+  final FlutterSceneSpritePreparedFrame<
+    scene.Texture2D,
+    scene.StaticInstanceTopology,
+    FlutterSceneSpriteInstanceResource
+  >
+  prepared;
+
+  @override
+  final List<FlutterSceneSpritePreparedSceneNode> nodes;
+
+  @override
+  void commit() {
+    prepared.commit();
+  }
+
+  @override
+  void rollback() {
+    prepared.rollback();
+  }
+}
+
 @immutable
 final class _EarthquakeAreaMaterialKey {
   _EarthquakeAreaMaterialKey.from(MapMaterialParameterBlock parameters)
@@ -220,5 +553,54 @@ loadEarthquakeObservationMaterialBinding() async {
   }
   return FlutterSceneShaderObservationMaterialBinding.fromShaderLibrary(
     shaderLibrary: shaderLibrary,
+  );
+}
+
+Future<FlutterSceneSpriteSceneResources> loadEarthquakeSpriteSceneResources({
+  required MapSpriteRendererLimits limits,
+  required int maxFramesInFlight,
+  required MapSpriteGpuCompletionBarrier waitForGpuCompletion,
+  MapGpuProbeRuntime? probeRuntime,
+  ValueChanged<MapGpuResourceCounterSnapshot>? onCounterSnapshot,
+}) async {
+  final (shaderLibrary, manifestBytes) = await (
+    scene_gpu.loadShaderLibraryAsync(
+      earthquakeObservationShaderBundleAssetKey,
+    ),
+    rootBundle.load(earthquakeOverlayShaderInterfaceAssetKey),
+  ).wait;
+  if (shaderLibrary == null) {
+    throw StateError(
+      'No DataAssets sprite shader bundle at '
+      '$earthquakeObservationShaderBundleAssetKey.',
+    );
+  }
+  final vertex = shaderLibrary[mapSpriteVertexShaderSymbol];
+  final fragment = shaderLibrary[mapSpriteFragmentShaderSymbol];
+  if (vertex == null || fragment == null) {
+    throw StateError(
+      'Sprite shader bundle must provide $mapSpriteVertexShaderSymbol and '
+      '$mapSpriteFragmentShaderSymbol.',
+    );
+  }
+  final backend = FlutterSceneProductionSpriteResourceBackend(
+    vertexShader: vertex,
+    fragmentShader: fragment,
+    manifest: MapShaderInterfaceManifest.parse(
+      jsonBytes: manifestBytes.buffer.asUint8List(
+        manifestBytes.offsetInBytes,
+        manifestBytes.lengthInBytes,
+      ),
+    ),
+  );
+  return FlutterSceneSpriteSceneResources(
+    owner: FlutterSceneSpriteResourceOwner(
+      limits: limits,
+      maxFramesInFlight: maxFramesInFlight,
+      backend: backend,
+      waitForGpuCompletion: waitForGpuCompletion,
+      probeRuntime: probeRuntime,
+      onCounterSnapshot: onCounterSnapshot,
+    ),
   );
 }

--- a/packages/eqmonitor_map/lib/src/flutter_scene/earthquake_overlay_material_owner.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/earthquake_overlay_material_owner.dart
@@ -281,14 +281,25 @@ void validateMapSpriteShaderManifest({
   mapSpriteVertexLayout.toGpuLayout();
 }
 
+final class FlutterSceneSpriteCandidateMaterialFactory<TMaterial> {
+  const FlutterSceneSpriteCandidateMaterialFactory({
+    required this.createMaterial,
+  });
+
+  final TMaterial Function() createMaterial;
+
+  TMaterial create() => createMaterial();
+}
+
 final class FlutterSceneSpriteInstanceResource {
   const FlutterSceneSpriteInstanceResource({
     required this.geometry,
-    required this.material,
+    required this.materialFactory,
   });
 
   final scene.StaticInstanceGeometry geometry;
-  final scene.ShaderMaterial material;
+  final FlutterSceneSpriteCandidateMaterialFactory<scene.ShaderMaterial>
+  materialFactory;
 }
 
 final class FlutterSceneProductionSpriteResourceBackend
@@ -385,11 +396,13 @@ final class FlutterSceneProductionSpriteResourceBackend
     geometry.prepare();
     return FlutterSceneSpriteInstanceResource(
       geometry: geometry,
-      material: scene.ShaderMaterial(
-        vertexShader: _vertexShader,
-        fragmentShader: _fragmentShader,
-        cullingMode: scene_gpu.CullMode.none,
-        isOpaqueOverride: false,
+      materialFactory: FlutterSceneSpriteCandidateMaterialFactory(
+        createMaterial: () => scene.ShaderMaterial(
+          vertexShader: _vertexShader,
+          fragmentShader: _fragmentShader,
+          cullingMode: scene_gpu.CullMode.none,
+          isOpaqueOverride: false,
+        ),
       ),
     );
   }
@@ -438,7 +451,7 @@ final class FlutterSceneSpriteSceneResources
             node: scene.Node(
               mesh: scene.Mesh(
                 entry.instance.geometry,
-                entry.instance.material
+                entry.instance.materialFactory.create()
                   ..setUniformBlock(
                     mapSpriteFrameUniformBlockName,
                     entry.batch.frameUniform,
@@ -556,6 +569,29 @@ loadEarthquakeObservationMaterialBinding() async {
   );
 }
 
+final class FlutterSceneSpriteInitializationFailure implements Exception {
+  const FlutterSceneSpriteInitializationFailure({
+    required this.message,
+    this.stackTrace,
+  });
+
+  final String message;
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() => 'FlutterSceneSpriteInitializationFailure($message)';
+}
+
+Future<T?> loadOptionalFlutterSceneSpriteResources<T>({
+  required Future<T> Function() load,
+}) async {
+  try {
+    return await load();
+  } on FlutterSceneSpriteInitializationFailure {
+    return null;
+  }
+}
+
 Future<FlutterSceneSpriteSceneResources> loadEarthquakeSpriteSceneResources({
   required MapSpriteRendererLimits limits,
   required int maxFramesInFlight,
@@ -563,35 +599,11 @@ Future<FlutterSceneSpriteSceneResources> loadEarthquakeSpriteSceneResources({
   MapGpuProbeRuntime? probeRuntime,
   ValueChanged<MapGpuResourceCounterSnapshot>? onCounterSnapshot,
 }) async {
-  final (shaderLibrary, manifestBytes) = await (
-    scene_gpu.loadShaderLibraryAsync(
-      earthquakeObservationShaderBundleAssetKey,
-    ),
-    rootBundle.load(earthquakeOverlayShaderInterfaceAssetKey),
-  ).wait;
-  if (shaderLibrary == null) {
-    throw StateError(
-      'No DataAssets sprite shader bundle at '
-      '$earthquakeObservationShaderBundleAssetKey.',
-    );
-  }
-  final vertex = shaderLibrary[mapSpriteVertexShaderSymbol];
-  final fragment = shaderLibrary[mapSpriteFragmentShaderSymbol];
-  if (vertex == null || fragment == null) {
-    throw StateError(
-      'Sprite shader bundle must provide $mapSpriteVertexShaderSymbol and '
-      '$mapSpriteFragmentShaderSymbol.',
-    );
-  }
+  final shaderInputs = await _loadEarthquakeSpriteShaderInputs();
   final backend = FlutterSceneProductionSpriteResourceBackend(
-    vertexShader: vertex,
-    fragmentShader: fragment,
-    manifest: MapShaderInterfaceManifest.parse(
-      jsonBytes: manifestBytes.buffer.asUint8List(
-        manifestBytes.offsetInBytes,
-        manifestBytes.lengthInBytes,
-      ),
-    ),
+    vertexShader: shaderInputs.vertex,
+    fragmentShader: shaderInputs.fragment,
+    manifest: shaderInputs.manifest,
   );
   return FlutterSceneSpriteSceneResources(
     owner: FlutterSceneSpriteResourceOwner(
@@ -603,4 +615,58 @@ Future<FlutterSceneSpriteSceneResources> loadEarthquakeSpriteSceneResources({
       onCounterSnapshot: onCounterSnapshot,
     ),
   );
+}
+
+Future<
+  ({
+    scene_gpu.Shader vertex,
+    scene_gpu.Shader fragment,
+    MapShaderInterfaceManifest manifest,
+  })
+>
+_loadEarthquakeSpriteShaderInputs() async {
+  try {
+    final (shaderLibrary, manifestBytes) = await (
+      scene_gpu.loadShaderLibraryAsync(
+        earthquakeObservationShaderBundleAssetKey,
+      ),
+      rootBundle.load(earthquakeOverlayShaderInterfaceAssetKey),
+    ).wait;
+    if (shaderLibrary == null) {
+      throw StateError(
+        'No DataAssets sprite shader bundle at '
+        '$earthquakeObservationShaderBundleAssetKey.',
+      );
+    }
+    final vertex = shaderLibrary[mapSpriteVertexShaderSymbol];
+    final fragment = shaderLibrary[mapSpriteFragmentShaderSymbol];
+    if (vertex == null || fragment == null) {
+      throw StateError(
+        'Sprite shader bundle must provide $mapSpriteVertexShaderSymbol and '
+        '$mapSpriteFragmentShaderSymbol.',
+      );
+    }
+    return (
+      vertex: vertex,
+      fragment: fragment,
+      manifest: MapShaderInterfaceManifest.parse(
+        jsonBytes: manifestBytes.buffer.asUint8List(
+          manifestBytes.offsetInBytes,
+          manifestBytes.lengthInBytes,
+        ),
+      ),
+    );
+  } on Exception catch (error, stackTrace) {
+    throw FlutterSceneSpriteInitializationFailure(
+      message: error.toString(),
+      stackTrace: stackTrace,
+    );
+    // rootBundle reports a missing declared asset as FlutterError.
+    // ignore: avoid_catching_errors
+  } on FlutterError catch (error, stackTrace) {
+    throw FlutterSceneSpriteInitializationFailure(
+      message: error.message,
+      stackTrace: stackTrace,
+    );
+  }
 }

--- a/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_map_adapter.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_map_adapter.dart
@@ -729,7 +729,9 @@ final class FlutterSceneMapAdapter {
             nodes.add(node);
         }
       }
-      _gpuProbeRuntime?.throwIfRequested(MapGpuFaultPoint.frameSubmit);
+      if (mapGpuProbeCompileTimeEnabled) {
+        _gpuProbeRuntime?.throwIfRequested(MapGpuFaultPoint.frameSubmit);
+      }
       _sceneGraph
         ..removeAll()
         ..addAll(nodes);

--- a/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_map_adapter.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_map_adapter.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_base_map_adapter.dart';
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
+import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
 import 'package:eqmonitor_map/src/foundation/render/map_packed_mesh.dart';
 import 'package:eqmonitor_map/src/foundation/render/map_render_batch.dart';
 import 'package:eqmonitor_map/src/renderer/base_map_material_parameters.dart';
@@ -9,6 +11,7 @@ import 'package:eqmonitor_map/src/renderer/base_map_render_submission_builder.da
 import 'package:eqmonitor_map/src/renderer/earthquake_area_render_submission_builder.dart';
 import 'package:eqmonitor_map/src/renderer/map_gpu_resource_ledger.dart';
 import 'package:eqmonitor_map/src/renderer/map_scene_frame_submission.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch.dart';
 import 'package:flutter_scene/gpu.dart' as scene_gpu;
 import 'package:flutter_scene/scene.dart' as scene;
@@ -54,6 +57,33 @@ abstract interface class FlutterSceneObservationMaterialBinding {
   void preflight({required ObservationPointBatch batch});
 
   void setFrameUniform(ByteData bytes);
+}
+
+final class FlutterSceneSpritePreparedSceneNode {
+  const FlutterSceneSpritePreparedSceneNode({
+    required this.batch,
+    required this.node,
+  });
+
+  final MapPointSpriteInstanceBatch batch;
+  final scene.Node node;
+}
+
+abstract interface class FlutterSceneSpritePreparedSceneFrame {
+  List<FlutterSceneSpritePreparedSceneNode> get nodes;
+
+  void commit();
+
+  void rollback();
+}
+
+abstract interface class FlutterSceneSpriteFrameResources {
+  FlutterSceneSpritePreparedSceneFrame prepareFrame({
+    required MapFrameSnapshot frame,
+    required List<MapPointSpriteInstanceBatch> batches,
+  });
+
+  void retireAll();
 }
 
 /// shader bundleの必須symbolを解決したproduction observation binding。
@@ -394,6 +424,17 @@ final class FlutterSceneObservationNodePlan extends FlutterSceneNodePlan {
   final ObservationPointBatch batch;
 }
 
+final class FlutterSceneSpriteNodePlan extends FlutterSceneNodePlan {
+  const FlutterSceneSpriteNodePlan({
+    required super.drawRank,
+    required this.layer,
+    required this.batch,
+  });
+
+  final MapSceneInstanceLayerSubmission layer;
+  final MapPointSpriteInstanceBatch batch;
+}
+
 List<FlutterSceneNodePlan> buildFlutterSceneNodePlans({
   required MapSceneFrameSubmission submission,
 }) {
@@ -412,19 +453,30 @@ List<FlutterSceneNodePlan> buildFlutterSceneNodePlans({
         }
       case MapSceneInstanceLayerSubmission():
         final batch = preflightFlutterSceneInstanceLayer(layer: layer);
-        plans.add(
-          FlutterSceneObservationNodePlan(
-            drawRank: plans.length,
-            layer: layer,
-            batch: batch,
-          ),
-        );
+        switch (batch) {
+          case ObservationPointBatch():
+            plans.add(
+              FlutterSceneObservationNodePlan(
+                drawRank: plans.length,
+                layer: layer,
+                batch: batch,
+              ),
+            );
+          case MapPointSpriteInstanceBatch():
+            plans.add(
+              FlutterSceneSpriteNodePlan(
+                drawRank: plans.length,
+                layer: layer,
+                batch: batch,
+              ),
+            );
+        }
     }
   }
   return List.unmodifiable(plans);
 }
 
-ObservationPointBatch preflightFlutterSceneInstanceLayer({
+MapSceneInstanceBatch preflightFlutterSceneInstanceLayer({
   required MapSceneInstanceLayerSubmission layer,
 }) => switch (layer) {
   MapSceneInstanceLayerSubmission(
@@ -442,11 +494,15 @@ ObservationPointBatch preflightFlutterSceneInstanceLayer({
     ),
   MapSceneInstanceLayerSubmission(
     kind: MapSceneInstanceLayerKind.pointSprite,
+    :final batch,
   ) =>
-    throw FlutterSceneLayerPreflightFailure(
-      reason: FlutterSceneLayerPreflightFailureReason.unsupportedInstanceKind,
-      layer: layer,
-    ),
+    batch is MapPointSpriteInstanceBatch
+        ? batch
+        : throw FlutterSceneLayerPreflightFailure(
+            reason: FlutterSceneLayerPreflightFailureReason
+                .instanceBatchTypeMismatch,
+            layer: layer,
+          ),
 };
 
 /// frame submissionをcanonicalなmesh batch planへ変換する。
@@ -474,10 +530,29 @@ ObservationPointBatch? observationPointBatchFrom({
       case MapSceneMeshLayerSubmission():
         continue;
       case MapSceneInstanceLayerSubmission():
-        observation = preflightFlutterSceneInstanceLayer(layer: layer);
+        final batch = preflightFlutterSceneInstanceLayer(layer: layer);
+        if (batch is ObservationPointBatch) {
+          observation = batch;
+        }
     }
   }
   return observation;
+}
+
+List<MapPointSpriteInstanceBatch> spriteBatchesFrom({
+  required MapSceneFrameSubmission submission,
+}) {
+  final batches = <MapPointSpriteInstanceBatch>[];
+  for (final layer in submission.layers) {
+    if (layer is! MapSceneInstanceLayerSubmission) {
+      continue;
+    }
+    final batch = preflightFlutterSceneInstanceLayer(layer: layer);
+    if (batch is MapPointSpriteInstanceBatch) {
+      batches.add(batch);
+    }
+  }
+  return List.unmodifiable(batches);
 }
 
 /// base mapとoverlayを1つのFlutter Sceneへ送る唯一のowner。
@@ -487,12 +562,16 @@ final class FlutterSceneMapAdapter {
     required FlutterSceneMapMaterialResolver materialFor,
     required int maxFramesInFlight,
     FlutterSceneObservationMaterialBinding? observationMaterial,
+    FlutterSceneSpriteFrameResources? spriteResources,
+    MapGpuProbeRuntime? gpuProbeRuntime,
     FlutterSceneGpuCompletionBarrier waitForGpuCompletion =
         scene.waitForPendingGpuSubmissions,
   }) : this._(
          sceneGraph,
          materialFor,
          observationMaterial,
+         spriteResources,
+         gpuProbeRuntime,
          MapGpuResourceLedger<scene.MeshGeometry>(
            maxFramesInFlight: maxFramesInFlight,
          ),
@@ -506,6 +585,8 @@ final class FlutterSceneMapAdapter {
     this._sceneGraph,
     this._materialFor,
     this._observationMaterial,
+    this._spriteResources,
+    this._gpuProbeRuntime,
     this._geometries,
     this._observationGeometries,
     this._waitForGpuCompletion,
@@ -514,6 +595,8 @@ final class FlutterSceneMapAdapter {
   final scene.SceneGraph _sceneGraph;
   final FlutterSceneMapMaterialResolver _materialFor;
   final FlutterSceneObservationMaterialBinding? _observationMaterial;
+  final FlutterSceneSpriteFrameResources? _spriteResources;
+  final MapGpuProbeRuntime? _gpuProbeRuntime;
   final MapGpuResourceLedger<scene.MeshGeometry> _geometries;
   final FlutterSceneObservationGeometryOwner _observationGeometries;
   final FlutterSceneGpuCompletionBarrier _waitForGpuCompletion;
@@ -540,6 +623,7 @@ final class FlutterSceneMapAdapter {
       materialFor: _materialFor,
     );
     final observation = observationPointBatchFrom(submission: submission);
+    final spriteBatches = spriteBatchesFrom(submission: submission);
     final observationMaterial = switch (observation) {
       null => null,
       _ =>
@@ -552,83 +636,122 @@ final class FlutterSceneMapAdapter {
       validateObservationPointBatchAbi(batch: observation);
       observationMaterial?.preflight(batch: observation);
     }
-    final frame = submission.frame;
-    _retiredGeometryCount += _geometries
-        .beginFrame(
-          contextGeneration: frame.contextGeneration,
-          frameNumber: frame.frameNumber,
-        )
-        .length;
-    _observationGeometries.beginFrame(
-      contextGeneration: frame.contextGeneration,
-      frameNumber: frame.frameNumber,
-    );
-
-    final nodes = <scene.Node>[];
-    final resolvedByBatch = {
-      for (final entry in resolved) entry.plan.batch: entry,
+    final spriteResources = switch (spriteBatches.isEmpty) {
+      true => _spriteResources,
+      false =>
+        _spriteResources ??
+            (throw StateError('No Flutter Scene sprite resources are loaded.')),
     };
-    for (final nodePlan in nodePlans) {
-      switch (nodePlan) {
-        case FlutterSceneMeshNodePlan(:final layer, :final packetIndex):
-          final entry = resolvedByBatch[layer.batch];
-          if (entry == null) {
-            throw StateError('A preflighted mesh material was not resolved.');
-          }
-          applyFlutterSceneMeshBatchMaterial(
-            plan: entry.plan,
-            parameters: entry.material.parameters,
-          );
-          final packet = layer.batch.packets[packetIndex];
-          final node = scene.Node(
-            localTransform: scene_math.Matrix4.fromList(
-              layer.batch.instanceTransforms[packetIndex],
-            ),
-            mesh: scene.Mesh(
-              _geometryFor(packet.mesh),
-              entry.material.material,
-            ),
-          );
-          applyFlutterSceneDrawRank(
-            node: node,
-            drawRank: nodePlan.drawRank,
-          );
-          nodes.add(node);
-        case FlutterSceneObservationNodePlan(:final batch):
-          final material = observationMaterial;
-          if (material == null) {
-            throw StateError(
-              'A preflighted observation material was not resolved.',
-            );
-          }
-          final before = _observationGeometries.liveGeometryCount;
-          final geometry = _observationGeometries.geometryFor(batch: batch);
-          if (_observationGeometries.liveGeometryCount > before) {
-            _uploadedObservationGeometryCount++;
-          }
-          material.setFrameUniform(batch.frameUniform);
-          final node = scene.Node(
-            mesh: scene.Mesh(geometry, material.material),
-          );
-          applyFlutterSceneDrawRank(
-            node: node,
-            drawRank: nodePlan.drawRank,
-          );
-          nodes.add(node);
-      }
-    }
+    final preparedSprites = spriteResources?.prepareFrame(
+      frame: submission.frame,
+      batches: spriteBatches,
+    );
+    try {
+      final frame = submission.frame;
+      _retiredGeometryCount += _geometries
+          .beginFrame(
+            contextGeneration: frame.contextGeneration,
+            frameNumber: frame.frameNumber,
+          )
+          .length;
+      _observationGeometries.beginFrame(
+        contextGeneration: frame.contextGeneration,
+        frameNumber: frame.frameNumber,
+      );
 
-    _sceneGraph
-      ..removeAll()
-      ..addAll(nodes);
-    _retiredGeometryCount += _geometries.retireIdle().length;
-    _observationGeometries.retireIdle();
+      final nodes = <scene.Node>[];
+      final preparedSpriteNodes =
+          preparedSprites?.nodes ??
+          const <FlutterSceneSpritePreparedSceneNode>[];
+      final spriteNodeByBatch = {
+        for (final prepared in preparedSpriteNodes)
+          prepared.batch: prepared.node,
+      };
+      final resolvedByBatch = {
+        for (final entry in resolved) entry.plan.batch: entry,
+      };
+      for (final nodePlan in nodePlans) {
+        switch (nodePlan) {
+          case FlutterSceneMeshNodePlan(:final layer, :final packetIndex):
+            final entry = resolvedByBatch[layer.batch];
+            if (entry == null) {
+              throw StateError('A preflighted mesh material was not resolved.');
+            }
+            applyFlutterSceneMeshBatchMaterial(
+              plan: entry.plan,
+              parameters: entry.material.parameters,
+            );
+            final packet = layer.batch.packets[packetIndex];
+            final node = scene.Node(
+              localTransform: scene_math.Matrix4.fromList(
+                layer.batch.instanceTransforms[packetIndex],
+              ),
+              mesh: scene.Mesh(
+                _geometryFor(packet.mesh),
+                entry.material.material,
+              ),
+            );
+            applyFlutterSceneDrawRank(
+              node: node,
+              drawRank: nodePlan.drawRank,
+            );
+            nodes.add(node);
+          case FlutterSceneObservationNodePlan(:final batch):
+            final material = observationMaterial;
+            if (material == null) {
+              throw StateError(
+                'A preflighted observation material was not resolved.',
+              );
+            }
+            final before = _observationGeometries.liveGeometryCount;
+            final geometry = _observationGeometries.geometryFor(batch: batch);
+            if (_observationGeometries.liveGeometryCount > before) {
+              _uploadedObservationGeometryCount++;
+            }
+            material.setFrameUniform(batch.frameUniform);
+            final node = scene.Node(
+              mesh: scene.Mesh(geometry, material.material),
+            );
+            applyFlutterSceneDrawRank(
+              node: node,
+              drawRank: nodePlan.drawRank,
+            );
+            nodes.add(node);
+          case FlutterSceneSpriteNodePlan(:final batch):
+            final node = spriteNodeByBatch[batch];
+            if (node == null) {
+              throw StateError('A preflighted sprite node was not prepared.');
+            }
+            applyFlutterSceneDrawRank(
+              node: node,
+              drawRank: nodePlan.drawRank,
+            );
+            nodes.add(node);
+        }
+      }
+      _gpuProbeRuntime?.throwIfRequested(MapGpuFaultPoint.frameSubmit);
+      _sceneGraph
+        ..removeAll()
+        ..addAll(nodes);
+      preparedSprites?.commit();
+      _retiredGeometryCount += _geometries.retireIdle().length;
+      _observationGeometries.retireIdle();
+    } on Exception {
+      preparedSprites?.rollback();
+      rethrow;
+      // Scene and GPU preparation can synchronously report StateError.
+      // ignore: avoid_catching_errors
+    } on Error {
+      preparedSprites?.rollback();
+      rethrow;
+    }
   }
 
   void retireAllGpuResources() {
     _sceneGraph.removeAll();
     _retiredGeometryCount += _geometries.retireAll().length;
     _observationGeometries.scheduleRetireAll();
+    _spriteResources?.retireAll();
     if (_observationGeometries.liveGeometryCount == 0) {
       return;
     }

--- a/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_sprite_resource_owner.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_sprite_resource_owner.dart
@@ -597,7 +597,10 @@ void _releaseSpriteFrame<TTexture, TTopology, TInstance>({
     entry._pinCount--;
     if (entry._pinCount == 0) {
       owner._instances.remove(entry.key);
-      owner.backend.retireInstance(entry.resource);
+      _retireSpriteResource(
+        label: 'instance',
+        retire: () => owner.backend.retireInstance(entry.resource),
+      );
       owner._instanceRetires++;
     }
   }
@@ -605,7 +608,10 @@ void _releaseSpriteFrame<TTexture, TTopology, TInstance>({
     entry._pinCount--;
     if (entry._pinCount == 0) {
       owner._topologies.remove(entry.key);
-      owner.backend.retireTopology(entry.resource);
+      _retireSpriteResource(
+        label: 'topology',
+        retire: () => owner.backend.retireTopology(entry.resource),
+      );
       owner._topologyRetires++;
     }
   }
@@ -613,9 +619,27 @@ void _releaseSpriteFrame<TTexture, TTopology, TInstance>({
     entry._pinCount--;
     if (entry._pinCount == 0) {
       owner._textures.remove(entry.key);
-      owner.backend.retireTexture(entry.resource);
+      _retireSpriteResource(
+        label: 'texture',
+        retire: () => owner.backend.retireTexture(entry.resource),
+      );
       owner._textureRetires++;
     }
+  }
+}
+
+void _retireSpriteResource({
+  required String label,
+  required VoidCallback retire,
+}) {
+  try {
+    retire();
+  } on Exception catch (error, stackTrace) {
+    debugPrint('Sprite $label retirement failed: $error\n$stackTrace');
+    // A GPU wrapper can report use-after-retire as StateError.
+    // ignore: avoid_catching_errors
+  } on Error catch (error, stackTrace) {
+    debugPrint('Sprite $label retirement failed: $error\n$stackTrace');
   }
 }
 

--- a/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_sprite_resource_owner.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_sprite_resource_owner.dart
@@ -158,17 +158,11 @@ final class FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance> {
   final _pending = <_MapSpritePendingFrame<TTexture, TTopology, TInstance>>[];
   _MapSpriteFramePins<TTexture, TTopology, TInstance>? _active;
   _MapSpriteFramePins<TTexture, TTopology, TInstance>? _candidate;
-  var _textureUploads = 0;
-  var _topologyUploads = 0;
-  var _instanceUploads = 0;
-  var _nodeCreates = 0;
-  var _textureRetires = 0;
-  var _topologyRetires = 0;
-  var _instanceRetires = 0;
-  var _nodeRetires = 0;
-  var _contextGeneration = 0;
+  final _MapGpuDebugResourceCounters? _debugCounters =
+      mapGpuProbeCompileTimeEnabled ? _MapGpuDebugResourceCounters() : null;
 
-  bool get hasCounterCallback => onCounterSnapshot != null;
+  bool get hasCounterCallback =>
+      mapGpuProbeCompileTimeEnabled && onCounterSnapshot != null;
 
   MapGpuResourceCounterSnapshot get snapshot =>
       mapGpuResourceCounterSnapshotFor(this);
@@ -204,7 +198,9 @@ prepareFlutterSceneSpriteFrame<TTexture, TTopology, TInstance>({
   );
   var failureReason = FlutterSceneSpriteResourceFailureReason.shaderInterface;
   try {
-    owner.probeRuntime?.throwIfRequested(MapGpuFaultPoint.shaderInterface);
+    if (mapGpuProbeCompileTimeEnabled) {
+      owner.probeRuntime?.throwIfRequested(MapGpuFaultPoint.shaderInterface);
+    }
     batches.forEach(owner.backend.preflightShaderInterface);
     final atlases = <String, MapSpriteAtlas>{
       for (final batch in batches) batch.atlas.identity.value: batch.atlas,
@@ -278,11 +274,14 @@ prepareFlutterSceneSpriteFrame<TTexture, TTopology, TInstance>({
     );
   }
   pins._nodeCount = nodes.length;
-  owner
-    .._candidate = pins
-    .._nodeCreates += nodes.length
-    .._contextGeneration = frame.contextGeneration;
-  _notifySpriteCounters(owner);
+  owner._candidate = pins;
+  if (mapGpuProbeCompileTimeEnabled) {
+    final counters = _debugCountersFor(owner);
+    counters
+      .._nodeCreates += nodes.length
+      .._contextGeneration = frame.contextGeneration;
+    _notifySpriteCounters(owner);
+  }
   return FlutterSceneSpritePreparedFrame._(
     owner,
     pins,
@@ -311,7 +310,9 @@ void commitFlutterSceneSpritePreparedFrame<TTexture, TTopology, TInstance>(
   if (previous != null) {
     _moveSpriteFrameToPending(owner: owner, pins: previous);
   }
-  _notifySpriteCounters(owner);
+  if (mapGpuProbeCompileTimeEnabled) {
+    _notifySpriteCounters(owner);
+  }
 }
 
 void rollbackFlutterSceneSpritePreparedFrame<TTexture, TTopology, TInstance>(
@@ -326,7 +327,9 @@ void rollbackFlutterSceneSpritePreparedFrame<TTexture, TTopology, TInstance>(
   }
   prepared._isFinalized = true;
   _releaseSpriteFrame(owner: owner, pins: prepared._pins);
-  _notifySpriteCounters(owner);
+  if (mapGpuProbeCompileTimeEnabled) {
+    _notifySpriteCounters(owner);
+  }
 }
 
 void retireAllFlutterSceneSpriteResources<TTexture, TTopology, TInstance>(
@@ -342,7 +345,9 @@ void retireAllFlutterSceneSpriteResources<TTexture, TTopology, TInstance>(
     owner._active = null;
     _moveSpriteFrameToPending(owner: owner, pins: active);
   }
-  _notifySpriteCounters(owner);
+  if (mapGpuProbeCompileTimeEnabled) {
+    _notifySpriteCounters(owner);
+  }
 }
 
 MapGpuResourceCounterSnapshot mapGpuResourceCounterSnapshotFor<
@@ -352,6 +357,7 @@ MapGpuResourceCounterSnapshot mapGpuResourceCounterSnapshotFor<
 >(FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance> owner) {
   final active = owner._active;
   final candidate = owner._candidate;
+  final counters = owner._debugCounters;
   return MapGpuResourceCounterSnapshot(
     texture: MapGpuResourceKindCounter(
       active: active?.textures.length ?? 0,
@@ -360,8 +366,8 @@ MapGpuResourceCounterSnapshot mapGpuResourceCounterSnapshotFor<
         0,
         (total, pending) => total + pending.pins.textures.length,
       ),
-      uploads: owner._textureUploads,
-      retires: owner._textureRetires,
+      uploads: counters?._textureUploads ?? 0,
+      retires: counters?._textureRetires ?? 0,
     ),
     topology: MapGpuResourceKindCounter(
       active: active?.topologies.length ?? 0,
@@ -370,8 +376,8 @@ MapGpuResourceCounterSnapshot mapGpuResourceCounterSnapshotFor<
         0,
         (total, pending) => total + pending.pins.topologies.length,
       ),
-      uploads: owner._topologyUploads,
-      retires: owner._topologyRetires,
+      uploads: counters?._topologyUploads ?? 0,
+      retires: counters?._topologyRetires ?? 0,
     ),
     instance: MapGpuResourceKindCounter(
       active: active?.instances.length ?? 0,
@@ -380,8 +386,8 @@ MapGpuResourceCounterSnapshot mapGpuResourceCounterSnapshotFor<
         0,
         (total, pending) => total + pending.pins.instances.length,
       ),
-      uploads: owner._instanceUploads,
-      retires: owner._instanceRetires,
+      uploads: counters?._instanceUploads ?? 0,
+      retires: counters?._instanceRetires ?? 0,
     ),
     node: MapGpuResourceKindCounter(
       active: active?._nodeCount ?? 0,
@@ -390,10 +396,10 @@ MapGpuResourceCounterSnapshot mapGpuResourceCounterSnapshotFor<
         0,
         (total, pending) => total + pending.pins._nodeCount,
       ),
-      uploads: owner._nodeCreates,
-      retires: owner._nodeRetires,
+      uploads: counters?._nodeCreates ?? 0,
+      retires: counters?._nodeRetires ?? 0,
     ),
-    rendererContextGeneration: owner._contextGeneration,
+    rendererContextGeneration: counters?._contextGeneration ?? 0,
   );
 }
 
@@ -432,16 +438,45 @@ void _validateSpriteFrame<TTexture, TTopology, TInstance>({
       message: 'Candidate exceeds maxPolicyBatches.',
     );
   }
-  final snapshot = owner.snapshot;
+  final active = owner._active;
+  final candidate = owner._candidate;
+  final textureLive =
+      (active?.textures.length ?? 0) +
+      (candidate?.textures.length ?? 0) +
+      owner._pending.fold(
+        0,
+        (total, pending) => total + pending.pins.textures.length,
+      );
+  final topologyLive =
+      (active?.topologies.length ?? 0) +
+      (candidate?.topologies.length ?? 0) +
+      owner._pending.fold(
+        0,
+        (total, pending) => total + pending.pins.topologies.length,
+      );
+  final instanceLive =
+      (active?.instances.length ?? 0) +
+      (candidate?.instances.length ?? 0) +
+      owner._pending.fold(
+        0,
+        (total, pending) => total + pending.pins.instances.length,
+      );
+  final nodeLive =
+      (active?._nodeCount ?? 0) +
+      (candidate?._nodeCount ?? 0) +
+      owner._pending.fold(
+        0,
+        (total, pending) => total + pending.pins._nodeCount,
+      );
   final frameMultiplier = owner.maxFramesInFlight + 1;
   final exceedsLivePins =
-      snapshot.texture.live + atlasCount >
+      textureLive + atlasCount >
           owner.limits.maxActiveAtlases * frameMultiplier ||
-      snapshot.topology.live + topologyCount >
+      topologyLive + topologyCount >
           owner.limits.maxTopologyVariants * frameMultiplier ||
-      snapshot.instance.live + batches.length >
+      instanceLive + batches.length >
           owner.limits.maxPolicyBatches * frameMultiplier ||
-      snapshot.node.live + batches.length >
+      nodeLive + batches.length >
           owner.limits.maxPolicyBatches * frameMultiplier;
   if (exceedsLivePins) {
     throw const FlutterSceneSpriteResourceFailure(
@@ -461,13 +496,17 @@ _pinTexture<TTexture, TTopology, TInstance>({
   final key = (frame.contextGeneration, atlas.identity.value);
   var entry = owner._textures[key];
   if (entry == null) {
-    owner.probeRuntime?.throwIfRequested(MapGpuFaultPoint.atlasUpload);
+    if (mapGpuProbeCompileTimeEnabled) {
+      owner.probeRuntime?.throwIfRequested(MapGpuFaultPoint.atlasUpload);
+    }
     entry = _MapSpriteResourceEntry(
       key: key,
       resource: owner.backend.uploadTexture(atlas),
     );
     owner._textures[key] = entry;
-    owner._textureUploads++;
+    if (mapGpuProbeCompileTimeEnabled) {
+      _debugCountersFor(owner)._textureUploads++;
+    }
   }
   entry._pinCount++;
   return entry;
@@ -494,7 +533,9 @@ _pinTopology<TTexture, TTopology, TInstance>({
       ),
     );
     owner._topologies[key] = entry;
-    owner._topologyUploads++;
+    if (mapGpuProbeCompileTimeEnabled) {
+      _debugCountersFor(owner)._topologyUploads++;
+    }
   }
   entry._pinCount++;
   return entry;
@@ -519,7 +560,9 @@ _pinInstance<TTexture, TTopology, TInstance>({
       ),
     );
     owner._instances[key] = entry;
-    owner._instanceUploads++;
+    if (mapGpuProbeCompileTimeEnabled) {
+      _debugCountersFor(owner)._instanceUploads++;
+    }
   }
   entry._pinCount++;
   return entry;
@@ -580,7 +623,9 @@ void _completePendingSpriteFrame<TTexture, TTopology, TInstance>({
   pending._didRelease = true;
   owner._pending.remove(pending);
   _releaseSpriteFrame(owner: owner, pins: pending.pins);
-  _notifySpriteCounters(owner);
+  if (mapGpuProbeCompileTimeEnabled) {
+    _notifySpriteCounters(owner);
+  }
 }
 
 void _releaseSpriteFrame<TTexture, TTopology, TInstance>({
@@ -592,7 +637,9 @@ void _releaseSpriteFrame<TTexture, TTopology, TInstance>({
     return;
   }
   pins._didRelease = true;
-  owner._nodeRetires += pins._nodeCount;
+  if (mapGpuProbeCompileTimeEnabled) {
+    _debugCountersFor(owner)._nodeRetires += pins._nodeCount;
+  }
   for (final entry in pins.instances) {
     entry._pinCount--;
     if (entry._pinCount == 0) {
@@ -601,7 +648,9 @@ void _releaseSpriteFrame<TTexture, TTopology, TInstance>({
         label: 'instance',
         retire: () => owner.backend.retireInstance(entry.resource),
       );
-      owner._instanceRetires++;
+      if (mapGpuProbeCompileTimeEnabled) {
+        _debugCountersFor(owner)._instanceRetires++;
+      }
     }
   }
   for (final entry in pins.topologies) {
@@ -612,7 +661,9 @@ void _releaseSpriteFrame<TTexture, TTopology, TInstance>({
         label: 'topology',
         retire: () => owner.backend.retireTopology(entry.resource),
       );
-      owner._topologyRetires++;
+      if (mapGpuProbeCompileTimeEnabled) {
+        _debugCountersFor(owner)._topologyRetires++;
+      }
     }
   }
   for (final entry in pins.textures) {
@@ -623,7 +674,9 @@ void _releaseSpriteFrame<TTexture, TTopology, TInstance>({
         label: 'texture',
         retire: () => owner.backend.retireTexture(entry.resource),
       );
-      owner._textureRetires++;
+      if (mapGpuProbeCompileTimeEnabled) {
+        _debugCountersFor(owner)._textureRetires++;
+      }
     }
   }
 }
@@ -650,6 +703,28 @@ void _notifySpriteCounters<TTexture, TTopology, TInstance>(
   if (callback != null) {
     callback(owner.snapshot);
   }
+}
+
+_MapGpuDebugResourceCounters _debugCountersFor<TTexture, TTopology, TInstance>(
+  FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance> owner,
+) {
+  final counters = owner._debugCounters;
+  if (counters == null) {
+    throw StateError('GPU probe counters are disabled at compile time.');
+  }
+  return counters;
+}
+
+final class _MapGpuDebugResourceCounters {
+  var _textureUploads = 0;
+  var _topologyUploads = 0;
+  var _instanceUploads = 0;
+  var _nodeCreates = 0;
+  var _textureRetires = 0;
+  var _topologyRetires = 0;
+  var _instanceRetires = 0;
+  var _nodeRetires = 0;
+  var _contextGeneration = 0;
 }
 
 final class _MapSpriteResourceEntry<TKey, TResource> {

--- a/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_sprite_resource_owner.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_sprite_resource_owner.dart
@@ -1,0 +1,657 @@
+import 'dart:async';
+
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
+import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
+import 'package:eqmonitor_map/src/overlay/map_sprite_atlas.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
+import 'package:flutter/foundation.dart';
+
+typedef _MapSpriteTextureKey = (int, String);
+typedef _MapSpriteTopologyKey = (int, int, int);
+typedef _MapSpriteInstanceKey = (int, MapSpriteInstanceGeneration);
+
+final class MapSpriteRendererLimits {
+  const MapSpriteRendererLimits({
+    required this.maxActiveAtlases,
+    required this.maxTopologyVariants,
+    required this.maxPolicyBatches,
+  });
+
+  final int maxActiveAtlases;
+  final int maxTopologyVariants;
+  final int maxPolicyBatches;
+}
+
+enum FlutterSceneSpriteResourceFailureReason {
+  invalidLimits,
+  frameMismatch,
+  atlasLimitExceeded,
+  topologyLimitExceeded,
+  policyLimitExceeded,
+  livePinLimitExceeded,
+  shaderInterface,
+  atlasUpload,
+  topologyPrepare,
+  instancePrepare,
+  candidateState,
+}
+
+final class FlutterSceneSpriteResourceFailure implements Exception {
+  const FlutterSceneSpriteResourceFailure({
+    required this.reason,
+    required this.message,
+    this.stackTrace,
+  });
+
+  final FlutterSceneSpriteResourceFailureReason reason;
+  final String message;
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() =>
+      'FlutterSceneSpriteResourceFailure('
+      '${reason.name}, $message)';
+}
+
+typedef MapSpriteGpuCompletionBarrier = Future<void> Function();
+
+abstract interface class FlutterSceneSpriteResourceBackend<
+  TTexture,
+  TTopology,
+  TInstance
+> {
+  void preflightShaderInterface(MapPointSpriteInstanceBatch batch);
+
+  TTexture uploadTexture(MapSpriteAtlas atlas);
+
+  TTopology prepareTopology({
+    required int spriteAbiVersion,
+    required int materialVersion,
+  });
+
+  TInstance prepareInstance({
+    required TTopology topology,
+    required MapPointSpriteInstanceBatch batch,
+  });
+
+  void retireTexture(TTexture texture);
+
+  void retireTopology(TTopology topology);
+
+  void retireInstance(TInstance instance);
+}
+
+final class FlutterSceneSpritePreparedNode<TTexture, TTopology, TInstance> {
+  const FlutterSceneSpritePreparedNode({
+    required this.batch,
+    required this.texture,
+    required this.topology,
+    required this.instance,
+  });
+
+  final MapPointSpriteInstanceBatch batch;
+  final TTexture texture;
+  final TTopology topology;
+  final TInstance instance;
+}
+
+final class FlutterSceneSpritePreparedFrame<TTexture, TTopology, TInstance> {
+  FlutterSceneSpritePreparedFrame._(this.owner, this._pins, this.nodes);
+
+  final FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance> owner;
+  final _MapSpriteFramePins<TTexture, TTopology, TInstance> _pins;
+  final List<FlutterSceneSpritePreparedNode<TTexture, TTopology, TInstance>>
+  nodes;
+  var _isFinalized = false;
+
+  bool get isFinalized => _isFinalized;
+
+  void commit() => commitFlutterSceneSpritePreparedFrame(this);
+
+  void rollback() => rollbackFlutterSceneSpritePreparedFrame(this);
+}
+
+/// Sprite resources are pinned per submitted frame and released after a fence.
+final class FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance> {
+  FlutterSceneSpriteResourceOwner({
+    required this.limits,
+    required this.maxFramesInFlight,
+    required this.backend,
+    required this.waitForGpuCompletion,
+    this.probeRuntime,
+    this.onCounterSnapshot,
+  }) {
+    if (maxFramesInFlight < 1 ||
+        limits.maxActiveAtlases < 1 ||
+        limits.maxTopologyVariants < 1 ||
+        limits.maxPolicyBatches < 1) {
+      throw const FlutterSceneSpriteResourceFailure(
+        reason: FlutterSceneSpriteResourceFailureReason.invalidLimits,
+        message: 'All caller limits must be positive.',
+      );
+    }
+  }
+
+  final MapSpriteRendererLimits limits;
+  final int maxFramesInFlight;
+  final FlutterSceneSpriteResourceBackend<TTexture, TTopology, TInstance>
+  backend;
+  final MapSpriteGpuCompletionBarrier waitForGpuCompletion;
+  final MapGpuProbeRuntime? probeRuntime;
+  final ValueChanged<MapGpuResourceCounterSnapshot>? onCounterSnapshot;
+
+  final _textures =
+      <
+        _MapSpriteTextureKey,
+        _MapSpriteResourceEntry<_MapSpriteTextureKey, TTexture>
+      >{};
+  final _topologies =
+      <
+        _MapSpriteTopologyKey,
+        _MapSpriteResourceEntry<_MapSpriteTopologyKey, TTopology>
+      >{};
+  final _instances =
+      <
+        _MapSpriteInstanceKey,
+        _MapSpriteResourceEntry<_MapSpriteInstanceKey, TInstance>
+      >{};
+  final _pending = <_MapSpritePendingFrame<TTexture, TTopology, TInstance>>[];
+  _MapSpriteFramePins<TTexture, TTopology, TInstance>? _active;
+  _MapSpriteFramePins<TTexture, TTopology, TInstance>? _candidate;
+  var _textureUploads = 0;
+  var _topologyUploads = 0;
+  var _instanceUploads = 0;
+  var _nodeCreates = 0;
+  var _textureRetires = 0;
+  var _topologyRetires = 0;
+  var _instanceRetires = 0;
+  var _nodeRetires = 0;
+  var _contextGeneration = 0;
+
+  bool get hasCounterCallback => onCounterSnapshot != null;
+
+  MapGpuResourceCounterSnapshot get snapshot =>
+      mapGpuResourceCounterSnapshotFor(this);
+
+  FlutterSceneSpritePreparedFrame<TTexture, TTopology, TInstance> prepareFrame({
+    required MapFrameSnapshot frame,
+    required List<MapPointSpriteInstanceBatch> batches,
+  }) => prepareFlutterSceneSpriteFrame(
+    owner: this,
+    frame: frame,
+    batches: batches,
+  );
+
+  void retireAll() => retireAllFlutterSceneSpriteResources(this);
+}
+
+FlutterSceneSpritePreparedFrame<TTexture, TTopology, TInstance>
+prepareFlutterSceneSpriteFrame<TTexture, TTopology, TInstance>({
+  required FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance>
+  owner,
+  required MapFrameSnapshot frame,
+  required List<MapPointSpriteInstanceBatch> batches,
+}) {
+  if (owner._candidate != null) {
+    throw const FlutterSceneSpriteResourceFailure(
+      reason: FlutterSceneSpriteResourceFailureReason.candidateState,
+      message: 'The previous candidate must be committed or rolled back.',
+    );
+  }
+  _validateSpriteFrame(owner: owner, frame: frame, batches: batches);
+  final pins = _MapSpriteFramePins<TTexture, TTopology, TInstance>(
+    frame: frame,
+  );
+  var failureReason = FlutterSceneSpriteResourceFailureReason.shaderInterface;
+  try {
+    owner.probeRuntime?.throwIfRequested(MapGpuFaultPoint.shaderInterface);
+    batches.forEach(owner.backend.preflightShaderInterface);
+    final atlases = <String, MapSpriteAtlas>{
+      for (final batch in batches) batch.atlas.identity.value: batch.atlas,
+    };
+    failureReason = FlutterSceneSpriteResourceFailureReason.atlasUpload;
+    for (final atlas in atlases.values) {
+      pins.textures.add(_pinTexture(owner: owner, frame: frame, atlas: atlas));
+    }
+    if (batches.isNotEmpty) {
+      failureReason = FlutterSceneSpriteResourceFailureReason.topologyPrepare;
+      pins.topologies.add(_pinTopology(owner: owner, frame: frame));
+    }
+    final topology = pins.topologies.firstOrNull?.resource;
+    if (topology != null) {
+      failureReason = FlutterSceneSpriteResourceFailureReason.instancePrepare;
+      for (final batch in batches) {
+        pins.instances.add(
+          _pinInstance(
+            owner: owner,
+            frame: frame,
+            topology: topology,
+            batch: batch,
+          ),
+        );
+      }
+    }
+  } on FlutterSceneSpriteResourceFailure {
+    _releaseSpriteFrame(owner: owner, pins: pins);
+    rethrow;
+  } on Exception catch (error, stackTrace) {
+    _releaseSpriteFrame(owner: owner, pins: pins);
+    throw FlutterSceneSpriteResourceFailure(
+      reason: failureReason,
+      message: error.toString(),
+      stackTrace: stackTrace,
+    );
+    // Candidate rollback must also cover synchronous GPU StateError failures.
+    // ignore: avoid_catching_errors
+  } on Error catch (error, stackTrace) {
+    _releaseSpriteFrame(owner: owner, pins: pins);
+    throw FlutterSceneSpriteResourceFailure(
+      reason: failureReason,
+      message: error.toString(),
+      stackTrace: stackTrace,
+    );
+  }
+  final textureByKey = {for (final entry in pins.textures) entry.key: entry};
+  final instanceByKey = {for (final entry in pins.instances) entry.key: entry};
+  final topology = pins.topologies.firstOrNull;
+  final nodes =
+      <FlutterSceneSpritePreparedNode<TTexture, TTopology, TInstance>>[];
+  for (final batch in batches) {
+    final texture =
+        textureByKey[(frame.contextGeneration, batch.atlas.identity.value)];
+    final instance =
+        instanceByKey[(frame.contextGeneration, batch.instanceGeneration)];
+    if (texture == null || topology == null || instance == null) {
+      _releaseSpriteFrame(owner: owner, pins: pins);
+      throw const FlutterSceneSpriteResourceFailure(
+        reason: FlutterSceneSpriteResourceFailureReason.candidateState,
+        message: 'Prepared sprite resources are incomplete.',
+      );
+    }
+    nodes.add(
+      FlutterSceneSpritePreparedNode(
+        batch: batch,
+        texture: texture.resource,
+        topology: topology.resource,
+        instance: instance.resource,
+      ),
+    );
+  }
+  pins._nodeCount = nodes.length;
+  owner
+    .._candidate = pins
+    .._nodeCreates += nodes.length
+    .._contextGeneration = frame.contextGeneration;
+  _notifySpriteCounters(owner);
+  return FlutterSceneSpritePreparedFrame._(
+    owner,
+    pins,
+    List.unmodifiable(nodes),
+  );
+}
+
+void commitFlutterSceneSpritePreparedFrame<TTexture, TTopology, TInstance>(
+  FlutterSceneSpritePreparedFrame<TTexture, TTopology, TInstance> prepared,
+) {
+  if (prepared._isFinalized) {
+    return;
+  }
+  final owner = prepared.owner;
+  if (!identical(owner._candidate, prepared._pins)) {
+    throw const FlutterSceneSpriteResourceFailure(
+      reason: FlutterSceneSpriteResourceFailureReason.candidateState,
+      message: 'Sprite candidate is no longer current.',
+    );
+  }
+  final previous = owner._active;
+  owner
+    .._candidate = null
+    .._active = prepared._pins;
+  prepared._isFinalized = true;
+  if (previous != null) {
+    _moveSpriteFrameToPending(owner: owner, pins: previous);
+  }
+  _notifySpriteCounters(owner);
+}
+
+void rollbackFlutterSceneSpritePreparedFrame<TTexture, TTopology, TInstance>(
+  FlutterSceneSpritePreparedFrame<TTexture, TTopology, TInstance> prepared,
+) {
+  if (prepared._isFinalized) {
+    return;
+  }
+  final owner = prepared.owner;
+  if (identical(owner._candidate, prepared._pins)) {
+    owner._candidate = null;
+  }
+  prepared._isFinalized = true;
+  _releaseSpriteFrame(owner: owner, pins: prepared._pins);
+  _notifySpriteCounters(owner);
+}
+
+void retireAllFlutterSceneSpriteResources<TTexture, TTopology, TInstance>(
+  FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance> owner,
+) {
+  final candidate = owner._candidate;
+  if (candidate != null) {
+    owner._candidate = null;
+    _releaseSpriteFrame(owner: owner, pins: candidate);
+  }
+  final active = owner._active;
+  if (active != null) {
+    owner._active = null;
+    _moveSpriteFrameToPending(owner: owner, pins: active);
+  }
+  _notifySpriteCounters(owner);
+}
+
+MapGpuResourceCounterSnapshot mapGpuResourceCounterSnapshotFor<
+  TTexture,
+  TTopology,
+  TInstance
+>(FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance> owner) {
+  final active = owner._active;
+  final candidate = owner._candidate;
+  return MapGpuResourceCounterSnapshot(
+    texture: MapGpuResourceKindCounter(
+      active: active?.textures.length ?? 0,
+      candidate: candidate?.textures.length ?? 0,
+      pendingRetire: owner._pending.fold(
+        0,
+        (total, pending) => total + pending.pins.textures.length,
+      ),
+      uploads: owner._textureUploads,
+      retires: owner._textureRetires,
+    ),
+    topology: MapGpuResourceKindCounter(
+      active: active?.topologies.length ?? 0,
+      candidate: candidate?.topologies.length ?? 0,
+      pendingRetire: owner._pending.fold(
+        0,
+        (total, pending) => total + pending.pins.topologies.length,
+      ),
+      uploads: owner._topologyUploads,
+      retires: owner._topologyRetires,
+    ),
+    instance: MapGpuResourceKindCounter(
+      active: active?.instances.length ?? 0,
+      candidate: candidate?.instances.length ?? 0,
+      pendingRetire: owner._pending.fold(
+        0,
+        (total, pending) => total + pending.pins.instances.length,
+      ),
+      uploads: owner._instanceUploads,
+      retires: owner._instanceRetires,
+    ),
+    node: MapGpuResourceKindCounter(
+      active: active?._nodeCount ?? 0,
+      candidate: candidate?._nodeCount ?? 0,
+      pendingRetire: owner._pending.fold(
+        0,
+        (total, pending) => total + pending.pins._nodeCount,
+      ),
+      uploads: owner._nodeCreates,
+      retires: owner._nodeRetires,
+    ),
+    rendererContextGeneration: owner._contextGeneration,
+  );
+}
+
+void _validateSpriteFrame<TTexture, TTopology, TInstance>({
+  required FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance>
+  owner,
+  required MapFrameSnapshot frame,
+  required List<MapPointSpriteInstanceBatch> batches,
+}) {
+  if (batches.any((batch) => !identical(batch.frame, frame))) {
+    throw const FlutterSceneSpriteResourceFailure(
+      reason: FlutterSceneSpriteResourceFailureReason.frameMismatch,
+      message: 'Every sprite batch must use the candidate frame.',
+    );
+  }
+  final atlasCount = batches
+      .map((batch) => batch.atlas.identity.value)
+      .toSet()
+      .length;
+  if (atlasCount > owner.limits.maxActiveAtlases) {
+    throw const FlutterSceneSpriteResourceFailure(
+      reason: FlutterSceneSpriteResourceFailureReason.atlasLimitExceeded,
+      message: 'Candidate exceeds maxActiveAtlases.',
+    );
+  }
+  final topologyCount = batches.isEmpty ? 0 : 1;
+  if (topologyCount > owner.limits.maxTopologyVariants) {
+    throw const FlutterSceneSpriteResourceFailure(
+      reason: FlutterSceneSpriteResourceFailureReason.topologyLimitExceeded,
+      message: 'Candidate exceeds maxTopologyVariants.',
+    );
+  }
+  if (batches.length > owner.limits.maxPolicyBatches) {
+    throw const FlutterSceneSpriteResourceFailure(
+      reason: FlutterSceneSpriteResourceFailureReason.policyLimitExceeded,
+      message: 'Candidate exceeds maxPolicyBatches.',
+    );
+  }
+  final snapshot = owner.snapshot;
+  final frameMultiplier = owner.maxFramesInFlight + 1;
+  final exceedsLivePins =
+      snapshot.texture.live + atlasCount >
+          owner.limits.maxActiveAtlases * frameMultiplier ||
+      snapshot.topology.live + topologyCount >
+          owner.limits.maxTopologyVariants * frameMultiplier ||
+      snapshot.instance.live + batches.length >
+          owner.limits.maxPolicyBatches * frameMultiplier ||
+      snapshot.node.live + batches.length >
+          owner.limits.maxPolicyBatches * frameMultiplier;
+  if (exceedsLivePins) {
+    throw const FlutterSceneSpriteResourceFailure(
+      reason: FlutterSceneSpriteResourceFailureReason.livePinLimitExceeded,
+      message: 'Candidate would exceed the frames-in-flight pin bound.',
+    );
+  }
+}
+
+_MapSpriteResourceEntry<_MapSpriteTextureKey, TTexture>
+_pinTexture<TTexture, TTopology, TInstance>({
+  required FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance>
+  owner,
+  required MapFrameSnapshot frame,
+  required MapSpriteAtlas atlas,
+}) {
+  final key = (frame.contextGeneration, atlas.identity.value);
+  var entry = owner._textures[key];
+  if (entry == null) {
+    owner.probeRuntime?.throwIfRequested(MapGpuFaultPoint.atlasUpload);
+    entry = _MapSpriteResourceEntry(
+      key: key,
+      resource: owner.backend.uploadTexture(atlas),
+    );
+    owner._textures[key] = entry;
+    owner._textureUploads++;
+  }
+  entry._pinCount++;
+  return entry;
+}
+
+_MapSpriteResourceEntry<_MapSpriteTopologyKey, TTopology>
+_pinTopology<TTexture, TTopology, TInstance>({
+  required FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance>
+  owner,
+  required MapFrameSnapshot frame,
+}) {
+  final key = (
+    frame.contextGeneration,
+    mapSpriteInstanceAbiVersion,
+    mapSpriteMaterialAbiVersion,
+  );
+  var entry = owner._topologies[key];
+  if (entry == null) {
+    entry = _MapSpriteResourceEntry(
+      key: key,
+      resource: owner.backend.prepareTopology(
+        spriteAbiVersion: mapSpriteInstanceAbiVersion,
+        materialVersion: mapSpriteMaterialAbiVersion,
+      ),
+    );
+    owner._topologies[key] = entry;
+    owner._topologyUploads++;
+  }
+  entry._pinCount++;
+  return entry;
+}
+
+_MapSpriteResourceEntry<_MapSpriteInstanceKey, TInstance>
+_pinInstance<TTexture, TTopology, TInstance>({
+  required FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance>
+  owner,
+  required MapFrameSnapshot frame,
+  required TTopology topology,
+  required MapPointSpriteInstanceBatch batch,
+}) {
+  final key = (frame.contextGeneration, batch.instanceGeneration);
+  var entry = owner._instances[key];
+  if (entry == null) {
+    entry = _MapSpriteResourceEntry(
+      key: key,
+      resource: owner.backend.prepareInstance(
+        topology: topology,
+        batch: batch,
+      ),
+    );
+    owner._instances[key] = entry;
+    owner._instanceUploads++;
+  }
+  entry._pinCount++;
+  return entry;
+}
+
+void _moveSpriteFrameToPending<TTexture, TTopology, TInstance>({
+  required FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance>
+  owner,
+  required _MapSpriteFramePins<TTexture, TTopology, TInstance> pins,
+}) {
+  final pending = _MapSpritePendingFrame(pins: pins);
+  owner._pending.add(pending);
+  late final Future<void> completion;
+  try {
+    completion = owner.waitForGpuCompletion();
+  } on Exception {
+    _completePendingSpriteFrame(owner: owner, pending: pending);
+    return;
+    // A synchronous GPU completion barrier may report context loss as Error.
+    // ignore: avoid_catching_errors
+  } on Error {
+    _completePendingSpriteFrame(owner: owner, pending: pending);
+    return;
+  }
+  unawaited(
+    _retireSpriteFrameAfter(
+      owner: owner,
+      pending: pending,
+      completion: completion,
+    ),
+  );
+}
+
+Future<void> _retireSpriteFrameAfter<TTexture, TTopology, TInstance>({
+  required FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance>
+  owner,
+  required _MapSpritePendingFrame<TTexture, TTopology, TInstance> pending,
+  required Future<void> completion,
+}) async {
+  try {
+    await completion;
+    // GPU integrations may complete with non-Exception context-loss objects.
+    // ignore: avoid_catches_without_on_clauses
+  } catch (_) {
+    // Context loss still releases app-owned references exactly once.
+  }
+  _completePendingSpriteFrame(owner: owner, pending: pending);
+}
+
+void _completePendingSpriteFrame<TTexture, TTopology, TInstance>({
+  required FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance>
+  owner,
+  required _MapSpritePendingFrame<TTexture, TTopology, TInstance> pending,
+}) {
+  if (pending._didRelease) {
+    return;
+  }
+  pending._didRelease = true;
+  owner._pending.remove(pending);
+  _releaseSpriteFrame(owner: owner, pins: pending.pins);
+  _notifySpriteCounters(owner);
+}
+
+void _releaseSpriteFrame<TTexture, TTopology, TInstance>({
+  required FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance>
+  owner,
+  required _MapSpriteFramePins<TTexture, TTopology, TInstance> pins,
+}) {
+  if (pins._didRelease) {
+    return;
+  }
+  pins._didRelease = true;
+  owner._nodeRetires += pins._nodeCount;
+  for (final entry in pins.instances) {
+    entry._pinCount--;
+    if (entry._pinCount == 0) {
+      owner._instances.remove(entry.key);
+      owner.backend.retireInstance(entry.resource);
+      owner._instanceRetires++;
+    }
+  }
+  for (final entry in pins.topologies) {
+    entry._pinCount--;
+    if (entry._pinCount == 0) {
+      owner._topologies.remove(entry.key);
+      owner.backend.retireTopology(entry.resource);
+      owner._topologyRetires++;
+    }
+  }
+  for (final entry in pins.textures) {
+    entry._pinCount--;
+    if (entry._pinCount == 0) {
+      owner._textures.remove(entry.key);
+      owner.backend.retireTexture(entry.resource);
+      owner._textureRetires++;
+    }
+  }
+}
+
+void _notifySpriteCounters<TTexture, TTopology, TInstance>(
+  FlutterSceneSpriteResourceOwner<TTexture, TTopology, TInstance> owner,
+) {
+  final callback = owner.onCounterSnapshot;
+  if (callback != null) {
+    callback(owner.snapshot);
+  }
+}
+
+final class _MapSpriteResourceEntry<TKey, TResource> {
+  _MapSpriteResourceEntry({required this.key, required this.resource});
+
+  final TKey key;
+  final TResource resource;
+  var _pinCount = 0;
+}
+
+final class _MapSpriteFramePins<TTexture, TTopology, TInstance> {
+  _MapSpriteFramePins({required this.frame});
+
+  final MapFrameSnapshot frame;
+  final textures = <_MapSpriteResourceEntry<_MapSpriteTextureKey, TTexture>>[];
+  final topologies =
+      <_MapSpriteResourceEntry<_MapSpriteTopologyKey, TTopology>>[];
+  final instances =
+      <_MapSpriteResourceEntry<_MapSpriteInstanceKey, TInstance>>[];
+  var _nodeCount = 0;
+  var _didRelease = false;
+}
+
+final class _MapSpritePendingFrame<TTexture, TTopology, TInstance> {
+  _MapSpritePendingFrame({required this.pins});
+
+  final _MapSpriteFramePins<TTexture, TTopology, TInstance> pins;
+  var _didRelease = false;
+}

--- a/packages/eqmonitor_map/lib/src/flutter_scene/map_gpu_probe.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/map_gpu_probe.dart
@@ -1,0 +1,119 @@
+enum MapGpuFaultPoint { atlasUpload, shaderInterface, frameSubmit }
+
+enum MapSpriteAtlasProbeFixture {
+  production,
+  orientation2x2,
+  alphaHalf,
+  edgeBleed,
+}
+
+final class MapGpuProbeConfiguration {
+  const MapGpuProbeConfiguration({
+    required this.faultPoint,
+    required this.atlasFixture,
+  });
+
+  final MapGpuFaultPoint? faultPoint;
+  final MapSpriteAtlasProbeFixture atlasFixture;
+}
+
+final class MapGpuProbeFault implements Exception {
+  const MapGpuProbeFault({required this.point});
+
+  final MapGpuFaultPoint point;
+
+  @override
+  String toString() => 'MapGpuProbeFault(${point.name})';
+}
+
+/// Debug-only fault state. Production callers do not construct this object.
+final class MapGpuProbeRuntime {
+  MapGpuProbeRuntime({required this.configuration});
+
+  final MapGpuProbeConfiguration configuration;
+  var _didFire = false;
+
+  MapSpriteAtlasProbeFixture get atlasFixture => configuration.atlasFixture;
+
+  void throwIfRequested(MapGpuFaultPoint point) {
+    if (_didFire || configuration.faultPoint != point) {
+      return;
+    }
+    _didFire = true;
+    throw MapGpuProbeFault(point: point);
+  }
+}
+
+final class MapGpuResourceKindCounter {
+  const MapGpuResourceKindCounter({
+    required this.active,
+    required this.candidate,
+    required this.pendingRetire,
+    required this.uploads,
+    required this.retires,
+  });
+
+  static const zero = MapGpuResourceKindCounter(
+    active: 0,
+    candidate: 0,
+    pendingRetire: 0,
+    uploads: 0,
+    retires: 0,
+  );
+
+  final int active;
+  final int candidate;
+  final int pendingRetire;
+  final int uploads;
+  final int retires;
+
+  int get live => active + candidate + pendingRetire;
+}
+
+final class MapGpuResourceCounterSnapshot {
+  const MapGpuResourceCounterSnapshot({
+    required this.texture,
+    required this.topology,
+    required this.instance,
+    required this.node,
+    required this.rendererContextGeneration,
+  });
+
+  final MapGpuResourceKindCounter texture;
+  final MapGpuResourceKindCounter topology;
+  final MapGpuResourceKindCounter instance;
+  final MapGpuResourceKindCounter node;
+  final int rendererContextGeneration;
+}
+
+abstract interface class MapGpuProbeHost {
+  void invalidateRendererContextGeneration();
+}
+
+/// Caller-owned debug controller. It never recreates the native GPU context.
+final class MapGpuProbeController {
+  MapGpuProbeHost? _host;
+
+  bool attach({required MapGpuProbeHost host}) {
+    if (_host != null) {
+      return false;
+    }
+    _host = host;
+    return true;
+  }
+
+  void detach({required MapGpuProbeHost host}) {
+    if (identical(_host, host)) {
+      _host = null;
+    }
+  }
+
+  bool invalidateRendererContextGeneration() {
+    final host = _host;
+    if (host == null) {
+      return false;
+    }
+    host.invalidateRendererContextGeneration();
+    return true;
+  }
+}

--- a/packages/eqmonitor_map/lib/src/flutter_scene/map_gpu_probe.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/map_gpu_probe.dart
@@ -1,3 +1,9 @@
+/// Build-time gate for the debug-map-only GPU lifecycle probe.
+// ignore: do_not_use_environment
+const mapGpuProbeCompileTimeEnabled = bool.fromEnvironment(
+  'EQMONITOR_MAP_GPU_PROBE',
+);
+
 enum MapGpuFaultPoint { atlasUpload, shaderInterface, frameSubmit }
 
 enum MapSpriteAtlasProbeFixture {
@@ -84,6 +90,28 @@ final class MapGpuResourceCounterSnapshot {
   final MapGpuResourceKindCounter instance;
   final MapGpuResourceKindCounter node;
   final int rendererContextGeneration;
+}
+
+typedef MapGpuResourceCounterCallback = void Function(
+  MapGpuResourceCounterSnapshot snapshot,
+);
+
+/// Prevents an in-flight retirement fence from notifying a disposed widget.
+final class MapGpuResourceCounterCallbackGate {
+  MapGpuResourceCounterCallbackGate({required this.callback});
+
+  final MapGpuResourceCounterCallback callback;
+  var _isDisposed = false;
+
+  void publish(MapGpuResourceCounterSnapshot snapshot) {
+    if (!_isDisposed) {
+      callback(snapshot);
+    }
+  }
+
+  void dispose() {
+    _isDisposed = true;
+  }
 }
 
 abstract interface class MapGpuProbeHost {

--- a/packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_owner.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_owner.dart
@@ -3,6 +3,7 @@ import 'package:eqmonitor_map/src/overlay/earthquake_overlay_coverage.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_overlay_coverage_owner.dart';
 import 'package:eqmonitor_map/src/renderer/base_map_overlay_frame_builder.dart';
 import 'package:eqmonitor_map/src/renderer/map_scene_frame_submission.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch.dart';
 import 'package:flutter/foundation.dart';
 
@@ -52,10 +53,13 @@ final class BaseMapOverlayFrameOwner {
   final EarthquakeOverlayCoverageOwner _coverage;
   EarthquakeMapOverlaySnapshot? _overlay;
   ObservationPointBatch? _previousObservationBatch;
+  List<MapPointSpriteInstanceBatch> _previousSpriteBatches = const [];
 
   EarthquakeMapOverlaySnapshot? get overlay => _overlay;
   ObservationPointBatch? get previousObservationBatch =>
       _previousObservationBatch;
+  List<MapPointSpriteInstanceBatch> get previousSpriteBatches =>
+      _previousSpriteBatches;
   EarthquakeOverlayCoverage get coverage => _coverage.coverage;
   EarthquakeOverlayCoverageSnapshot get coverageSnapshot => _coverage.snapshot;
 
@@ -98,6 +102,7 @@ final class BaseMapOverlayFrameOwner {
       failClosedResources();
       _overlay = null;
       _previousObservationBatch = null;
+      _previousSpriteBatches = const [];
       _coverage.hide(overlay: null);
       return BaseMapOverlayFrameCommitFailed(
         error: error,
@@ -107,6 +112,7 @@ final class BaseMapOverlayFrameOwner {
     }
     _overlay = candidate.overlay;
     _previousObservationBatch = candidate.observationBatchForReuse;
+    _previousSpriteBatches = candidate.spriteBatchesForReuse;
     _coverage.publish(overlay: _overlay, coverage: candidate.coverage);
     return const BaseMapOverlayFrameCommitSucceeded();
   }

--- a/packages/eqmonitor_map/lib/src/renderer/map_sprite_batch.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/map_sprite_batch.dart
@@ -8,6 +8,7 @@ import 'package:eqmonitor_map/src/renderer/map_scene_frame_submission.dart';
 
 const mapSpriteQuadVertexStrideInBytes = 8;
 const mapPointSpriteInstanceStrideInBytes = 40;
+const mapSpriteInstanceAbiVersion = 1;
 const mapSpriteFrameUniformByteLength = 64;
 const mapSpriteMaterialAbiVersion = 1;
 const mapSpriteFrameUniformBlockName = 'SpriteFrame';

--- a/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
+++ b/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
@@ -651,12 +651,14 @@ class _BaseMapController extends ChangeNotifier
       final observationMaterial =
           await loadEarthquakeObservationMaterialBinding();
       final counterCallbackGate = _gpuCounterCallbackGate;
-      final spriteResources = await loadEarthquakeSpriteSceneResources(
-        limits: limits.spriteRendererLimits,
-        maxFramesInFlight: limits.maxFramesInFlight,
-        waitForGpuCompletion: scene.waitForPendingGpuSubmissions,
-        probeRuntime: _gpuProbeRuntime,
-        onCounterSnapshot: counterCallbackGate?.publish,
+      final spriteResources = await loadOptionalFlutterSceneSpriteResources(
+        load: () => loadEarthquakeSpriteSceneResources(
+          limits: limits.spriteRendererLimits,
+          maxFramesInFlight: limits.maxFramesInFlight,
+          waitForGpuCompletion: scene.waitForPendingGpuSubmissions,
+          probeRuntime: _gpuProbeRuntime,
+          onCounterSnapshot: counterCallbackGate?.publish,
+        ),
       );
       prepareInitialOverlay:
       while (true) {

--- a/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
+++ b/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
@@ -4,6 +4,8 @@ import 'dart:math' as math;
 import 'package:eqmonitor_map/src/flutter_scene/base_map_material_library.dart';
 import 'package:eqmonitor_map/src/flutter_scene/earthquake_overlay_material_owner.dart';
 import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_map_adapter.dart';
+import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_sprite_resource_owner.dart';
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_revision.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
@@ -111,6 +113,9 @@ abstract class MapBaseLayerLimits with _$MapBaseLayerLimits {
     /// してしまう。この frame 数ぶん未使用が続いた resource だけを手放す。
     required int maxFramesInFlight,
 
+    /// Sprite atlas/topology/policy batchesのcaller-owned上限。
+    required MapSpriteRendererLimits spriteRendererLimits,
+
     /// 一つのScene frameへ送るmesh packet / instance batch node総数の上限。
     required int maxSceneNodeCount,
   }) = _MapBaseLayerLimits;
@@ -134,6 +139,9 @@ class BaseMapView extends HookWidget {
     this.cameraController,
     this.earthquakeOverlay,
     this.onEarthquakeOverlayCoverageChanged,
+    this.gpuProbeConfiguration,
+    this.onGpuResourceCounterChanged,
+    this.gpuProbeController,
     super.key,
   });
 
@@ -169,6 +177,17 @@ class BaseMapView extends HookWidget {
   // ignore: diagnostic_describe_all_properties
   onEarthquakeOverlayCoverageChanged;
 
+  // Debug map probe configuration is not useful in Flutter Inspector output.
+  // ignore: diagnostic_describe_all_properties
+  final MapGpuProbeConfiguration? gpuProbeConfiguration;
+  final ValueChanged<MapGpuResourceCounterSnapshot>?
+  // Resource counter callback is caller-owned debug instrumentation.
+  // ignore: diagnostic_describe_all_properties
+  onGpuResourceCounterChanged;
+  // Debug map owns and disposes the controller lifecycle.
+  // ignore: diagnostic_describe_all_properties
+  final MapGpuProbeController? gpuProbeController;
+
   @override
   Widget build(BuildContext context) {
     final controller = useMemoized(
@@ -180,11 +199,23 @@ class BaseMapView extends HookWidget {
         externalCameraController: cameraController,
         earthquakeOverlay: earthquakeOverlay,
         onEarthquakeOverlayCoverageChanged: onEarthquakeOverlayCoverageChanged,
+        gpuProbeConfiguration: gpuProbeConfiguration,
+        onGpuResourceCounterChanged: onGpuResourceCounterChanged,
+        gpuProbeController: gpuProbeController,
       ),
-      [source, limits, clock, cameraController],
+      [
+        source,
+        limits,
+        clock,
+        cameraController,
+        gpuProbeConfiguration,
+        onGpuResourceCounterChanged,
+        gpuProbeController,
+      ],
     );
     useEffect(() {
       controller.attachCameraController();
+      controller.attachGpuProbeController();
       return controller.dispose;
     }, [controller]);
     useListenable(controller);
@@ -333,7 +364,8 @@ class _BaseMapDebugHud extends StatelessWidget {
 
 /// gesture・decode・Scene node管理を持つ内部controller。[BaseMapView]の外へは
 /// 公開しない(brief要求)。
-class _BaseMapController extends ChangeNotifier implements MapViewCameraHost {
+class _BaseMapController extends ChangeNotifier
+    implements MapViewCameraHost, MapGpuProbeHost {
   new({
     required this.source,
     required this.limits,
@@ -343,6 +375,9 @@ class _BaseMapController extends ChangeNotifier implements MapViewCameraHost {
     required EarthquakeMapOverlaySnapshot? earthquakeOverlay,
     required ValueChanged<EarthquakeOverlayCoverageSnapshot>?
     onEarthquakeOverlayCoverageChanged,
+    required this.gpuProbeConfiguration,
+    required this.onGpuResourceCounterChanged,
+    required this.gpuProbeController,
   }) : _cameraOwner = MapCameraCandidateOwner(initialCamera: initialCamera),
        _inputOverlay = earthquakeOverlay,
        _acceptedOverlay = earthquakeOverlay,
@@ -391,6 +426,22 @@ class _BaseMapController extends ChangeNotifier implements MapViewCameraHost {
   /// #1595)が、frame snapshotの契約を最初から満たしておく。
   final MapClock mapClock;
   final MapViewCameraController? externalCameraController;
+  final MapGpuProbeConfiguration? gpuProbeConfiguration;
+  final ValueChanged<MapGpuResourceCounterSnapshot>?
+  onGpuResourceCounterChanged;
+  final MapGpuProbeController? gpuProbeController;
+  late final MapGpuProbeRuntime? _gpuProbeRuntime =
+      switch (gpuProbeConfiguration) {
+        final configuration? when mapGpuProbeCompileTimeEnabled =>
+          MapGpuProbeRuntime(configuration: configuration),
+        _ => null,
+      };
+  late final MapGpuResourceCounterCallbackGate? _gpuCounterCallbackGate =
+      switch (onGpuResourceCounterChanged) {
+        final callback? when mapGpuProbeCompileTimeEnabled =>
+          MapGpuResourceCounterCallbackGate(callback: callback),
+        _ => null,
+      };
   static const _cameraBoundsFitter = MapCameraBoundsFitter();
 
   // Line layerの半線幅(全layer共通)。`docs/map_spec_v3.md`は線幅もzoomで
@@ -475,6 +526,31 @@ class _BaseMapController extends ChangeNotifier implements MapViewCameraHost {
         _initError = StateError('camera controller is disposed');
         notifyListeners();
     }
+  }
+
+  void attachGpuProbeController() {
+    if (!mapGpuProbeCompileTimeEnabled) {
+      return;
+    }
+    final controller = gpuProbeController;
+    if (controller == null) {
+      return;
+    }
+    if (!controller.attach(host: this)) {
+      _initError = StateError('GPU probe controller is already attached');
+      notifyListeners();
+    }
+  }
+
+  @override
+  void invalidateRendererContextGeneration() {
+    if (_isDisposed) {
+      return;
+    }
+    _adapter?.retireAllGpuResources();
+    _contextGeneration++;
+    _refresh();
+    notifyListeners();
   }
 
   @override
@@ -574,6 +650,14 @@ class _BaseMapController extends ChangeNotifier implements MapViewCameraHost {
       }
       final observationMaterial =
           await loadEarthquakeObservationMaterialBinding();
+      final counterCallbackGate = _gpuCounterCallbackGate;
+      final spriteResources = await loadEarthquakeSpriteSceneResources(
+        limits: limits.spriteRendererLimits,
+        maxFramesInFlight: limits.maxFramesInFlight,
+        waitForGpuCompletion: scene.waitForPendingGpuSubmissions,
+        probeRuntime: _gpuProbeRuntime,
+        onCounterSnapshot: counterCallbackGate?.publish,
+      );
       prepareInitialOverlay:
       while (true) {
         final candidate = _inputOverlay;
@@ -634,6 +718,8 @@ class _BaseMapController extends ChangeNotifier implements MapViewCameraHost {
               : FlutterScenePreprocessedMaterialBinding(material);
         },
         observationMaterial: observationMaterial,
+        spriteResources: spriteResources,
+        gpuProbeRuntime: _gpuProbeRuntime,
         maxFramesInFlight: limits.maxFramesInFlight,
       );
       _isReady = true;
@@ -922,6 +1008,7 @@ class _BaseMapController extends ChangeNotifier implements MapViewCameraHost {
       currentOverlay: _overlayFrameOwner.overlay,
       requestedOverlay: _requestedOverlay,
       previousObservationBatch: _overlayFrameOwner.previousObservationBatch,
+      previousSpriteBatches: _overlayFrameOwner.previousSpriteBatches,
       requestedCover: cover,
       tileSourceInstanceId: source.cacheIdentity,
       tileCache: _cache,
@@ -1058,7 +1145,9 @@ class _BaseMapController extends ChangeNotifier implements MapViewCameraHost {
       return;
     }
     _isDisposed = true;
+    _gpuCounterCallbackGate?.dispose();
     externalCameraController?.detach(host: this);
+    gpuProbeController?.detach(host: this);
     _cache.dispose();
     _packedMeshCache.clear();
     _earthquakePackedMeshCache.clear();

--- a/packages/eqmonitor_map/lib/src/widget/base_map_view.freezed.dart
+++ b/packages/eqmonitor_map/lib/src/widget/base_map_view.freezed.dart
@@ -59,7 +59,8 @@ mixin _$MapBaseLayerLimits {
 /// GPU完了を意味しない」)。可視 tile から外れた geometry の参照を即座に
 /// 落とすと、まだ in-flight の frame が参照している最中に GC 対象へ
 /// してしまう。この frame 数ぶん未使用が続いた resource だけを手放す。
- int get maxFramesInFlight;/// 一つのScene frameへ送るmesh packet / instance batch node総数の上限。
+ int get maxFramesInFlight;/// Sprite atlas/topology/policy batchesのcaller-owned上限。
+ MapSpriteRendererLimits get spriteRendererLimits;/// 一つのScene frameへ送るmesh packet / instance batch node総数の上限。
  int get maxSceneNodeCount;
 /// Create a copy of MapBaseLayerLimits
 /// with the given fields replaced by the non-null parameter values.
@@ -71,16 +72,16 @@ $MapBaseLayerLimitsCopyWith<MapBaseLayerLimits> get copyWith => _$MapBaseLayerLi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MapBaseLayerLimits&&(identical(other.minZoom, minZoom) || other.minZoom == minZoom)&&(identical(other.maxZoom, maxZoom) || other.maxZoom == maxZoom)&&(identical(other.pmTilesLimits, pmTilesLimits) || other.pmTilesLimits == pmTilesLimits)&&(identical(other.decodeLimits, decodeLimits) || other.decodeLimits == decodeLimits)&&(identical(other.maxCachedTileGeometries, maxCachedTileGeometries) || other.maxCachedTileGeometries == maxCachedTileGeometries)&&(identical(other.maxParentFallbackSteps, maxParentFallbackSteps) || other.maxParentFallbackSteps == maxParentFallbackSteps)&&(identical(other.maxInFlightDecodes, maxInFlightDecodes) || other.maxInFlightDecodes == maxInFlightDecodes)&&(identical(other.maxFramesInFlight, maxFramesInFlight) || other.maxFramesInFlight == maxFramesInFlight)&&(identical(other.maxSceneNodeCount, maxSceneNodeCount) || other.maxSceneNodeCount == maxSceneNodeCount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MapBaseLayerLimits&&(identical(other.minZoom, minZoom) || other.minZoom == minZoom)&&(identical(other.maxZoom, maxZoom) || other.maxZoom == maxZoom)&&(identical(other.pmTilesLimits, pmTilesLimits) || other.pmTilesLimits == pmTilesLimits)&&(identical(other.decodeLimits, decodeLimits) || other.decodeLimits == decodeLimits)&&(identical(other.maxCachedTileGeometries, maxCachedTileGeometries) || other.maxCachedTileGeometries == maxCachedTileGeometries)&&(identical(other.maxParentFallbackSteps, maxParentFallbackSteps) || other.maxParentFallbackSteps == maxParentFallbackSteps)&&(identical(other.maxInFlightDecodes, maxInFlightDecodes) || other.maxInFlightDecodes == maxInFlightDecodes)&&(identical(other.maxFramesInFlight, maxFramesInFlight) || other.maxFramesInFlight == maxFramesInFlight)&&(identical(other.spriteRendererLimits, spriteRendererLimits) || other.spriteRendererLimits == spriteRendererLimits)&&(identical(other.maxSceneNodeCount, maxSceneNodeCount) || other.maxSceneNodeCount == maxSceneNodeCount));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,minZoom,maxZoom,pmTilesLimits,decodeLimits,maxCachedTileGeometries,maxParentFallbackSteps,maxInFlightDecodes,maxFramesInFlight,maxSceneNodeCount);
+int get hashCode => Object.hash(runtimeType,minZoom,maxZoom,pmTilesLimits,decodeLimits,maxCachedTileGeometries,maxParentFallbackSteps,maxInFlightDecodes,maxFramesInFlight,spriteRendererLimits,maxSceneNodeCount);
 
 @override
 String toString() {
-  return 'MapBaseLayerLimits(minZoom: $minZoom, maxZoom: $maxZoom, pmTilesLimits: $pmTilesLimits, decodeLimits: $decodeLimits, maxCachedTileGeometries: $maxCachedTileGeometries, maxParentFallbackSteps: $maxParentFallbackSteps, maxInFlightDecodes: $maxInFlightDecodes, maxFramesInFlight: $maxFramesInFlight, maxSceneNodeCount: $maxSceneNodeCount)';
+  return 'MapBaseLayerLimits(minZoom: $minZoom, maxZoom: $maxZoom, pmTilesLimits: $pmTilesLimits, decodeLimits: $decodeLimits, maxCachedTileGeometries: $maxCachedTileGeometries, maxParentFallbackSteps: $maxParentFallbackSteps, maxInFlightDecodes: $maxInFlightDecodes, maxFramesInFlight: $maxFramesInFlight, spriteRendererLimits: $spriteRendererLimits, maxSceneNodeCount: $maxSceneNodeCount)';
 }
 
 
@@ -91,7 +92,7 @@ abstract mixin class $MapBaseLayerLimitsCopyWith<$Res>  {
   factory $MapBaseLayerLimitsCopyWith(MapBaseLayerLimits value, $Res Function(MapBaseLayerLimits) _then) = _$MapBaseLayerLimitsCopyWithImpl;
 @useResult
 $Res call({
- int minZoom, int maxZoom, PmTilesV3Limits pmTilesLimits, BaseMapTileDecodeLimits decodeLimits, int maxCachedTileGeometries, int maxParentFallbackSteps, int maxInFlightDecodes, int maxFramesInFlight, int maxSceneNodeCount
+ int minZoom, int maxZoom, PmTilesV3Limits pmTilesLimits, BaseMapTileDecodeLimits decodeLimits, int maxCachedTileGeometries, int maxParentFallbackSteps, int maxInFlightDecodes, int maxFramesInFlight, MapSpriteRendererLimits spriteRendererLimits, int maxSceneNodeCount
 });
 
 
@@ -108,7 +109,7 @@ class _$MapBaseLayerLimitsCopyWithImpl<$Res>
 
 /// Create a copy of MapBaseLayerLimits
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? minZoom = null,Object? maxZoom = null,Object? pmTilesLimits = null,Object? decodeLimits = null,Object? maxCachedTileGeometries = null,Object? maxParentFallbackSteps = null,Object? maxInFlightDecodes = null,Object? maxFramesInFlight = null,Object? maxSceneNodeCount = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? minZoom = null,Object? maxZoom = null,Object? pmTilesLimits = null,Object? decodeLimits = null,Object? maxCachedTileGeometries = null,Object? maxParentFallbackSteps = null,Object? maxInFlightDecodes = null,Object? maxFramesInFlight = null,Object? spriteRendererLimits = null,Object? maxSceneNodeCount = null,}) {
   return _then(MapBaseLayerLimits(
 minZoom: null == minZoom ? _self.minZoom : minZoom // ignore: cast_nullable_to_non_nullable
 as int,maxZoom: null == maxZoom ? _self.maxZoom : maxZoom // ignore: cast_nullable_to_non_nullable
@@ -118,7 +119,8 @@ as BaseMapTileDecodeLimits,maxCachedTileGeometries: null == maxCachedTileGeometr
 as int,maxParentFallbackSteps: null == maxParentFallbackSteps ? _self.maxParentFallbackSteps : maxParentFallbackSteps // ignore: cast_nullable_to_non_nullable
 as int,maxInFlightDecodes: null == maxInFlightDecodes ? _self.maxInFlightDecodes : maxInFlightDecodes // ignore: cast_nullable_to_non_nullable
 as int,maxFramesInFlight: null == maxFramesInFlight ? _self.maxFramesInFlight : maxFramesInFlight // ignore: cast_nullable_to_non_nullable
-as int,maxSceneNodeCount: null == maxSceneNodeCount ? _self.maxSceneNodeCount : maxSceneNodeCount // ignore: cast_nullable_to_non_nullable
+as int,spriteRendererLimits: null == spriteRendererLimits ? _self.spriteRendererLimits : spriteRendererLimits // ignore: cast_nullable_to_non_nullable
+as MapSpriteRendererLimits,maxSceneNodeCount: null == maxSceneNodeCount ? _self.maxSceneNodeCount : maxSceneNodeCount // ignore: cast_nullable_to_non_nullable
 as int,
   ));
 }
@@ -222,10 +224,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int minZoom,  int maxZoom,  PmTilesV3Limits pmTilesLimits,  BaseMapTileDecodeLimits decodeLimits,  int maxCachedTileGeometries,  int maxParentFallbackSteps,  int maxInFlightDecodes,  int maxFramesInFlight,  int maxSceneNodeCount)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int minZoom,  int maxZoom,  PmTilesV3Limits pmTilesLimits,  BaseMapTileDecodeLimits decodeLimits,  int maxCachedTileGeometries,  int maxParentFallbackSteps,  int maxInFlightDecodes,  int maxFramesInFlight,  MapSpriteRendererLimits spriteRendererLimits,  int maxSceneNodeCount)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _MapBaseLayerLimits() when $default != null:
-return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimits,_that.maxCachedTileGeometries,_that.maxParentFallbackSteps,_that.maxInFlightDecodes,_that.maxFramesInFlight,_that.maxSceneNodeCount);case _:
+return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimits,_that.maxCachedTileGeometries,_that.maxParentFallbackSteps,_that.maxInFlightDecodes,_that.maxFramesInFlight,_that.spriteRendererLimits,_that.maxSceneNodeCount);case _:
   return orElse();
 
 }
@@ -243,10 +245,10 @@ return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimi
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int minZoom,  int maxZoom,  PmTilesV3Limits pmTilesLimits,  BaseMapTileDecodeLimits decodeLimits,  int maxCachedTileGeometries,  int maxParentFallbackSteps,  int maxInFlightDecodes,  int maxFramesInFlight,  int maxSceneNodeCount)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int minZoom,  int maxZoom,  PmTilesV3Limits pmTilesLimits,  BaseMapTileDecodeLimits decodeLimits,  int maxCachedTileGeometries,  int maxParentFallbackSteps,  int maxInFlightDecodes,  int maxFramesInFlight,  MapSpriteRendererLimits spriteRendererLimits,  int maxSceneNodeCount)  $default,) {final _that = this;
 switch (_that) {
 case _MapBaseLayerLimits():
-return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimits,_that.maxCachedTileGeometries,_that.maxParentFallbackSteps,_that.maxInFlightDecodes,_that.maxFramesInFlight,_that.maxSceneNodeCount);case _:
+return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimits,_that.maxCachedTileGeometries,_that.maxParentFallbackSteps,_that.maxInFlightDecodes,_that.maxFramesInFlight,_that.spriteRendererLimits,_that.maxSceneNodeCount);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -263,10 +265,10 @@ return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimi
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int minZoom,  int maxZoom,  PmTilesV3Limits pmTilesLimits,  BaseMapTileDecodeLimits decodeLimits,  int maxCachedTileGeometries,  int maxParentFallbackSteps,  int maxInFlightDecodes,  int maxFramesInFlight,  int maxSceneNodeCount)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int minZoom,  int maxZoom,  PmTilesV3Limits pmTilesLimits,  BaseMapTileDecodeLimits decodeLimits,  int maxCachedTileGeometries,  int maxParentFallbackSteps,  int maxInFlightDecodes,  int maxFramesInFlight,  MapSpriteRendererLimits spriteRendererLimits,  int maxSceneNodeCount)?  $default,) {final _that = this;
 switch (_that) {
 case _MapBaseLayerLimits() when $default != null:
-return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimits,_that.maxCachedTileGeometries,_that.maxParentFallbackSteps,_that.maxInFlightDecodes,_that.maxFramesInFlight,_that.maxSceneNodeCount);case _:
+return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimits,_that.maxCachedTileGeometries,_that.maxParentFallbackSteps,_that.maxInFlightDecodes,_that.maxFramesInFlight,_that.spriteRendererLimits,_that.maxSceneNodeCount);case _:
   return null;
 
 }
@@ -278,7 +280,7 @@ return $default(_that.minZoom,_that.maxZoom,_that.pmTilesLimits,_that.decodeLimi
 
 
 class _MapBaseLayerLimits implements MapBaseLayerLimits {
-  const _MapBaseLayerLimits({required this.minZoom, required this.maxZoom, required this.pmTilesLimits, required this.decodeLimits, required this.maxCachedTileGeometries, required this.maxParentFallbackSteps, required this.maxInFlightDecodes, required this.maxFramesInFlight, required this.maxSceneNodeCount});
+  const _MapBaseLayerLimits({required this.minZoom, required this.maxZoom, required this.pmTilesLimits, required this.decodeLimits, required this.maxCachedTileGeometries, required this.maxParentFallbackSteps, required this.maxInFlightDecodes, required this.maxFramesInFlight, required this.spriteRendererLimits, required this.maxSceneNodeCount});
   
 
 /// pan/pinch zoom gestureが許すcamera zoomの下限、および
@@ -333,6 +335,8 @@ class _MapBaseLayerLimits implements MapBaseLayerLimits {
 /// 落とすと、まだ in-flight の frame が参照している最中に GC 対象へ
 /// してしまう。この frame 数ぶん未使用が続いた resource だけを手放す。
 @override final  int maxFramesInFlight;
+/// Sprite atlas/topology/policy batchesのcaller-owned上限。
+@override final  MapSpriteRendererLimits spriteRendererLimits;
 /// 一つのScene frameへ送るmesh packet / instance batch node総数の上限。
 @override final  int maxSceneNodeCount;
 
@@ -346,16 +350,16 @@ _$MapBaseLayerLimitsCopyWith<_MapBaseLayerLimits> get copyWith => __$MapBaseLaye
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MapBaseLayerLimits&&(identical(other.minZoom, minZoom) || other.minZoom == minZoom)&&(identical(other.maxZoom, maxZoom) || other.maxZoom == maxZoom)&&(identical(other.pmTilesLimits, pmTilesLimits) || other.pmTilesLimits == pmTilesLimits)&&(identical(other.decodeLimits, decodeLimits) || other.decodeLimits == decodeLimits)&&(identical(other.maxCachedTileGeometries, maxCachedTileGeometries) || other.maxCachedTileGeometries == maxCachedTileGeometries)&&(identical(other.maxParentFallbackSteps, maxParentFallbackSteps) || other.maxParentFallbackSteps == maxParentFallbackSteps)&&(identical(other.maxInFlightDecodes, maxInFlightDecodes) || other.maxInFlightDecodes == maxInFlightDecodes)&&(identical(other.maxFramesInFlight, maxFramesInFlight) || other.maxFramesInFlight == maxFramesInFlight)&&(identical(other.maxSceneNodeCount, maxSceneNodeCount) || other.maxSceneNodeCount == maxSceneNodeCount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MapBaseLayerLimits&&(identical(other.minZoom, minZoom) || other.minZoom == minZoom)&&(identical(other.maxZoom, maxZoom) || other.maxZoom == maxZoom)&&(identical(other.pmTilesLimits, pmTilesLimits) || other.pmTilesLimits == pmTilesLimits)&&(identical(other.decodeLimits, decodeLimits) || other.decodeLimits == decodeLimits)&&(identical(other.maxCachedTileGeometries, maxCachedTileGeometries) || other.maxCachedTileGeometries == maxCachedTileGeometries)&&(identical(other.maxParentFallbackSteps, maxParentFallbackSteps) || other.maxParentFallbackSteps == maxParentFallbackSteps)&&(identical(other.maxInFlightDecodes, maxInFlightDecodes) || other.maxInFlightDecodes == maxInFlightDecodes)&&(identical(other.maxFramesInFlight, maxFramesInFlight) || other.maxFramesInFlight == maxFramesInFlight)&&(identical(other.spriteRendererLimits, spriteRendererLimits) || other.spriteRendererLimits == spriteRendererLimits)&&(identical(other.maxSceneNodeCount, maxSceneNodeCount) || other.maxSceneNodeCount == maxSceneNodeCount));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,minZoom,maxZoom,pmTilesLimits,decodeLimits,maxCachedTileGeometries,maxParentFallbackSteps,maxInFlightDecodes,maxFramesInFlight,maxSceneNodeCount);
+int get hashCode => Object.hash(runtimeType,minZoom,maxZoom,pmTilesLimits,decodeLimits,maxCachedTileGeometries,maxParentFallbackSteps,maxInFlightDecodes,maxFramesInFlight,spriteRendererLimits,maxSceneNodeCount);
 
 @override
 String toString() {
-  return 'MapBaseLayerLimits(minZoom: $minZoom, maxZoom: $maxZoom, pmTilesLimits: $pmTilesLimits, decodeLimits: $decodeLimits, maxCachedTileGeometries: $maxCachedTileGeometries, maxParentFallbackSteps: $maxParentFallbackSteps, maxInFlightDecodes: $maxInFlightDecodes, maxFramesInFlight: $maxFramesInFlight, maxSceneNodeCount: $maxSceneNodeCount)';
+  return 'MapBaseLayerLimits(minZoom: $minZoom, maxZoom: $maxZoom, pmTilesLimits: $pmTilesLimits, decodeLimits: $decodeLimits, maxCachedTileGeometries: $maxCachedTileGeometries, maxParentFallbackSteps: $maxParentFallbackSteps, maxInFlightDecodes: $maxInFlightDecodes, maxFramesInFlight: $maxFramesInFlight, spriteRendererLimits: $spriteRendererLimits, maxSceneNodeCount: $maxSceneNodeCount)';
 }
 
 
@@ -366,7 +370,7 @@ abstract mixin class _$MapBaseLayerLimitsCopyWith<$Res> implements $MapBaseLayer
   factory _$MapBaseLayerLimitsCopyWith(_MapBaseLayerLimits value, $Res Function(_MapBaseLayerLimits) _then) = __$MapBaseLayerLimitsCopyWithImpl;
 @override @useResult
 $Res call({
- int minZoom, int maxZoom, PmTilesV3Limits pmTilesLimits, BaseMapTileDecodeLimits decodeLimits, int maxCachedTileGeometries, int maxParentFallbackSteps, int maxInFlightDecodes, int maxFramesInFlight, int maxSceneNodeCount
+ int minZoom, int maxZoom, PmTilesV3Limits pmTilesLimits, BaseMapTileDecodeLimits decodeLimits, int maxCachedTileGeometries, int maxParentFallbackSteps, int maxInFlightDecodes, int maxFramesInFlight, MapSpriteRendererLimits spriteRendererLimits, int maxSceneNodeCount
 });
 
 
@@ -383,7 +387,7 @@ class __$MapBaseLayerLimitsCopyWithImpl<$Res>
 
 /// Create a copy of MapBaseLayerLimits
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? minZoom = null,Object? maxZoom = null,Object? pmTilesLimits = null,Object? decodeLimits = null,Object? maxCachedTileGeometries = null,Object? maxParentFallbackSteps = null,Object? maxInFlightDecodes = null,Object? maxFramesInFlight = null,Object? maxSceneNodeCount = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? minZoom = null,Object? maxZoom = null,Object? pmTilesLimits = null,Object? decodeLimits = null,Object? maxCachedTileGeometries = null,Object? maxParentFallbackSteps = null,Object? maxInFlightDecodes = null,Object? maxFramesInFlight = null,Object? spriteRendererLimits = null,Object? maxSceneNodeCount = null,}) {
   return _then(_MapBaseLayerLimits(
 minZoom: null == minZoom ? _self.minZoom : minZoom // ignore: cast_nullable_to_non_nullable
 as int,maxZoom: null == maxZoom ? _self.maxZoom : maxZoom // ignore: cast_nullable_to_non_nullable
@@ -393,7 +397,8 @@ as BaseMapTileDecodeLimits,maxCachedTileGeometries: null == maxCachedTileGeometr
 as int,maxParentFallbackSteps: null == maxParentFallbackSteps ? _self.maxParentFallbackSteps : maxParentFallbackSteps // ignore: cast_nullable_to_non_nullable
 as int,maxInFlightDecodes: null == maxInFlightDecodes ? _self.maxInFlightDecodes : maxInFlightDecodes // ignore: cast_nullable_to_non_nullable
 as int,maxFramesInFlight: null == maxFramesInFlight ? _self.maxFramesInFlight : maxFramesInFlight // ignore: cast_nullable_to_non_nullable
-as int,maxSceneNodeCount: null == maxSceneNodeCount ? _self.maxSceneNodeCount : maxSceneNodeCount // ignore: cast_nullable_to_non_nullable
+as int,spriteRendererLimits: null == spriteRendererLimits ? _self.spriteRendererLimits : spriteRendererLimits // ignore: cast_nullable_to_non_nullable
+as MapSpriteRendererLimits,maxSceneNodeCount: null == maxSceneNodeCount ? _self.maxSceneNodeCount : maxSceneNodeCount // ignore: cast_nullable_to_non_nullable
 as int,
   ));
 }

--- a/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
@@ -1095,6 +1095,9 @@ void main() {
   });
 
   test('frame-submit probe rolls back once then allows the next frame', () {
+    if (!mapGpuProbeCompileTimeEnabled) {
+      return;
+    }
     final batch = spriteBatch(spriteFrame: frame);
     final value = MapSceneFrameSubmission(
       frame: frame,

--- a/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/flutter_scene_map_adapter_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_map_adapter.dart';
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
 import 'package:eqmonitor_map/src/foundation/map_node_identity.dart';
@@ -16,12 +17,17 @@ import 'package:eqmonitor_map/src/geo/map_viewport.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh.dart';
 import 'package:eqmonitor_map/src/overlay/earthquake_map_overlay_snapshot.dart';
 import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
+import 'package:eqmonitor_map/src/overlay/map_point_sprite_feature.dart';
+import 'package:eqmonitor_map/src/overlay/map_sprite_atlas.dart';
+import 'package:eqmonitor_map/src/overlay/map_zoom_scalar_policy.dart';
 import 'package:eqmonitor_map/src/renderer/base_map_packed_mesh.dart';
 import 'package:eqmonitor_map/src/renderer/base_map_render_submission_builder.dart';
 import 'package:eqmonitor_map/src/renderer/earthquake_area_render_submission_builder.dart';
 import 'package:eqmonitor_map/src/renderer/map_render_batch_adapter.dart';
 import 'package:eqmonitor_map/src/renderer/map_scene_frame_submission.dart';
 import 'package:eqmonitor_map/src/renderer/map_scene_render_phase_policy.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch_builder.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch.dart';
 import 'package:eqmonitor_map/src/renderer/observation_point_batch_builder.dart';
 import 'package:flutter_scene/scene.dart' as scene;
@@ -110,6 +116,70 @@ final class _TestObservationMaterialBinding
       bytes,
       stage: scene.ShaderStage.vertex,
     );
+  }
+}
+
+final class _TestSpritePreparedFrame
+    implements FlutterSceneSpritePreparedSceneFrame {
+  _TestSpritePreparedFrame({required this.nodes});
+
+  @override
+  final List<FlutterSceneSpritePreparedSceneNode> nodes;
+
+  var _commitCount = 0;
+  var _rollbackCount = 0;
+
+  int get commitCount => _commitCount;
+  int get rollbackCount => _rollbackCount;
+
+  @override
+  void commit() {
+    _commitCount++;
+  }
+
+  @override
+  void rollback() {
+    _rollbackCount++;
+  }
+}
+
+final class _TestSpriteFrameResources
+    implements FlutterSceneSpriteFrameResources {
+  _TestSpriteFrameResources({this.prepareError});
+
+  final Error? prepareError;
+  _TestSpritePreparedFrame? prepared;
+  final preparedFrames = <_TestSpritePreparedFrame>[];
+  var _retireAllCount = 0;
+
+  int get retireAllCount => _retireAllCount;
+
+  @override
+  FlutterSceneSpritePreparedSceneFrame prepareFrame({
+    required MapFrameSnapshot frame,
+    required List<MapPointSpriteInstanceBatch> batches,
+  }) {
+    final error = prepareError;
+    if (error != null) {
+      throw error;
+    }
+    final value = _TestSpritePreparedFrame(
+      nodes: [
+        for (final batch in batches)
+          FlutterSceneSpritePreparedSceneNode(
+            batch: batch,
+            node: scene.Node(),
+          ),
+      ],
+    );
+    prepared = value;
+    preparedFrames.add(value);
+    return value;
+  }
+
+  @override
+  void retireAll() {
+    _retireAllCount++;
   }
 }
 
@@ -259,6 +329,56 @@ void main() {
     renderGeneration: sequence,
     renderDigest: 'render-$sequence',
   );
+
+  MapPointSpriteInstanceBatch spriteBatch({
+    required MapFrameSnapshot spriteFrame,
+  }) {
+    final atlas = createMapSpriteAtlas(
+      identity: createMapSourceIdentity(value: 'sprite-atlas'),
+      width: 4,
+      height: 4,
+      rgbaBytes: Uint8List(64),
+      regions: const [
+        MapSpriteRegion(
+          id: 'hypocenter',
+          normalizedUv: Rect.fromLTRB(0.125, 0.125, 0.375, 0.375),
+          logicalSize: Size(24, 24),
+        ),
+      ],
+      limits: const MapSpriteAtlasLimits(
+        maxWidth: 4,
+        maxHeight: 4,
+        maxPixelBytes: 64,
+        maxRegions: 1,
+      ),
+    );
+    return buildMapPointSpriteBatches(
+      frame: spriteFrame,
+      versionStamp: stampOf(1),
+      atlas: atlas,
+      features: [
+        createMapPointSpriteFeature(
+          id: 'hypocenter:event-1',
+          longitude: 139.7,
+          latitude: 35.7,
+          spriteRegionId: 'hypocenter',
+          sizeScale: createMapZoomLinearRange(
+            startZoom: 3,
+            startValue: 0.5,
+            endZoom: 20,
+            endValue: 1.5,
+          ),
+          opacity: createMapZoomStep(
+            thresholdZoom: 5,
+            belowValue: 0,
+            atOrAboveValue: 1,
+          ),
+          priority: 1,
+        ),
+      ],
+      maxPolicyBatches: 1,
+    ).single;
+  }
 
   MapSceneMeshLayerSubmission meshLayer({
     required MapSceneComponentKey componentKey,
@@ -756,6 +876,7 @@ void main() {
                   '${layer.batch.compatibility.batchKey.materialKey}:'
                       '$packetIndex',
                 FlutterSceneObservationNodePlan() => 'observation',
+                FlutterSceneSpriteNodePlan() => 'sprite',
               },
             ),
         ],
@@ -870,7 +991,7 @@ void main() {
     expect(adapter.liveGeometryCount, 0);
   });
 
-  test('rejects an unimplemented point sprite kind with a typed failure', () {
+  test('rejects a wrong point sprite batch type with a typed failure', () {
     final spritePhase = mapSceneRenderPhasePolicy.rankOf(
       mapSceneSpritePhaseId,
     );
@@ -900,10 +1021,126 @@ void main() {
         isA<FlutterSceneLayerPreflightFailure>().having(
           (error) => error.reason,
           'reason',
-          FlutterSceneLayerPreflightFailureReason.unsupportedInstanceKind,
+          FlutterSceneLayerPreflightFailureReason.instanceBatchTypeMismatch,
         ),
       ),
     );
+  });
+
+  test('prepares and commits sprite nodes only after Scene replacement', () {
+    final batch = spriteBatch(spriteFrame: frame);
+    final value = MapSceneFrameSubmission(
+      frame: frame,
+      layers: [
+        MapSceneInstanceLayerSubmission(
+          logicalSourceKey: mapSceneEarthquakeHistorySourceKey,
+          componentKey: mapSceneHypocenterSpriteComponentKey,
+          overlayVersion: batch.versionStamp,
+          orderWithinPhase: 0,
+          kind: MapSceneInstanceLayerKind.pointSprite,
+          batch: batch,
+        ),
+      ],
+      limits: MapSceneFrameLimits(maxNodeCount: 1),
+    );
+    final sceneGraph = _RecordingSceneGraph()..add(scene.Node());
+    final sprites = _TestSpriteFrameResources();
+    final adapter = FlutterSceneMapAdapter(
+      sceneGraph: sceneGraph,
+      materialFor: (_) => null,
+      maxFramesInFlight: 2,
+      spriteResources: sprites,
+    );
+
+    adapter.submitFrame(submission: value);
+
+    expect(sceneGraph.children, hasLength(1));
+    expect(sceneGraph.children.single.translucentSortPriority, 0);
+    expect(sprites.prepared?.commitCount, 1);
+    expect(sprites.prepared?.rollbackCount, 0);
+  });
+
+  test('sprite prepare failure leaves the current Scene untouched', () {
+    final batch = spriteBatch(spriteFrame: frame);
+    final value = MapSceneFrameSubmission(
+      frame: frame,
+      layers: [
+        MapSceneInstanceLayerSubmission(
+          logicalSourceKey: mapSceneEarthquakeHistorySourceKey,
+          componentKey: mapSceneHypocenterSpriteComponentKey,
+          overlayVersion: batch.versionStamp,
+          orderWithinPhase: 0,
+          kind: MapSceneInstanceLayerKind.pointSprite,
+          batch: batch,
+        ),
+      ],
+      limits: MapSceneFrameLimits(maxNodeCount: 1),
+    );
+    final existing = scene.Node();
+    final sceneGraph = _RecordingSceneGraph()..add(existing);
+    final adapter = FlutterSceneMapAdapter(
+      sceneGraph: sceneGraph,
+      materialFor: (_) => null,
+      maxFramesInFlight: 2,
+      spriteResources: _TestSpriteFrameResources(
+        prepareError: StateError('sprite prepare'),
+      ),
+    );
+
+    expect(
+      () => adapter.submitFrame(submission: value),
+      throwsA(isA<StateError>()),
+    );
+    expect(sceneGraph.children, [same(existing)]);
+  });
+
+  test('frame-submit probe rolls back once then allows the next frame', () {
+    final batch = spriteBatch(spriteFrame: frame);
+    final value = MapSceneFrameSubmission(
+      frame: frame,
+      layers: [
+        MapSceneInstanceLayerSubmission(
+          logicalSourceKey: mapSceneEarthquakeHistorySourceKey,
+          componentKey: mapSceneHypocenterSpriteComponentKey,
+          overlayVersion: batch.versionStamp,
+          orderWithinPhase: 0,
+          kind: MapSceneInstanceLayerKind.pointSprite,
+          batch: batch,
+        ),
+      ],
+      limits: MapSceneFrameLimits(maxNodeCount: 1),
+    );
+    final existing = scene.Node();
+    final sceneGraph = _RecordingSceneGraph()..add(existing);
+    final sprites = _TestSpriteFrameResources();
+    final adapter = FlutterSceneMapAdapter(
+      sceneGraph: sceneGraph,
+      materialFor: (_) => null,
+      maxFramesInFlight: 2,
+      spriteResources: sprites,
+      gpuProbeRuntime: MapGpuProbeRuntime(
+        configuration: const MapGpuProbeConfiguration(
+          faultPoint: MapGpuFaultPoint.frameSubmit,
+          atlasFixture: MapSpriteAtlasProbeFixture.production,
+        ),
+      ),
+    );
+
+    expect(
+      () => adapter.submitFrame(submission: value),
+      throwsA(
+        isA<MapGpuProbeFault>().having(
+          (fault) => fault.point,
+          'point',
+          MapGpuFaultPoint.frameSubmit,
+        ),
+      ),
+    );
+    expect(sceneGraph.children, [same(existing)]);
+    expect(sprites.preparedFrames.first.rollbackCount, 1);
+    adapter.submitFrame(submission: value);
+    expect(sprites.preparedFrames.last.commitCount, 1);
+    expect(sceneGraph.children, hasLength(1));
   });
 
   test('base builder uses the same phase policy as earthquake fill', () {

--- a/packages/eqmonitor_map/test/flutter_scene/flutter_scene_sprite_resource_owner_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/flutter_scene_sprite_resource_owner_test.dart
@@ -1,0 +1,591 @@
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_sprite_resource_owner.dart';
+import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
+import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
+import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
+import 'package:eqmonitor_map/src/geo/map_camera.dart';
+import 'package:eqmonitor_map/src/geo/map_viewport.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
+import 'package:eqmonitor_map/src/overlay/map_point_sprite_feature.dart';
+import 'package:eqmonitor_map/src/overlay/map_sprite_atlas.dart';
+import 'package:eqmonitor_map/src/overlay/map_zoom_scalar_policy.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
+import 'package:eqmonitor_map/src/renderer/map_sprite_batch_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final clock = SystemMapClock.start(
+    domain: createMapClockDomainId(value: 'sprite-resource-owner-test'),
+  );
+  final sizePolicy = createMapZoomLinearRange(
+    startZoom: 3,
+    startValue: 0.5,
+    endZoom: 20,
+    endValue: 1.5,
+  );
+  final secondSizePolicy = createMapZoomLinearRange(
+    startZoom: 4,
+    startValue: 0.75,
+    endZoom: 18,
+    endValue: 1.25,
+  );
+  final opacityPolicy = createMapZoomStep(
+    thresholdZoom: 5,
+    belowValue: 0,
+    atOrAboveValue: 1,
+  );
+
+  MapFrameSnapshot frame({
+    required int number,
+    int contextGeneration = 0,
+    double longitude = 139.7,
+  }) => captureMapFrameSnapshot(
+    clock: clock,
+    frameNumber: number,
+    camera: MapCamera(
+      centerLongitude: longitude,
+      centerLatitude: 35.7,
+      zoom: 6,
+    ),
+    viewport: MapViewport(
+      logicalSize: const Size(400, 800),
+      devicePixelRatio: 3,
+    ),
+    revisions: const [],
+    lifecycle: MapAppLifecycle.active,
+    contextGeneration: contextGeneration,
+  );
+
+  MapSpriteAtlas atlas(String identity) => createMapSpriteAtlas(
+    identity: createMapSourceIdentity(value: identity),
+    width: 4,
+    height: 4,
+    rgbaBytes: Uint8List(64),
+    regions: const [
+      MapSpriteRegion(
+        id: 'normal',
+        normalizedUv: Rect.fromLTRB(0.125, 0.125, 0.375, 0.375),
+        logicalSize: Size(24, 32),
+      ),
+    ],
+    limits: const MapSpriteAtlasLimits(
+      maxWidth: 4,
+      maxHeight: 4,
+      maxPixelBytes: 64,
+      maxRegions: 1,
+    ),
+  );
+
+  MapOverlayVersionStamp stamp(int generation) => createMapOverlayVersionStamp(
+    sourceIdentity: createMapSourceIdentity(value: 'event'),
+    sourceIncarnation: createMapSourceIncarnation(value: 'incarnation'),
+    dataSequence: generation,
+    dataDigest: 'data-$generation',
+    renderGeneration: generation,
+    renderDigest: 'render-$generation',
+  );
+
+  List<MapPointSpriteInstanceBatch> batches({
+    required MapFrameSnapshot frame,
+    required MapSpriteAtlas atlas,
+    required int generation,
+    int priority = 0,
+    bool twoPolicies = false,
+    List<MapPointSpriteInstanceBatch> previous = const [],
+  }) => buildMapPointSpriteBatches(
+    frame: frame,
+    versionStamp: stamp(generation),
+    atlas: atlas,
+    features: [
+      createMapPointSpriteFeature(
+        id: 'a',
+        longitude: 139.7,
+        latitude: 35.7,
+        spriteRegionId: 'normal',
+        sizeScale: sizePolicy,
+        opacity: opacityPolicy,
+        priority: priority,
+      ),
+      if (twoPolicies)
+        createMapPointSpriteFeature(
+          id: 'b',
+          longitude: 140,
+          latitude: 36,
+          spriteRegionId: 'normal',
+          sizeScale: secondSizePolicy,
+          opacity: opacityPolicy,
+          priority: 1,
+        ),
+    ],
+    maxPolicyBatches: twoPolicies ? 2 : 1,
+    previous: previous,
+  );
+
+  test('reuses texture topology and camera-only instance resources', () {
+    final backend = _FakeSpriteBackend();
+    final completions = <Completer<void>>[];
+    final owner = _owner(
+      backend: backend,
+      maxFramesInFlight: 2,
+      maxActiveAtlases: 1,
+      maxTopologyVariants: 1,
+      maxPolicyBatches: 2,
+      completions: completions,
+    );
+    final spriteAtlas = atlas('sha256:atlas-a');
+    final firstFrame = frame(number: 0);
+    final firstBatches = batches(
+      frame: firstFrame,
+      atlas: spriteAtlas,
+      generation: 1,
+    );
+    owner.prepareFrame(frame: firstFrame, batches: firstBatches).commit();
+    final secondFrame = frame(number: 1, longitude: 140);
+    final cameraOnly = batches(
+      frame: secondFrame,
+      atlas: spriteAtlas,
+      generation: 1,
+      previous: firstBatches,
+    );
+    owner.prepareFrame(frame: secondFrame, batches: cameraOnly).commit();
+
+    expect(backend.textureUploads, 1);
+    expect(backend.topologyPrepares, 1);
+    expect(backend.topologyAbiVersions, [mapSpriteInstanceAbiVersion]);
+    expect(backend.instancePrepares, 1);
+    expect(owner.snapshot.texture.active, 1);
+    expect(owner.snapshot.texture.pendingRetire, 1);
+    expect(owner.snapshot.node.active, 1);
+    expect(owner.snapshot.node.pendingRetire, 1);
+
+    completions.single.complete();
+    return pumpEventQueue().then((_) {
+      expect(backend.textureRetires, 0);
+      expect(backend.topologyRetires, 0);
+      expect(backend.instanceRetires, 0);
+      expect(owner.snapshot.texture.pendingRetire, 0);
+    });
+  });
+
+  test(
+    'different batch uploads only instance and shared atlas survives',
+    () async {
+      final backend = _FakeSpriteBackend();
+      final completions = <Completer<void>>[];
+      final owner = _owner(
+        backend: backend,
+        maxFramesInFlight: 2,
+        maxActiveAtlases: 1,
+        maxTopologyVariants: 1,
+        maxPolicyBatches: 2,
+        completions: completions,
+      );
+      final spriteAtlas = atlas('sha256:atlas-a');
+      final firstFrame = frame(number: 0);
+      final first = batches(
+        frame: firstFrame,
+        atlas: spriteAtlas,
+        generation: 1,
+        twoPolicies: true,
+      );
+      owner.prepareFrame(frame: firstFrame, batches: first).commit();
+      final secondFrame = frame(number: 1);
+      final second = batches(
+        frame: secondFrame,
+        atlas: spriteAtlas,
+        generation: 2,
+        priority: 3,
+      );
+      owner.prepareFrame(frame: secondFrame, batches: second).commit();
+
+      expect(backend.textureUploads, 1);
+      expect(backend.topologyPrepares, 1);
+      expect(backend.instancePrepares, 3);
+      expect(owner.snapshot.node.active, 1);
+      expect(owner.snapshot.node.pendingRetire, 2);
+
+      completions.single.complete();
+      await pumpEventQueue();
+      expect(backend.textureRetires, 0);
+      expect(backend.topologyRetires, 0);
+      expect(backend.instanceRetires, 2);
+      expect(owner.snapshot.instance.active, 1);
+    },
+  );
+
+  test('preflight upload and prepare failures rollback before commit', () {
+    for (final failure in _FakeFailurePoint.values) {
+      final backend = _FakeSpriteBackend(failurePoint: failure);
+      final owner = _owner(
+        backend: backend,
+        maxFramesInFlight: 1,
+        maxActiveAtlases: 1,
+        maxTopologyVariants: 1,
+        maxPolicyBatches: 1,
+        completions: [],
+      );
+      final candidateFrame = frame(number: 0);
+      final candidateBatches = batches(
+        frame: candidateFrame,
+        atlas: atlas('sha256:$failure'),
+        generation: 1,
+      );
+
+      expect(
+        () => owner.prepareFrame(
+          frame: candidateFrame,
+          batches: candidateBatches,
+        ),
+        throwsA(
+          isA<FlutterSceneSpriteResourceFailure>().having(
+            (failure) => failure.reason,
+            'reason',
+            switch (failure) {
+              _FakeFailurePoint.shaderInterface =>
+                FlutterSceneSpriteResourceFailureReason.shaderInterface,
+              _FakeFailurePoint.atlasUpload =>
+                FlutterSceneSpriteResourceFailureReason.atlasUpload,
+              _FakeFailurePoint.topology =>
+                FlutterSceneSpriteResourceFailureReason.topologyPrepare,
+              _FakeFailurePoint.instance =>
+                FlutterSceneSpriteResourceFailureReason.instancePrepare,
+            },
+          ),
+        ),
+      );
+      expect(owner.snapshot.node.live, 0);
+      expect(owner.snapshot.texture.live, 0);
+      expect(owner.snapshot.topology.live, 0);
+      expect(owner.snapshot.instance.live, 0);
+      expect(backend.liveResources, 0);
+    }
+  });
+
+  test('explicit rollback retires candidate resources exactly once', () {
+    final backend = _FakeSpriteBackend();
+    final owner = _owner(
+      backend: backend,
+      maxFramesInFlight: 1,
+      maxActiveAtlases: 1,
+      maxTopologyVariants: 1,
+      maxPolicyBatches: 1,
+      completions: [],
+    );
+    final candidateFrame = frame(number: 0);
+    final prepared = owner.prepareFrame(
+      frame: candidateFrame,
+      batches: batches(
+        frame: candidateFrame,
+        atlas: atlas('sha256:rollback'),
+        generation: 1,
+      ),
+    );
+
+    prepared.rollback();
+    prepared.rollback();
+    expect(backend.textureRetires, 1);
+    expect(backend.topologyRetires, 1);
+    expect(backend.instanceRetires, 1);
+    expect(backend.liveResources, 0);
+  });
+
+  test('F plus 2 worst case rejects before exceeding resource bounds', () {
+    final backend = _FakeSpriteBackend();
+    final completions = <Completer<void>>[];
+    final owner = _owner(
+      backend: backend,
+      maxFramesInFlight: 2,
+      maxActiveAtlases: 1,
+      maxTopologyVariants: 1,
+      maxPolicyBatches: 1,
+      completions: completions,
+    );
+    for (var number = 0; number < 3; number++) {
+      final currentFrame = frame(
+        number: number,
+        contextGeneration: number,
+      );
+      owner
+          .prepareFrame(
+            frame: currentFrame,
+            batches: batches(
+              frame: currentFrame,
+              atlas: atlas('sha256:atlas-$number'),
+              generation: number + 1,
+            ),
+          )
+          .commit();
+      expect(owner.snapshot.texture.live, lessThanOrEqualTo(3));
+      expect(owner.snapshot.topology.live, lessThanOrEqualTo(3));
+      expect(owner.snapshot.instance.live, lessThanOrEqualTo(3));
+      expect(owner.snapshot.node.pendingRetire, lessThanOrEqualTo(2));
+    }
+    final overflowFrame = frame(number: 3, contextGeneration: 3);
+
+    expect(
+      () => owner.prepareFrame(
+        frame: overflowFrame,
+        batches: batches(
+          frame: overflowFrame,
+          atlas: atlas('sha256:atlas-3'),
+          generation: 4,
+        ),
+      ),
+      throwsA(
+        isA<FlutterSceneSpriteResourceFailure>().having(
+          (failure) => failure.reason,
+          'reason',
+          FlutterSceneSpriteResourceFailureReason.livePinLimitExceeded,
+        ),
+      ),
+    );
+    expect(backend.textureUploads, 3);
+    expect(owner.snapshot.texture.live, 3);
+  });
+
+  test('retire all waits for fence and is idempotent after errors', () async {
+    final backend = _FakeSpriteBackend();
+    final completion = Completer<void>();
+    final owner = FlutterSceneSpriteResourceOwner(
+      limits: const MapSpriteRendererLimits(
+        maxActiveAtlases: 1,
+        maxTopologyVariants: 1,
+        maxPolicyBatches: 1,
+      ),
+      maxFramesInFlight: 1,
+      backend: backend,
+      waitForGpuCompletion: () => completion.future,
+    );
+    final currentFrame = frame(number: 0);
+    owner
+        .prepareFrame(
+          frame: currentFrame,
+          batches: batches(
+            frame: currentFrame,
+            atlas: atlas('sha256:dispose'),
+            generation: 1,
+          ),
+        )
+        .commit();
+
+    owner.retireAll();
+    owner.retireAll();
+    expect(backend.liveResources, 3);
+    completion.completeError(StateError('context lost'));
+    await pumpEventQueue();
+    expect(backend.textureRetires, 1);
+    expect(backend.topologyRetires, 1);
+    expect(backend.instanceRetires, 1);
+    expect(owner.snapshot.node.live, 0);
+  });
+
+  test('nullable probe and callback allocate no debug runtime path', () {
+    final backend = _FakeSpriteBackend();
+    final owner = _owner(
+      backend: backend,
+      maxFramesInFlight: 1,
+      maxActiveAtlases: 1,
+      maxTopologyVariants: 1,
+      maxPolicyBatches: 1,
+      completions: [],
+    );
+
+    expect(owner.probeRuntime, isNull);
+    expect(owner.hasCounterCallback, isFalse);
+  });
+
+  test('caller limits and frames in flight must be positive', () {
+    for (final limits in [
+      const MapSpriteRendererLimits(
+        maxActiveAtlases: 0,
+        maxTopologyVariants: 1,
+        maxPolicyBatches: 1,
+      ),
+      const MapSpriteRendererLimits(
+        maxActiveAtlases: 1,
+        maxTopologyVariants: 0,
+        maxPolicyBatches: 1,
+      ),
+      const MapSpriteRendererLimits(
+        maxActiveAtlases: 1,
+        maxTopologyVariants: 1,
+        maxPolicyBatches: 0,
+      ),
+    ]) {
+      expect(
+        () => FlutterSceneSpriteResourceOwner(
+          limits: limits,
+          maxFramesInFlight: 1,
+          backend: _FakeSpriteBackend(),
+          waitForGpuCompletion: Future<void>.value,
+        ),
+        throwsA(
+          isA<FlutterSceneSpriteResourceFailure>().having(
+            (failure) => failure.reason,
+            'reason',
+            FlutterSceneSpriteResourceFailureReason.invalidLimits,
+          ),
+        ),
+      );
+    }
+    expect(
+      () => FlutterSceneSpriteResourceOwner(
+        limits: const MapSpriteRendererLimits(
+          maxActiveAtlases: 1,
+          maxTopologyVariants: 1,
+          maxPolicyBatches: 1,
+        ),
+        maxFramesInFlight: 0,
+        backend: _FakeSpriteBackend(),
+        waitForGpuCompletion: Future<void>.value,
+      ),
+      throwsA(
+        isA<FlutterSceneSpriteResourceFailure>().having(
+          (failure) => failure.reason,
+          'reason',
+          FlutterSceneSpriteResourceFailureReason.invalidLimits,
+        ),
+      ),
+    );
+  });
+}
+
+FlutterSceneSpriteResourceOwner<_FakeTexture, _FakeTopology, _FakeInstance>
+_owner({
+  required _FakeSpriteBackend backend,
+  required int maxFramesInFlight,
+  required int maxActiveAtlases,
+  required int maxTopologyVariants,
+  required int maxPolicyBatches,
+  required List<Completer<void>> completions,
+}) => FlutterSceneSpriteResourceOwner(
+  limits: MapSpriteRendererLimits(
+    maxActiveAtlases: maxActiveAtlases,
+    maxTopologyVariants: maxTopologyVariants,
+    maxPolicyBatches: maxPolicyBatches,
+  ),
+  maxFramesInFlight: maxFramesInFlight,
+  backend: backend,
+  waitForGpuCompletion: () {
+    final completion = Completer<void>();
+    completions.add(completion);
+    return completion.future;
+  },
+);
+
+enum _FakeFailurePoint { shaderInterface, atlasUpload, topology, instance }
+
+sealed class _FakeResource {
+  _FakeResource() : retired = false;
+
+  bool retired;
+}
+
+final class _FakeTexture extends _FakeResource {}
+
+final class _FakeTopology extends _FakeResource {}
+
+final class _FakeInstance extends _FakeResource {}
+
+final class _FakeSpriteBackend
+    implements
+        FlutterSceneSpriteResourceBackend<
+          _FakeTexture,
+          _FakeTopology,
+          _FakeInstance
+        > {
+  _FakeSpriteBackend({this.failurePoint})
+    : textureUploads = 0,
+      topologyPrepares = 0,
+      instancePrepares = 0,
+      textureRetires = 0,
+      topologyRetires = 0,
+      instanceRetires = 0;
+
+  final _FakeFailurePoint? failurePoint;
+  final resources = <_FakeResource>[];
+  int textureUploads;
+  int topologyPrepares;
+  final topologyAbiVersions = <int>[];
+  int instancePrepares;
+  int textureRetires;
+  int topologyRetires;
+  int instanceRetires;
+
+  int get liveResources =>
+      resources.where((resource) => !resource.retired).length;
+
+  @override
+  void preflightShaderInterface(MapPointSpriteInstanceBatch batch) {
+    if (failurePoint == _FakeFailurePoint.shaderInterface) {
+      throw StateError('shader interface');
+    }
+  }
+
+  @override
+  _FakeTexture uploadTexture(MapSpriteAtlas atlas) {
+    if (failurePoint == _FakeFailurePoint.atlasUpload) {
+      throw StateError('atlas upload');
+    }
+    textureUploads++;
+    final resource = _FakeTexture();
+    resources.add(resource);
+    return resource;
+  }
+
+  @override
+  _FakeTopology prepareTopology({
+    required int spriteAbiVersion,
+    required int materialVersion,
+  }) {
+    if (failurePoint == _FakeFailurePoint.topology) {
+      throw StateError('topology prepare');
+    }
+    topologyPrepares++;
+    topologyAbiVersions.add(spriteAbiVersion);
+    final resource = _FakeTopology();
+    resources.add(resource);
+    return resource;
+  }
+
+  @override
+  _FakeInstance prepareInstance({
+    required _FakeTopology topology,
+    required MapPointSpriteInstanceBatch batch,
+  }) {
+    if (failurePoint == _FakeFailurePoint.instance) {
+      throw StateError('instance prepare');
+    }
+    instancePrepares++;
+    final resource = _FakeInstance();
+    resources.add(resource);
+    return resource;
+  }
+
+  @override
+  void retireTexture(_FakeTexture texture) {
+    if (!texture.retired) {
+      textureRetires++;
+      texture.retired = true;
+    }
+  }
+
+  @override
+  void retireTopology(_FakeTopology topology) {
+    if (!topology.retired) {
+      topologyRetires++;
+      topology.retired = true;
+    }
+  }
+
+  @override
+  void retireInstance(_FakeInstance instance) {
+    if (!instance.retired) {
+      instanceRetires++;
+      instance.retired = true;
+    }
+  }
+}

--- a/packages/eqmonitor_map/test/flutter_scene/flutter_scene_sprite_resource_owner_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/flutter_scene_sprite_resource_owner_test.dart
@@ -320,9 +320,11 @@ void main() {
     expect(backend.instanceRetires, 2);
     expect(backend.topologyRetires, 1);
     expect(backend.textureRetires, 1);
-    expect(owner.snapshot.instance.retires, 2);
-    expect(owner.snapshot.topology.retires, 1);
-    expect(owner.snapshot.texture.retires, 1);
+    if (mapGpuProbeCompileTimeEnabled) {
+      expect(owner.snapshot.instance.retires, 2);
+      expect(owner.snapshot.topology.retires, 1);
+      expect(owner.snapshot.texture.retires, 1);
+    }
   });
 
   test('F plus 2 worst case rejects before exceeding resource bounds', () {
@@ -430,9 +432,52 @@ void main() {
     expect(owner.hasCounterCallback, isFalse);
   });
 
+  test('compile-time disabled owner bypasses probe and counter hot paths', () {
+    if (mapGpuProbeCompileTimeEnabled) {
+      return;
+    }
+    final snapshots = <MapGpuResourceCounterSnapshot>[];
+    final backend = _FakeSpriteBackend();
+    final owner = FlutterSceneSpriteResourceOwner(
+      limits: const MapSpriteRendererLimits(
+        maxActiveAtlases: 1,
+        maxTopologyVariants: 1,
+        maxPolicyBatches: 1,
+      ),
+      maxFramesInFlight: 1,
+      backend: backend,
+      waitForGpuCompletion: Future<void>.value,
+      probeRuntime: MapGpuProbeRuntime(
+        configuration: const MapGpuProbeConfiguration(
+          faultPoint: MapGpuFaultPoint.shaderInterface,
+          atlasFixture: MapSpriteAtlasProbeFixture.production,
+        ),
+      ),
+      onCounterSnapshot: snapshots.add,
+    );
+    final candidateFrame = frame(number: 0);
+
+    final prepared = owner.prepareFrame(
+      frame: candidateFrame,
+      batches: batches(
+        frame: candidateFrame,
+        atlas: atlas('sha256:production-no-probe'),
+        generation: 1,
+      ),
+    );
+    prepared.commit();
+
+    expect(snapshots, isEmpty);
+    expect(owner.snapshot.texture.uploads, 0);
+    expect(owner.snapshot.node.active, 1);
+  });
+
   test(
     'counter callback reports candidate commit and fence retirement states',
     () async {
+      if (!mapGpuProbeCompileTimeEnabled) {
+        return;
+      }
       final snapshots = <MapGpuResourceCounterSnapshot>[];
       final backend = _FakeSpriteBackend();
       final owner = FlutterSceneSpriteResourceOwner(

--- a/packages/eqmonitor_map/test/flutter_scene/flutter_scene_sprite_resource_owner_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/flutter_scene_sprite_resource_owner_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_sprite_resource_owner.dart';
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
 import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
@@ -292,6 +293,38 @@ void main() {
     expect(backend.liveResources, 0);
   });
 
+  test('one retirement failure does not block remaining exact releases', () {
+    final backend = _FakeSpriteBackend(failFirstInstanceRetire: true);
+    final owner = _owner(
+      backend: backend,
+      maxFramesInFlight: 1,
+      maxActiveAtlases: 1,
+      maxTopologyVariants: 1,
+      maxPolicyBatches: 2,
+      completions: [],
+    );
+    final candidateFrame = frame(number: 0);
+    final prepared = owner.prepareFrame(
+      frame: candidateFrame,
+      batches: batches(
+        frame: candidateFrame,
+        atlas: atlas('sha256:retire-failure'),
+        generation: 1,
+        twoPolicies: true,
+      ),
+    );
+
+    prepared.rollback();
+    prepared.rollback();
+
+    expect(backend.instanceRetires, 2);
+    expect(backend.topologyRetires, 1);
+    expect(backend.textureRetires, 1);
+    expect(owner.snapshot.instance.retires, 2);
+    expect(owner.snapshot.topology.retires, 1);
+    expect(owner.snapshot.texture.retires, 1);
+  });
+
   test('F plus 2 worst case rejects before exceeding resource bounds', () {
     final backend = _FakeSpriteBackend();
     final completions = <Completer<void>>[];
@@ -397,6 +430,43 @@ void main() {
     expect(owner.hasCounterCallback, isFalse);
   });
 
+  test(
+    'counter callback reports candidate commit and fence retirement states',
+    () async {
+      final snapshots = <MapGpuResourceCounterSnapshot>[];
+      final backend = _FakeSpriteBackend();
+      final owner = FlutterSceneSpriteResourceOwner(
+        limits: const MapSpriteRendererLimits(
+          maxActiveAtlases: 1,
+          maxTopologyVariants: 1,
+          maxPolicyBatches: 1,
+        ),
+        maxFramesInFlight: 1,
+        backend: backend,
+        waitForGpuCompletion: Future<void>.value,
+        onCounterSnapshot: snapshots.add,
+      );
+      final candidateFrame = frame(number: 0);
+      final prepared = owner.prepareFrame(
+        frame: candidateFrame,
+        batches: batches(
+          frame: candidateFrame,
+          atlas: atlas('sha256:counters'),
+          generation: 1,
+        ),
+      );
+      prepared.commit();
+      owner.retireAll();
+      await pumpEventQueue();
+
+      expect(snapshots.first.node.candidate, 1);
+      expect(snapshots[1].node.active, 1);
+      expect(snapshots[2].node.pendingRetire, 1);
+      expect(snapshots.last.node.live, 0);
+      expect(snapshots.last.node.retires, 1);
+    },
+  );
+
   test('caller limits and frames in flight must be positive', () {
     for (final limits in [
       const MapSpriteRendererLimits(
@@ -497,19 +567,23 @@ final class _FakeSpriteBackend
           _FakeTopology,
           _FakeInstance
         > {
-  _FakeSpriteBackend({this.failurePoint})
-    : textureUploads = 0,
-      topologyPrepares = 0,
-      instancePrepares = 0,
-      textureRetires = 0,
-      topologyRetires = 0,
-      instanceRetires = 0;
+  _FakeSpriteBackend({
+    this.failurePoint,
+    this.failFirstInstanceRetire = false,
+  }) : textureUploads = 0,
+       topologyPrepares = 0,
+       instancePrepares = 0,
+       textureRetires = 0,
+       topologyRetires = 0,
+       instanceRetires = 0;
 
   final _FakeFailurePoint? failurePoint;
+  final bool failFirstInstanceRetire;
   final resources = <_FakeResource>[];
   int textureUploads;
   int topologyPrepares;
   final topologyAbiVersions = <int>[];
+  var _didFailInstanceRetire = false;
   int instancePrepares;
   int textureRetires;
   int topologyRetires;
@@ -586,6 +660,10 @@ final class _FakeSpriteBackend
     if (!instance.retired) {
       instanceRetires++;
       instance.retired = true;
+      if (failFirstInstanceRetire && !_didFailInstanceRetire) {
+        _didFailInstanceRetire = true;
+        throw StateError('instance retire');
+      }
     }
   }
 }

--- a/packages/eqmonitor_map/test/flutter_scene/map_gpu_probe_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/map_gpu_probe_test.dart
@@ -1,0 +1,81 @@
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('configured fault fires exactly once at its typed point', () {
+    final runtime = MapGpuProbeRuntime(
+      configuration: const MapGpuProbeConfiguration(
+        faultPoint: MapGpuFaultPoint.atlasUpload,
+        atlasFixture: MapSpriteAtlasProbeFixture.alphaHalf,
+      ),
+    );
+
+    expect(
+      () => runtime.throwIfRequested(MapGpuFaultPoint.shaderInterface),
+      returnsNormally,
+    );
+    expect(
+      () => runtime.throwIfRequested(MapGpuFaultPoint.atlasUpload),
+      throwsA(
+        isA<MapGpuProbeFault>().having(
+          (fault) => fault.point,
+          'point',
+          MapGpuFaultPoint.atlasUpload,
+        ),
+      ),
+    );
+    expect(
+      () => runtime.throwIfRequested(MapGpuFaultPoint.atlasUpload),
+      returnsNormally,
+    );
+    expect(runtime.atlasFixture, MapSpriteAtlasProbeFixture.alphaHalf);
+  });
+
+  test('controller invalidates only its currently attached renderer host', () {
+    final controller = MapGpuProbeController();
+    final first = _FakeProbeHost();
+    final second = _FakeProbeHost();
+
+    expect(controller.invalidateRendererContextGeneration(), isFalse);
+    expect(controller.attach(host: first), isTrue);
+    expect(controller.attach(host: second), isFalse);
+    expect(controller.invalidateRendererContextGeneration(), isTrue);
+    expect(first.invalidations, 1);
+    expect(second.invalidations, 0);
+
+    controller.detach(host: second);
+    expect(controller.invalidateRendererContextGeneration(), isTrue);
+    controller.detach(host: first);
+    expect(controller.invalidateRendererContextGeneration(), isFalse);
+  });
+
+  test('resource snapshots expose immutable per-kind lifecycle counters', () {
+    const snapshot = MapGpuResourceCounterSnapshot(
+      texture: MapGpuResourceKindCounter(
+        active: 1,
+        candidate: 1,
+        pendingRetire: 2,
+        uploads: 3,
+        retires: 4,
+      ),
+      topology: MapGpuResourceKindCounter.zero,
+      instance: MapGpuResourceKindCounter.zero,
+      node: MapGpuResourceKindCounter.zero,
+      rendererContextGeneration: 7,
+    );
+
+    expect(snapshot.texture.live, 4);
+    expect(snapshot.rendererContextGeneration, 7);
+  });
+}
+
+final class _FakeProbeHost implements MapGpuProbeHost {
+  _FakeProbeHost() : invalidations = 0;
+
+  int invalidations;
+
+  @override
+  void invalidateRendererContextGeneration() {
+    invalidations++;
+  }
+}

--- a/packages/eqmonitor_map/test/flutter_scene/map_gpu_probe_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/map_gpu_probe_test.dart
@@ -67,6 +67,24 @@ void main() {
     expect(snapshot.texture.live, 4);
     expect(snapshot.rendererContextGeneration, 7);
   });
+
+  test('counter callback gate suppresses in-flight updates after dispose', () {
+    final values = <MapGpuResourceCounterSnapshot>[];
+    final gate = MapGpuResourceCounterCallbackGate(callback: values.add);
+    const snapshot = MapGpuResourceCounterSnapshot(
+      texture: MapGpuResourceKindCounter.zero,
+      topology: MapGpuResourceKindCounter.zero,
+      instance: MapGpuResourceKindCounter.zero,
+      node: MapGpuResourceKindCounter.zero,
+      rendererContextGeneration: 1,
+    );
+
+    gate.publish(snapshot);
+    gate.dispose();
+    gate.publish(snapshot);
+
+    expect(values, [same(snapshot)]);
+  });
 }
 
 final class _FakeProbeHost implements MapGpuProbeHost {

--- a/packages/eqmonitor_map/test/flutter_scene/map_shader_interface_manifest_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/map_shader_interface_manifest_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:eqmonitor_map/src/flutter_scene/earthquake_overlay_material_owner.dart';
 import 'package:eqmonitor_map/src/flutter_scene/map_shader_interface_manifest.dart';
 import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -130,5 +131,33 @@ void main() {
     expect(declarations.single.group(1), 'sampler2D');
     expect(source, isNot(contains('samplerCube spriteAtlas')));
     expect(source, isNot(contains('sampler2DArray spriteAtlas')));
+  });
+
+  test('runtime sprite preflight accepts only the checked-in ABI', () {
+    final checkedIn = File(
+      'shaders/earthquake_overlay.shaderinterface.json',
+    ).readAsStringSync();
+    final valid = MapShaderInterfaceManifest.parse(
+      jsonBytes: Uint8List.fromList(utf8.encode(checkedIn)),
+    );
+    final invalid = MapShaderInterfaceManifest.parse(
+      jsonBytes: Uint8List.fromList(
+        utf8.encode(
+          checkedIn.replaceFirst(
+            '"name":"spriteAtlas","set":0,"binding":64',
+            '"name":"spriteAtlas","set":0,"binding":63',
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      () => validateMapSpriteShaderManifest(manifest: valid),
+      returnsNormally,
+    );
+    expect(
+      () => validateMapSpriteShaderManifest(manifest: invalid),
+      throwsFormatException,
+    );
   });
 }

--- a/packages/eqmonitor_map/test/flutter_scene/map_shader_interface_manifest_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/map_shader_interface_manifest_test.dart
@@ -8,6 +8,19 @@ import 'package:eqmonitor_map/src/renderer/map_sprite_batch.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('candidate material factory creates isolated mutable state', () {
+    var generation = 0;
+    final factory = FlutterSceneSpriteCandidateMaterialFactory(
+      createMaterial: () => ++generation,
+    );
+
+    final first = factory.create();
+    final second = factory.create();
+
+    expect(first, 1);
+    expect(second, 2);
+  });
+
   test(
     'defensively parses typed input, uniform, and sampled-image metadata',
     () {

--- a/packages/eqmonitor_map/test/widget/base_map_overlay_frame_builder_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_overlay_frame_builder_test.dart
@@ -419,6 +419,33 @@ void main() {
     },
   );
 
+  test('frame owner publishes sprite reuse only after commit', () {
+    final frames = BaseMapOverlayFrameOwner();
+    final value = snapshot(atlas: spriteAtlas(), sprites: [sprite()]);
+    final candidate = build(frame: frameAt(6), requested: value);
+    final fallback = build(
+      frame: frameAt(6),
+      current: value,
+      requested: null,
+    );
+
+    expect(frames.previousSpriteBatches, isEmpty);
+    final fallbackSubmission = fallback.submission;
+    if (fallbackSubmission == null) {
+      fail('Expected a base-only fallback submission.');
+    }
+    frames.commit(
+      candidate: candidate,
+      baseOnlySubmission: fallbackSubmission,
+      resources: null,
+      submitFrame: (_) {},
+      retireAllGpuResources: () {},
+      failClosedResources: () {},
+    );
+
+    expect(frames.previousSpriteBatches, candidate.spriteBatchesForReuse);
+  });
+
   test('null snapshot atomically hides the previous overlay', () {
     final result = build(
       frame: frameAt(6),
@@ -826,6 +853,7 @@ void main() {
       expect(submitted, hasLength(1));
       expect(frames.overlay, isNull);
       expect(frames.previousObservationBatch, isNull);
+      expect(frames.previousSpriteBatches, isEmpty);
       expect(frames.coverage, const EarthquakeOverlayCoverage.hidden());
       expect(coverages, [
         EarthquakeOverlayCoverageSnapshot(
@@ -956,6 +984,7 @@ void main() {
       expect(sceneGraph.children, isEmpty);
       expect(frames.overlay, isNull);
       expect(frames.previousObservationBatch, isNull);
+      expect(frames.previousSpriteBatches, isEmpty);
       expect(frames.coverage, const EarthquakeOverlayCoverage.hidden());
       expect(coverages, [
         EarthquakeOverlayCoverageSnapshot(

--- a/packages/eqmonitor_map/test/widget/base_map_view_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_view_test.dart
@@ -2,6 +2,7 @@
 // (Global Constraints「widget testとgolden testは追加しない」)。ここでは
 // gesture callbackから分離したpure関数(`cameraAfterGestureUpdate`/
 // `canonicalZoomFor`)だけを検証する。
+import 'package:eqmonitor_map/src/flutter_scene/earthquake_overlay_material_owner.dart';
 import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_sprite_resource_owner.dart';
 import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
@@ -23,6 +24,28 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pmtiles_v3/pmtiles_v3.dart';
 
 void main() {
+  test(
+    'typed sprite initialization failure disables only sprite resources',
+    () async {
+      final resources = await loadOptionalFlutterSceneSpriteResources<int>(
+        load: () async => throw const FlutterSceneSpriteInitializationFailure(
+          message: 'invalid manifest',
+        ),
+      );
+
+      expect(resources, isNull);
+    },
+  );
+
+  test('unexpected sprite initialization error still propagates', () async {
+    await expectLater(
+      loadOptionalFlutterSceneSpriteResources<int>(
+        load: () async => throw StateError('unexpected'),
+      ),
+      throwsStateError,
+    );
+  });
+
   test('exposes nullable earthquake overlay and coverage callback inputs', () {
     final overlay = createEarthquakeMapOverlaySnapshot(
       versionStamp: createMapOverlayVersionStamp(

--- a/packages/eqmonitor_map/test/widget/base_map_view_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_view_test.dart
@@ -2,6 +2,8 @@
 // (Global Constraints「widget testとgolden testは追加しない」)。ここでは
 // gesture callbackから分離したpure関数(`cameraAfterGestureUpdate`/
 // `canonicalZoomFor`)だけを検証する。
+import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_sprite_resource_owner.dart';
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
 import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
 import 'package:eqmonitor_map/src/geo/map_camera.dart';
@@ -45,6 +47,12 @@ void main() {
       domain: createMapClockDomainId(value: 'base-map-view-test'),
     );
     final cameraController = MapViewCameraController();
+    final gpuProbeController = MapGpuProbeController();
+    const gpuProbeConfiguration = MapGpuProbeConfiguration(
+      faultPoint: null,
+      atlasFixture: MapSpriteAtlasProbeFixture.production,
+    );
+    void gpuCounterCallback(MapGpuResourceCounterSnapshot _) {}
     addTearDown(cameraController.dispose);
     final view = BaseMapView(
       source: const VerifiedPmTilesSource(
@@ -93,16 +101,27 @@ void main() {
         maxParentFallbackSteps: 4,
         maxInFlightDecodes: 2,
         maxFramesInFlight: 3,
+        spriteRendererLimits: MapSpriteRendererLimits(
+          maxActiveAtlases: 1,
+          maxTopologyVariants: 1,
+          maxPolicyBatches: 1,
+        ),
         maxSceneNodeCount: 32,
       ),
       earthquakeOverlay: overlay,
       onEarthquakeOverlayCoverageChanged: callback,
+      gpuProbeConfiguration: gpuProbeConfiguration,
+      onGpuResourceCounterChanged: gpuCounterCallback,
+      gpuProbeController: gpuProbeController,
     );
 
     expect(view.earthquakeOverlay, same(overlay));
     expect(view.onEarthquakeOverlayCoverageChanged, same(callback));
     expect(view.clock, same(clock));
     expect(view.cameraController, same(cameraController));
+    expect(view.gpuProbeConfiguration, same(gpuProbeConfiguration));
+    expect(view.onGpuResourceCounterChanged, same(gpuCounterCallback));
+    expect(view.gpuProbeController, same(gpuProbeController));
   });
 
   group('cameraAfterGestureUpdate', () {


### PR DESCRIPTION
## 概要

- sprite atlas / shared topology / instance resourceをcandidate・active・pending-retire transactionで所有
- shader manifestとnative reflectionをScene mutation前に検証し、sprite nodeを原子的にsubmit
- compile-time gated GPU probe、resource counter、fault injection、debug UIを追加
- candidate material共有、dispose後callback、resource retirement failure、sprite初期化failureをfail-closedに処理

## 検証

- `mise exec -- flutter test test/flutter_scene test/widget/base_map_overlay_frame_builder_test.dart test/widget/base_map_view_test.dart`: 116 tests passed
- `mise exec -- flutter test --dart-define=EQMONITOR_MAP_GPU_PROBE=true test/flutter_scene/flutter_scene_sprite_resource_owner_test.dart test/flutter_scene/flutter_scene_map_adapter_test.dart test/flutter_scene/map_gpu_probe_test.dart`: 47 tests passed
- scoped `dart analyze`: No issues found
- app debug probe tests: 4 tests passed
- app debug probe lib/test scoped analyze: No issues found
- format / diff check: clean

## 既知の全体解析状況

full app `dart analyze` は今回差分外の既知 `flutter_hooks_lint_plugin` RangeError と既存診断によりexit 2です。今回変更したdebug probeのlib/testは個別analyzeでcleanを確認しています。

## 依存

- base: `codex/gpu-map-07-sprite-batch`
- `third_party/flutter_scene` gitlinkはYumNumm/flutter_sceneへmerge済みのshared topology APIを参照