### PR TITLE
Device IDをサーバー発行JWTへ統一

### DIFF
--- a/app/lib/core/provider/device_id.dart
+++ b/app/lib/core/provider/device_id.dart
@@ -1,20 +1,16 @@
-import 'dart:convert';
-
-import 'package:crypto/crypto.dart';
-import 'package:flutter_udid/flutter_udid.dart';
+import 'package:eqmonitor/feature/devices/data/logic/device_id_decoder.dart';
+import 'package:eqmonitor/feature/devices/data/repository/device_auth_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'device_id.g.dart';
 
-/// デバイスIDを提供するProvider
-/// UDIDのSHA512ハッシュをUUID形式に変換して返す
+/// サーバー発行 JWT の sub claim からデバイス ID を提供する。
 @Riverpod(keepAlive: true)
 Future<String> deviceId(Ref ref) async {
-  final udid = await FlutterUdid.udid;
-  final bytes = utf8.encode(udid);
-  final digest = sha512.convert(bytes);
-  final hash = digest.toString();
-
-  // SHA512ハッシュ（128文字）をUUID形式（8-4-4-4-12）に変換
-  return '${hash.substring(0, 8)}-${hash.substring(8, 12)}-${hash.substring(12, 16)}-${hash.substring(16, 20)}-${hash.substring(20, 32)}';
+  final repository = await ref.watch(deviceAuthRepositoryProvider.future);
+  final token = await repository.readToken();
+  if (token == null || token.isEmpty) {
+    throw StateError('Device JWT is not available');
+  }
+  return ref.watch(deviceIdDecoderProvider).decode(token: token);
 }

--- a/app/lib/core/provider/device_id.g.dart
+++ b/app/lib/core/provider/device_id.g.dart
@@ -10,20 +10,17 @@ part of 'device_id.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// デバイスIDを提供するProvider
-/// UDIDのSHA512ハッシュをUUID形式に変換して返す
+/// サーバー発行 JWT の sub claim からデバイス ID を提供する。
 
 @ProviderFor(deviceId)
 final deviceIdProvider = DeviceIdProvider._();
 
-/// デバイスIDを提供するProvider
-/// UDIDのSHA512ハッシュをUUID形式に変換して返す
+/// サーバー発行 JWT の sub claim からデバイス ID を提供する。
 
 final class DeviceIdProvider
     extends $FunctionalProvider<AsyncValue<String>, String, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
-  /// デバイスIDを提供するProvider
-  /// UDIDのSHA512ハッシュをUUID形式に変換して返す
+  /// サーバー発行 JWT の sub claim からデバイス ID を提供する。
   DeviceIdProvider._()
     : super(
         from: null,
@@ -49,4 +46,4 @@ final class DeviceIdProvider
   }
 }
 
-String _$deviceIdHash() => r'484f9de5df37e8548c3af9c59f980a04fe57123a';
+String _$deviceIdHash() => r'd9c75dc86739f7d76274b7c1ff80abd4e2595091';

--- a/app/lib/core/provider/interceptor/device_id_interceptor.dart
+++ b/app/lib/core/provider/interceptor/device_id_interceptor.dart
@@ -1,24 +1,44 @@
 import 'package:dio/dio.dart';
-import 'package:eqmonitor/core/provider/device_id.dart';
+import 'package:eqmonitor/feature/devices/data/logic/device_id_decoder.dart';
+import 'package:eqmonitor/feature/devices/data/repository/device_auth_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'device_id_interceptor.g.dart';
 
 @Riverpod(keepAlive: true)
 Future<DeviceIdInterceptor> deviceIdInterceptor(Ref ref) async {
-  final deviceId = await ref.watch(deviceIdProvider.future);
-  return DeviceIdInterceptor(deviceId: deviceId);
+  final repository = await ref.watch(deviceAuthRepositoryProvider.future);
+  return DeviceIdInterceptor(
+    readToken: repository.readToken,
+    decoder: ref.watch(deviceIdDecoderProvider),
+  );
 }
 
 class DeviceIdInterceptor extends Interceptor {
-  new({required this.deviceId});
+  new({
+    required Future<String?> Function() readToken,
+    DeviceIdDecoder decoder = const DeviceIdDecoder(),
+  }) : _readToken = readToken,
+       _decoder = decoder;
 
-  final String deviceId;
+  final Future<String?> Function() _readToken;
+  final DeviceIdDecoder _decoder;
 
   @override
-  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    if (deviceId.isNotEmpty) {
-      options.headers['x-eqmonitor-device-id'] = deviceId;
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    final token = await _readToken();
+    if (token == null || token.isEmpty) {
+      handler.next(options);
+      return;
+    }
+    try {
+      options.headers['x-eqmonitor-device-id'] = _decoder.decode(token: token);
+    } on FormatException {
+      handler.next(options);
+      return;
     }
     handler.next(options);
   }

--- a/app/lib/core/provider/interceptor/device_id_interceptor.g.dart
+++ b/app/lib/core/provider/interceptor/device_id_interceptor.g.dart
@@ -51,4 +51,4 @@ final class DeviceIdInterceptorProvider
 }
 
 String _$deviceIdInterceptorHash() =>
-    r'100206eca1ee4b75a8dfc53d8412dfed0de35cc0';
+    r'25f069a4d432d423f400701d9acc90efaf88eedf';

--- a/app/lib/feature/devices/data/logic/device_id_decoder.dart
+++ b/app/lib/feature/devices/data/logic/device_id_decoder.dart
@@ -1,0 +1,33 @@
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'device_id_decoder.g.dart';
+
+@riverpod
+DeviceIdDecoder deviceIdDecoder(Ref ref) => const DeviceIdDecoder();
+
+final class DeviceIdDecoder {
+  const new();
+
+  String decode({required String token}) {
+    try {
+      final payload = JWT.decode(token).payload;
+      if (payload is! Map<String, dynamic>) {
+        throw const FormatException('JWT payload must be an object');
+      }
+      final subject = payload['sub'];
+      if (subject is! String || !subject.startsWith('device:')) {
+        throw const FormatException(
+          'JWT sub must use the device:<id> format',
+        );
+      }
+      final deviceId = subject.substring('device:'.length);
+      if (deviceId.isEmpty) {
+        throw const FormatException('JWT device id must not be empty');
+      }
+      return deviceId;
+    } on JWTException catch (exception) {
+      throw FormatException('Unable to decode device JWT: $exception');
+    }
+  }
+}

--- a/app/lib/feature/devices/data/logic/device_id_decoder.g.dart
+++ b/app/lib/feature/devices/data/logic/device_id_decoder.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'device_id_decoder.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(deviceIdDecoder)
+final deviceIdDecoderProvider = DeviceIdDecoderProvider._();
+
+final class DeviceIdDecoderProvider
+    extends
+        $FunctionalProvider<DeviceIdDecoder, DeviceIdDecoder, DeviceIdDecoder>
+    with $Provider<DeviceIdDecoder> {
+  DeviceIdDecoderProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'deviceIdDecoderProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$deviceIdDecoderHash();
+
+  @$internal
+  @override
+  $ProviderElement<DeviceIdDecoder> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  DeviceIdDecoder create(Ref ref) {
+    return deviceIdDecoder(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DeviceIdDecoder value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DeviceIdDecoder>(value),
+    );
+  }
+}
+
+String _$deviceIdDecoderHash() => r'd3ee39db712c7a1ee7d75fa730ba73f62599e938';

