### PR TITLE
feat: GPU地図の震度coverage診断を追加

### DIFF
--- a/packages/eqmonitor_map/lib/src/overlay/earthquake_overlay_coverage.dart
+++ b/packages/eqmonitor_map/lib/src/overlay/earthquake_overlay_coverage.dart
@@ -20,6 +20,38 @@ sealed class EarthquakeOverlayCoverage {
     required int requestedTileCount,
   }) = EarthquakeOverlayComplete;
 
+  /// 可視範囲について確認済みの診断だけからcoverageを導出する。
+  factory EarthquakeOverlayCoverage.fromDiagnostic(
+    EarthquakeOverlayCoverageDiagnostic diagnostic,
+  ) {
+    if (diagnostic.visibleCanonicalTileCount == 0) {
+      return const EarthquakeOverlayCoverage.hidden();
+    }
+    if (diagnostic.pendingTileCount > 0) {
+      return const EarthquakeOverlayCoverage.loading();
+    }
+    final incomplete =
+        diagnostic.sourceLayerAbsentTileCount > 0 ||
+        diagnostic.missingOrInvalidPropertyFeatureCount > 0 ||
+        diagnostic.decodeOrSchemaFailureTileCount > 0 ||
+        diagnostic.requiredCodeUnresolvedCount > 0;
+    if (incomplete) {
+      return EarthquakeOverlayCoverage.incomplete(
+        requestedTileCount: diagnostic.visibleCanonicalTileCount,
+        readyTileCount:
+            diagnostic.visibleCanonicalTileCount -
+            diagnostic.sourceLayerAbsentTileCount -
+            diagnostic.decodeOrSchemaFailureTileCount,
+        missingOrInvalidCodeCount:
+            diagnostic.missingOrInvalidPropertyFeatureCount +
+            diagnostic.requiredCodeUnresolvedCount,
+      );
+    }
+    return EarthquakeOverlayCoverage.complete(
+      requestedTileCount: diagnostic.visibleCanonicalTileCount,
+    );
+  }
+
   /// tile準備数とcodeの妥当性からcoverageを導出する。
   factory EarthquakeOverlayCoverage.fromCounts({
     required int requestedTileCount,
@@ -64,23 +96,157 @@ final class EarthquakeOverlayCoverageSnapshot {
   const EarthquakeOverlayCoverageSnapshot({
     required MapOverlayVersionStamp this.versionStamp,
     required this.coverage,
+    this.diagnostic = const EarthquakeOverlayCoverageDiagnostic.empty(),
   });
 
   const EarthquakeOverlayCoverageSnapshot.hidden()
     : versionStamp = null,
-      coverage = const EarthquakeOverlayCoverage.hidden();
+      coverage = const EarthquakeOverlayCoverage.hidden(),
+      diagnostic = const EarthquakeOverlayCoverageDiagnostic.empty();
 
   final MapOverlayVersionStamp? versionStamp;
   final EarthquakeOverlayCoverage coverage;
+  final EarthquakeOverlayCoverageDiagnostic diagnostic;
 
   @override
   bool operator ==(Object other) =>
       other is EarthquakeOverlayCoverageSnapshot &&
       other.versionStamp == versionStamp &&
-      other.coverage == coverage;
+      other.coverage == coverage &&
+      other.diagnostic == diagnostic;
 
   @override
-  int get hashCode => Object.hash(versionStamp, coverage);
+  int get hashCode => Object.hash(versionStamp, coverage, diagnostic);
+}
+
+/// 同じoverlay stampとatomicに通知する可視範囲の診断値。
+@immutable
+final class EarthquakeOverlayCoverageDiagnostic {
+  factory EarthquakeOverlayCoverageDiagnostic({
+    required int visibleCanonicalTileCount,
+    required int pendingTileCount,
+    required int authoritativeEmptyTileCount,
+    required int sourceLayerAbsentTileCount,
+    required int missingOrInvalidPropertyFeatureCount,
+    required int decodeOrSchemaFailureTileCount,
+    required int requiredCodeUnresolvedCount,
+    required int stationCount,
+    required int spriteCount,
+  }) {
+    final counts = [
+      visibleCanonicalTileCount,
+      pendingTileCount,
+      authoritativeEmptyTileCount,
+      sourceLayerAbsentTileCount,
+      missingOrInvalidPropertyFeatureCount,
+      decodeOrSchemaFailureTileCount,
+      requiredCodeUnresolvedCount,
+      stationCount,
+      spriteCount,
+    ];
+    if (counts.any((count) => count < 0)) {
+      throw ArgumentError.value(counts, 'counts', 'must be non-negative');
+    }
+    final classifiedTileCount =
+        pendingTileCount +
+        authoritativeEmptyTileCount +
+        sourceLayerAbsentTileCount +
+        decodeOrSchemaFailureTileCount;
+    if (classifiedTileCount > visibleCanonicalTileCount) {
+      throw ArgumentError.value(
+        classifiedTileCount,
+        'classifiedTileCount',
+        'must not exceed visibleCanonicalTileCount',
+      );
+    }
+    return EarthquakeOverlayCoverageDiagnostic._(
+      visibleCanonicalTileCount: visibleCanonicalTileCount,
+      pendingTileCount: pendingTileCount,
+      authoritativeEmptyTileCount: authoritativeEmptyTileCount,
+      sourceLayerAbsentTileCount: sourceLayerAbsentTileCount,
+      missingOrInvalidPropertyFeatureCount:
+          missingOrInvalidPropertyFeatureCount,
+      decodeOrSchemaFailureTileCount: decodeOrSchemaFailureTileCount,
+      requiredCodeUnresolvedCount: requiredCodeUnresolvedCount,
+      stationCount: stationCount,
+      spriteCount: spriteCount,
+    );
+  }
+
+  const EarthquakeOverlayCoverageDiagnostic._({
+    required this.visibleCanonicalTileCount,
+    required this.pendingTileCount,
+    required this.authoritativeEmptyTileCount,
+    required this.sourceLayerAbsentTileCount,
+    required this.missingOrInvalidPropertyFeatureCount,
+    required this.decodeOrSchemaFailureTileCount,
+    required this.requiredCodeUnresolvedCount,
+    required this.stationCount,
+    required this.spriteCount,
+  });
+
+  const EarthquakeOverlayCoverageDiagnostic.empty()
+    : visibleCanonicalTileCount = 0,
+      pendingTileCount = 0,
+      authoritativeEmptyTileCount = 0,
+      sourceLayerAbsentTileCount = 0,
+      missingOrInvalidPropertyFeatureCount = 0,
+      decodeOrSchemaFailureTileCount = 0,
+      requiredCodeUnresolvedCount = 0,
+      stationCount = 0,
+      spriteCount = 0;
+
+  factory EarthquakeOverlayCoverageDiagnostic.preparing({
+    required int stationCount,
+    required int spriteCount,
+  }) => EarthquakeOverlayCoverageDiagnostic(
+    visibleCanonicalTileCount: 0,
+    pendingTileCount: 0,
+    authoritativeEmptyTileCount: 0,
+    sourceLayerAbsentTileCount: 0,
+    missingOrInvalidPropertyFeatureCount: 0,
+    decodeOrSchemaFailureTileCount: 0,
+    requiredCodeUnresolvedCount: 0,
+    stationCount: stationCount,
+    spriteCount: spriteCount,
+  );
+
+  final int visibleCanonicalTileCount;
+  final int pendingTileCount;
+  final int authoritativeEmptyTileCount;
+  final int sourceLayerAbsentTileCount;
+  final int missingOrInvalidPropertyFeatureCount;
+  final int decodeOrSchemaFailureTileCount;
+  final int requiredCodeUnresolvedCount;
+  final int stationCount;
+  final int spriteCount;
+
+  @override
+  bool operator ==(Object other) =>
+      other is EarthquakeOverlayCoverageDiagnostic &&
+      other.visibleCanonicalTileCount == visibleCanonicalTileCount &&
+      other.pendingTileCount == pendingTileCount &&
+      other.authoritativeEmptyTileCount == authoritativeEmptyTileCount &&
+      other.sourceLayerAbsentTileCount == sourceLayerAbsentTileCount &&
+      other.missingOrInvalidPropertyFeatureCount ==
+          missingOrInvalidPropertyFeatureCount &&
+      other.decodeOrSchemaFailureTileCount == decodeOrSchemaFailureTileCount &&
+      other.requiredCodeUnresolvedCount == requiredCodeUnresolvedCount &&
+      other.stationCount == stationCount &&
+      other.spriteCount == spriteCount;
+
+  @override
+  int get hashCode => Object.hash(
+    visibleCanonicalTileCount,
+    pendingTileCount,
+    authoritativeEmptyTileCount,
+    sourceLayerAbsentTileCount,
+    missingOrInvalidPropertyFeatureCount,
+    decodeOrSchemaFailureTileCount,
+    requiredCodeUnresolvedCount,
+    stationCount,
+    spriteCount,
+  );
 }
 
 /// overlayが非表示で、可視tileを要求していない状態。

--- a/packages/eqmonitor_map/lib/src/overlay/earthquake_overlay_coverage_owner.dart
+++ b/packages/eqmonitor_map/lib/src/overlay/earthquake_overlay_coverage_owner.dart
@@ -15,17 +15,20 @@ final class EarthquakeOverlayCoverageOwner {
   void hide({required EarthquakeMapOverlaySnapshot? overlay}) => publish(
     overlay: overlay,
     coverage: const EarthquakeOverlayCoverage.hidden(),
+    diagnostic: const EarthquakeOverlayCoverageDiagnostic.empty(),
   );
 
   void publish({
     required EarthquakeMapOverlaySnapshot? overlay,
     required EarthquakeOverlayCoverage coverage,
+    required EarthquakeOverlayCoverageDiagnostic diagnostic,
   }) {
     final next = overlay == null
         ? const EarthquakeOverlayCoverageSnapshot.hidden()
         : EarthquakeOverlayCoverageSnapshot(
             versionStamp: overlay.versionStamp,
             coverage: coverage,
+            diagnostic: diagnostic,
           );
     if (next == _snapshot) {
       return;

--- a/packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_builder.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_builder.dart
@@ -16,12 +16,16 @@ import 'package:eqmonitor_map/src/renderer/observation_point_batch_builder.dart'
 import 'package:eqmonitor_map/src/tile/base_map_tile_cache.dart';
 import 'package:eqmonitor_map/src/tile/earthquake_overlay_exact_tile_resolver.dart';
 
+typedef EarthquakeOverlayExactTileMissReasonFor =
+    EarthquakeOverlayExactTileMissReason Function(CanonicalTileId tileId);
+
 /// BaseMapViewが1 frameでsubmitする内容と次frameへ持ち越すoverlay state。
 final class BaseMapOverlayFrameResult {
   const new({
     required this.overlay,
     required this.submission,
     required this.coverage,
+    required this.diagnostic,
     required this.observationBatchForReuse,
     required this.spriteBatchesForReuse,
     required this.shouldRetireGpuResources,
@@ -30,6 +34,7 @@ final class BaseMapOverlayFrameResult {
   final EarthquakeMapOverlaySnapshot? overlay;
   final MapSceneFrameSubmission? submission;
   final EarthquakeOverlayCoverage coverage;
+  final EarthquakeOverlayCoverageDiagnostic diagnostic;
   final ObservationPointBatch? observationBatchForReuse;
   final List<MapPointSpriteInstanceBatch> spriteBatchesForReuse;
   final bool shouldRetireGpuResources;
@@ -48,6 +53,8 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
   required EarthquakeAreaPackedMeshResolver packedMeshFor,
   required EarthquakeAreaRenderStyleCache styleCache,
   required MapSceneFrameLimits sceneFrameLimits,
+  required EarthquakeOverlayExactTileMissReasonFor missingExactTileReasonFor,
+  required int requiredCodeUnresolvedCount,
   List<MapPointSpriteInstanceBatch> previousSpriteBatches = const [],
 }) {
   if (!identical(baseMap.frame, frame)) {
@@ -62,6 +69,7 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
       overlay: overlay,
       submission: null,
       coverage: const EarthquakeOverlayCoverage.hidden(),
+      diagnostic: const EarthquakeOverlayCoverageDiagnostic.empty(),
       observationBatchForReuse: _reusableObservation(
         previous: previousObservationBatch,
         overlay: overlay,
@@ -82,6 +90,7 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
         sceneFrameLimits: sceneFrameLimits,
       ),
       coverage: const EarthquakeOverlayCoverage.hidden(),
+      diagnostic: const EarthquakeOverlayCoverageDiagnostic.empty(),
       observationBatchForReuse: null,
       spriteBatchesForReuse: const [],
       shouldRetireGpuResources: false,
@@ -98,11 +107,16 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
         sourceInstanceId: tileSourceInstanceId,
         cache: tileCache,
         mode: layerMode,
+        missReason: missingExactTileReasonFor(tile.canonical),
       ),
   ];
-  final coverage = earthquakeOverlayCoverageFor(
+  final diagnostic = earthquakeOverlayCoverageDiagnosticFor(
     exactTileResults: exactTileResults,
+    requiredCodeUnresolvedCount: requiredCodeUnresolvedCount,
+    stationCount: overlay.stations.length,
+    spriteCount: overlay.sprites.length,
   );
+  final coverage = EarthquakeOverlayCoverage.fromDiagnostic(diagnostic);
   final styles = styleCache.resolve(
     snapshot: overlay,
     layerMode: layerMode,
@@ -170,6 +184,7 @@ BaseMapOverlayFrameResult buildBaseMapOverlayFrame({
       limits: sceneFrameLimits,
     ),
     coverage: coverage,
+    diagnostic: diagnostic,
     observationBatchForReuse:
         observation ??
         _reusableObservation(
@@ -229,23 +244,52 @@ EarthquakeMapOverlaySnapshot? selectEarthquakeOverlaySnapshot({
 }
 
 /// exact tile結果からsource layer/code欠損を含むcoverageを数える。
-EarthquakeOverlayCoverage earthquakeOverlayCoverageFor({
+EarthquakeOverlayCoverageDiagnostic earthquakeOverlayCoverageDiagnosticFor({
   required List<EarthquakeOverlayExactTileResult> exactTileResults,
+  required int requiredCodeUnresolvedCount,
+  required int stationCount,
+  required int spriteCount,
 }) {
-  var readyTileCount = 0;
-  var missingOrInvalidCodeCount = 0;
+  final visited = <CanonicalTileId>{};
+  var pendingTileCount = 0;
+  var authoritativeEmptyTileCount = 0;
+  var sourceLayerAbsentTileCount = 0;
+  var missingOrInvalidPropertyFeatureCount = 0;
+  var decodeOrSchemaFailureTileCount = 0;
   for (final result in exactTileResults) {
-    if (result is! EarthquakeOverlayExactTileHit ||
-        result.areaGeometry.extent == null) {
+    if (!visited.add(result.canonicalTileId)) {
       continue;
     }
-    readyTileCount++;
-    missingOrInvalidCodeCount += result.areaGeometry.missingOrInvalidCodeCount;
+    switch (result) {
+      case EarthquakeOverlayExactTilePending():
+        pendingTileCount++;
+      case EarthquakeOverlayExactTileAuthoritativeEmpty():
+        authoritativeEmptyTileCount++;
+      case EarthquakeOverlayExactTileDecodeFailure():
+        decodeOrSchemaFailureTileCount++;
+      case EarthquakeOverlayExactTileHit(:final areaGeometry):
+        if (areaGeometry.extent == null) {
+          sourceLayerAbsentTileCount++;
+          continue;
+        }
+        missingOrInvalidPropertyFeatureCount +=
+            areaGeometry.missingOrInvalidCodeCount;
+        if (areaGeometry.features.isEmpty &&
+            areaGeometry.missingOrInvalidCodeCount == 0) {
+          authoritativeEmptyTileCount++;
+        }
+    }
   }
-  return EarthquakeOverlayCoverage.fromCounts(
-    requestedTileCount: exactTileResults.length,
-    readyTileCount: readyTileCount,
-    missingOrInvalidCodeCount: missingOrInvalidCodeCount,
+  return EarthquakeOverlayCoverageDiagnostic(
+    visibleCanonicalTileCount: visited.length,
+    pendingTileCount: pendingTileCount,
+    authoritativeEmptyTileCount: authoritativeEmptyTileCount,
+    sourceLayerAbsentTileCount: sourceLayerAbsentTileCount,
+    missingOrInvalidPropertyFeatureCount: missingOrInvalidPropertyFeatureCount,
+    decodeOrSchemaFailureTileCount: decodeOrSchemaFailureTileCount,
+    requiredCodeUnresolvedCount: requiredCodeUnresolvedCount,
+    stationCount: stationCount,
+    spriteCount: spriteCount,
   );
 }
 

--- a/packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_owner.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_owner.dart
@@ -69,6 +69,17 @@ final class BaseMapOverlayFrameOwner {
 
   void hide() => _coverage.hide(overlay: _overlay);
 
+  void hideCandidate() => _coverage.hide(overlay: null);
+
+  void beginLoading({
+    required EarthquakeMapOverlaySnapshot overlay,
+    required EarthquakeOverlayCoverageDiagnostic diagnostic,
+  }) => _coverage.publish(
+    overlay: overlay,
+    coverage: const EarthquakeOverlayCoverage.loading(),
+    diagnostic: diagnostic,
+  );
+
   BaseMapOverlayFrameCommitResult commit({
     required BaseMapOverlayFrameResult candidate,
     required MapSceneFrameSubmission baseOnlySubmission,
@@ -76,6 +87,7 @@ final class BaseMapOverlayFrameOwner {
     required SubmitBaseMapOverlayFrame submitFrame,
     required VoidCallback retireAllGpuResources,
     required VoidCallback failClosedResources,
+    EarthquakeMapOverlaySnapshot? preparingOverlay,
   }) {
     final submission = candidate.submission;
     if (submission == null) {
@@ -113,7 +125,22 @@ final class BaseMapOverlayFrameOwner {
     _overlay = candidate.overlay;
     _previousObservationBatch = candidate.observationBatchForReuse;
     _previousSpriteBatches = candidate.spriteBatchesForReuse;
-    _coverage.publish(overlay: _overlay, coverage: candidate.coverage);
+    if (preparingOverlay != null) {
+      _coverage.publish(
+        overlay: preparingOverlay,
+        coverage: const EarthquakeOverlayCoverage.loading(),
+        diagnostic: EarthquakeOverlayCoverageDiagnostic.preparing(
+          stationCount: preparingOverlay.stations.length,
+          spriteCount: preparingOverlay.sprites.length,
+        ),
+      );
+      return const BaseMapOverlayFrameCommitSucceeded();
+    }
+    _coverage.publish(
+      overlay: _overlay,
+      coverage: candidate.coverage,
+      diagnostic: candidate.diagnostic,
+    );
     return const BaseMapOverlayFrameCommitSucceeded();
   }
 }

--- a/packages/eqmonitor_map/lib/src/tile/earthquake_overlay_exact_tile_resolver.dart
+++ b/packages/eqmonitor_map/lib/src/tile/earthquake_overlay_exact_tile_resolver.dart
@@ -6,36 +6,71 @@ import 'package:flutter/foundation.dart';
 /// 地震overlayで描画する区域layer。
 enum EarthquakeAreaLayerMode { region, city }
 
+/// exact cache missについて、呼び出し側が確認済みの理由。
+enum EarthquakeOverlayExactTileMissReason {
+  /// scheduler待ち、実行中、またはまだschedulerへ渡していないcache miss。
+  pending,
+
+  /// PMTiles directoryにcanonical tile entryが存在しない。
+  authoritativeEmpty,
+
+  /// entryは存在したがdecodeまたはschema検証に失敗した。
+  decodeFailure,
+}
+
 /// exact tileの区域geometryを取得した結果。
 @immutable
 sealed class EarthquakeOverlayExactTileResult {
-  const EarthquakeOverlayExactTileResult();
+  const EarthquakeOverlayExactTileResult({
+    required this.tileId,
+    required this.canonicalTileId,
+    required this.sourceInstanceId,
+  });
+
+  final UnwrappedTileId tileId;
+  final CanonicalTileId canonicalTileId;
+  final String sourceInstanceId;
 }
 
-/// 要求されたcanonical tileがcacheにない結果。
-final class EarthquakeOverlayExactTileMiss
+/// exact tileがschedulerまたはdecode待ちの結果。
+final class EarthquakeOverlayExactTilePending
     extends EarthquakeOverlayExactTileResult {
-  const EarthquakeOverlayExactTileMiss();
+  const EarthquakeOverlayExactTilePending({
+    required super.tileId,
+    required super.canonicalTileId,
+    required super.sourceInstanceId,
+  });
+}
+
+/// PMTiles directoryがcanonical tileの不存在を証明した結果。
+final class EarthquakeOverlayExactTileAuthoritativeEmpty
+    extends EarthquakeOverlayExactTileResult {
+  const EarthquakeOverlayExactTileAuthoritativeEmpty({
+    required super.tileId,
+    required super.canonicalTileId,
+    required super.sourceInstanceId,
+  });
+}
+
+/// canonical tileのdecodeまたはschema検証に失敗した結果。
+final class EarthquakeOverlayExactTileDecodeFailure
+    extends EarthquakeOverlayExactTileResult {
+  const EarthquakeOverlayExactTileDecodeFailure({
+    required super.tileId,
+    required super.canonicalTileId,
+    required super.sourceInstanceId,
+  });
 }
 
 /// 要求されたcanonical tileの区域geometry。
 final class EarthquakeOverlayExactTileHit
     extends EarthquakeOverlayExactTileResult {
   const EarthquakeOverlayExactTileHit({
-    required this.tileId,
-    required this.canonicalTileId,
-    required this.sourceInstanceId,
+    required super.tileId,
+    required super.canonicalTileId,
+    required super.sourceInstanceId,
     required this.areaGeometry,
   });
-
-  /// world wrapを含む、描画位置としての要求tile。
-  final UnwrappedTileId tileId;
-
-  /// cache lookupに使用したcanonical tile。
-  final CanonicalTileId canonicalTileId;
-
-  /// cache lookupに使用したsourceの識別子。
-  final String sourceInstanceId;
 
   /// 表示modeで選んだ区域layer。source layer欠損時はextentが`null`になる。
   final EarthquakeAreaTileLayerGeometry areaGeometry;
@@ -50,13 +85,33 @@ EarthquakeOverlayExactTileResult resolveEarthquakeOverlayExactTile({
   required String sourceInstanceId,
   required BaseMapTileCache cache,
   required EarthquakeAreaLayerMode mode,
+  required EarthquakeOverlayExactTileMissReason missReason,
 }) {
   final geometry = cache.get(
     sourceInstanceId: sourceInstanceId,
     tileId: requestedTile.canonical,
   );
   if (geometry == null) {
-    return const EarthquakeOverlayExactTileMiss();
+    return switch (missReason) {
+      EarthquakeOverlayExactTileMissReason.pending =>
+        EarthquakeOverlayExactTilePending(
+          tileId: requestedTile,
+          canonicalTileId: requestedTile.canonical,
+          sourceInstanceId: sourceInstanceId,
+        ),
+      EarthquakeOverlayExactTileMissReason.authoritativeEmpty =>
+        EarthquakeOverlayExactTileAuthoritativeEmpty(
+          tileId: requestedTile,
+          canonicalTileId: requestedTile.canonical,
+          sourceInstanceId: sourceInstanceId,
+        ),
+      EarthquakeOverlayExactTileMissReason.decodeFailure =>
+        EarthquakeOverlayExactTileDecodeFailure(
+          tileId: requestedTile,
+          canonicalTileId: requestedTile.canonical,
+          sourceInstanceId: sourceInstanceId,
+        ),
+    };
   }
   final areaGeometry = switch (mode) {
     EarthquakeAreaLayerMode.region => geometry.earthquakeAreas.forecastRegions,

--- a/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
+++ b/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
@@ -33,6 +33,7 @@ import 'package:eqmonitor_map/src/tile/base_map_tile_cache.dart';
 import 'package:eqmonitor_map/src/tile/base_map_tile_decode_failure_owner.dart';
 import 'package:eqmonitor_map/src/tile/base_map_tile_decoder.dart';
 import 'package:eqmonitor_map/src/tile/base_map_tile_repository.dart';
+import 'package:eqmonitor_map/src/tile/earthquake_overlay_exact_tile_resolver.dart';
 import 'package:eqmonitor_map/src/tile/scheduler/map_tile_scheduler.dart';
 import 'package:eqmonitor_map/src/tile/tile_cover_calculator.dart';
 import 'package:eqmonitor_map/src/tile/verified_pm_tiles_source.dart';
@@ -458,6 +459,7 @@ class _BaseMapController extends ChangeNotifier
   EarthquakeMapOverlaySnapshot? _inputOverlay;
   EarthquakeMapOverlaySnapshot? _acceptedOverlay;
   EarthquakeMapOverlaySnapshot? _requestedOverlay;
+  EarthquakeMapOverlaySnapshot? _preparingOverlay;
   EarthquakeOverlayMaterialStage? _requestedMaterialStage;
   final BaseMapOverlayFrameOwner _overlayFrameOwner;
   var _overlayRequestGeneration = 0;
@@ -625,6 +627,17 @@ class _BaseMapController extends ChangeNotifier
       .color;
 
   Future<void> initialize() async {
+    final initialOverlay = _inputOverlay;
+    if (initialOverlay != null) {
+      _preparingOverlay = initialOverlay;
+      _overlayFrameOwner.beginLoading(
+        overlay: initialOverlay,
+        diagnostic: EarthquakeOverlayCoverageDiagnostic.preparing(
+          stationCount: initialOverlay.stations.length,
+          spriteCount: initialOverlay.sprites.length,
+        ),
+      );
+    }
     try {
       await scene.Scene.initializeStaticResources();
       // materialは`styleLayerId`ごとに1つ読み込むだけで、色や半線幅は
@@ -681,10 +694,13 @@ class _BaseMapController extends ChangeNotifier
           case EarthquakeOverlayMaterialPreparationReady(:final stage):
             _requestedOverlay = candidate;
             _requestedMaterialStage = stage;
+            _preparingOverlay = null;
             break prepareInitialOverlay;
           case EarthquakeOverlayMaterialPreparationFailed(:final error):
             _requestedOverlay = null;
+            _preparingOverlay = null;
             _requestedMaterialStage = _earthquakeMaterialOwner.stageClear();
+            _overlayFrameOwner.hideCandidate();
             debugPrint(
               'BaseMapView: failed to load earthquake overlay material: '
               '$error',
@@ -731,6 +747,8 @@ class _BaseMapController extends ChangeNotifier
       // 型を問わず受け止める。
       // ignore: avoid_catches_without_on_clauses
     } catch (error) {
+      _preparingOverlay = null;
+      _overlayFrameOwner.hideCandidate();
       _initError = error;
     } finally {
       if (!_isDisposed) {
@@ -768,6 +786,7 @@ class _BaseMapController extends ChangeNotifier
       _acceptedOverlay = null;
       _overlayRequestGeneration++;
       _requestedOverlay = null;
+      _preparingOverlay = null;
       _requestedMaterialStage = _earthquakeMaterialOwner.stageClear();
       _earthquakeStyleCache.clear();
       _refresh();
@@ -789,8 +808,19 @@ class _BaseMapController extends ChangeNotifier
     _inputOverlay = selected;
     _acceptedOverlay = selected;
     final requestGeneration = ++_overlayRequestGeneration;
-    _requestedOverlay = _overlayFrameOwner.overlay;
-    _requestedMaterialStage = null;
+    _requestedOverlay = null;
+    _preparingOverlay = selected;
+    _requestedMaterialStage = _earthquakeMaterialOwner.stageClear();
+    _earthquakeStyleCache.clear();
+    _overlayFrameOwner.hideCandidate();
+    _overlayFrameOwner.beginLoading(
+      overlay: selected,
+      diagnostic: EarthquakeOverlayCoverageDiagnostic.preparing(
+        stationCount: selected.stations.length,
+        spriteCount: selected.sprites.length,
+      ),
+    );
+    _refresh();
     final prepared = await _earthquakeMaterialOwner.prepare(
       resources: earthquakeAreaRenderStyleResourcesForSnapshot(
         cache: _earthquakeStyleCache,
@@ -805,11 +835,14 @@ class _BaseMapController extends ChangeNotifier
     }
     switch (prepared) {
       case EarthquakeOverlayMaterialPreparationReady(:final stage):
+        _preparingOverlay = null;
         _requestedOverlay = selected;
         _requestedMaterialStage = stage;
       case EarthquakeOverlayMaterialPreparationFailed(:final error):
+        _preparingOverlay = null;
         _requestedOverlay = null;
         _requestedMaterialStage = _earthquakeMaterialOwner.stageClear();
+        _overlayFrameOwner.hideCandidate();
         debugPrint(
           'BaseMapView: failed to load earthquake overlay material: $error',
         );
@@ -1016,6 +1049,18 @@ class _BaseMapController extends ChangeNotifier
       tileCache: _cache,
       packedMeshFor: _earthquakePackedMeshCache.resolve,
       styleCache: _earthquakeStyleCache,
+      missingExactTileReasonFor: (tileId) {
+        if (_decodeFailures.contains(tileId)) {
+          return EarthquakeOverlayExactTileMissReason.decodeFailure;
+        }
+        if (_knownAbsentTiles.contains(tileId)) {
+          return EarthquakeOverlayExactTileMissReason.authoritativeEmpty;
+        }
+        return EarthquakeOverlayExactTileMissReason.pending;
+      },
+      // Required codeの可視性はtile featureとの照合だけでは証明できない。
+      // 画面外style codeを未解決と推測せず、検証済み入力が追加されるまで0とする。
+      requiredCodeUnresolvedCount: 0,
       sceneFrameLimits: MapSceneFrameLimits(
         maxNodeCount: limits.maxSceneNodeCount,
       ),
@@ -1043,6 +1088,7 @@ class _BaseMapController extends ChangeNotifier
       ),
       retireAllGpuResources: adapter.retireAllGpuResources,
       failClosedResources: _earthquakeMaterialOwner.clear,
+      preparingOverlay: _preparingOverlay,
     );
     _requestedMaterialStage = null;
     if (commit is BaseMapOverlayFrameCommitFailed) {

--- a/packages/eqmonitor_map/test/overlay/earthquake_overlay_coverage_test.dart
+++ b/packages/eqmonitor_map/test/overlay/earthquake_overlay_coverage_test.dart
@@ -24,7 +24,115 @@ void main() {
     expect(hidden.coverage, isA<EarthquakeOverlayHidden>());
     expect(loading.versionStamp, versionStamp);
     expect(loading.coverage, isA<EarthquakeOverlayLoading>());
+    expect(
+      loading.diagnostic,
+      const EarthquakeOverlayCoverageDiagnostic.empty(),
+    );
   });
+
+  test(
+    'derives loading, incomplete, and complete only from explicit evidence',
+    () {
+      final pending = EarthquakeOverlayCoverageDiagnostic(
+        visibleCanonicalTileCount: 2,
+        pendingTileCount: 1,
+        authoritativeEmptyTileCount: 1,
+        sourceLayerAbsentTileCount: 0,
+        missingOrInvalidPropertyFeatureCount: 0,
+        decodeOrSchemaFailureTileCount: 0,
+        requiredCodeUnresolvedCount: 0,
+        stationCount: 3,
+        spriteCount: 1,
+      );
+      final invalid = EarthquakeOverlayCoverageDiagnostic(
+        visibleCanonicalTileCount: 3,
+        pendingTileCount: 0,
+        authoritativeEmptyTileCount: 1,
+        sourceLayerAbsentTileCount: 1,
+        missingOrInvalidPropertyFeatureCount: 2,
+        decodeOrSchemaFailureTileCount: 1,
+        requiredCodeUnresolvedCount: 1,
+        stationCount: 3,
+        spriteCount: 1,
+      );
+      final complete = EarthquakeOverlayCoverageDiagnostic(
+        visibleCanonicalTileCount: 2,
+        pendingTileCount: 0,
+        authoritativeEmptyTileCount: 2,
+        sourceLayerAbsentTileCount: 0,
+        missingOrInvalidPropertyFeatureCount: 0,
+        decodeOrSchemaFailureTileCount: 0,
+        requiredCodeUnresolvedCount: 0,
+        stationCount: 0,
+        spriteCount: 0,
+      );
+
+      expect(
+        EarthquakeOverlayCoverage.fromDiagnostic(pending),
+        isA<EarthquakeOverlayLoading>(),
+      );
+      expect(
+        EarthquakeOverlayCoverage.fromDiagnostic(invalid),
+        isA<EarthquakeOverlayIncomplete>(),
+      );
+      expect(
+        EarthquakeOverlayCoverage.fromDiagnostic(complete),
+        isA<EarthquakeOverlayComplete>(),
+      );
+    },
+  );
+
+  test('snapshot equality includes the diagnostic in the same stamp', () {
+    final diagnostic = EarthquakeOverlayCoverageDiagnostic(
+      visibleCanonicalTileCount: 1,
+      pendingTileCount: 0,
+      authoritativeEmptyTileCount: 1,
+      sourceLayerAbsentTileCount: 0,
+      missingOrInvalidPropertyFeatureCount: 0,
+      decodeOrSchemaFailureTileCount: 0,
+      requiredCodeUnresolvedCount: 0,
+      stationCount: 2,
+      spriteCount: 1,
+    );
+    final snapshot = EarthquakeOverlayCoverageSnapshot(
+      versionStamp: versionStamp,
+      coverage: const EarthquakeOverlayCoverage.complete(
+        requestedTileCount: 1,
+      ),
+      diagnostic: diagnostic,
+    );
+
+    expect(snapshot.diagnostic, diagnostic);
+    expect(
+      snapshot,
+      isNot(
+        EarthquakeOverlayCoverageSnapshot(
+          versionStamp: versionStamp,
+          coverage: snapshot.coverage,
+        ),
+      ),
+    );
+  });
+
+  test(
+    'rejects overlapping tile categories before ready count can go negative',
+    () {
+      expect(
+        () => EarthquakeOverlayCoverageDiagnostic(
+          visibleCanonicalTileCount: 1,
+          pendingTileCount: 0,
+          authoritativeEmptyTileCount: 0,
+          sourceLayerAbsentTileCount: 1,
+          missingOrInvalidPropertyFeatureCount: 0,
+          decodeOrSchemaFailureTileCount: 1,
+          requiredCodeUnresolvedCount: 0,
+          stationCount: 0,
+          spriteCount: 0,
+        ),
+        throwsArgumentError,
+      );
+    },
+  );
 
   test('is hidden when no tiles are requested', () {
     final coverage = EarthquakeOverlayCoverage.fromCounts(

--- a/packages/eqmonitor_map/test/tile/earthquake_overlay_exact_tile_resolver_test.dart
+++ b/packages/eqmonitor_map/test/tile/earthquake_overlay_exact_tile_resolver_test.dart
@@ -58,9 +58,11 @@ void main() {
       sourceInstanceId: 'source-a',
       cache: cache,
       mode: EarthquakeAreaLayerMode.region,
+      missReason: EarthquakeOverlayExactTileMissReason.pending,
     );
 
-    expect(result, isA<EarthquakeOverlayExactTileMiss>());
+    expect(result, isA<EarthquakeOverlayExactTilePending>());
+    expect(result.canonicalTileId, requested.canonical);
   });
 
   test('uses only the exact source identity', () {
@@ -82,6 +84,7 @@ void main() {
       sourceInstanceId: 'source-a',
       cache: cache,
       mode: EarthquakeAreaLayerMode.region,
+      missReason: EarthquakeOverlayExactTileMissReason.decodeFailure,
     );
 
     expect(result, isA<EarthquakeOverlayExactTileHit>());
@@ -106,12 +109,14 @@ void main() {
       sourceInstanceId: 'source-a',
       cache: cache,
       mode: EarthquakeAreaLayerMode.region,
+      missReason: EarthquakeOverlayExactTileMissReason.pending,
     );
     final city = resolveEarthquakeOverlayExactTile(
       requestedTile: requested,
       sourceInstanceId: 'source-a',
       cache: cache,
       mode: EarthquakeAreaLayerMode.city,
+      missReason: EarthquakeOverlayExactTileMissReason.pending,
     );
 
     expect(region, isA<EarthquakeOverlayExactTileHit>());
@@ -136,6 +141,7 @@ void main() {
       sourceInstanceId: 'source-a',
       cache: cache,
       mode: EarthquakeAreaLayerMode.city,
+      missReason: EarthquakeOverlayExactTileMissReason.pending,
     );
 
     expect(result, isA<EarthquakeOverlayExactTileHit>());
@@ -143,5 +149,30 @@ void main() {
       (result as EarthquakeOverlayExactTileHit).areaGeometry.extent,
       isNull,
     );
+  });
+
+  test('distinguishes directory absence and decode failure', () {
+    const requested = UnwrappedTileId(
+      wrap: 0,
+      canonical: CanonicalTileId(z: 7, x: 24, y: 46),
+    );
+
+    final absent = resolveEarthquakeOverlayExactTile(
+      requestedTile: requested,
+      sourceInstanceId: 'source-a',
+      cache: cache,
+      mode: EarthquakeAreaLayerMode.city,
+      missReason: EarthquakeOverlayExactTileMissReason.authoritativeEmpty,
+    );
+    final failure = resolveEarthquakeOverlayExactTile(
+      requestedTile: requested,
+      sourceInstanceId: 'source-a',
+      cache: cache,
+      mode: EarthquakeAreaLayerMode.city,
+      missReason: EarthquakeOverlayExactTileMissReason.decodeFailure,
+    );
+
+    expect(absent, isA<EarthquakeOverlayExactTileAuthoritativeEmpty>());
+    expect(failure, isA<EarthquakeOverlayExactTileDecodeFailure>());
   });
 }

--- a/packages/eqmonitor_map/test/widget/base_map_overlay_frame_builder_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_overlay_frame_builder_test.dart
@@ -303,6 +303,7 @@ void main() {
     int? cityExtent = 4096,
     int regionInvalidCodes = 0,
     int cityInvalidCodes = 0,
+    bool emptyCityLayer = false,
   }) => BaseMapTileGeometry(
     layers: const [],
     earthquakeAreas: EarthquakeAreaTileGeometry(
@@ -317,10 +318,12 @@ void main() {
       cities: EarthquakeAreaTileLayerGeometry(
         extent: cityExtent,
         missingOrInvalidCodeCount: cityInvalidCodes,
-        features: [
-          CodedFillGeometry(code: '13101', meshes: [mesh()]),
-          CodedFillGeometry(code: '99999', meshes: [mesh()]),
-        ],
+        features: emptyCityLayer
+            ? const []
+            : [
+                CodedFillGeometry(code: '13101', meshes: [mesh()]),
+                CodedFillGeometry(code: '99999', meshes: [mesh()]),
+              ],
       ),
     ),
   );
@@ -347,6 +350,9 @@ void main() {
     List<MapPointSpriteInstanceBatch> previousSprites = const [],
     BaseMapTileCache? cache,
     EarthquakeAreaRenderStyleCache? styleCache,
+    EarthquakeOverlayExactTileMissReason missReason =
+        EarthquakeOverlayExactTileMissReason.pending,
+    int requiredCodeUnresolvedCount = 0,
   }) {
     final baseMap = createMapRenderSubmission(frame: frame, batches: const []);
     final packed = EarthquakeAreaPackedMeshCache(maxEntries: 8);
@@ -362,6 +368,8 @@ void main() {
       tileCache: cache ?? cacheWith(geometry()),
       packedMeshFor: packed.resolve,
       styleCache: styleCache ?? EarthquakeAreaRenderStyleCache(),
+      missingExactTileReasonFor: (_) => missReason,
+      requiredCodeUnresolvedCount: requiredCodeUnresolvedCount,
       sceneFrameLimits: MapSceneFrameLimits(maxNodeCount: 64),
     );
   }
@@ -415,6 +423,8 @@ void main() {
         secondSprite.instanceGeneration,
         same(firstSprite.instanceGeneration),
       );
+      expect(first.diagnostic.stationCount, 1);
+      expect(first.diagnostic.spriteCount, 1);
       expect(secondSprite.frameUniform, isNot(same(firstSprite.frameUniform)));
     },
   );
@@ -513,16 +523,52 @@ void main() {
     expect(result.coverage, const EarthquakeOverlayCoverage.hidden());
   });
 
-  test('exact miss, source layer absence, and invalid code are incomplete', () {
+  test('pending exact tile is loading with the candidate diagnostic', () {
     final missing = build(
       frame: frameAt(6),
       requested: snapshot(),
       cache: BaseMapTileCache(maxEntries: 8, maxParentFallbackSteps: 4),
     );
+
+    expect(missing.coverage, isA<EarthquakeOverlayLoading>());
+    expect(
+      missing.diagnostic,
+      EarthquakeOverlayCoverageDiagnostic(
+        visibleCanonicalTileCount: 1,
+        pendingTileCount: 1,
+        authoritativeEmptyTileCount: 0,
+        sourceLayerAbsentTileCount: 0,
+        missingOrInvalidPropertyFeatureCount: 0,
+        decodeOrSchemaFailureTileCount: 0,
+        requiredCodeUnresolvedCount: 0,
+        stationCount: 1,
+        spriteCount: 0,
+      ),
+    );
+  });
+
+  test('distinguishes authoritative empty from invalid tile evidence', () {
+    final directoryEmpty = build(
+      frame: frameAt(6),
+      requested: snapshot(),
+      cache: BaseMapTileCache(maxEntries: 8, maxParentFallbackSteps: 4),
+      missReason: EarthquakeOverlayExactTileMissReason.authoritativeEmpty,
+    );
+    final explicitEmpty = build(
+      frame: frameAt(6),
+      requested: snapshot(),
+      cache: cacheWith(geometry(emptyCityLayer: true)),
+    );
     final noLayer = build(
       frame: frameAt(6),
       requested: snapshot(),
       cache: cacheWith(geometry(cityExtent: null)),
+    );
+    final decodeFailure = build(
+      frame: frameAt(6),
+      requested: snapshot(),
+      cache: BaseMapTileCache(maxEntries: 8, maxParentFallbackSteps: 4),
+      missReason: EarthquakeOverlayExactTileMissReason.decodeFailure,
     );
     final invalidCode = build(
       frame: frameAt(6),
@@ -530,30 +576,52 @@ void main() {
       cache: cacheWith(geometry(cityInvalidCodes: 2)),
     );
 
-    expect(
-      missing.coverage,
-      const EarthquakeOverlayCoverage.incomplete(
-        requestedTileCount: 1,
-        readyTileCount: 0,
-        missingOrInvalidCodeCount: 0,
-      ),
+    expect(directoryEmpty.coverage, isA<EarthquakeOverlayComplete>());
+    expect(directoryEmpty.diagnostic.authoritativeEmptyTileCount, 1);
+    expect(explicitEmpty.coverage, isA<EarthquakeOverlayComplete>());
+    expect(explicitEmpty.diagnostic.authoritativeEmptyTileCount, 1);
+    expect(noLayer.coverage, isA<EarthquakeOverlayIncomplete>());
+    expect(noLayer.diagnostic.sourceLayerAbsentTileCount, 1);
+    expect(decodeFailure.coverage, isA<EarthquakeOverlayIncomplete>());
+    expect(decodeFailure.diagnostic.decodeOrSchemaFailureTileCount, 1);
+    expect(invalidCode.coverage, isA<EarthquakeOverlayIncomplete>());
+    expect(invalidCode.diagnostic.missingOrInvalidPropertyFeatureCount, 2);
+  });
+
+  test('uses only explicitly supplied unresolved required code evidence', () {
+    final result = build(
+      frame: frameAt(6),
+      requested: snapshot(),
+      requiredCodeUnresolvedCount: 2,
     );
-    expect(
-      noLayer.coverage,
-      const EarthquakeOverlayCoverage.incomplete(
-        requestedTileCount: 1,
-        readyTileCount: 0,
-        missingOrInvalidCodeCount: 0,
-      ),
+
+    expect(result.coverage, isA<EarthquakeOverlayIncomplete>());
+    expect(result.diagnostic.requiredCodeUnresolvedCount, 2);
+  });
+
+  test('counts world wraps once as one visible canonical tile', () {
+    final cache = cacheWith(geometry(cityInvalidCodes: 1));
+    final canonical = cover.single.canonical;
+    final exactTiles = [
+      for (final wrap in [0, 1])
+        resolveEarthquakeOverlayExactTile(
+          requestedTile: UnwrappedTileId(wrap: wrap, canonical: canonical),
+          sourceInstanceId: 'archive-a',
+          cache: cache,
+          mode: EarthquakeAreaLayerMode.city,
+          missReason: EarthquakeOverlayExactTileMissReason.pending,
+        ),
+    ];
+
+    final diagnostic = earthquakeOverlayCoverageDiagnosticFor(
+      exactTileResults: exactTiles,
+      requiredCodeUnresolvedCount: 0,
+      stationCount: 1,
+      spriteCount: 0,
     );
-    expect(
-      invalidCode.coverage,
-      const EarthquakeOverlayCoverage.incomplete(
-        requestedTileCount: 1,
-        readyTileCount: 1,
-        missingOrInvalidCodeCount: 2,
-      ),
-    );
+
+    expect(diagnostic.visibleCanonicalTileCount, 1);
+    expect(diagnostic.missingOrInvalidPropertyFeatureCount, 1);
   });
 
   test('camera-only frames reuse station geometry and style parameters', () {
@@ -604,13 +672,33 @@ void main() {
       missingOrInvalidCodeCount: 0,
     );
 
-    owner.publish(overlay: value, coverage: incomplete);
-    owner.publish(overlay: value, coverage: incomplete);
+    final diagnostic = EarthquakeOverlayCoverageDiagnostic(
+      visibleCanonicalTileCount: 1,
+      pendingTileCount: 0,
+      authoritativeEmptyTileCount: 0,
+      sourceLayerAbsentTileCount: 1,
+      missingOrInvalidPropertyFeatureCount: 0,
+      decodeOrSchemaFailureTileCount: 0,
+      requiredCodeUnresolvedCount: 0,
+      stationCount: 1,
+      spriteCount: 0,
+    );
+    owner.publish(
+      overlay: value,
+      coverage: incomplete,
+      diagnostic: diagnostic,
+    );
+    owner.publish(
+      overlay: value,
+      coverage: incomplete,
+      diagnostic: diagnostic,
+    );
     owner.publish(
       overlay: value,
       coverage: const EarthquakeOverlayCoverage.complete(
         requestedTileCount: 1,
       ),
+      diagnostic: diagnostic,
     );
     owner.hide(overlay: value);
 
@@ -618,18 +706,70 @@ void main() {
       EarthquakeOverlayCoverageSnapshot(
         versionStamp: value.versionStamp,
         coverage: incomplete,
+        diagnostic: diagnostic,
       ),
       EarthquakeOverlayCoverageSnapshot(
         versionStamp: value.versionStamp,
         coverage: const EarthquakeOverlayCoverage.complete(
           requestedTileCount: 1,
         ),
+        diagnostic: diagnostic,
       ),
       EarthquakeOverlayCoverageSnapshot(
         versionStamp: value.versionStamp,
         coverage: const EarthquakeOverlayCoverage.hidden(),
       ),
     ]);
+  });
+
+  test('material preparation publishes candidate then failure hides it', () {
+    final values = <EarthquakeOverlayCoverageSnapshot>[];
+    final frames = BaseMapOverlayFrameOwner(onCoverageChanged: values.add);
+    final candidate = snapshot(sourceIdentity: 'event-b');
+    final diagnostic = EarthquakeOverlayCoverageDiagnostic.preparing(
+      stationCount: 1,
+      spriteCount: 0,
+    );
+
+    frames.beginLoading(overlay: candidate, diagnostic: diagnostic);
+    frames.hideCandidate();
+
+    expect(values, [
+      EarthquakeOverlayCoverageSnapshot(
+        versionStamp: candidate.versionStamp,
+        coverage: const EarthquakeOverlayCoverage.loading(),
+        diagnostic: diagnostic,
+      ),
+      const EarthquakeOverlayCoverageSnapshot.hidden(),
+    ]);
+  });
+
+  test('base-only refresh cannot overwrite candidate loading with hidden', () {
+    final values = <EarthquakeOverlayCoverageSnapshot>[];
+    final frames = BaseMapOverlayFrameOwner(onCoverageChanged: values.add);
+    final preparing = snapshot(sourceIdentity: 'event-b');
+    final baseOnly = build(frame: frameAt(6), requested: null);
+    final diagnostic = EarthquakeOverlayCoverageDiagnostic.preparing(
+      stationCount: 1,
+      spriteCount: 0,
+    );
+    frames.beginLoading(overlay: preparing, diagnostic: diagnostic);
+    values.clear();
+
+    frames.commit(
+      candidate: baseOnly,
+      baseOnlySubmission: baseOnly.submission!,
+      resources: null,
+      submitFrame: (_) {},
+      retireAllGpuResources: () {},
+      failClosedResources: () {},
+      preparingOverlay: preparing,
+    );
+
+    expect(frames.overlay, isNull);
+    expect(frames.coverageSnapshot.versionStamp, preparing.versionStamp);
+    expect(frames.coverage, isA<EarthquakeOverlayLoading>());
+    expect(values, isEmpty);
   });
 
   test('same-source data regression publishes committed provenance', () {
@@ -670,7 +810,7 @@ void main() {
 
     expect(candidate.overlay, same(current));
     expect(values.single.versionStamp, current.versionStamp);
-    expect(values.single.coverage, isA<EarthquakeOverlayIncomplete>());
+    expect(values.single.coverage, isA<EarthquakeOverlayLoading>());
   });
 
   test('material preparation中の旧coverageは旧snapshot identityで通知する', () {
@@ -713,7 +853,7 @@ void main() {
     expect(delayedCallbackValues.single.versionStamp, eventA.versionStamp);
     expect(
       delayedCallbackValues.single.coverage,
-      isA<EarthquakeOverlayIncomplete>(),
+      isA<EarthquakeOverlayLoading>(),
     );
   });
 
@@ -861,6 +1001,7 @@ void main() {
           coverage: const EarthquakeOverlayCoverage.complete(
             requestedTileCount: 1,
           ),
+          diagnostic: first.diagnostic,
         ),
         const EarthquakeOverlayCoverageSnapshot.hidden(),
       ]);
@@ -992,6 +1133,7 @@ void main() {
           coverage: const EarthquakeOverlayCoverage.complete(
             requestedTileCount: 1,
           ),
+          diagnostic: first.diagnostic,
         ),
         const EarthquakeOverlayCoverageSnapshot.hidden(),
       ]);
@@ -1046,6 +1188,7 @@ void main() {
         overlay: first.overlay,
         submission: initialSubmission,
         coverage: first.coverage,
+        diagnostic: first.diagnostic,
         observationBatchForReuse: first.observationBatchForReuse,
         spriteBatchesForReuse: first.spriteBatchesForReuse,
         shouldRetireGpuResources: false,


### PR DESCRIPTION
## 概要

Flutter GPU地図の震度overlay coverageを、確認済みの可視範囲証拠から診断できるようにします。

- exact tileのpendingとPMTiles directoryによるauthoritative emptyを分離
- explicit empty layer、source layer absent、decode/schema failure、missing/invalid propertyを分離
- visible canonical tile、未解決code、観測点、spriteの件数をversion stampとatomicに通知
- material/texture準備中とbase-only refreshのraceをcandidate loadingとして維持
- 親tile fallbackや水域推測によるcomplete判定は行わない

## 検証

- package targeted tests: 64 passed
- scoped dart analyze: No issues found
- dart format: 0 changed
- independent review: APPROVED (Critical / Important / Minor 0)

Depends on #1768