### PR TITLE
feat: GPU地図へ地震震源spriteを統合

### DIFF
--- a/app/lib/feature/earthquake_history/data/logic/earthquake_map_overlay_builder.dart
+++ b/app/lib/feature/earthquake_history/data/logic/earthquake_map_overlay_builder.dart
@@ -8,8 +8,6 @@ import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_inten
 import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
 import 'package:eqmonitor_map/eqmonitor_map.dart';
 
-const earthquakeOverlayRegionToCityZoom = 6.0;
-const earthquakeOverlayStationMinZoom = 6.0;
 const earthquakeOverlayMaxSpritePolicyBatches = 1;
 
 enum EarthquakeMapOverlayUnavailableReason {

--- a/app/lib/feature/earthquake_history/data/logic/earthquake_map_overlay_builder.dart
+++ b/app/lib/feature/earthquake_history/data/logic/earthquake_map_overlay_builder.dart
@@ -1,6 +1,9 @@
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/theme/model/intensity_colors.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_map_sprite_atlas_builder.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity.dart';
 import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
 import 'package:eqmonitor_map/eqmonitor_map.dart';
@@ -44,6 +47,8 @@ final class EarthquakeMapOverlayBuilder {
     required Earthquake earthquake,
     required IntensityColors colorModel,
     required MapOverlayVersionStamp versionStamp,
+    required EarthquakeHistoryMapLayerParameter parameter,
+    required MapSpriteAtlas spriteAtlas,
   }) {
     final reason = unavailableReason(earthquake);
     if (reason != null) {
@@ -60,22 +65,27 @@ final class EarthquakeMapOverlayBuilder {
     return EarthquakeMapOverlayAvailable(
       snapshot: createEarthquakeMapOverlaySnapshot(
         versionStamp: versionStamp,
-        regionToCityZoom: earthquakeOverlayRegionToCityZoom,
-        stationMinZoom: earthquakeOverlayStationMinZoom,
+        regionToCityZoom: parameter.regionToCity,
+        stationMinZoom: parameter.stationMinZoom,
         regionStyles: regionStyles(
           intensity: intensity,
           colorModel: colorModel,
+          opacity: parameter.regionFillOpacity,
         ),
         cityStyles: cityStyles(
           intensity: intensity,
           colorModel: colorModel,
+          opacity: parameter.cityFillOpacity,
         ),
         stations: observationPoints(
           intensity: intensity,
           colorModel: colorModel,
         ),
-        spriteAtlas: null,
-        sprites: const [],
+        spriteAtlas: spriteAtlas,
+        sprites: hypocenterSprites(
+          earthquake: earthquake,
+          parameter: parameter,
+        ),
         maxSpritePolicyBatches: earthquakeOverlayMaxSpritePolicyBatches,
       ),
     );
@@ -96,9 +106,11 @@ final class EarthquakeMapOverlayBuilder {
   List<EarthquakeAreaStyle> regionStyles({
     required EarthquakeIntensity intensity,
     required IntensityColors colorModel,
+    required double opacity,
   }) => areaStyles(
     levels: regionIntensityLevels(intensity: intensity),
     colorModel: colorModel,
+    opacity: opacity,
   );
 
   Map<String, JmaIntensity> regionIntensityLevels({
@@ -123,9 +135,11 @@ final class EarthquakeMapOverlayBuilder {
   List<EarthquakeAreaStyle> cityStyles({
     required EarthquakeIntensity intensity,
     required IntensityColors colorModel,
+    required double opacity,
   }) => areaStyles(
     levels: cityIntensityLevels(intensity: intensity),
     colorModel: colorModel,
+    opacity: opacity,
   );
 
   Map<String, JmaIntensity> cityIntensityLevels({
@@ -163,6 +177,7 @@ final class EarthquakeMapOverlayBuilder {
   List<EarthquakeAreaStyle> areaStyles({
     required Map<String, JmaIntensity> levels,
     required IntensityColors colorModel,
+    required double opacity,
   }) {
     final entries = levels.entries.toList()
       ..sort((first, second) => first.key.compareTo(second.key));
@@ -171,7 +186,7 @@ final class EarthquakeMapOverlayBuilder {
         EarthquakeAreaStyle(
           code: entry.key,
           color: colorModel.fromJmaIntensity(entry.value).background,
-          opacity: 0.6,
+          opacity: opacity,
         ),
     ];
   }
@@ -220,5 +235,41 @@ final class EarthquakeMapOverlayBuilder {
       }
     }
     return observations;
+  }
+
+  List<MapPointSpriteFeature> hypocenterSprites({
+    required Earthquake earthquake,
+    required EarthquakeHistoryMapLayerParameter parameter,
+  }) {
+    final coordinates = earthquake.hypocenter?.coordinates;
+    if (coordinates case CoordinateLatLng(:final longitude, :final latitude)
+        when longitude.isFinite &&
+            longitude >= -180 &&
+            longitude <= 180 &&
+            latitude.isFinite &&
+            latitude >= -90 &&
+            latitude <= 90) {
+      return [
+        createMapPointSpriteFeature(
+          id: 'hypocenter:${earthquake.eventId}',
+          longitude: longitude,
+          latitude: latitude,
+          spriteRegionId: earthquakeMapNormalSpriteRegionId,
+          sizeScale: createMapZoomLinearRange(
+            startZoom: 3,
+            startValue: parameter.hypocenterIconSizeMin,
+            endZoom: 20,
+            endValue: parameter.hypocenterIconSizeMax,
+          ),
+          opacity: createMapZoomStep(
+            thresholdZoom: parameter.hypocenterFadeZoom,
+            belowValue: 1,
+            atOrAboveValue: parameter.hypocenterFadeOpacity,
+          ),
+          priority: 0,
+        ),
+      ];
+    }
+    return const [];
   }
 }

--- a/app/lib/feature/earthquake_history/data/logic/earthquake_map_overlay_digest_builder.dart
+++ b/app/lib/feature/earthquake_history/data/logic/earthquake_map_overlay_digest_builder.dart
@@ -101,6 +101,8 @@ final class EarthquakeMapOverlayDigestBuilder {
     required List<EarthquakeAreaStyle> regionStyles,
     required List<EarthquakeAreaStyle> cityStyles,
     required List<EarthquakeObservationPoint> stations,
+    required MapSpriteAtlas spriteAtlas,
+    required List<MapPointSpriteFeature> sprites,
   }) {
     final records = <CanonicalOverlayRecord>[
       CanonicalOverlayRecord(
@@ -109,6 +111,15 @@ final class EarthquakeMapOverlayDigestBuilder {
         fields: {
           'regionToCityZoom': canonicalDouble(regionToCityZoom),
           'stationMinZoom': canonicalDouble(stationMinZoom),
+        },
+      ),
+      CanonicalOverlayRecord(
+        recordType: 'spriteAtlas',
+        stableId: spriteAtlas.identity.value,
+        fields: {
+          'height': spriteAtlas.height.toString(),
+          'regionCount': spriteAtlas.regions.length.toString(),
+          'width': spriteAtlas.width.toString(),
         },
       ),
       for (final style in regionStyles)
@@ -128,9 +139,31 @@ final class EarthquakeMapOverlayDigestBuilder {
             ),
           },
         ),
+      for (final sprite in sprites)
+        CanonicalOverlayRecord(
+          recordType: 'sprite',
+          stableId: sprite.id,
+          fields: {
+            'latitude': canonicalDouble(sprite.latitude),
+            'longitude': canonicalDouble(sprite.longitude),
+            'opacityAtOrAboveValue': canonicalDouble(
+              sprite.opacity.atOrAboveValue,
+            ),
+            'opacityBelowValue': canonicalDouble(sprite.opacity.belowValue),
+            'opacityThresholdZoom': canonicalDouble(
+              sprite.opacity.thresholdZoom,
+            ),
+            'priority': sprite.priority.toString(),
+            'sizeEndValue': canonicalDouble(sprite.sizeScale.endValue),
+            'sizeEndZoom': canonicalDouble(sprite.sizeScale.endZoom),
+            'sizeStartValue': canonicalDouble(sprite.sizeScale.startValue),
+            'sizeStartZoom': canonicalDouble(sprite.sizeScale.startZoom),
+            'spriteRegionId': sprite.spriteRegionId,
+          },
+        ),
     ];
     return canonicalDigest(
-      format: 'earthquake-overlay-render-v1',
+      format: 'earthquake-overlay-render-v2',
       headerFields: {
         'dataDigest': dataDigest,
         'dataSequence': dataSequence.toString(),

--- a/app/lib/feature/earthquake_history/data/logic/earthquake_map_sprite_atlas_builder.dart
+++ b/app/lib/feature/earthquake_history/data/logic/earthquake_map_sprite_atlas_builder.dart
@@ -1,0 +1,282 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:crypto/crypto.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+
+const earthquakeMapNormalSpriteRegionId = 'normal';
+const earthquakeMapLowPrecisionSpriteRegionId = 'low-precision';
+
+final class EarthquakeMapSpriteImage {
+  new({required int width, required int height, required Uint8List rgbaBytes})
+    : width = width,
+      height = height,
+      rgbaBytes = Uint8List.fromList(rgbaBytes).asUnmodifiableView() {
+    if (width <= 0) {
+      throw ArgumentError.value(width, 'width', 'must be positive');
+    }
+    if (height <= 0) {
+      throw ArgumentError.value(height, 'height', 'must be positive');
+    }
+    final hasTightPixels =
+        rgbaBytes.length.remainder(MapSpriteAtlas.bytesPerPixel) == 0 &&
+        rgbaBytes.length ~/ MapSpriteAtlas.bytesPerPixel ~/ width == height &&
+        rgbaBytes.length ~/ MapSpriteAtlas.bytesPerPixel % width == 0;
+    if (!hasTightPixels) {
+      throw ArgumentError.value(rgbaBytes.length, 'rgbaBytes');
+    }
+  }
+
+  final int width;
+  final int height;
+  final Uint8List rgbaBytes;
+}
+
+final class EarthquakeMapSpriteAtlasBuilder {
+  const new();
+
+  MapSpriteAtlas build({
+    required EarthquakeMapSpriteImage normalImage,
+    required EarthquakeMapSpriteImage lowPrecisionImage,
+    required MapSpriteAtlasLimits limits,
+  }) {
+    const limitValidator = _EarthquakeMapSpriteAtlasLimitValidator();
+    limitValidator.validateDimensions(
+      normalImage: normalImage,
+      lowPrecisionImage: lowPrecisionImage,
+      limits: limits,
+    );
+    final layout = _EarthquakeMapSpriteAtlasLayout(
+      normalImage: normalImage,
+      lowPrecisionImage: lowPrecisionImage,
+    );
+    final rgbaBytes = Uint8List(
+      limitValidator.validatedByteCount(layout: layout, limits: limits),
+    );
+    for (final placement in layout.placements) {
+      placement.blitTo(atlasWidth: layout.width, destination: rgbaBytes);
+    }
+    final regions = [
+      for (final placement in layout.placements)
+        placement.toRegion(
+          atlasWidth: layout.width,
+          atlasHeight: layout.height,
+        ),
+    ];
+    return createMapSpriteAtlas(
+      identity: createMapSourceIdentity(
+        value: const _EarthquakeMapSpriteAtlasIdentityBuilder().build(
+          layout: layout,
+          rgbaBytes: rgbaBytes,
+        ),
+      ),
+      width: layout.width,
+      height: layout.height,
+      rgbaBytes: rgbaBytes,
+      regions: regions,
+      limits: limits,
+    );
+  }
+}
+
+final class _EarthquakeMapSpriteAtlasLayout {
+  new({
+    required EarthquakeMapSpriteImage normalImage,
+    required EarthquakeMapSpriteImage lowPrecisionImage,
+  }) : placements = [
+         _EarthquakeMapSpritePlacement(
+           regionId: earthquakeMapNormalSpriteRegionId,
+           image: normalImage,
+           cellLeft: 0,
+         ),
+         _EarthquakeMapSpritePlacement(
+           regionId: earthquakeMapLowPrecisionSpriteRegionId,
+           image: lowPrecisionImage,
+           cellLeft: normalImage.width + _padding * 2,
+         ),
+       ],
+       width = normalImage.width + lowPrecisionImage.width + _padding * 4,
+       height =
+           (normalImage.height > lowPrecisionImage.height
+               ? normalImage.height
+               : lowPrecisionImage.height) +
+           _padding * 2;
+
+  static const _padding = MapSpriteAtlas.regionExtrusionPixels;
+
+  final List<_EarthquakeMapSpritePlacement> placements;
+  final int width;
+  final int height;
+}
+
+final class _EarthquakeMapSpriteAtlasLimitValidator {
+  const new();
+
+  void validateDimensions({
+    required EarthquakeMapSpriteImage normalImage,
+    required EarthquakeMapSpriteImage lowPrecisionImage,
+    required MapSpriteAtlasLimits limits,
+  }) {
+    if (limits.maxWidth <= 0 ||
+        limits.maxHeight <= 0 ||
+        limits.maxPixelBytes <= 0 ||
+        limits.maxRegions <= 0) {
+      throw ArgumentError.value(limits, 'limits');
+    }
+    if (limits.maxRegions < 2) {
+      throw ArgumentError.value(2, 'regions');
+    }
+    final horizontalPadding = MapSpriteAtlas.regionExtrusionPixels * 4;
+    if (horizontalPadding > limits.maxWidth ||
+        normalImage.width > limits.maxWidth - horizontalPadding ||
+        lowPrecisionImage.width >
+            limits.maxWidth - horizontalPadding - normalImage.width) {
+      throw ArgumentError.value(limits.maxWidth, 'limits.maxWidth');
+    }
+    final verticalPadding = MapSpriteAtlas.regionExtrusionPixels * 2;
+    final sourceHeight = normalImage.height > lowPrecisionImage.height
+        ? normalImage.height
+        : lowPrecisionImage.height;
+    if (verticalPadding > limits.maxHeight ||
+        sourceHeight > limits.maxHeight - verticalPadding) {
+      throw ArgumentError.value(limits.maxHeight, 'limits.maxHeight');
+    }
+  }
+
+  int validatedByteCount({
+    required _EarthquakeMapSpriteAtlasLayout layout,
+    required MapSpriteAtlasLimits limits,
+  }) {
+    if (layout.width > limits.maxPixelBytes ~/ MapSpriteAtlas.bytesPerPixel) {
+      throw ArgumentError.value(limits.maxPixelBytes, 'limits.maxPixelBytes');
+    }
+    final rowByteCount = layout.width * MapSpriteAtlas.bytesPerPixel;
+    if (layout.height > limits.maxPixelBytes ~/ rowByteCount) {
+      throw ArgumentError.value(limits.maxPixelBytes, 'limits.maxPixelBytes');
+    }
+    return rowByteCount * layout.height;
+  }
+}
+
+final class _EarthquakeMapSpritePlacement {
+  const new({
+    required this.regionId,
+    required this.image,
+    required this.cellLeft,
+  });
+
+  static const _padding = MapSpriteAtlas.regionExtrusionPixels;
+
+  final String regionId;
+  final EarthquakeMapSpriteImage image;
+  final int cellLeft;
+
+  int get cellWidth => image.width + _padding * 2;
+
+  void blitTo({required int atlasWidth, required Uint8List destination}) {
+    for (var cellY = 0; cellY < image.height + _padding * 2; cellY++) {
+      final sourceY = clampedSourceIndex(
+        cellIndex: cellY,
+        sourceLength: image.height,
+      );
+      for (var cellX = 0; cellX < cellWidth; cellX++) {
+        final sourceX = clampedSourceIndex(
+          cellIndex: cellX,
+          sourceLength: image.width,
+        );
+        final sourceOffset =
+            (sourceY * image.width + sourceX) * MapSpriteAtlas.bytesPerPixel;
+        final destinationOffset =
+            (cellY * atlasWidth + cellLeft + cellX) *
+            MapSpriteAtlas.bytesPerPixel;
+        destination.setRange(
+          destinationOffset,
+          destinationOffset + MapSpriteAtlas.bytesPerPixel,
+          image.rgbaBytes,
+          sourceOffset,
+        );
+      }
+    }
+  }
+
+  MapSpriteRegion toRegion({
+    required int atlasWidth,
+    required int atlasHeight,
+  }) {
+    final contentLeft = cellLeft + _padding;
+    const contentTop = _padding;
+    return MapSpriteRegion(
+      id: regionId,
+      normalizedUv: Rect.fromLTRB(
+        (contentLeft + 0.5) / atlasWidth,
+        (contentTop + 0.5) / atlasHeight,
+        (contentLeft + image.width - 0.5) / atlasWidth,
+        (contentTop + image.height - 0.5) / atlasHeight,
+      ),
+      logicalSize: Size(image.width.toDouble(), image.height.toDouble()),
+    );
+  }
+
+  int clampedSourceIndex({required int cellIndex, required int sourceLength}) {
+    final contentIndex = cellIndex - MapSpriteAtlas.regionExtrusionPixels;
+    if (contentIndex < 0) {
+      return 0;
+    }
+    if (contentIndex >= sourceLength) {
+      return sourceLength - 1;
+    }
+    return contentIndex;
+  }
+}
+
+final class _EarthquakeMapSpriteAtlasIdentityBuilder {
+  const new();
+
+  String build({
+    required _EarthquakeMapSpriteAtlasLayout layout,
+    required Uint8List rgbaBytes,
+  }) {
+    final digestInput = BytesBuilder(copy: false);
+    appendField(
+      destination: digestInput,
+      tag: 'format',
+      value: 'earthquake-map-sprite-atlas-v1',
+    );
+    appendField(
+      destination: digestInput,
+      tag: 'size',
+      value: '${layout.width}x${layout.height}',
+    );
+    for (final placement in layout.placements) {
+      appendField(
+        destination: digestInput,
+        tag: 'region',
+        value:
+            '${placement.regionId}:${placement.cellLeft}:'
+            '${placement.image.width}x${placement.image.height}',
+      );
+    }
+    appendField(
+      destination: digestInput,
+      tag: 'rgbaLength',
+      value: rgbaBytes.length.toString(),
+    );
+    digestInput.add(rgbaBytes);
+    return 'sha256:${sha256.convert(digestInput.takeBytes())}';
+  }
+
+  void appendField({
+    required BytesBuilder destination,
+    required String tag,
+    required String value,
+  }) {
+    final tagBytes = utf8.encode(tag);
+    final valueBytes = utf8.encode(value);
+    destination
+      ..add(ascii.encode('${tagBytes.length}:'))
+      ..add(tagBytes)
+      ..add(ascii.encode('${valueBytes.length}:'))
+      ..add(valueBytes);
+  }
+}

--- a/app/lib/feature/earthquake_history/data/provider/earthquake_map_sprite_atlas_provider.dart
+++ b/app/lib/feature/earthquake_history/data/provider/earthquake_map_sprite_atlas_provider.dart
@@ -1,0 +1,280 @@
+import 'dart:ui' as ui;
+
+import 'package:eqmonitor/core/gen/assets.gen.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_map_sprite_atlas_builder.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'earthquake_map_sprite_atlas_provider.g.dart';
+
+enum EarthquakeMapSpriteAtlasFailureReason {
+  assetLoad,
+  imageDecode,
+  pixelConversion,
+  atlasBuild,
+}
+
+typedef EarthquakeMapSpriteAtlasLimitsKey = ({
+  int maxWidth,
+  int maxHeight,
+  int maxPixelBytes,
+  int maxRegions,
+});
+
+extension EarthquakeMapSpriteAtlasLimitsKeyConverter on MapSpriteAtlasLimits {
+  EarthquakeMapSpriteAtlasLimitsKey get earthquakeMapSpriteAtlasLimitsKey => (
+    maxWidth: maxWidth,
+    maxHeight: maxHeight,
+    maxPixelBytes: maxPixelBytes,
+    maxRegions: maxRegions,
+  );
+}
+
+final class EarthquakeMapSpriteAtlasException implements Exception {
+  const new({required this.reason, required this.assetPath});
+
+  final EarthquakeMapSpriteAtlasFailureReason reason;
+  final String? assetPath;
+
+  @override
+  String toString() => 'Earthquake map sprite atlas failed: ${reason.name}';
+}
+
+abstract final class EarthquakeMapSpriteAtlasRetryPolicy {
+  static Duration? noRetry(int retryCount, Object error) => null;
+}
+
+abstract interface class EarthquakeMapSpriteImageDecoder {
+  Future<EarthquakeMapSpriteImage> decode({
+    required String assetPath,
+    required Uint8List encodedBytes,
+  });
+}
+
+final class FlutterEarthquakeMapSpriteImageDecoder
+    implements EarthquakeMapSpriteImageDecoder {
+  const new();
+
+  @override
+  Future<EarthquakeMapSpriteImage> decode({
+    required String assetPath,
+    required Uint8List encodedBytes,
+  }) async {
+    final frame = await decodeFirstFrame(
+      assetPath: assetPath,
+      encodedBytes: encodedBytes,
+    );
+    try {
+      return await convertToStraightRgba(
+        assetPath: assetPath,
+        image: frame.image,
+      );
+    } finally {
+      frame.image.dispose();
+      frame.codec.dispose();
+    }
+  }
+
+  Future<({ui.Codec codec, ui.Image image})> decodeFirstFrame({
+    required String assetPath,
+    required Uint8List encodedBytes,
+  }) async {
+    ui.Codec? codec;
+    try {
+      codec = await ui.instantiateImageCodec(encodedBytes);
+      final frame = await codec.getNextFrame();
+      return (codec: codec, image: frame.image);
+    } on Exception {
+      codec?.dispose();
+      throw EarthquakeMapSpriteAtlasException(
+        reason: .imageDecode,
+        assetPath: assetPath,
+      );
+    }
+  }
+
+  Future<EarthquakeMapSpriteImage> convertToStraightRgba({
+    required String assetPath,
+    required ui.Image image,
+  }) async {
+    try {
+      final byteData = await image.toByteData(
+        format: ui.ImageByteFormat.rawStraightRgba,
+      );
+      if (byteData == null) {
+        throw EarthquakeMapSpriteAtlasException(
+          reason: .pixelConversion,
+          assetPath: assetPath,
+        );
+      }
+      return EarthquakeMapSpriteImage(
+        width: image.width,
+        height: image.height,
+        rgbaBytes: byteData.buffer.asUint8List(
+          byteData.offsetInBytes,
+          byteData.lengthInBytes,
+        ),
+      );
+    } on EarthquakeMapSpriteAtlasException {
+      rethrow;
+    } on Exception {
+      throw EarthquakeMapSpriteAtlasException(
+        reason: .pixelConversion,
+        assetPath: assetPath,
+      );
+    }
+  }
+}
+
+final class EarthquakeMapSpriteAssetLoader {
+  const new();
+
+  Future<EarthquakeMapSpriteImage> load({
+    required AssetBundle bundle,
+    required EarthquakeMapSpriteImageDecoder decoder,
+    required String assetPath,
+  }) async {
+    final ByteData encoded;
+    try {
+      encoded = await bundle.load(assetPath);
+    } on FlutterError {
+      throw EarthquakeMapSpriteAtlasException(
+        reason: .assetLoad,
+        assetPath: assetPath,
+      );
+    } on Exception {
+      throw EarthquakeMapSpriteAtlasException(
+        reason: .assetLoad,
+        assetPath: assetPath,
+      );
+    }
+    return decoder.decode(
+      assetPath: assetPath,
+      encodedBytes: encoded.buffer.asUint8List(
+        encoded.offsetInBytes,
+        encoded.lengthInBytes,
+      ),
+    );
+  }
+
+  Future<(EarthquakeMapSpriteImage, EarthquakeMapSpriteImage)> loadPair({
+    required AssetBundle bundle,
+    required EarthquakeMapSpriteImageDecoder decoder,
+    required String firstAssetPath,
+    required String secondAssetPath,
+  }) async {
+    final (first, second) = await (
+      settle(load(bundle: bundle, decoder: decoder, assetPath: firstAssetPath)),
+      settle(
+        load(bundle: bundle, decoder: decoder, assetPath: secondAssetPath),
+      ),
+    ).wait;
+    return (first.unwrap(), second.unwrap());
+  }
+
+  Future<_EarthquakeMapSpriteLoadResult> settle(
+    Future<EarthquakeMapSpriteImage> pending,
+  ) async {
+    try {
+      return _EarthquakeMapSpriteLoadSuccess(await pending);
+    } on Exception catch (error, stackTrace) {
+      return _EarthquakeMapSpriteLoadException(error, stackTrace);
+    } on Error catch (error, stackTrace) {
+      return _EarthquakeMapSpriteLoadError(error, stackTrace);
+    }
+  }
+}
+
+sealed class _EarthquakeMapSpriteLoadResult {
+  const new();
+
+  EarthquakeMapSpriteImage unwrap();
+}
+
+final class _EarthquakeMapSpriteLoadSuccess
+    extends _EarthquakeMapSpriteLoadResult {
+  const new(this.image);
+
+  final EarthquakeMapSpriteImage image;
+
+  @override
+  EarthquakeMapSpriteImage unwrap() => image;
+}
+
+final class _EarthquakeMapSpriteLoadException
+    extends _EarthquakeMapSpriteLoadResult {
+  const new(this.error, this.stackTrace);
+
+  final Exception error;
+  final StackTrace stackTrace;
+
+  @override
+  Never unwrap() => Error.throwWithStackTrace(error, stackTrace);
+}
+
+final class _EarthquakeMapSpriteLoadError
+    extends _EarthquakeMapSpriteLoadResult {
+  const new(this.error, this.stackTrace);
+
+  final Error error;
+  final StackTrace stackTrace;
+
+  @override
+  Never unwrap() => Error.throwWithStackTrace(error, stackTrace);
+}
+
+@Riverpod(keepAlive: true)
+AssetBundle earthquakeMapSpriteAssetBundle(Ref ref) => rootBundle;
+
+@Riverpod(keepAlive: true)
+EarthquakeMapSpriteImageDecoder earthquakeMapSpriteImageDecoder(Ref ref) =>
+    const FlutterEarthquakeMapSpriteImageDecoder();
+
+@Riverpod(keepAlive: true)
+EarthquakeMapSpriteAssetLoader earthquakeMapSpriteAssetLoader(Ref ref) =>
+    const EarthquakeMapSpriteAssetLoader();
+
+@Riverpod(keepAlive: true)
+EarthquakeMapSpriteAtlasBuilder earthquakeMapSpriteAtlasBuilder(Ref ref) =>
+    const EarthquakeMapSpriteAtlasBuilder();
+
+@Riverpod(
+  keepAlive: true,
+  retry: EarthquakeMapSpriteAtlasRetryPolicy.noRetry,
+)
+Future<MapSpriteAtlas> earthquakeMapSpriteAtlas(
+  Ref ref,
+  EarthquakeMapSpriteAtlasLimitsKey limitsKey,
+) async {
+  final loader = ref.watch(earthquakeMapSpriteAssetLoaderProvider);
+  final bundle = ref.watch(earthquakeMapSpriteAssetBundleProvider);
+  final decoder = ref.watch(earthquakeMapSpriteImageDecoderProvider);
+  final (normalImage, lowPrecisionImage) = await loader.loadPair(
+    bundle: bundle,
+    decoder: decoder,
+    firstAssetPath: Assets.images.map.normalHypocenter.path,
+    secondAssetPath: Assets.images.map.lowPreciseHypocenter.path,
+  );
+  final limits = MapSpriteAtlasLimits(
+    maxWidth: limitsKey.maxWidth,
+    maxHeight: limitsKey.maxHeight,
+    maxPixelBytes: limitsKey.maxPixelBytes,
+    maxRegions: limitsKey.maxRegions,
+  );
+  try {
+    return ref
+        .watch(earthquakeMapSpriteAtlasBuilderProvider)
+        .build(
+          normalImage: normalImage,
+          lowPrecisionImage: lowPrecisionImage,
+          limits: limits,
+        );
+  } on ArgumentError {
+    throw const EarthquakeMapSpriteAtlasException(
+      reason: .atlasBuild,
+      assetPath: null,
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/data/provider/earthquake_map_sprite_atlas_provider.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/earthquake_map_sprite_atlas_provider.g.dart
@@ -1,0 +1,290 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'earthquake_map_sprite_atlas_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(earthquakeMapSpriteAssetBundle)
+final earthquakeMapSpriteAssetBundleProvider =
+    EarthquakeMapSpriteAssetBundleProvider._();
+
+final class EarthquakeMapSpriteAssetBundleProvider
+    extends $FunctionalProvider<AssetBundle, AssetBundle, AssetBundle>
+    with $Provider<AssetBundle> {
+  EarthquakeMapSpriteAssetBundleProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'earthquakeMapSpriteAssetBundleProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$earthquakeMapSpriteAssetBundleHash();
+
+  @$internal
+  @override
+  $ProviderElement<AssetBundle> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  AssetBundle create(Ref ref) {
+    return earthquakeMapSpriteAssetBundle(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AssetBundle value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AssetBundle>(value),
+    );
+  }
+}
+
+String _$earthquakeMapSpriteAssetBundleHash() =>
+    r'761eb802450e20e7cb2622abc974483d64dfffe6';
+
+@ProviderFor(earthquakeMapSpriteImageDecoder)
+final earthquakeMapSpriteImageDecoderProvider =
+    EarthquakeMapSpriteImageDecoderProvider._();
+
+final class EarthquakeMapSpriteImageDecoderProvider
+    extends
+        $FunctionalProvider<
+          EarthquakeMapSpriteImageDecoder,
+          EarthquakeMapSpriteImageDecoder,
+          EarthquakeMapSpriteImageDecoder
+        >
+    with $Provider<EarthquakeMapSpriteImageDecoder> {
+  EarthquakeMapSpriteImageDecoderProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'earthquakeMapSpriteImageDecoderProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$earthquakeMapSpriteImageDecoderHash();
+
+  @$internal
+  @override
+  $ProviderElement<EarthquakeMapSpriteImageDecoder> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EarthquakeMapSpriteImageDecoder create(Ref ref) {
+    return earthquakeMapSpriteImageDecoder(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EarthquakeMapSpriteImageDecoder value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EarthquakeMapSpriteImageDecoder>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$earthquakeMapSpriteImageDecoderHash() =>
+    r'1a57722a8fd0fd45588b7e5be6a3fb0e25c67382';
+
+@ProviderFor(earthquakeMapSpriteAssetLoader)
+final earthquakeMapSpriteAssetLoaderProvider =
+    EarthquakeMapSpriteAssetLoaderProvider._();
+
+final class EarthquakeMapSpriteAssetLoaderProvider
+    extends
+        $FunctionalProvider<
+          EarthquakeMapSpriteAssetLoader,
+          EarthquakeMapSpriteAssetLoader,
+          EarthquakeMapSpriteAssetLoader
+        >
+    with $Provider<EarthquakeMapSpriteAssetLoader> {
+  EarthquakeMapSpriteAssetLoaderProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'earthquakeMapSpriteAssetLoaderProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$earthquakeMapSpriteAssetLoaderHash();
+
+  @$internal
+  @override
+  $ProviderElement<EarthquakeMapSpriteAssetLoader> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EarthquakeMapSpriteAssetLoader create(Ref ref) {
+    return earthquakeMapSpriteAssetLoader(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EarthquakeMapSpriteAssetLoader value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EarthquakeMapSpriteAssetLoader>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$earthquakeMapSpriteAssetLoaderHash() =>
+    r'1d02ede0a853734eba16ca2607173d4b9acbe380';
+
+@ProviderFor(earthquakeMapSpriteAtlasBuilder)
+final earthquakeMapSpriteAtlasBuilderProvider =
+    EarthquakeMapSpriteAtlasBuilderProvider._();
+
+final class EarthquakeMapSpriteAtlasBuilderProvider
+    extends
+        $FunctionalProvider<
+          EarthquakeMapSpriteAtlasBuilder,
+          EarthquakeMapSpriteAtlasBuilder,
+          EarthquakeMapSpriteAtlasBuilder
+        >
+    with $Provider<EarthquakeMapSpriteAtlasBuilder> {
+  EarthquakeMapSpriteAtlasBuilderProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'earthquakeMapSpriteAtlasBuilderProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$earthquakeMapSpriteAtlasBuilderHash();
+
+  @$internal
+  @override
+  $ProviderElement<EarthquakeMapSpriteAtlasBuilder> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EarthquakeMapSpriteAtlasBuilder create(Ref ref) {
+    return earthquakeMapSpriteAtlasBuilder(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EarthquakeMapSpriteAtlasBuilder value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EarthquakeMapSpriteAtlasBuilder>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$earthquakeMapSpriteAtlasBuilderHash() =>
+    r'f1c1bcf347a7bc8d9884409c9b482586dbeb7116';
+
+@ProviderFor(earthquakeMapSpriteAtlas)
+final earthquakeMapSpriteAtlasProvider = EarthquakeMapSpriteAtlasFamily._();
+
+final class EarthquakeMapSpriteAtlasProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<MapSpriteAtlas>,
+          MapSpriteAtlas,
+          FutureOr<MapSpriteAtlas>
+        >
+    with $FutureModifier<MapSpriteAtlas>, $FutureProvider<MapSpriteAtlas> {
+  EarthquakeMapSpriteAtlasProvider._({
+    required EarthquakeMapSpriteAtlasFamily super.from,
+    required EarthquakeMapSpriteAtlasLimitsKey super.argument,
+  }) : super(
+         retry: EarthquakeMapSpriteAtlasRetryPolicy.noRetry,
+         name: r'earthquakeMapSpriteAtlasProvider',
+         isAutoDispose: false,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$earthquakeMapSpriteAtlasHash();
+
+  @override
+  String toString() {
+    return r'earthquakeMapSpriteAtlasProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<MapSpriteAtlas> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<MapSpriteAtlas> create(Ref ref) {
+    final argument = this.argument as EarthquakeMapSpriteAtlasLimitsKey;
+    return earthquakeMapSpriteAtlas(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is EarthquakeMapSpriteAtlasProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$earthquakeMapSpriteAtlasHash() =>
+    r'e4d0decb4228e8440f79af91723f292091f001e8';
+
+final class EarthquakeMapSpriteAtlasFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<MapSpriteAtlas>,
+          EarthquakeMapSpriteAtlasLimitsKey
+        > {
+  EarthquakeMapSpriteAtlasFamily._()
+    : super(
+        retry: EarthquakeMapSpriteAtlasRetryPolicy.noRetry,
+        name: r'earthquakeMapSpriteAtlasProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: false,
+      );
+
+  EarthquakeMapSpriteAtlasProvider call(
+    EarthquakeMapSpriteAtlasLimitsKey limitsKey,
+  ) => EarthquakeMapSpriteAtlasProvider._(argument: limitsKey, from: this);
+
+  @override
+  String toString() => r'earthquakeMapSpriteAtlasProvider';
+}

--- a/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.dart
+++ b/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.dart
@@ -5,11 +5,14 @@ import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_map_overlay_builder.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_map_overlay_digest_builder.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_details_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_map_layer_parameter_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/earthquake_map_sprite_atlas_provider.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/provider/earthquake_overlay_source_incarnation_provider.dart';
 import 'package:eqmonitor/feature/live_monitor/data/logic/live_monitor_latest_earthquake_selector.dart';
 import 'package:eqmonitor_map/eqmonitor_map.dart';
@@ -24,6 +27,13 @@ const latestEarthquakeOverlayParameter = EarthquakeHistoryParameter.all(
   intensityGte: JmaIntensity.one,
 );
 
+const latestEarthquakeOverlaySpriteAtlasLimits = MapSpriteAtlasLimits(
+  maxWidth: 1024,
+  maxHeight: 512,
+  maxPixelBytes: 1024 * 512 * MapSpriteAtlas.bytesPerPixel,
+  maxRegions: 2,
+);
+
 @riverpod
 EarthquakeMapOverlayBuilder earthquakeMapOverlayBuilder(Ref ref) =>
     const EarthquakeMapOverlayBuilder();
@@ -31,6 +41,19 @@ EarthquakeMapOverlayBuilder earthquakeMapOverlayBuilder(Ref ref) =>
 @riverpod
 EarthquakeMapOverlayDigestBuilder earthquakeMapOverlayDigestBuilder(Ref ref) =>
     const EarthquakeMapOverlayDigestBuilder();
+
+@Riverpod(retry: EarthquakeMapSpriteAtlasRetryPolicy.noRetry)
+Future<MapSpriteAtlas> latestEarthquakeOverlaySpriteAtlas(Ref ref) => ref.watch(
+  earthquakeMapSpriteAtlasProvider(
+    latestEarthquakeOverlaySpriteAtlasLimits.earthquakeMapSpriteAtlasLimitsKey,
+  ).future,
+);
+
+@riverpod
+Future<EarthquakeHistoryMapLayerParameter>
+latestEarthquakeOverlayMapLayerParameter(Ref ref) => ref.watch(
+  earthquakeHistoryMapLayerParameterProvider.future,
+);
 
 enum LatestEarthquakeOverlayAvailability {
   available,
@@ -117,6 +140,21 @@ class LatestEarthquakeOverlay extends _$LatestEarthquakeOverlay {
         overlay: null,
       );
     }
+    final parameter = await ref.watch(
+      latestEarthquakeOverlayMapLayerParameterProvider.future,
+    );
+    final spriteAtlas = await ref.watch(
+      latestEarthquakeOverlaySpriteAtlasProvider.future,
+    );
+    if (!asyncGeneration.isCurrent) {
+      return LatestEarthquakeOverlayData(
+        eventId: eventId,
+        originTime: null,
+        telegramStatus: null,
+        availability: .superseded,
+        overlay: null,
+      );
+    }
     final intensity = earthquake.intensity as EarthquakeIntensity;
     final regionLevels = overlayBuilder.regionIntensityLevels(
       intensity: intensity,
@@ -128,14 +166,20 @@ class LatestEarthquakeOverlay extends _$LatestEarthquakeOverlay {
     final regionStyles = overlayBuilder.areaStyles(
       levels: regionLevels,
       colorModel: colorModel,
+      opacity: parameter.regionFillOpacity,
     );
     final cityStyles = overlayBuilder.areaStyles(
       levels: cityLevels,
       colorModel: colorModel,
+      opacity: parameter.cityFillOpacity,
     );
     final stations = overlayBuilder.observationPoints(
       intensity: intensity,
       colorModel: colorModel,
+    );
+    final sprites = overlayBuilder.hypocenterSprites(
+      earthquake: earthquake,
+      parameter: parameter,
     );
     final digestBuilder = ref.watch(earthquakeMapOverlayDigestBuilderProvider);
     final hypocenterInput = digestBuilder.hypocenterInput(earthquake);
@@ -169,26 +213,21 @@ class LatestEarthquakeOverlay extends _$LatestEarthquakeOverlay {
       renderDigestFor: (dataSequence) => digestBuilder.buildRenderDigest(
         dataSequence: dataSequence,
         dataDigest: dataDigest,
-        regionToCityZoom: earthquakeOverlayRegionToCityZoom,
-        stationMinZoom: earthquakeOverlayStationMinZoom,
+        regionToCityZoom: parameter.regionToCity,
+        stationMinZoom: parameter.stationMinZoom,
         regionStyles: regionStyles,
         cityStyles: cityStyles,
         stations: stations,
+        spriteAtlas: spriteAtlas,
+        sprites: sprites,
       ),
     );
-    if (!asyncGeneration.isCurrent) {
-      return LatestEarthquakeOverlayData(
-        eventId: eventId,
-        originTime: null,
-        telegramStatus: null,
-        availability: .superseded,
-        overlay: null,
-      );
-    }
     final result = overlayBuilder.build(
       earthquake: earthquake,
       colorModel: colorModel,
       versionStamp: versionStamp,
+      parameter: parameter,
+      spriteAtlas: spriteAtlas,
     );
     return switch (result) {
       EarthquakeMapOverlayAvailable(:final snapshot) =>

--- a/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.dart
+++ b/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.dart
@@ -206,7 +206,7 @@ class LatestEarthquakeOverlay extends _$LatestEarthquakeOverlay {
       hypocenterLongitude: hypocenterInput.longitude,
       hypocenterLatitude: hypocenterInput.latitude,
     );
-    final versionStamp = _versionOwner.next(
+    final versionCandidate = _versionOwner.preview(
       sourceIdentity: createMapSourceIdentity(value: eventId),
       sourceIncarnation: sourceIncarnation,
       dataDigest: dataDigest,
@@ -225,21 +225,31 @@ class LatestEarthquakeOverlay extends _$LatestEarthquakeOverlay {
     final result = overlayBuilder.build(
       earthquake: earthquake,
       colorModel: colorModel,
-      versionStamp: versionStamp,
+      versionStamp: versionCandidate.versionStamp,
       parameter: parameter,
       spriteAtlas: spriteAtlas,
     );
-    return switch (result) {
-      EarthquakeMapOverlayAvailable(:final snapshot) =>
-        LatestEarthquakeOverlayData(
+    switch (result) {
+      case EarthquakeMapOverlayAvailable(:final snapshot):
+        if (!asyncGeneration.isCurrent) {
+          return LatestEarthquakeOverlayData(
+            eventId: eventId,
+            originTime: null,
+            telegramStatus: null,
+            availability: .superseded,
+            overlay: null,
+          );
+        }
+        _versionOwner.commit(versionCandidate);
+        return LatestEarthquakeOverlayData(
           eventId: earthquake.eventId,
           originTime: earthquake.originTime,
           telegramStatus: earthquake.status,
           availability: .available,
           overlay: snapshot,
-        ),
-      EarthquakeMapOverlayUnavailable(:final reason) =>
-        LatestEarthquakeOverlayData(
+        );
+      case EarthquakeMapOverlayUnavailable(:final reason):
+        return LatestEarthquakeOverlayData(
           eventId: earthquake.eventId,
           originTime: earthquake.originTime,
           telegramStatus: earthquake.status,
@@ -249,15 +259,29 @@ class LatestEarthquakeOverlay extends _$LatestEarthquakeOverlay {
               .missingTelegramMetadata,
           },
           overlay: null,
-        ),
-    };
+        );
+    }
   }
+}
+
+final class EarthquakeOverlayVersionCandidate {
+  new _({
+    required EarthquakeOverlayVersionOwner owner,
+    required MapOverlayVersionStamp? previous,
+    required this.versionStamp,
+  }) : _owner = owner,
+       _previous = previous;
+
+  final EarthquakeOverlayVersionOwner _owner;
+  final MapOverlayVersionStamp? _previous;
+  final MapOverlayVersionStamp versionStamp;
+  bool _committed = false;
 }
 
 final class EarthquakeOverlayVersionOwner {
   MapOverlayVersionStamp? _current;
 
-  MapOverlayVersionStamp next({
+  EarthquakeOverlayVersionCandidate preview({
     required MapSourceIdentity sourceIdentity,
     required MapSourceIncarnation sourceIncarnation,
     required String dataDigest,
@@ -291,7 +315,21 @@ final class EarthquakeOverlayVersionOwner {
         !canAdvanceMapOverlayVersionStamp(current: current, next: next)) {
       throw StateError('Invalid earthquake overlay version transition.');
     }
-    _current = next;
-    return next;
+    return EarthquakeOverlayVersionCandidate._(
+      owner: this,
+      previous: current,
+      versionStamp: next,
+    );
+  }
+
+  void commit(EarthquakeOverlayVersionCandidate candidate) {
+    if (!identical(candidate._owner, this)) {
+      throw ArgumentError.value(candidate, 'candidate', 'belongs to owner');
+    }
+    if (candidate._committed || !identical(_current, candidate._previous)) {
+      throw StateError('Stale earthquake overlay version candidate.');
+    }
+    _current = candidate.versionStamp;
+    candidate._committed = true;
   }
 }

--- a/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.g.dart
@@ -112,6 +112,92 @@ final class EarthquakeMapOverlayDigestBuilderProvider
 String _$earthquakeMapOverlayDigestBuilderHash() =>
     r'acf123b9b4bdceb13ea98e9ca2d8e2f67929722e';
 
+@ProviderFor(latestEarthquakeOverlaySpriteAtlas)
+final latestEarthquakeOverlaySpriteAtlasProvider =
+    LatestEarthquakeOverlaySpriteAtlasProvider._();
+
+final class LatestEarthquakeOverlaySpriteAtlasProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<MapSpriteAtlas>,
+          MapSpriteAtlas,
+          FutureOr<MapSpriteAtlas>
+        >
+    with $FutureModifier<MapSpriteAtlas>, $FutureProvider<MapSpriteAtlas> {
+  LatestEarthquakeOverlaySpriteAtlasProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: EarthquakeMapSpriteAtlasRetryPolicy.noRetry,
+        name: r'latestEarthquakeOverlaySpriteAtlasProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$latestEarthquakeOverlaySpriteAtlasHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<MapSpriteAtlas> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<MapSpriteAtlas> create(Ref ref) {
+    return latestEarthquakeOverlaySpriteAtlas(ref);
+  }
+}
+
+String _$latestEarthquakeOverlaySpriteAtlasHash() =>
+    r'c6501371a2c8cad517d3a3ced47e877e60e7a4be';
+
+@ProviderFor(latestEarthquakeOverlayMapLayerParameter)
+final latestEarthquakeOverlayMapLayerParameterProvider =
+    LatestEarthquakeOverlayMapLayerParameterProvider._();
+
+final class LatestEarthquakeOverlayMapLayerParameterProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<EarthquakeHistoryMapLayerParameter>,
+          EarthquakeHistoryMapLayerParameter,
+          FutureOr<EarthquakeHistoryMapLayerParameter>
+        >
+    with
+        $FutureModifier<EarthquakeHistoryMapLayerParameter>,
+        $FutureProvider<EarthquakeHistoryMapLayerParameter> {
+  LatestEarthquakeOverlayMapLayerParameterProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'latestEarthquakeOverlayMapLayerParameterProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$latestEarthquakeOverlayMapLayerParameterHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<EarthquakeHistoryMapLayerParameter> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<EarthquakeHistoryMapLayerParameter> create(Ref ref) {
+    return latestEarthquakeOverlayMapLayerParameter(ref);
+  }
+}
+
+String _$latestEarthquakeOverlayMapLayerParameterHash() =>
+    r'1461072ac6cf2de4c1eb5357aa45f6c7c613b4a5';
+
 @ProviderFor(LatestEarthquakeOverlay)
 final latestEarthquakeOverlayProvider = LatestEarthquakeOverlayProvider._();
 
@@ -141,7 +227,7 @@ final class LatestEarthquakeOverlayProvider
 }
 
 String _$latestEarthquakeOverlayHash() =>
-    r'f6b8f793c524f68d8ddeb4e302436c83442b5be2';
+    r'f634a7b2a4557affac13c7d8d928c933f72e314d';
 
 abstract class _$LatestEarthquakeOverlay
     extends $AsyncNotifier<LatestEarthquakeOverlayData> {

--- a/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.g.dart
@@ -227,7 +227,7 @@ final class LatestEarthquakeOverlayProvider
 }
 
 String _$latestEarthquakeOverlayHash() =>
-    r'f634a7b2a4557affac13c7d8d928c933f72e314d';
+    r'1c585b2577dc3b9c45a7abec1d786fe090c4e1e5';
 
 abstract class _$LatestEarthquakeOverlay
     extends $AsyncNotifier<LatestEarthquakeOverlayData> {

--- a/app/test/feature/earthquake_history/data/earthquake_map_overlay_builder_test.dart
+++ b/app/test/feature/earthquake_history/data/earthquake_map_overlay_builder_test.dart
@@ -1,9 +1,16 @@
+import 'dart:typed_data';
+
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
 import 'package:eqmonitor/core/theme/model/app_theme.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_map_overlay_builder.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_depth.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_hypocenter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_magnitude.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_metadata.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_station.dart';
@@ -135,6 +142,7 @@ EarthquakeIntensity _intensity() {
 Earthquake _earthquake({
   required EarthquakeIntensity? intensity,
   required List<EarthquakeTelegramMetadata> metadata,
+  EarthquakeHypocenter? hypocenter,
 }) => Earthquake(
   eventId: '20260823123456',
   status: TelegramStatus.normal,
@@ -144,9 +152,45 @@ Earthquake _earthquake({
   dataSources: const [],
   telegramTypes: const [EarthquakeTelegramType.vxse53],
   telegramMetadata: metadata,
-  hypocenter: null,
+  hypocenter: hypocenter,
   intensity: intensity,
   estimatedIntensityTileUrl: null,
+);
+
+EarthquakeHypocenter _hypocenter(Coordinate? coordinates) =>
+    EarthquakeHypocenter(
+      code: '477',
+      name: '東京湾',
+      coordinates: coordinates,
+      magnitude: const EarthquakeMagnitude.value(value: 5.2),
+      depth: const EarthquakeDepth.value(value: 40),
+      detailedCode: null,
+      detailedName: null,
+    );
+
+MapSpriteAtlas _spriteAtlas() => createMapSpriteAtlas(
+  identity: createMapSourceIdentity(value: 'sha256:atlas-a'),
+  width: 2,
+  height: 1,
+  rgbaBytes: Uint8List.fromList(const [255, 0, 0, 255, 0, 0, 255, 255]),
+  regions: const [
+    MapSpriteRegion(
+      id: 'normal',
+      normalizedUv: Rect.fromLTRB(0.25, 0.5, 0.25, 0.5),
+      logicalSize: Size(1, 1),
+    ),
+    MapSpriteRegion(
+      id: 'low-precision',
+      normalizedUv: Rect.fromLTRB(0.75, 0.5, 0.75, 0.5),
+      logicalSize: Size(1, 1),
+    ),
+  ],
+  limits: const MapSpriteAtlasLimits(
+    maxWidth: 2,
+    maxHeight: 1,
+    maxPixelBytes: 8,
+    maxRegions: 2,
+  ),
 );
 
 void main() {
@@ -154,6 +198,7 @@ void main() {
       .colorSetFor(Brightness.light)
       .intensity;
   const builder = EarthquakeMapOverlayBuilder();
+  const parameter = EarthquakeHistoryMapLayerParameter();
 
   MapOverlayVersionStamp versionStamp({
     String sourceIdentity = '20260823123456',
@@ -179,6 +224,8 @@ void main() {
       ),
       colorModel: colors,
       versionStamp: versionStamp(),
+      parameter: parameter,
+      spriteAtlas: _spriteAtlas(),
     );
 
     expect(result, isA<EarthquakeMapOverlayAvailable>());
@@ -206,6 +253,8 @@ void main() {
       ),
       colorModel: colors,
       versionStamp: versionStamp(),
+      parameter: parameter,
+      spriteAtlas: _spriteAtlas(),
     ) as EarthquakeMapOverlayAvailable;
     final snapshot = result.snapshot;
     final max = snapshot.stations.singleWhere((point) => point.id == 'ST-MAX');
@@ -250,6 +299,8 @@ void main() {
       ),
       colorModel: colors,
       versionStamp: stamp,
+      parameter: parameter,
+      spriteAtlas: _spriteAtlas(),
     ) as EarthquakeMapOverlayAvailable;
 
     expect(result.snapshot.versionStamp, same(stamp));
@@ -269,6 +320,8 @@ void main() {
         ),
         colorModel: colors,
         versionStamp: versionStamp(sourceIdentity: 'another-event'),
+        parameter: parameter,
+        spriteAtlas: _spriteAtlas(),
       ),
       throwsArgumentError,
     );
@@ -279,6 +332,8 @@ void main() {
       earthquake: _earthquake(intensity: _intensity(), metadata: const []),
       colorModel: colors,
       versionStamp: versionStamp(),
+      parameter: parameter,
+      spriteAtlas: _spriteAtlas(),
     );
 
     expect(result, isA<EarthquakeMapOverlayUnavailable>());
@@ -293,6 +348,8 @@ void main() {
       earthquake: _earthquake(intensity: null, metadata: const []),
       colorModel: colors,
       versionStamp: versionStamp(),
+      parameter: parameter,
+      spriteAtlas: _spriteAtlas(),
     );
 
     expect(result, isA<EarthquakeMapOverlayUnavailable>());
@@ -300,5 +357,109 @@ void main() {
       (result as EarthquakeMapOverlayUnavailable).reason,
       EarthquakeMapOverlayUnavailableReason.noIntensity,
     );
+  });
+
+  test('有限かつ範囲内のCoordinateLatLngだけをnormal震源spriteへ変換する', () {
+    final result = builder.build(
+      earthquake: _earthquake(
+        intensity: _intensity(),
+        metadata: [
+          EarthquakeTelegramMetadata(
+            type: EarthquakeTelegramType.vxse53,
+            reportedAt: DateTime.utc(2026, 8, 23, 12, 35),
+          ),
+        ],
+        hypocenter: _hypocenter(
+          const Coordinate.latLng(latitude: 35.5, longitude: 139.8),
+        ),
+      ),
+      colorModel: colors,
+      versionStamp: versionStamp(),
+      parameter: parameter,
+      spriteAtlas: _spriteAtlas(),
+    ) as EarthquakeMapOverlayAvailable;
+
+    final sprite = result.snapshot.sprites.single;
+    expect(sprite.id, 'hypocenter:20260823123456');
+    expect((sprite.longitude, sprite.latitude), (139.8, 35.5));
+    expect(sprite.spriteRegionId, 'normal');
+    expect(sprite.priority, 0);
+    expect(sprite.sizeScale.valueAt(zoom: 3), 0.15);
+    expect(sprite.sizeScale.valueAt(zoom: 20), 0.4);
+    expect(sprite.opacity.valueAt(zoom: 7.999), 1);
+    expect(sprite.opacity.valueAt(zoom: 8), 0.6);
+  });
+
+  test('missing・unknown・非有限・範囲外の震源座標へ固定位置を作らない', () {
+    final invalidHypocenters = <EarthquakeHypocenter?>[
+      null,
+      _hypocenter(null),
+      _hypocenter(const Coordinate.unknown()),
+      _hypocenter(
+        const Coordinate.latLng(latitude: double.nan, longitude: 139),
+      ),
+      _hypocenter(
+        const Coordinate.latLng(latitude: 35, longitude: double.infinity),
+      ),
+      _hypocenter(const Coordinate.latLng(latitude: 91, longitude: 139)),
+      _hypocenter(const Coordinate.latLng(latitude: 35, longitude: 181)),
+    ];
+    for (final hypocenter in invalidHypocenters) {
+      final result = builder.build(
+        earthquake: _earthquake(
+          intensity: _intensity(),
+          metadata: [
+            EarthquakeTelegramMetadata(
+              type: EarthquakeTelegramType.vxse53,
+              reportedAt: DateTime.utc(2026, 8, 23, 12, 35),
+            ),
+          ],
+          hypocenter: hypocenter,
+        ),
+        colorModel: colors,
+        versionStamp: versionStamp(),
+        parameter: parameter,
+        spriteAtlas: _spriteAtlas(),
+      ) as EarthquakeMapOverlayAvailable;
+
+      expect(result.snapshot.sprites, isEmpty);
+    }
+  });
+
+  test('parameterのzoom・size・fade policyをsnapshotへ変換する', () {
+    const customParameter = EarthquakeHistoryMapLayerParameter(
+      regionToCity: 7,
+      stationMinZoom: 8,
+      hypocenterFadeZoom: 9,
+      hypocenterIconSizeMin: 0.2,
+      hypocenterIconSizeMax: 0.5,
+      hypocenterFadeOpacity: 0.4,
+    );
+    final result = builder.build(
+      earthquake: _earthquake(
+        intensity: _intensity(),
+        metadata: [
+          EarthquakeTelegramMetadata(
+            type: EarthquakeTelegramType.vxse53,
+            reportedAt: DateTime.utc(2026, 8, 23, 12, 35),
+          ),
+        ],
+        hypocenter: _hypocenter(
+          const Coordinate.latLng(latitude: 35.5, longitude: 139.8),
+        ),
+      ),
+      colorModel: colors,
+      versionStamp: versionStamp(),
+      parameter: customParameter,
+      spriteAtlas: _spriteAtlas(),
+    ) as EarthquakeMapOverlayAvailable;
+
+    final sprite = result.snapshot.sprites.single;
+    expect(result.snapshot.regionToCityZoom, 7);
+    expect(result.snapshot.stationMinZoom, 8);
+    expect(sprite.sizeScale.valueAt(zoom: 3), 0.2);
+    expect(sprite.sizeScale.valueAt(zoom: 20), 0.5);
+    expect(sprite.opacity.valueAt(zoom: 8.999), 1);
+    expect(sprite.opacity.valueAt(zoom: 9), 0.4);
   });
 }

--- a/app/test/feature/earthquake_history/data/earthquake_map_overlay_digest_builder_test.dart
+++ b/app/test/feature/earthquake_history/data/earthquake_map_overlay_digest_builder_test.dart
@@ -1,4 +1,5 @@
 import 'dart:ui';
+import 'dart:typed_data';
 
 import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_map_overlay_digest_builder.dart';
 import 'package:eqmonitor_map/eqmonitor_map.dart';
@@ -41,6 +42,42 @@ void main() {
     hypocenterState: .latLng,
     hypocenterLongitude: 140,
     hypocenterLatitude: 36,
+  );
+
+  MapSpriteAtlas atlas(String identity) => createMapSpriteAtlas(
+    identity: createMapSourceIdentity(value: identity),
+    width: 1,
+    height: 1,
+    rgbaBytes: Uint8List.fromList(const [255, 255, 255, 255]),
+    regions: const [],
+    limits: const MapSpriteAtlasLimits(
+      maxWidth: 1,
+      maxHeight: 1,
+      maxPixelBytes: 4,
+      maxRegions: 1,
+    ),
+  );
+
+  MapPointSpriteFeature sprite({
+    double sizeAtZoom3 = 0.15,
+    double fadeOpacity = 0.6,
+  }) => createMapPointSpriteFeature(
+    id: 'hypocenter:A',
+    longitude: 140,
+    latitude: 36,
+    spriteRegionId: 'normal-hypocenter',
+    sizeScale: createMapZoomLinearRange(
+      startZoom: 3,
+      startValue: sizeAtZoom3,
+      endZoom: 20,
+      endValue: 0.4,
+    ),
+    opacity: createMapZoomStep(
+      thresholdZoom: 8,
+      belowValue: 1,
+      atOrAboveValue: fadeOpacity,
+    ),
+    priority: 0,
   );
 
   test('canonical UTF-8 records produce the known SHA-256 digest', () {
@@ -103,6 +140,8 @@ void main() {
       ],
       cityStyles: const [],
       stations: const [],
+      spriteAtlas: atlas('atlas-a'),
+      sprites: [sprite()],
     );
     final blue = builder.buildRenderDigest(
       dataSequence: 0,
@@ -118,9 +157,43 @@ void main() {
       ],
       cityStyles: const [],
       stations: const [],
+      spriteAtlas: atlas('atlas-a'),
+      sprites: [sprite()],
     );
 
     expect(blue, isNot(red));
+    expect(dataDigest(), data);
+  });
+
+  test('atlas identityとsprite policy変更はdata digestを維持しrender digestを変える', () {
+    final data = dataDigest();
+
+    String render({
+      String atlasIdentity = 'atlas-a',
+      double sizeAtZoom3 = 0.15,
+      double fadeOpacity = 0.6,
+    }) => builder.buildRenderDigest(
+      dataSequence: 0,
+      dataDigest: data,
+      regionToCityZoom: 6,
+      stationMinZoom: 6,
+      regionStyles: const [],
+      cityStyles: const [],
+      stations: const [],
+      spriteAtlas: atlas(atlasIdentity),
+      sprites: [
+        sprite(
+          sizeAtZoom3: sizeAtZoom3,
+          fadeOpacity: fadeOpacity,
+        ),
+      ],
+    );
+
+    final baseline = render();
+
+    expect(render(atlasIdentity: 'atlas-b'), isNot(baseline));
+    expect(render(sizeAtZoom3: 0.2), isNot(baseline));
+    expect(render(fadeOpacity: 0.5), isNot(baseline));
     expect(dataDigest(), data);
   });
 }

--- a/app/test/feature/earthquake_history/data/earthquake_map_sprite_atlas_builder_test.dart
+++ b/app/test/feature/earthquake_history/data/earthquake_map_sprite_atlas_builder_test.dart
@@ -1,9 +1,11 @@
-import 'dart:typed_data';
-import 'dart:ui';
-
+import 'package:eqmonitor/core/gen/assets.gen.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_map_sprite_atlas_builder.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/earthquake_map_sprite_atlas_provider.dart';
 import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 const _limits = MapSpriteAtlasLimits(
   maxWidth: 32,
@@ -25,6 +27,45 @@ EarthquakeMapSpriteImage _image({
 List<int> _pixel(MapSpriteAtlas atlas, {required int x, required int y}) {
   final offset = (y * atlas.width + x) * MapSpriteAtlas.bytesPerPixel;
   return atlas.rgbaBytes.sublist(offset, offset + MapSpriteAtlas.bytesPerPixel);
+}
+
+final class _CountingAssetBundle extends CachingAssetBundle {
+  final loadedPaths = <String>[];
+
+  @override
+  Future<ByteData> load(String key) async {
+    loadedPaths.add(key);
+    return ByteData.sublistView(Uint8List.fromList(const [1, 2, 3]));
+  }
+}
+
+final class _CountingImageDecoder implements EarthquakeMapSpriteImageDecoder {
+  final decodedPaths = <String>[];
+
+  @override
+  Future<EarthquakeMapSpriteImage> decode({
+    required String assetPath,
+    required Uint8List encodedBytes,
+  }) async {
+    decodedPaths.add(assetPath);
+    return _image(
+      width: 1,
+      height: 1,
+      rgbaBytes: assetPath == Assets.images.map.normalHypocenter.path
+          ? const [255, 0, 0, 128]
+          : const [0, 0, 255, 255],
+    );
+  }
+}
+
+final class _ThrowingAssetBundle extends CachingAssetBundle {
+  @override
+  Future<ByteData> load(String key) => throw FlutterError('fixture failure');
+}
+
+final class _UnexpectedErrorAssetBundle extends CachingAssetBundle {
+  @override
+  Future<ByteData> load(String key) => throw StateError('programming error');
 }
 
 void main() {
@@ -180,5 +221,120 @@ void main() {
     bytes.setAll(0, const [9, 9, 9, 9]);
 
     expect(_pixel(atlas, x: 2, y: 2), const [1, 2, 3, 128]);
+  });
+
+  test('providerはroot bundle相当から各assetを一度だけload/decodeする', () async {
+    final bundle = _CountingAssetBundle();
+    final decoder = _CountingImageDecoder();
+    final container = ProviderContainer(
+      overrides: [
+        earthquakeMapSpriteAssetBundleProvider.overrideWithValue(bundle),
+        earthquakeMapSpriteImageDecoderProvider.overrideWithValue(decoder),
+      ],
+    );
+    addTearDown(container.dispose);
+    final provider = earthquakeMapSpriteAtlasProvider(
+      _limits.earthquakeMapSpriteAtlasLimitsKey,
+    );
+
+    final first = await container.read(provider.future);
+    final second = await container.read(
+      earthquakeMapSpriteAtlasProvider(
+        const MapSpriteAtlasLimits(
+          maxWidth: 32,
+          maxHeight: 32,
+          maxPixelBytes: 32 * 32 * 4,
+          maxRegions: 2,
+        ).earthquakeMapSpriteAtlasLimitsKey,
+      ).future,
+    );
+
+    expect(second, same(first));
+    expect(bundle.loadedPaths, [
+      Assets.images.map.normalHypocenter.path,
+      Assets.images.map.lowPreciseHypocenter.path,
+    ]);
+    expect(decoder.decodedPaths, bundle.loadedPaths);
+    expect(first.regions.map((region) => region.id), [
+      earthquakeMapNormalSpriteRegionId,
+      earthquakeMapLowPrecisionSpriteRegionId,
+    ]);
+  });
+
+  test('asset load失敗はtyped AsyncErrorになりatlasを返さない', () async {
+    final container = ProviderContainer(
+      overrides: [
+        earthquakeMapSpriteAssetBundleProvider.overrideWithValue(
+          _ThrowingAssetBundle(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final provider = earthquakeMapSpriteAtlasProvider(
+      _limits.earthquakeMapSpriteAtlasLimitsKey,
+    );
+
+    await expectLater(
+      container.read(provider.future),
+      throwsA(
+        isA<EarthquakeMapSpriteAtlasException>().having(
+          (error) => error.reason,
+          'reason',
+          EarthquakeMapSpriteAtlasFailureReason.assetLoad,
+        ),
+      ),
+    );
+    expect(
+      container.read(provider).error,
+      isA<EarthquakeMapSpriteAtlasException>(),
+    );
+  });
+
+  test('unexpected Errorはtyped化せずそのまま伝播する', () async {
+    final container = ProviderContainer(
+      overrides: [
+        earthquakeMapSpriteAssetBundleProvider.overrideWithValue(
+          _UnexpectedErrorAssetBundle(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container.read(
+        earthquakeMapSpriteAtlasProvider(
+          _limits.earthquakeMapSpriteAtlasLimitsKey,
+        ).future,
+      ),
+      throwsStateError,
+    );
+  });
+
+  testWidgets('production decoderは既存2assetをraw straight RGBA atlasへ変換する', (
+    tester,
+  ) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final result = await tester.runAsync(
+      () => container.read(
+        earthquakeMapSpriteAtlasProvider(
+          const MapSpriteAtlasLimits(
+            maxWidth: 1024,
+            maxHeight: 512,
+            maxPixelBytes: 1024 * 512 * 4,
+            maxRegions: 2,
+          ).earthquakeMapSpriteAtlasLimitsKey,
+        ).future,
+      ),
+    );
+    final atlas = result ?? (throw StateError('atlas decode returned null'));
+
+    expect((atlas.width, atlas.height), (608, 304));
+    expect(atlas.rgbaBytes.length, 608 * 304 * 4);
+    expect(atlas.regions.map((region) => region.logicalSize), [
+      const Size(300, 300),
+      const Size(300, 300),
+    ]);
   });
 }

--- a/app/test/feature/earthquake_history/data/earthquake_map_sprite_atlas_builder_test.dart
+++ b/app/test/feature/earthquake_history/data/earthquake_map_sprite_atlas_builder_test.dart
@@ -1,0 +1,184 @@
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:eqmonitor/feature/earthquake_history/data/logic/earthquake_map_sprite_atlas_builder.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _limits = MapSpriteAtlasLimits(
+  maxWidth: 32,
+  maxHeight: 32,
+  maxPixelBytes: 32 * 32 * 4,
+  maxRegions: 2,
+);
+
+EarthquakeMapSpriteImage _image({
+  required int width,
+  required int height,
+  required List<int> rgbaBytes,
+}) => EarthquakeMapSpriteImage(
+  width: width,
+  height: height,
+  rgbaBytes: Uint8List.fromList(rgbaBytes),
+);
+
+List<int> _pixel(MapSpriteAtlas atlas, {required int x, required int y}) {
+  final offset = (y * atlas.width + x) * MapSpriteAtlas.bytesPerPixel;
+  return atlas.rgbaBytes.sublist(offset, offset + MapSpriteAtlas.bytesPerPixel);
+}
+
+void main() {
+  const builder = EarthquakeMapSpriteAtlasBuilder();
+  final normal = _image(
+    width: 2,
+    height: 2,
+    rgbaBytes: const [
+      255,
+      0,
+      0,
+      255,
+      0,
+      255,
+      0,
+      128,
+      0,
+      0,
+      255,
+      255,
+      255,
+      255,
+      255,
+      255,
+    ],
+  );
+  final lowPrecision = _image(
+    width: 1,
+    height: 1,
+    rgbaBytes: const [12, 34, 56, 78],
+  );
+
+  MapSpriteAtlas build({
+    EarthquakeMapSpriteImage? normalImage,
+    MapSpriteAtlasLimits limits = _limits,
+  }) => builder.build(
+    normalImage: normalImage ?? normal,
+    lowPrecisionImage: lowPrecision,
+    limits: limits,
+  );
+
+  test('image dimensionとtight RGBA byte countをallocation前に拒否する', () {
+    expect(
+      () => _image(width: 0, height: 1, rgbaBytes: const []),
+      throwsArgumentError,
+    );
+    expect(
+      () => _image(width: 1, height: 0, rgbaBytes: const []),
+      throwsArgumentError,
+    );
+    expect(
+      () => _image(width: 1, height: 1, rgbaBytes: const [1, 2, 3]),
+      throwsArgumentError,
+    );
+    expect(
+      () => _image(width: 1 << 62, height: 1 << 62, rgbaBytes: const []),
+      throwsArgumentError,
+    );
+  });
+
+  test('top-left RGBAを保ち各regionの端を2px extrusionする', () {
+    final atlas = build();
+
+    expect((atlas.width, atlas.height), (11, 6));
+    expect(_pixel(atlas, x: 0, y: 0), [255, 0, 0, 255]);
+    expect(_pixel(atlas, x: 2, y: 2), [255, 0, 0, 255]);
+    expect(_pixel(atlas, x: 3, y: 2), [0, 255, 0, 128]);
+    expect(_pixel(atlas, x: 2, y: 3), [0, 0, 255, 255]);
+    expect(_pixel(atlas, x: 5, y: 5), [255, 255, 255, 255]);
+    expect(_pixel(atlas, x: 6, y: 0), [12, 34, 56, 78]);
+    expect(_pixel(atlas, x: 10, y: 4), [12, 34, 56, 78]);
+    expect(_pixel(atlas, x: 10, y: 5), [0, 0, 0, 0]);
+  });
+
+  test('paddingを除いたcontent texel-center UVとlogical sizeを返す', () {
+    final atlas = build();
+    final normalRegion = atlas.regions.singleWhere(
+      (region) => region.id == earthquakeMapNormalSpriteRegionId,
+    );
+    final lowRegion = atlas.regions.singleWhere(
+      (region) => region.id == earthquakeMapLowPrecisionSpriteRegionId,
+    );
+
+    expect(normalRegion.logicalSize, const Size(2, 2));
+    expect(
+      normalRegion.normalizedUv,
+      const Rect.fromLTRB(2.5 / 11, 2.5 / 6, 3.5 / 11, 3.5 / 6),
+    );
+    expect(lowRegion.logicalSize, const Size(1, 1));
+    expect(
+      lowRegion.normalizedUv,
+      const Rect.fromLTRB(8.5 / 11, 2.5 / 6, 8.5 / 11, 2.5 / 6),
+    );
+  });
+
+  test('atlas identityは内容のSHA-256で安定しpixel変更で変化する', () {
+    final first = build();
+    final second = build();
+    final changed = build(
+      normalImage: _image(
+        width: 2,
+        height: 2,
+        rgbaBytes: [254, ...normal.rgbaBytes.skip(1)],
+      ),
+    );
+
+    expect(first.identity.value, matches(RegExp(r'^sha256:[0-9a-f]{64}$')));
+    expect(second.identity, first.identity);
+    expect(changed.identity, isNot(first.identity));
+  });
+
+  test('caller limitsのdimension・byte count・region countをすべて適用する', () {
+    for (final limits in const [
+      MapSpriteAtlasLimits(
+        maxWidth: 10,
+        maxHeight: 6,
+        maxPixelBytes: 264,
+        maxRegions: 2,
+      ),
+      MapSpriteAtlasLimits(
+        maxWidth: 11,
+        maxHeight: 5,
+        maxPixelBytes: 264,
+        maxRegions: 2,
+      ),
+      MapSpriteAtlasLimits(
+        maxWidth: 11,
+        maxHeight: 6,
+        maxPixelBytes: 263,
+        maxRegions: 2,
+      ),
+      MapSpriteAtlasLimits(
+        maxWidth: 11,
+        maxHeight: 6,
+        maxPixelBytes: 264,
+        maxRegions: 1,
+      ),
+    ]) {
+      expect(() => build(limits: limits), throwsArgumentError);
+    }
+  });
+
+  test('build後に入力bufferを変更してもatlasは変化しない', () {
+    final bytes = Uint8List.fromList(const [1, 2, 3, 128]);
+    final atlas = build(
+      normalImage: EarthquakeMapSpriteImage(
+        width: 1,
+        height: 1,
+        rgbaBytes: bytes,
+      ),
+    );
+
+    bytes.setAll(0, const [9, 9, 9, 9]);
+
+    expect(_pixel(atlas, x: 2, y: 2), const [1, 2, 3, 128]);
+  });
+}

--- a/app/test/feature/earthquake_history/data/latest_earthquake_overlay_provider_test.dart
+++ b/app/test/feature/earthquake_history/data/latest_earthquake_overlay_provider_test.dart
@@ -159,7 +159,9 @@ ProviderContainer _providerContainer({
   required List<Override> overrides,
   Future<MapSpriteAtlas> Function(Ref ref)? spriteAtlas,
   Future<EarthquakeHistoryMapLayerParameter> Function(Ref ref)? parameter,
+  bool disableRetry = false,
 }) => ProviderContainer(
+  retry: disableRetry ? (retryCount, error) => null : null,
   overrides: [
     latestEarthquakeOverlaySpriteAtlasProvider.overrideWith(
       spriteAtlas ?? (ref) async => _spriteAtlas('atlas-a'),
@@ -480,6 +482,50 @@ void main() {
       parameterChanged.renderGeneration,
       atlasChanged.renderGeneration + 1,
     );
+  });
+
+  test('invalid parameterで失敗したcandidateはversion ownerを進めない', () async {
+    var parameter = const EarthquakeHistoryMapLayerParameter(
+      regionToCity: double.nan,
+    );
+    final colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
+    final container = _providerContainer(
+      parameter: (ref) async => parameter,
+      disableRetry: true,
+      overrides: [
+        activeColorSetProvider.overrideWithValue(colorSet),
+        earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
+          () => _incarnation('incarnation-a'),
+        ),
+        earthquakeHistoryProvider(
+          latestEarthquakeOverlayParameter,
+        ).overrideWith(() => _MutableHistoryNotifier(_page('A'))),
+        earthquakeHistoryDetailsProvider('A').overrideWith(
+          () => _MutableDetailsNotifier(_availableEarthquake()),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      latestEarthquakeOverlayProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+
+    await expectLater(
+      container.read(latestEarthquakeOverlayProvider.future),
+      throwsA(isA<ArgumentError>()),
+    );
+    parameter = const EarthquakeHistoryMapLayerParameter();
+    container.invalidate(latestEarthquakeOverlayMapLayerParameterProvider);
+    await pumpEventQueue();
+    final firstSuccessful = _stamp(
+      await container.read(latestEarthquakeOverlayProvider.future),
+    );
+
+    expect(firstSuccessful.dataSequence, 0);
+    expect(firstSuccessful.renderGeneration, 0);
   });
 
   test('provider再生成時は同じeventを新incarnationのsequence 0にする', () async {

--- a/app/test/feature/earthquake_history/data/latest_earthquake_overlay_provider_test.dart
+++ b/app/test/feature/earthquake_history/data/latest_earthquake_overlay_provider_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
@@ -7,6 +8,7 @@ import 'package:eqmonitor/core/provider/clock/map_clock_source_identity_provider
 import 'package:eqmonitor/core/theme/model/app_theme.dart';
 import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_search_response.dart';
@@ -22,6 +24,7 @@ import 'package:eqmonitor/feature/earthquake_history/data/provider/latest_earthq
 import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
 import 'package:eqmonitor_map/eqmonitor_map.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -138,6 +141,36 @@ Earthquake _availableEarthquake({
 MapSourceIncarnation _incarnation(String value) =>
     createMapSourceIncarnation(value: value);
 
+MapSpriteAtlas _spriteAtlas(String identity) => createMapSpriteAtlas(
+  identity: createMapSourceIdentity(value: identity),
+  width: 1,
+  height: 1,
+  rgbaBytes: Uint8List.fromList(const [255, 255, 255, 255]),
+  regions: const [],
+  limits: const MapSpriteAtlasLimits(
+    maxWidth: 1,
+    maxHeight: 1,
+    maxPixelBytes: 4,
+    maxRegions: 1,
+  ),
+);
+
+ProviderContainer _providerContainer({
+  required List<Override> overrides,
+  Future<MapSpriteAtlas> Function(Ref ref)? spriteAtlas,
+  Future<EarthquakeHistoryMapLayerParameter> Function(Ref ref)? parameter,
+}) => ProviderContainer(
+  overrides: [
+    latestEarthquakeOverlaySpriteAtlasProvider.overrideWith(
+      spriteAtlas ?? (ref) async => _spriteAtlas('atlas-a'),
+    ),
+    latestEarthquakeOverlayMapLayerParameterProvider.overrideWith(
+      parameter ?? (ref) async => const EarthquakeHistoryMapLayerParameter(),
+    ),
+    ...overrides,
+  ],
+);
+
 MapOverlayVersionStamp _stamp(LatestEarthquakeOverlayData data) {
   final overlay = data.overlay;
   expect(overlay, isNotNull);
@@ -158,7 +191,7 @@ void main() {
     final requestedA = Completer<void>();
     final requestedB = Completer<void>();
     final colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
-    final container = ProviderContainer(
+    final container = _providerContainer(
       overrides: [
         activeColorSetProvider.overrideWith((ref) => colorSet),
         earthquakeHistoryProvider(
@@ -210,11 +243,95 @@ void main() {
     );
   });
 
+  test('event Aのlate atlasはBを公開せずversion ownerも進めない', () async {
+    final history = _MutableHistoryNotifier(_page('B'));
+    final detailsB = _MutableDetailsNotifier(
+      _availableEarthquake(eventId: 'B'),
+    );
+    final detailA = Completer<Earthquake>();
+    final requestedA = Completer<void>();
+    final pendingAtlas = Completer<MapSpriteAtlas>();
+    final pendingAtlasRequested = Completer<void>();
+    var atlasFuture = Future.value(_spriteAtlas('atlas-a'));
+    var atlasRequestCount = 0;
+    final colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
+    final container = _providerContainer(
+      spriteAtlas: (ref) {
+        atlasRequestCount++;
+        if (atlasRequestCount > 1 && !pendingAtlasRequested.isCompleted) {
+          pendingAtlasRequested.complete();
+        }
+        return atlasFuture;
+      },
+      overrides: [
+        activeColorSetProvider.overrideWithValue(colorSet),
+        earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
+          () => _incarnation('incarnation-a'),
+        ),
+        earthquakeHistoryProvider(
+          latestEarthquakeOverlayParameter,
+        ).overrideWith(() => history),
+        earthquakeHistoryDetailsProvider(
+          'B',
+        ).overrideWith(() => detailsB),
+        earthquakeHistoryDetailsProvider('A').overrideWith(
+          () => _PendingDetailsNotifier(
+            completer: detailA,
+            requested: requestedA,
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final publishedEventIds = <String>[];
+    final subscription = container.listen(
+      latestEarthquakeOverlayProvider,
+      (_, next) {
+        if (next case AsyncData(:final value)) {
+          final eventId = value.eventId;
+          if (eventId != null) {
+            publishedEventIds.add(eventId);
+          }
+        }
+      },
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+
+    final firstB = _stamp(
+      await container.read(latestEarthquakeOverlayProvider.future),
+    );
+    history.publish(_page('A'));
+    await requestedA.future;
+    atlasFuture = pendingAtlas.future;
+    container.invalidate(latestEarthquakeOverlaySpriteAtlasProvider);
+    detailA.complete(_availableEarthquake(eventId: 'A'));
+    await pendingAtlasRequested.future;
+
+    detailsB.publish(
+      _availableEarthquake(
+        eventId: 'B',
+        intensity: JmaIntensity.four,
+      ),
+    );
+    history.publish(_page('B'));
+    await pumpEventQueue();
+    pendingAtlas.complete(_spriteAtlas('atlas-b'));
+    final secondB = _stamp(
+      await container.read(latestEarthquakeOverlayProvider.future),
+    );
+
+    expect(publishedEventIds, isNot(contains('A')));
+    expect(firstB.dataSequence, 0);
+    expect(secondB.dataSequence, 1);
+    expect(secondB.dataDigest, isNot(firstB.dataDigest));
+  });
+
   test('reportedAtが同一でもcanonical data変更でdata sequenceが進む', () async {
     final earthquake = _availableEarthquake();
     final details = _MutableDetailsNotifier(earthquake);
     final colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
-    final container = ProviderContainer(
+    final container = _providerContainer(
       overrides: [
         activeColorSetProvider.overrideWithValue(colorSet),
         earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
@@ -261,7 +378,7 @@ void main() {
   test('theme色だけの変更はdata versionを維持してrender generationを進める', () async {
     var colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
     final details = _MutableDetailsNotifier(_availableEarthquake());
-    final container = ProviderContainer(
+    final container = _providerContainer(
       overrides: [
         activeColorSetProvider.overrideWith((ref) => colorSet),
         earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
@@ -310,12 +427,67 @@ void main() {
     expect(second.renderDigest, isNot(first.renderDigest));
   });
 
+  test('atlasと表示parameterだけの変更はdata versionを維持する', () async {
+    var atlas = _spriteAtlas('atlas-a');
+    var parameter = const EarthquakeHistoryMapLayerParameter();
+    final colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
+    final container = _providerContainer(
+      spriteAtlas: (ref) async => atlas,
+      parameter: (ref) async => parameter,
+      overrides: [
+        activeColorSetProvider.overrideWithValue(colorSet),
+        earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
+          () => _incarnation('incarnation-a'),
+        ),
+        earthquakeHistoryProvider(
+          latestEarthquakeOverlayParameter,
+        ).overrideWith(() => _MutableHistoryNotifier(_page('A'))),
+        earthquakeHistoryDetailsProvider('A').overrideWith(
+          () => _MutableDetailsNotifier(_availableEarthquake()),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      latestEarthquakeOverlayProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+
+    final first = _stamp(
+      await container.read(latestEarthquakeOverlayProvider.future),
+    );
+    atlas = _spriteAtlas('atlas-b');
+    container.invalidate(latestEarthquakeOverlaySpriteAtlasProvider);
+    await pumpEventQueue();
+    final atlasChanged = _stamp(
+      await container.read(latestEarthquakeOverlayProvider.future),
+    );
+    parameter = parameter.copyWith(regionFillOpacity: 0.5);
+    container.invalidate(latestEarthquakeOverlayMapLayerParameterProvider);
+    await pumpEventQueue();
+    final parameterChanged = _stamp(
+      await container.read(latestEarthquakeOverlayProvider.future),
+    );
+
+    expect(atlasChanged.dataSequence, first.dataSequence);
+    expect(atlasChanged.dataDigest, first.dataDigest);
+    expect(atlasChanged.renderGeneration, first.renderGeneration + 1);
+    expect(parameterChanged.dataSequence, first.dataSequence);
+    expect(parameterChanged.dataDigest, first.dataDigest);
+    expect(
+      parameterChanged.renderGeneration,
+      atlasChanged.renderGeneration + 1,
+    );
+  });
+
   test('provider再生成時は同じeventを新incarnationのsequence 0にする', () async {
     Future<MapOverlayVersionStamp> readStamp(String incarnation) async {
       final colorSet = AppTheme.eqmonitorDefault().colorSetFor(
         Brightness.light,
       );
-      final container = ProviderContainer(
+      final container = _providerContainer(
         overrides: [
           activeColorSetProvider.overrideWithValue(colorSet),
           earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
@@ -352,7 +524,7 @@ void main() {
       _incarnation('incarnation-b'),
     ].iterator;
     final colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
-    final container = ProviderContainer(
+    final container = _providerContainer(
       overrides: [
         activeColorSetProvider.overrideWithValue(colorSet),
         earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
@@ -410,7 +582,7 @@ void main() {
       _incarnation('time-shift-incarnation'),
     ].iterator;
     final colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
-    final container = ProviderContainer(
+    final container = _providerContainer(
       overrides: [
         activeColorSetProvider.overrideWithValue(colorSet),
         earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
@@ -465,7 +637,7 @@ void main() {
       _incarnation('replay-incarnation'),
     ].iterator;
     final colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
-    final container = ProviderContainer(
+    final container = _providerContainer(
       overrides: [
         activeColorSetProvider.overrideWithValue(colorSet),
         earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
@@ -529,7 +701,7 @@ void main() {
       _incarnation('second-replay-incarnation'),
     ].iterator;
     final colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
-    final container = ProviderContainer(
+    final container = _providerContainer(
       overrides: [
         activeColorSetProvider.overrideWithValue(colorSet),
         earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(
@@ -589,7 +761,7 @@ void main() {
   test('通常のreplay tickはoverlay incarnationを再生成しない', () async {
     var incarnationRequestCount = 0;
     final colorSet = AppTheme.eqmonitorDefault().colorSetFor(Brightness.light);
-    final container = ProviderContainer(
+    final container = _providerContainer(
       overrides: [
         activeColorSetProvider.overrideWithValue(colorSet),
         earthquakeOverlaySourceIncarnationFactoryProvider.overrideWithValue(


### PR DESCRIPTION
## 概要

Flutter Scene / GPU 地図の地震履歴 overlay に、app asset 由来の震源 sprite atlas と震源 feature を接続します。

## 変更内容

- normal / low-precision 震源画像を一度だけ decode し、straight RGBA atlasへ変換
- 2px edge extrusion、texel-center UV、SHA-256 identity、caller limitsを実装
- 有効な震源座標だけを normal spriteへ変換し、固定位置fallbackを禁止
- atlas・表示parameter・sprite policyをrender digestへ反映
- detail / parameter / atlas のlate resultをgenerationで拒否
- version更新をpreview / commitの二相処理にし、validation failureでownerを進めない

## 検証

- Task 7対象テスト 36件: PASS
- `mise exec -- dart analyze lib/feature/earthquake_history/data test/feature/earthquake_history/data`: No issues found
- format / `git diff --check`: PASS
- 独立レビュー: APPROVED（Critical / Important / Minor 0）

## Stack

- Depends on #1761
- Flutter GPU Map migration Stack #1756