--- a/app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart
+++ b/app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart
@@ -6,6 +6,7 @@ import 'package:eqmonitor/core/provider/device_id.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/feature/devices/data/exception/device_provisioning_exception.dart';
 import 'package:eqmonitor/feature/devices/data/exception/dio_exception_mapper.dart';
+import 'package:eqmonitor/feature/devices/data/logic/device_id_decoder.dart';
 import 'package:eqmonitor/feature/devices/data/notifier/push_token_sync_notifier.dart';
 import 'package:eqmonitor/feature/devices/data/repository/device_auth_repository.dart';
 import 'package:eqmonitor/feature/devices/data/repository/device_provisioning_repository.dart';
@@ -46,6 +47,14 @@ class DeviceProvisioningNotifier extends _$DeviceProvisioningNotifier {
       await repo.clearProvisioned();
       return .required;
     }
+    try {
+      ref.watch(deviceIdDecoderProvider).decode(token: token);
+    } on FormatException {
+      await authRepo.clearToken();
+      await repo.clearProvisioned();
+      ref.invalidate(deviceIdProvider);
+      return .required;
+    }
     return .notRequired;
   }
 
@@ -53,58 +62,59 @@ class DeviceProvisioningNotifier extends _$DeviceProvisioningNotifier {
   Future<void> provision() async {
     final repo = await ref.read(deviceProvisioningRepositoryProvider.future);
     final deviceRepo = await ref.read(deviceRepositoryProvider.future);
-    final deviceId = await ref.read(deviceIdProvider.future);
 
-    await _retryController.run(() async {
-      try {
-        final legacy = await repo.readLegacyDeviceId();
-        final alreadyMigrated = await repo.wasMigratedFromLegacy();
-        if (legacy != null && legacy.isNotEmpty && !alreadyMigrated) {
-          talker.info(
-            '[Provisioning] legacy device detected; '
-            'running v2→v3 migration workflow',
-          );
-          await const DeviceMigrationWorkflow().run(
-            runner: repo.buildRunner(),
-            repository: deviceRepo,
-            deviceId: deviceId,
-            oldDeviceId: legacy,
-          );
-          await repo.markMigratedFromLegacy();
-          talker.info('[Provisioning] v2→v3 migration workflow completed');
-        } else {
-          final result = await deviceRepo.registerDevice(
-            deviceId: deviceId,
-            devicePlatform: kIsWeb
-                ? .ios
-                : Platform.isIOS
-                ? .ios
-                : .android,
-            deviceLocale: .ja,
-          );
-          switch (result) {
-            case Success():
-              break;
-            case Failure(:final exception, :final stackTrace):
-              Error.throwWithStackTrace(
-                exception,
-                stackTrace ?? StackTrace.empty,
-              );
+    try {
+      await _retryController.run(() async {
+        try {
+          final legacy = await repo.readLegacyDeviceId();
+          final alreadyMigrated = await repo.wasMigratedFromLegacy();
+          if (legacy != null && legacy.isNotEmpty && !alreadyMigrated) {
+            talker.info(
+              '[Provisioning] legacy device detected; '
+              'running v2→v3 migration workflow',
+            );
+            await const DeviceMigrationWorkflow().run(
+              runner: repo.buildRunner(),
+              repository: deviceRepo,
+              oldDeviceId: legacy,
+            );
+            await repo.markMigratedFromLegacy();
+            talker.info('[Provisioning] v2→v3 migration workflow completed');
+          } else {
+            final result = await deviceRepo.registerDevice(
+              devicePlatform: kIsWeb
+                  ? .ios
+                  : Platform.isIOS
+                  ? .ios
+                  : .android,
+              deviceLocale: .ja,
+            );
+            switch (result) {
+              case Success():
+                break;
+              case Failure(:final exception, :final stackTrace):
+                Error.throwWithStackTrace(
+                  exception,
+                  stackTrace ?? StackTrace.empty,
+                );
+            }
           }
+          await repo.markProvisioned();
+        } on DeviceProvisioningException catch (e, st) {
+          talker.error('[Provisioning] failed', e, st);
+          rethrow;
+        } on DioException catch (e, st) {
+          final mapped = DioExceptionMapper.map(e, st);
+          talker.error('[Provisioning] failed', mapped, st);
+          throw mapped;
+        } catch (e, st) {
+          talker.error('[Provisioning] unexpected failure', e, st);
+          throw UnexpectedProvisioningException(cause: e, stackTrace: st);
         }
-        await repo.markProvisioned();
-      } on DeviceProvisioningException catch (e, st) {
-        talker.error('[Provisioning] failed', e, st);
-        rethrow;
-      } on DioException catch (e, st) {
-        final mapped = DioExceptionMapper.map(e, st);
-        talker.error('[Provisioning] failed', mapped, st);
-        throw mapped;
-      } catch (e, st) {
-        talker.error('[Provisioning] unexpected failure', e, st);
-        throw UnexpectedProvisioningException(cause: e, stackTrace: st);
-      }
-    });
+      });
+    } finally {
+      ref.invalidate(deviceIdProvider);
+    }
 
     state = const AsyncData(DeviceProvisioningStatus.notRequired);
     ref.invalidate(pushTokenSyncProvider, asReload: true);
@@ -116,9 +126,7 @@ class DeviceProvisioningNotifier extends _$DeviceProvisioningNotifier {
     final provisioningRepo = await ref.read(
       deviceProvisioningRepositoryProvider.future,
     );
-    final deviceId = await ref.read(deviceIdProvider.future);
-
-    final result = await deviceRepo.deleteDevice(deviceId);
+    final result = await deviceRepo.deleteDevice();
     switch (result) {
       case Success():
         break;
@@ -127,6 +135,7 @@ class DeviceProvisioningNotifier extends _$DeviceProvisioningNotifier {
     }
 
     await provisioningRepo.clearProvisioned();
+    ref.invalidate(deviceIdProvider);
     ref.invalidate(notificationSlotRepositoryProvider);
     _retryController.reset();
     state = const AsyncData(DeviceProvisioningStatus.required);

--- a/app/lib/feature/devices/data/notifier/device_provisioning_notifier.g.dart
+++ b/app/lib/feature/devices/data/notifier/device_provisioning_notifier.g.dart
@@ -74,7 +74,7 @@ final class DeviceProvisioningNotifierProvider
 }
 
 String _$deviceProvisioningNotifierHash() =>
-    r'6f6f8cc9168debd4e655060da62b744324381e0d';
+    r'a265b9c739375efbb8e42f8a26f9e9b8139a96ee';
 
 abstract class _$DeviceProvisioningNotifier
     extends $AsyncNotifier<DeviceProvisioningStatus> {

--- a/app/lib/feature/devices/data/repository/device_repository.dart
+++ b/app/lib/feature/devices/data/repository/device_repository.dart
@@ -35,7 +35,7 @@ class DeviceRepository {
   final DeviceAuthRepository _authRepository;
   final api.ApnsEnvironment _apnsEnvironment;
 
-  Future<Result<RegisteredDevice, Exception>> getDevice(String deviceId) =>
+  Future<Result<RegisteredDevice, Exception>> getDevice() =>
       Result.capture(() async {
         final response = await _api.device.getV2DeviceMe();
         return response.data.toRegisteredDevice;
@@ -53,7 +53,6 @@ class DeviceRepository {
       });
 
   Future<Result<RegisteredDevice, Exception>> registerDevice({
-    required String deviceId,
     required DevicePlatform devicePlatform,
     required DeviceLocale deviceLocale,
   }) => Result.capture(() async {
@@ -81,25 +80,22 @@ class DeviceRepository {
     return getResponse.data.toRegisteredDevice;
   });
 
-  Future<Result<void, Exception>> deleteDevice(String deviceId) =>
-      Result.capture(() async {
-        await _api.device.deleteV2DeviceMe();
-        await _authRepository.clearToken();
-      });
+  Future<Result<void, Exception>> deleteDevice() => Result.capture(() async {
+    await _api.device.deleteV2DeviceMe();
+    await _authRepository.clearToken();
+  });
 
   Future<Result<RegisteredDevice, Exception>> fetchOrRegister({
-    required String deviceId,
     required DevicePlatform devicePlatform,
     required DeviceLocale deviceLocale,
   }) async {
-    final getResult = await getDevice(deviceId);
+    final getResult = await getDevice();
     switch (getResult) {
       case Success(:final value):
         return Success(value);
       case Failure(:final exception, :final stackTrace):
         if (_shouldRegisterAfterGetFailure(exception)) {
           return registerDevice(
-            deviceId: deviceId,
             devicePlatform: devicePlatform,
             deviceLocale: deviceLocale,
           );
@@ -111,17 +107,16 @@ class DeviceRepository {
   /// Migrates settings from a v2.6 Supabase device to this v3 device.
   ///
   /// Sequence (per spec):
-  /// 1. GET device — if 200 it already exists, skip PUT.
-  /// 2. PUT device  — only when step 1 returned 404.
-  /// 3. POST /migrate with [oldDeviceId].
+  /// 1. GET /v2/device/me — if 200 it already exists, skip registration.
+  /// 2. POST /v2/device — only when step 1 returned 404.
+  /// 3. POST /v2/device/me/migrate with [oldDeviceId].
   ///
   /// 409 on migrate is treated as idempotent success (already migrated).
   Future<Result<void, Exception>> migrateFromLegacy({
-    required String deviceId,
     required String oldDeviceId,
   }) async {
     // Step 1 — check existence
-    final getResult = await getDevice(deviceId);
+    final getResult = await getDevice();
     final alreadyRegistered = switch (getResult) {
       Success() => true,
       Failure(:final exception) when _isNotFound(exception) => false,
@@ -133,8 +128,7 @@ class DeviceRepository {
 
     // Step 2 — register only when absent
     if (!alreadyRegistered) {
-      final putResult = await registerDevice(
-        deviceId: deviceId,
+      final registerResult = await registerDevice(
         devicePlatform: kIsWeb
             ? .ios
             : Platform.isIOS
@@ -142,8 +136,8 @@ class DeviceRepository {
             : .android,
         deviceLocale: .ja,
       );
-      if (putResult is Failure<RegisteredDevice, Exception>) {
-        return Failure(putResult.exception, putResult.stackTrace);
+      if (registerResult is Failure<RegisteredDevice, Exception>) {
+        return Failure(registerResult.exception, registerResult.stackTrace);
       }
     }
 

--- a/app/lib/feature/devices/data/workflow/device_migration_workflow.dart
+++ b/app/lib/feature/devices/data/workflow/device_migration_workflow.dart
@@ -21,10 +21,11 @@ class DeviceMigrationWorkflow {
   /// Runs the v2.6 → v3 device migration as a durable workflow.
   ///
   /// Steps:
-  /// 1. `ensureDeviceAbsent`  — GET /v2/device/{id}; records whether device
+  /// 1. `ensureDeviceAbsent`  — GET /v2/device/me; records whether device
   ///    already existed.
-  /// 2. `registerDevice`      — PUT only when absent.
-  /// 3. `migrateLegacySettings` — POST /migrate with [oldDeviceId].
+  /// 2. `registerDevice`      — POST /v2/device only when absent.
+  /// 3. `migrateLegacySettings` — POST /v2/device/me/migrate with
+  ///    [oldDeviceId].
   /// 4. `markLocalComplete`   — writes true to persistence.
   ///
   /// Caller must ensure [oldDeviceId] was successfully retrieved from legacy
@@ -33,7 +34,6 @@ class DeviceMigrationWorkflow {
   Future<void> run({
     required WorkflowRunner runner,
     required DeviceRepository repository,
-    required String deviceId,
     required String oldDeviceId,
   }) async {
     await runner.run(
@@ -43,7 +43,7 @@ class DeviceMigrationWorkflow {
         final alreadyRegistered = await step<bool>(
           'ensureDeviceAbsent',
           () async {
-            final result = await repository.getDevice(deviceId);
+            final result = await repository.getDevice();
             return switch (result) {
               Success() => true,
               Failure(:final exception)
@@ -72,7 +72,6 @@ class DeviceMigrationWorkflow {
         if (!alreadyRegistered) {
           await step<void>('registerDevice', () async {
             final result = await repository.registerDevice(
-              deviceId: deviceId,
               devicePlatform: kIsWeb
                   ? .ios
                   : Platform.isIOS
@@ -95,7 +94,6 @@ class DeviceMigrationWorkflow {
         // Step 3 — migrate legacy settings
         await step<void>('migrateLegacySettings', () async {
           final result = await repository.migrateFromLegacy(
-            deviceId: deviceId,
             oldDeviceId: oldDeviceId,
           );
           switch (result) {

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -513,7 +513,7 @@ Future<RegisteredDevice> _deviceInfo(Ref ref, String deviceId) async {
     throw ArgumentError('deviceId is empty');
   }
   final repo = await ref.watch(deviceRepositoryProvider.future);
-  final result = await repo.getDevice(deviceId);
+  final result = await repo.getDevice();
   return switch (result) {
     Success(:final value) => value,
     Failure(:final exception) => throw exception,

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.g.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.g.dart
@@ -66,7 +66,7 @@ final class _DeviceInfoProvider
   }
 }
 
-String _$_deviceInfoHash() => r'ee2acd4f0440b61dfea0d82b15347af70ba51313';
+String _$_deviceInfoHash() => r'b93771d9b3a6f185138707392533b763d1739368';
 
 final class _DeviceInfoFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<RegisteredDevice>, String> {

--- a/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
+++ b/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
@@ -7,10 +5,10 @@ import 'package:eqmonitor/core/foundation/result.dart';
 import 'package:eqmonitor/core/gen/fonts.gen.dart';
 import 'package:eqmonitor/core/provider/device_id.dart';
 import 'package:eqmonitor/feature/devices/data/model/registered_device.dart';
+import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
 import 'package:eqmonitor/feature/devices/data/repository/device_repository.dart';
 import 'package:eqmonitor/feature/notification/data/model/general_notification_settings.dart';
 import 'package:eqmonitor/feature/notification/data/repository/push_notification_repository.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -47,7 +45,7 @@ class _DebugDeviceAdminBody extends HookConsumerWidget {
     Future<({RegisteredDevice? device, GeneralNotificationSettings? settings})>
     fetch() async {
       final deviceRepository = await ref.read(deviceRepositoryProvider.future);
-      final getResult = await deviceRepository.getDevice(deviceId);
+      final getResult = await deviceRepository.getDevice();
       switch (getResult) {
         case Success(:final value):
           final notificationRepository = await ref.read(
@@ -172,32 +170,28 @@ class _Body extends HookConsumerWidget {
     Future<void> registerOrRefresh() async {
       await runWithBusy(() async {
         final messenger = ScaffoldMessenger.of(context);
-        final repo = await ref.read(deviceRepositoryProvider.future);
-        final result = await repo.registerDevice(
-          deviceId: deviceId,
-          devicePlatform: kIsWeb
-              ? .ios
-              : Platform.isIOS
-              ? .ios
-              : .android,
-          deviceLocale: .ja,
-        );
-        if (!context.mounted) {
-          return;
-        }
-        switch (result) {
-          case Success():
-            messenger.showSnackBar(
-              const SnackBar(content: Text('サーバーにデバイスを登録しました')),
-            );
-            await onReload();
-          case Failure(:final exception):
+        try {
+          await DeviceProvisioningNotifier.provisionMutation.run(
+            ref,
+            (tsx) async =>
+                tsx.get(deviceProvisioningProvider.notifier).provision(),
+          );
+          if (!context.mounted) {
+            return;
+          }
+          messenger.showSnackBar(
+            const SnackBar(content: Text('サーバーにデバイスを登録しました')),
+          );
+          await onReload();
+        } on Object catch (exception) {
+          if (context.mounted) {
             messenger.showSnackBar(
               SnackBar(
                 content: Text('登録に失敗しました: $exception'),
                 backgroundColor: context.designSystem.colorTheme.error,
               ),
             );
+          }
         }
       });
     }
@@ -232,24 +226,29 @@ class _Body extends HookConsumerWidget {
       }
       await runWithBusy(() async {
         final messenger = ScaffoldMessenger.of(context);
-        final repo = await ref.read(deviceRepositoryProvider.future);
-        final result = await repo.deleteDevice(deviceId);
-        if (!context.mounted) {
-          return;
-        }
-        switch (result) {
-          case Success():
-            messenger.showSnackBar(
-              const SnackBar(content: Text('サーバーからデバイスを削除しました')),
-            );
-            await onReload();
-          case Failure(:final exception):
+        try {
+          await DeviceProvisioningNotifier.deleteMutation.run(
+            ref,
+            (tsx) async => tsx
+                .get(deviceProvisioningProvider.notifier)
+                .deleteDeviceAndClearLocal(),
+          );
+          if (!context.mounted) {
+            return;
+          }
+          messenger.showSnackBar(
+            const SnackBar(content: Text('サーバーからデバイスを削除しました')),
+          );
+          await onReload();
+        } on Object catch (exception) {
+          if (context.mounted) {
             messenger.showSnackBar(
               SnackBar(
                 content: Text('削除に失敗しました: $exception'),
                 backgroundColor: context.designSystem.colorTheme.error,
               ),
             );
+          }
         }
       });
     }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -108,10 +108,6 @@ dependencies:
   flutter_test:
     sdk: flutter
   flutter_timezone: ^5.0.1
-  flutter_udid:
-    git:
-      url: https://github.com/YumNumm/flutter_udid.git
-      ref: d8f72a1e9e09a9f76f4e5051f167b31c5e2af52e
   freezed_annotation: ^3.0.0
   geobase: ^1.5.0
   geodata: ^1.3.0
@@ -191,6 +187,7 @@ dependencies:
   material_ui: ^1.0.0
   cupertino_ui: ^1.0.0
   unorm_dart: ^0.3.2
+  dart_jsonwebtoken: ^3.4.1
 
 dev_dependencies:
   build_runner: ^2.11.1

--- a/app/test/core/provider/device_id_test.dart
+++ b/app/test/core/provider/device_id_test.dart
@@ -1,0 +1,100 @@
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:eqmonitor/core/data/preferences/preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
+import 'package:eqmonitor/core/provider/device_id.dart';
+import 'package:eqmonitor/feature/devices/data/repository/device_auth_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  test('DeviceIdProvider は保存済み JWT の sub から Device ID を返す', () async {
+    final token = JWT({
+      'sub': 'device:01976d8e-7d12-7000-8000-1234567890ab',
+    }).sign(SecretKey('test-secret'));
+    final preferences = _MemorySecurePreferencesDataSource()
+      ..values[SecureStorageKey.deviceToken] = token;
+    final container = ProviderContainer(
+      overrides: [
+        deviceAuthRepositoryProvider.overrideWith(
+          (ref) async => DeviceAuthRepository(preferences),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      await container.read(deviceIdProvider.future),
+      '01976d8e-7d12-7000-8000-1234567890ab',
+    );
+  });
+
+  test('DeviceIdProvider は JWT が保存されていない場合にエラーを返す', () async {
+    final container = ProviderContainer(
+      overrides: [
+        deviceAuthRepositoryProvider.overrideWith(
+          (ref) async => DeviceAuthRepository(
+            _MemorySecurePreferencesDataSource(),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container.read(deviceIdProvider.future),
+      throwsA(isA<StateError>()),
+    );
+  });
+}
+
+final class _MemorySecurePreferencesDataSource
+    implements PreferencesDataSource<SecureStorageKey> {
+  final values = <SecureStorageKey, String>{};
+
+  @override
+  Future<String?> getString({required SecureStorageKey key}) async =>
+      values[key];
+
+  @override
+  Future<void> setString({
+    required SecureStorageKey key,
+    required String value,
+  }) async {
+    values[key] = value;
+  }
+
+  @override
+  Future<void> remove({required SecureStorageKey key}) async {
+    values.remove(key);
+  }
+
+  @override
+  Future<void> clear() async => values.clear();
+
+  @override
+  Future<bool?> getBool({required SecureStorageKey key}) async => null;
+
+  @override
+  Future<double?> getDouble({required SecureStorageKey key}) async => null;
+
+  @override
+  Future<int?> getInt({required SecureStorageKey key}) async => null;
+
+  @override
+  Future<void> setBool({
+    required SecureStorageKey key,
+    required bool value,
+  }) async {}
+
+  @override
+  Future<void> setDouble({
+    required SecureStorageKey key,
+    required double value,
+  }) async {}
+
+  @override
+  Future<void> setInt({
+    required SecureStorageKey key,
+    required int value,
+  }) async {}
+}

--- a/app/test/core/provider/interceptor/device_registration_interceptor_test.dart
+++ b/app/test/core/provider/interceptor/device_registration_interceptor_test.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/provider/interceptor/app_check_interceptor.dart';
 import 'package:eqmonitor/core/provider/interceptor/device_id_interceptor.dart';
@@ -13,40 +14,60 @@ import 'package:talker_flutter/talker_flutter.dart';
 void main() {
   talker_lib.talker = Talker();
 
-  test('DeviceIdInterceptor attaches device id to POST /v2/device', () {
-    final interceptor = DeviceIdInterceptor(deviceId: 'device-1');
+  test('DeviceIdInterceptor attaches JWT device id to requests', () async {
+    final token = JWT({'sub': 'device:device-1'}).sign(
+      SecretKey('test-secret'),
+    );
+    final interceptor = DeviceIdInterceptor(readToken: () async => token);
     final options = RequestOptions(path: '/v2/device', method: 'POST');
     final handler = _CapturingRequestHandler();
 
-    interceptor.onRequest(options, handler);
+    await interceptor.onRequest(options, handler);
 
     expect(options.headers['x-eqmonitor-device-id'], 'device-1');
     expect(handler.nextOptions, same(options));
   });
 
-  test('DeviceIdInterceptor attaches device id to arbitrary requests', () {
-    final interceptor = DeviceIdInterceptor(deviceId: 'device-1');
+  test(
+    'DeviceIdInterceptor uses the latest saved JWT for every request',
+    () async {
+      var token = JWT({'sub': 'device:device-1'}).sign(
+        SecretKey('test-secret'),
+      );
+      final interceptor = DeviceIdInterceptor(readToken: () async => token);
+      final firstOptions = RequestOptions(
+        path: '/v2/parameters/manifest',
+        method: 'GET',
+      );
+      final firstHandler = _CapturingRequestHandler();
+
+      await interceptor.onRequest(firstOptions, firstHandler);
+      token = JWT({'sub': 'device:device-2'}).sign(
+        SecretKey('test-secret'),
+      );
+      final secondOptions = RequestOptions(
+        path: '/v2/parameters/manifest',
+        method: 'GET',
+      );
+      final secondHandler = _CapturingRequestHandler();
+      await interceptor.onRequest(secondOptions, secondHandler);
+
+      expect(firstOptions.headers['x-eqmonitor-device-id'], 'device-1');
+      expect(secondOptions.headers['x-eqmonitor-device-id'], 'device-2');
+      expect(firstHandler.nextOptions, same(firstOptions));
+      expect(secondHandler.nextOptions, same(secondOptions));
+    },
+  );
+
+  test('DeviceIdInterceptor skips device id before registration', () async {
+    final interceptor = DeviceIdInterceptor(readToken: () async => null);
     final options = RequestOptions(
       path: '/v2/parameters/manifest',
       method: 'GET',
     );
     final handler = _CapturingRequestHandler();
 
-    interceptor.onRequest(options, handler);
-
-    expect(options.headers['x-eqmonitor-device-id'], 'device-1');
-    expect(handler.nextOptions, same(options));
-  });
-
-  test('DeviceIdInterceptor skips device id when unavailable', () {
-    final interceptor = DeviceIdInterceptor(deviceId: '');
-    final options = RequestOptions(
-      path: '/v2/parameters/manifest',
-      method: 'GET',
-    );
-    final handler = _CapturingRequestHandler();
-
-    interceptor.onRequest(options, handler);
+    await interceptor.onRequest(options, handler);
 
     expect(options.headers.containsKey('x-eqmonitor-device-id'), isFalse);
     expect(handler.nextOptions, same(options));

--- a/app/test/feature/devices/device_id_decoder_test.dart
+++ b/app/test/feature/devices/device_id_decoder_test.dart
@@ -1,0 +1,57 @@
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:eqmonitor/feature/devices/data/logic/device_id_decoder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const decoder = DeviceIdDecoder();
+
+  test('署名と有効期限を検証せず sub から Device ID を取り出す', () {
+    final signedToken = JWT({
+      'sub': 'device:01976d8e-7d12-7000-8000-1234567890ab',
+      'exp': 0,
+    }).sign(SecretKey('test-secret'));
+    final parts = signedToken.split('.');
+    final tokenWithInvalidSignature = '${parts[0]}.${parts[1]}.invalid';
+
+    expect(
+      decoder.decode(token: tokenWithInvalidSignature),
+      '01976d8e-7d12-7000-8000-1234567890ab',
+    );
+  });
+
+  test('JWT が不正な場合は FormatException を投げる', () {
+    expect(
+      () => decoder.decode(token: 'not-a-jwt'),
+      throwsA(isA<FormatException>()),
+    );
+  });
+
+  test('sub が文字列でない場合は FormatException を投げる', () {
+    final token = JWT({'sub': 123}).sign(SecretKey('test-secret'));
+
+    expect(
+      () => decoder.decode(token: token),
+      throwsA(isA<FormatException>()),
+    );
+  });
+
+  test('sub が device prefix を持たない場合は FormatException を投げる', () {
+    final token = JWT({
+      'sub': '01976d8e-7d12-7000-8000-1234567890ab',
+    }).sign(SecretKey('test-secret'));
+
+    expect(
+      () => decoder.decode(token: token),
+      throwsA(isA<FormatException>()),
+    );
+  });
+
+  test('sub の Device ID が空の場合は FormatException を投げる', () {
+    final token = JWT({'sub': 'device:'}).sign(SecretKey('test-secret'));
+
+    expect(
+      () => decoder.decode(token: token),
+      throwsA(isA<FormatException>()),
+    );
+  });
+}

--- a/app/test/feature/devices/device_provisioning_migration_test.dart
+++ b/app/test/feature/devices/device_provisioning_migration_test.dart
@@ -1,3 +1,4 @@
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/data/preferences/preferences_data_source.dart';
 import 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
@@ -22,6 +23,10 @@ import 'package:talker_flutter/talker_flutter.dart';
 const _deviceId = 'test-device-id';
 const _legacyId = 'legacy-supabase-id';
 
+String _deviceToken(String deviceId) => JWT({
+  'sub': 'device:$deviceId',
+}).sign(SecretKey('test-secret'));
+
 const _fakeDevice = RegisteredDevice(
   id: _deviceId,
   platform: DevicePlatform.ios,
@@ -42,19 +47,23 @@ void main() {
   buildContainer({
     required Map<String, Object> initialPrefs,
     required FakeDeviceRepository deviceRepo,
+    _MemoryDeviceAuthRepository? authRepository,
   }) async {
     SharedPreferences.setMockInitialValues(initialPrefs);
     final prefs = await SharedPreferences.getInstance();
+    final resolvedAuthRepository =
+        authRepository ??
+        (_MemoryDeviceAuthRepository()..savedToken = _deviceToken(_deviceId));
     final container = ProviderContainer(
+      retry: (_, _) => null,
       overrides: [
         app_prefs.sharedPreferencesProvider.overrideWithValue(
           app_prefs.SharedPreferencesAsync(prefs),
         ),
         deviceAuthRepositoryProvider.overrideWith(
-          (ref) async => _MemoryDeviceAuthRepository()..savedToken = 'jwt',
+          (ref) async => resolvedAuthRepository,
         ),
         deviceRepositoryProvider.overrideWith((ref) async => deviceRepo),
-        deviceIdProvider.overrideWith((ref) => _deviceId),
         // _NoopPushTokenSync overrides build() to avoid Firebase init,
         // and sync() to be a no-op. provision() swallows sync errors anyway.
         pushTokenSyncProvider.overrideWith(() => _NoopPushTokenSync()),
@@ -152,6 +161,89 @@ void main() {
       isNot(isTrue),
     );
   });
+
+  test('再登録後は DeviceIdProvider が新しい JWT の ID を返す', () async {
+    final authRepository = _MemoryDeviceAuthRepository()
+      ..savedToken = _deviceToken('device-a');
+    final deviceRepo = FakeDeviceRepository(
+      getResult: () => const Success(_fakeDevice),
+      putResult: () {
+        authRepository.savedToken = _deviceToken('device-b');
+        return const Success(_fakeDevice);
+      },
+      migrateResult: () => const Success(null),
+    );
+    final (container, _, _) = await buildContainer(
+      initialPrefs: {},
+      deviceRepo: deviceRepo,
+      authRepository: authRepository,
+    );
+
+    expect(await container.read(deviceIdProvider.future), 'device-a');
+
+    await container.read(deviceProvisioningProvider.notifier).provision();
+
+    expect(await container.read(deviceIdProvider.future), 'device-b');
+  });
+
+  test('削除後は DeviceIdProvider のキャッシュが破棄される', () async {
+    final authRepository = _MemoryDeviceAuthRepository()
+      ..savedToken = _deviceToken('device-a');
+    final deviceRepo = FakeDeviceRepository(
+      getResult: () => const Success(_fakeDevice),
+      putResult: () => const Success(_fakeDevice),
+      migrateResult: () => const Success(null),
+      deleteResult: () {
+        authRepository.savedToken = null;
+        return const Success(null);
+      },
+    );
+    final (container, _, _) = await buildContainer(
+      initialPrefs: {SharedPreferencesKey.deviceProvisioned.key: true},
+      deviceRepo: deviceRepo,
+      authRepository: authRepository,
+    );
+
+    expect(await container.read(deviceIdProvider.future), 'device-a');
+
+    await container
+        .read(deviceProvisioningProvider.notifier)
+        .deleteDeviceAndClearLocal();
+
+    await expectLater(
+      container.read(deviceIdProvider.future),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('登録失敗後も変更されたJWTに合わせてDevice IDキャッシュを破棄する', () async {
+    final authRepository = _MemoryDeviceAuthRepository()
+      ..savedToken = _deviceToken('device-a');
+    final deviceRepo = FakeDeviceRepository(
+      getResult: () => const Success(_fakeDevice),
+      putResult: () {
+        authRepository.savedToken = null;
+        return Failure(Exception('register failed'));
+      },
+      migrateResult: () => const Success(null),
+    );
+    final (container, _, _) = await buildContainer(
+      initialPrefs: {},
+      deviceRepo: deviceRepo,
+      authRepository: authRepository,
+    );
+
+    expect(await container.read(deviceIdProvider.future), 'device-a');
+
+    await expectLater(
+      container.read(deviceProvisioningProvider.notifier).provision(),
+      throwsA(isA<UnexpectedProvisioningException>()),
+    );
+    await expectLater(
+      container.read(deviceIdProvider.future),
+      throwsA(isA<StateError>()),
+    );
+  });
 }
 
 // 400 BadRequest を表す非再試行エラー。
@@ -191,9 +283,11 @@ class FakeDeviceRepository extends DeviceRepository {
     required Result<RegisteredDevice, Exception> Function() getResult,
     required Result<RegisteredDevice, Exception> Function() putResult,
     required Result<void, Exception> Function() migrateResult,
+    Result<void, Exception> Function()? deleteResult,
   }) : _getResult = getResult,
        _putResult = putResult,
        _migrateResult = migrateResult,
+       _deleteResult = deleteResult,
        super(
          api: api.ApiClient(Dio()),
          authRepository: _MemoryDeviceAuthRepository(),
@@ -203,6 +297,7 @@ class FakeDeviceRepository extends DeviceRepository {
   final Result<RegisteredDevice, Exception> Function() _getResult;
   final Result<RegisteredDevice, Exception> Function() _putResult;
   final Result<void, Exception> Function() _migrateResult;
+  final Result<void, Exception> Function()? _deleteResult;
 
   // ignore: type_annotate_public_apis
   var getCalls = 0;
@@ -212,14 +307,13 @@ class FakeDeviceRepository extends DeviceRepository {
   var migrateCalls = 0;
 
   @override
-  Future<Result<RegisteredDevice, Exception>> getDevice(String deviceId) async {
+  Future<Result<RegisteredDevice, Exception>> getDevice() async {
     getCalls++;
     return _getResult();
   }
 
   @override
   Future<Result<RegisteredDevice, Exception>> registerDevice({
-    required String deviceId,
     required DevicePlatform devicePlatform,
     required DeviceLocale deviceLocale,
   }) async {
@@ -229,12 +323,15 @@ class FakeDeviceRepository extends DeviceRepository {
 
   @override
   Future<Result<void, Exception>> migrateFromLegacy({
-    required String deviceId,
     required String oldDeviceId,
   }) async {
     migrateCalls++;
     return _migrateResult();
   }
+
+  @override
+  Future<Result<void, Exception>> deleteDevice() async =>
+      _deleteResult?.call() ?? const Success(null);
 }
 
 final class _MemoryDeviceAuthRepository extends DeviceAuthRepository {

--- a/app/test/feature/devices/device_provisioning_token_check_test.dart
+++ b/app/test/feature/devices/device_provisioning_token_check_test.dart
@@ -1,6 +1,8 @@
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:eqmonitor/core/data/preferences/preferences_data_source.dart';
 import 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
 import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:eqmonitor/core/provider/device_id.dart';
 import 'package:eqmonitor/core/provider/shared_preferences.dart' as app_prefs;
 import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
 import 'package:eqmonitor/feature/devices/data/repository/device_auth_repository.dart';
@@ -50,7 +52,11 @@ void main() {
         SharedPreferencesKey.deviceProvisioned.key: true,
       });
       final prefs = await SharedPreferences.getInstance();
-      final authRepo = _MemoryDeviceAuthRepository()..savedToken = 'valid-jwt';
+      final authRepo = _MemoryDeviceAuthRepository()
+        ..savedToken = JWT({
+          'sub': 'device:01976d8e-7d12-7000-8000-1234567890ab',
+          'exp': 0,
+        }).sign(SecretKey('test-secret'));
 
       final container = ProviderContainer(
         overrides: [
@@ -68,6 +74,101 @@ void main() {
       expect(status, DeviceProvisioningStatus.notRequired);
     },
   );
+
+  test(
+    'provisioning clears malformed JWT and returns required',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        SharedPreferencesKey.deviceProvisioned.key: true,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final authRepo = _MemoryDeviceAuthRepository()..savedToken = 'not-a-jwt';
+
+      final container = ProviderContainer(
+        overrides: [
+          app_prefs.sharedPreferencesProvider.overrideWithValue(
+            app_prefs.SharedPreferencesAsync(prefs),
+          ),
+          deviceAuthRepositoryProvider.overrideWith((ref) async => authRepo),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final status = await container.read(deviceProvisioningProvider.future);
+      expect(status, DeviceProvisioningStatus.required);
+      expect(authRepo.savedToken, isNull);
+
+      final repo = await container.read(
+        deviceProvisioningRepositoryProvider.future,
+      );
+      expect(await repo.isProvisioned(), isFalse);
+    },
+  );
+
+  test(
+    'provisioning clears JWT without device subject and returns required',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        SharedPreferencesKey.deviceProvisioned.key: true,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final authRepo = _MemoryDeviceAuthRepository()
+        ..savedToken = JWT({
+          'sub': 'user:01976d8e-7d12-7000-8000-1234567890ab',
+        }).sign(SecretKey('test-secret'));
+
+      final container = ProviderContainer(
+        overrides: [
+          app_prefs.sharedPreferencesProvider.overrideWithValue(
+            app_prefs.SharedPreferencesAsync(prefs),
+          ),
+          deviceAuthRepositoryProvider.overrideWith((ref) async => authRepo),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final status = await container.read(deviceProvisioningProvider.future);
+      expect(status, DeviceProvisioningStatus.required);
+      expect(authRepo.savedToken, isNull);
+
+      final repo = await container.read(
+        deviceProvisioningRepositoryProvider.future,
+      );
+      expect(await repo.isProvisioned(), isFalse);
+    },
+  );
+
+  test('不正JWTを削除した後はキャッシュ済みDevice IDも破棄する', () async {
+    SharedPreferences.setMockInitialValues({
+      SharedPreferencesKey.deviceProvisioned.key: true,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final authRepo = _MemoryDeviceAuthRepository()
+      ..savedToken = JWT({
+        'sub': 'device:device-a',
+      }).sign(SecretKey('test-secret'));
+    final container = ProviderContainer(
+      overrides: [
+        app_prefs.sharedPreferencesProvider.overrideWithValue(
+          app_prefs.SharedPreferencesAsync(prefs),
+        ),
+        deviceAuthRepositoryProvider.overrideWith((ref) async => authRepo),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(await container.read(deviceIdProvider.future), 'device-a');
+    authRepo.savedToken = 'not-a-jwt';
+
+    expect(
+      await container.read(deviceProvisioningProvider.future),
+      DeviceProvisioningStatus.required,
+    );
+    await expectLater(
+      container.read(deviceIdProvider.future),
+      throwsA(isA<StateError>()),
+    );
+  });
 
   test(
     'provisioning returns required when flag is false',

--- a/app/test/feature/devices/device_repository_auth_token_test.dart
+++ b/app/test/feature/devices/device_repository_auth_token_test.dart
@@ -30,7 +30,6 @@ void main() {
       );
 
       final result = await repository.registerDevice(
-        deviceId: 'local-device-id',
         devicePlatform: DevicePlatform.ios,
         deviceLocale: DeviceLocale.ja,
       );
@@ -59,12 +58,10 @@ void main() {
       );
 
       final first = await repository.registerDevice(
-        deviceId: 'local-device-id',
         devicePlatform: DevicePlatform.ios,
         deviceLocale: DeviceLocale.ja,
       );
       final second = await repository.registerDevice(
-        deviceId: 'local-device-id',
         devicePlatform: DevicePlatform.ios,
         deviceLocale: DeviceLocale.ja,
       );
@@ -99,7 +96,6 @@ void main() {
       );
 
       final result = await repository.registerDevice(
-        deviceId: 'local-device-id',
         devicePlatform: DevicePlatform.ios,
         deviceLocale: DeviceLocale.ja,
       );
@@ -133,7 +129,6 @@ void main() {
       );
 
       final result = await repository.fetchOrRegister(
-        deviceId: 'local-device-id',
         devicePlatform: DevicePlatform.ios,
         deviceLocale: DeviceLocale.ja,
       );
@@ -163,7 +158,7 @@ void main() {
         apnsEnvironment: api.ApnsEnvironment.development,
       );
 
-      final result = await repository.deleteDevice('local-device-id');
+      final result = await repository.deleteDevice();
 
       expect(result, isA<Success<void, Exception>>());
       expect(authRepository.savedToken, isNull);

--- a/app/test/feature/devices/device_repository_migrate_test.dart
+++ b/app/test/feature/devices/device_repository_migrate_test.dart
@@ -34,7 +34,6 @@ void main() {
     final repository = buildRepository(adapter);
 
     final result = await repository.migrateFromLegacy(
-      deviceId: 'device-id',
       oldDeviceId: _oldDeviceId,
     );
 
@@ -48,7 +47,6 @@ void main() {
     final repository = buildRepository(adapter);
 
     final result = await repository.migrateFromLegacy(
-      deviceId: 'device-id',
       oldDeviceId: _oldDeviceId,
     );
 
@@ -60,7 +58,6 @@ void main() {
     final repository = buildRepository(adapter);
 
     final result = await repository.migrateFromLegacy(
-      deviceId: 'device-id',
       oldDeviceId: _oldDeviceId,
     );
 
@@ -72,7 +69,6 @@ void main() {
     final repository = buildRepository(adapter);
 
     final result = await repository.migrateFromLegacy(
-      deviceId: 'device-id',
       oldDeviceId: _oldDeviceId,
     );
 
@@ -84,7 +80,6 @@ void main() {
     final repository = buildRepository(adapter);
 
     final result = await repository.migrateFromLegacy(
-      deviceId: 'device-id',
       oldDeviceId: _oldDeviceId,
     );
 
@@ -97,7 +92,6 @@ void main() {
     final repository = buildRepository(adapter);
 
     final result = await repository.migrateFromLegacy(
-      deviceId: 'device-id',
       oldDeviceId: _oldDeviceId,
     );
 
@@ -115,7 +109,6 @@ void main() {
     final repository = buildRepository(adapter);
 
     final result = await repository.migrateFromLegacy(
-      deviceId: 'device-id',
       oldDeviceId: _oldDeviceId,
     );
 

--- a/app/test/feature/devices/push_token_sync_auth_recovery_test.dart
+++ b/app/test/feature/devices/push_token_sync_auth_recovery_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/data/preferences/preferences_data_source.dart';
 import 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
@@ -112,7 +113,9 @@ final class _MemoryDeviceAuthRepository extends DeviceAuthRepository {
   Future<void> saveToken({required String token}) async {}
 
   @override
-  Future<String?> readToken() async => 'auth-token';
+  Future<String?> readToken() async => JWT({
+    'sub': 'device:device-id',
+  }).sign(SecretKey('test-secret'));
 
   @override
   Future<void> clearToken() async {}

--- a/app/test/feature/devices/push_token_sync_wiring_test.dart
+++ b/app/test/feature/devices/push_token_sync_wiring_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/data/preferences/preferences_data_source.dart';
 import 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
@@ -657,12 +658,11 @@ final class _StartupDeviceRepository extends DeviceRepository {
 
   @override
   Future<Result<RegisteredDevice, Exception>> registerDevice({
-    required String deviceId,
     required DevicePlatform devicePlatform,
     required DeviceLocale deviceLocale,
   }) async => Success(
     RegisteredDevice(
-      id: deviceId,
+      id: 'device-id',
       platform: devicePlatform,
       userId: null,
       locale: deviceLocale,
@@ -727,7 +727,9 @@ final class _MemoryDeviceAuthRepository extends DeviceAuthRepository {
   Future<void> saveToken({required String token}) async {}
 
   @override
-  Future<String?> readToken() async => 'auth-token';
+  Future<String?> readToken() async => JWT({
+    'sub': 'device:device-id',
+  }).sign(SecretKey('test-secret'));
 
   @override
   Future<void> clearToken() async {}

--- a/app/test/feature/migration/v3_migration_workflow_test.dart
+++ b/app/test/feature/migration/v3_migration_workflow_test.dart
@@ -73,14 +73,13 @@ void main() {
   Future<void> run(FakeDeviceRepository repo) => workflow.run(
     runner: runner,
     repository: repo,
-    deviceId: _deviceId,
     oldDeviceId: _oldDeviceId,
   );
 
   // ── happy path: device absent ───────────────────────────────────────────
 
   group('デバイス未登録のフルハッピーパス', () {
-    test('GET→PUT→POSTの順に呼ばれ、完了フラグが立つ', () async {
+    test('GET→デバイス登録→migrateの順に呼ばれ、完了フラグが立つ', () async {
       final repo = FakeDeviceRepository(
         getResult: _notFound,
         putResult: () => const Success(_fakeDevice),
@@ -119,10 +118,10 @@ void main() {
 
   // ── happy path: device already registered ──────────────────────────────
 
-  test('GETが200のとき PUT をスキップして POST migrate を呼ぶ', () async {
+  test('GETが200のときデバイス登録をスキップしてmigrateを呼ぶ', () async {
     final repo = FakeDeviceRepository(
       getResult: () => const Success(_fakeDevice),
-      putResult: () => throw StateError('PUT should not be called'),
+      putResult: () => throw StateError('register should not be called'),
       migrateResult: () => const Success(null),
     );
 
@@ -133,7 +132,7 @@ void main() {
     expect(repo.migrateCalls, 1);
   });
 
-  test('GETが401のとき未登録扱いで PUT と migrate を呼ぶ', () async {
+  test('GETが401のとき未登録扱いでデバイス登録とmigrateを呼ぶ', () async {
     final repo = FakeDeviceRepository(
       getResult: _unauthorized,
       putResult: () => const Success(_fakeDevice),
@@ -148,7 +147,7 @@ void main() {
     expect(await workflow.isComplete(persistence), isTrue);
   });
 
-  test('GETがunauthenticatedのとき未登録扱いで PUT と migrate を呼ぶ', () async {
+  test('GETがunauthenticatedのとき未登録扱いでデバイス登録とmigrateを呼ぶ', () async {
     final repo = FakeDeviceRepository(
       getResult: _unauthenticated,
       putResult: () => const Success(_fakeDevice),
@@ -165,31 +164,31 @@ void main() {
 
   // ── resume: registerDevice failure ─────────────────────────────────────
 
-  test('PUT失敗後の再実行: ensureDeviceAbsent はスキップされ PUT が再試行される', () async {
+  test('登録失敗後の再実行: 存在確認をスキップして登録が再試行される', () async {
     var putShouldFail = true;
     final repo = FakeDeviceRepository(
       getResult: _notFound,
       putResult: () {
         if (putShouldFail) {
-          return Failure(Exception('PUT network error'));
+          return Failure(Exception('register network error'));
         }
         return const Success(_fakeDevice);
       },
       migrateResult: () => const Success(null),
     );
 
-    // 1回目: GET成功 (キャッシュ), PUT失敗
+    // 1回目: GET成功 (キャッシュ), 登録失敗
     await expectLater(run(repo), throwsA(isA<Exception>()));
     expect(repo.getCalls, 1, reason: 'GET は1回だけ呼ばれるはず');
-    expect(repo.putCalls, 1, reason: 'PUT は1回試行されるはず');
+    expect(repo.putCalls, 1, reason: '登録は1回試行されるはず');
     expect(repo.migrateCalls, 0, reason: 'migrate はまだ呼ばれないはず');
 
-    // 2回目: PUT を成功させる
+    // 2回目: 登録を成功させる
     putShouldFail = false;
     await run(repo);
 
     expect(repo.getCalls, 1, reason: 'GET は2回目でキャッシュ済みなので再実行されない');
-    expect(repo.putCalls, 2, reason: 'PUT は2回目で再試行される');
+    expect(repo.putCalls, 2, reason: '登録は2回目で再試行される');
     expect(repo.migrateCalls, 1, reason: 'migrate は2回目で呼ばれる');
     expect(await workflow.isComplete(persistence), isTrue);
   });
@@ -211,7 +210,7 @@ void main() {
         },
       );
 
-      // 1回目: GET・PUT成功, migrate失敗
+      // 1回目: GET・登録成功, migrate失敗
       await expectLater(run(repo), throwsA(isA<Exception>()));
       expect(repo.getCalls, 1);
       expect(repo.putCalls, 1);
@@ -270,14 +269,13 @@ class FakeDeviceRepository extends DeviceRepository {
   var migrateCalls = 0;
 
   @override
-  Future<Result<RegisteredDevice, Exception>> getDevice(String deviceId) async {
+  Future<Result<RegisteredDevice, Exception>> getDevice() async {
     getCalls++;
     return _getResult();
   }
 
   @override
   Future<Result<RegisteredDevice, Exception>> registerDevice({
-    required String deviceId,
     required DevicePlatform devicePlatform,
     required DeviceLocale deviceLocale,
   }) async {
@@ -287,7 +285,6 @@ class FakeDeviceRepository extends DeviceRepository {
 
   @override
   Future<Result<void, Exception>> migrateFromLegacy({
-    required String deviceId,
     required String oldDeviceId,
   }) async {
     migrateCalls++;

--- a/app/test/feature/settings/children/application_info/about_this_app_page_test.dart
+++ b/app/test/feature/settings/children/application_info/about_this_app_page_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:eqmonitor/core/theme/build_theme.dart';
 import 'package:eqmonitor/core/theme/model/app_theme.dart';
+import 'package:eqmonitor/core/provider/device_id.dart';
 import 'package:eqmonitor/feature/settings/children/application_info/about_this_app_page.dart';
 import 'package:cupertino_ui/cupertino_ui.dart'
     show GlobalCupertinoLocalizations;
@@ -11,6 +12,7 @@ import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 void main() {
   testWidgets('マークダウン本文はテーマのonSurface色を使う', (tester) async {
@@ -24,22 +26,29 @@ void main() {
       }
 
       await tester.pumpWidget(
-        DefaultAssetBundle(
-          bundle: _MarkdownAssetBundle(),
-          child: MaterialApp(
-            theme: AppThemeDataBuilder.build(
-              colorSet: colorSet,
-              brightness: brightness,
+        ProviderScope(
+          overrides: [
+            deviceIdProvider.overrideWith(
+              (ref) => '01976d8e-7d12-7000-8000-1234567890ab',
             ),
-            localizationsDelegates: const [
-              GlobalMaterialLocalizations.delegate,
-              flutter_localizations.GlobalMaterialLocalizations.delegate,
-              flutter_localizations.GlobalWidgetsLocalizations.delegate,
-              GlobalCupertinoLocalizations.delegate,
-            ],
-            supportedLocales: const [Locale('ja', 'JP')],
-            themeAnimationDuration: Duration.zero,
-            home: const AboutThisAppPage(),
+          ],
+          child: DefaultAssetBundle(
+            bundle: _MarkdownAssetBundle(),
+            child: MaterialApp(
+              theme: AppThemeDataBuilder.build(
+                colorSet: colorSet,
+                brightness: brightness,
+              ),
+              localizationsDelegates: const [
+                GlobalMaterialLocalizations.delegate,
+                flutter_localizations.GlobalMaterialLocalizations.delegate,
+                flutter_localizations.GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+              ],
+              supportedLocales: const [Locale('ja', 'JP')],
+              themeAnimationDuration: Duration.zero,
+              home: const AboutThisAppPage(),
+            ),
           ),
         ),
       );
@@ -49,6 +58,10 @@ void main() {
       expect(markdown.styleSheet?.p?.color, colorSet.onSurface);
       expect(markdown.styleSheet?.a?.color, colorSet.primary);
       expect(find.byType(ListView), findsOneWidget);
+      expect(
+        find.text('01976d8e-7d12-7000-8000-1234567890ab'),
+        findsOneWidget,
+      );
     }
   });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -433,6 +433,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  dart_jsonwebtoken:
+    dependency: transitive
+    description:
+      name: dart_jsonwebtoken
+      sha256: ad84e60181696513d04d5f2078e0bbc20365b911f46f647797317414bdc88fbe
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   dart_style:
     dependency: "direct overridden"
     description:
@@ -1061,15 +1069,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
-  flutter_udid:
-    dependency: transitive
-    description:
-      path: "."
-      ref: d8f72a1e9e09a9f76f4e5051f167b31c5e2af52e
-      resolved-ref: d8f72a1e9e09a9f76f4e5051f167b31c5e2af52e
-      url: "https://github.com/YumNumm/flutter_udid.git"
-    source: git
-    version: "4.1.2"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -1905,6 +1904,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.10.3"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   pool:
     dependency: transitive
     description:


### PR DESCRIPTION
## 概要

- FlutterUdidによるローカルDevice ID生成を削除
- POST /v2/deviceが発行したJWTのsubからDevice IDを取得して設定画面へ表示
- x-eqmonitor-device-idをリクエストごとに最新JWTから生成
- 登録・削除・認証失敗時のDevice IDキャッシュとprovisioning状態を同期
- dart_jsonwebtokenのJWT.decodeのみを使用し、署名・有効期限は検証しない

## テスト

- 関連テスト62件: 成功
- mise exec -- dart analyze lib: No issues found
- mise exec -- flutter analyze: 今回と無関係な既存のapp_clock_test警告1件
- mise exec -- flutter test: 全体実行では23件失敗。Device関連の1件は古い固定文字列fixtureが原因でJWTへ修正し、単独再実行で成功。残りはClock、WebView、通知設定、テーマ編集など未変更領域の既存失敗