### PR TITLE
feat: GPU地図の震源移動Actionを追加

### DIFF
--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action.dart
@@ -1,0 +1,81 @@
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eqmonitor_map_camera_action.g.dart';
+
+@riverpod
+EqmonitorMapCameraAction eqmonitorMapCameraAction(Ref ref) =>
+    const EqmonitorMapCameraAction();
+
+sealed class EqmonitorMapCameraActionResult {
+  const new();
+}
+
+final class EqmonitorMapCameraActionSucceeded
+    extends EqmonitorMapCameraActionResult {
+  const new({required this.command});
+
+  final MapCameraCommandSucceeded command;
+}
+
+final class EqmonitorMapCameraActionNotReady
+    extends EqmonitorMapCameraActionResult {
+  const new();
+}
+
+final class EqmonitorMapCameraActionHypocenterUnavailable
+    extends EqmonitorMapCameraActionResult {
+  const new();
+}
+
+final class EqmonitorMapCameraActionInvalidHypocenter
+    extends EqmonitorMapCameraActionResult {
+  const new();
+}
+
+final class EqmonitorMapCameraActionCommandFailed
+    extends EqmonitorMapCameraActionResult {
+  const new({required this.failure});
+
+  final MapCameraCommandFailure failure;
+}
+
+final class EqmonitorMapCameraAction {
+  const new();
+
+  Future<EqmonitorMapCameraActionResult> moveToHypocenter({
+    required MapViewCameraController controller,
+    required double? longitude,
+    required double? latitude,
+  }) async {
+    final camera = controller.committedCamera;
+    if (camera == null) {
+      return const EqmonitorMapCameraActionNotReady();
+    }
+    if (longitude == null || latitude == null) {
+      return const EqmonitorMapCameraActionHypocenterUnavailable();
+    }
+    if (!longitude.isFinite ||
+        !latitude.isFinite ||
+        longitude < -180 ||
+        longitude > 180 ||
+        latitude < -90 ||
+        latitude > 90) {
+      return const EqmonitorMapCameraActionInvalidHypocenter();
+    }
+    final result = await controller.moveTo(
+      camera: camera.copyWith(
+        centerLongitude: longitude,
+        centerLatitude: latitude,
+      ),
+    );
+    return switch (result) {
+      MapCameraCommandSucceeded() => EqmonitorMapCameraActionSucceeded(
+        command: result,
+      ),
+      MapCameraCommandFailure() => EqmonitorMapCameraActionCommandFailed(
+        failure: result,
+      ),
+    };
+  }
+}

--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action.g.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eqmonitor_map_camera_action.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eqmonitorMapCameraAction)
+final eqmonitorMapCameraActionProvider = EqmonitorMapCameraActionProvider._();
+
+final class EqmonitorMapCameraActionProvider
+    extends
+        $FunctionalProvider<
+          EqmonitorMapCameraAction,
+          EqmonitorMapCameraAction,
+          EqmonitorMapCameraAction
+        >
+    with $Provider<EqmonitorMapCameraAction> {
+  EqmonitorMapCameraActionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eqmonitorMapCameraActionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eqmonitorMapCameraActionHash();
+
+  @$internal
+  @override
+  $ProviderElement<EqmonitorMapCameraAction> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EqmonitorMapCameraAction create(Ref ref) {
+    return eqmonitorMapCameraAction(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EqmonitorMapCameraAction value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EqmonitorMapCameraAction>(value),
+    );
+  }
+}
+
+String _$eqmonitorMapCameraActionHash() =>
+    r'2208fb004c0514881b7bfcac088b54dd3be62ab5';

--- a/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action_test.dart
+++ b/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action_test.dart
@@ -1,0 +1,97 @@
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final class RecordingCameraHost implements MapViewCameraHost {
+  new({this.failure});
+
+  final MapCameraCommandFailure? failure;
+  final commands = <MapCamera>[];
+
+  @override
+  Future<MapCameraCommandResult> applyCameraCommand({
+    required int generation,
+    required MapCamera camera,
+    required MapCameraCommandCancellation cancellation,
+  }) async {
+    commands.add(camera);
+    return failure ??
+        MapCameraCommandSucceeded(
+          generation: generation,
+          committedCamera: camera,
+        );
+  }
+
+  @override
+  MapCameraBoundsFitResult cameraForBounds({
+    required MapCameraBounds bounds,
+    required EdgeInsets padding,
+  }) => const MapCameraBoundsFitInvalid(
+    reason: MapCameraBoundsFitInvalidReason.invalidBounds,
+  );
+}
+
+void main() {
+  const action = EqmonitorMapCameraAction();
+  const current = MapCamera(
+    centerLongitude: 137.5,
+    centerLatitude: 36.5,
+    zoom: 7.25,
+  );
+
+  test('committed cameraがない場合はtyped not-readyを返す', () async {
+    final controller = MapViewCameraController();
+    addTearDown(controller.dispose);
+
+    final result = await action.moveToHypocenter(
+      controller: controller,
+      longitude: 140.1,
+      latitude: 36.2,
+    );
+
+    expect(result, isA<EqmonitorMapCameraActionNotReady>());
+  });
+
+  test('震源座標の欠損はtyped unavailableでcommandを送らない', () async {
+    final controller = MapViewCameraController();
+    final host = RecordingCameraHost();
+    addTearDown(controller.dispose);
+    controller.attach(host: host, initialCamera: current);
+    controller.commitCameraFromHost(host: host, camera: current);
+
+    final result = await action.moveToHypocenter(
+      controller: controller,
+      longitude: null,
+      latitude: 36.2,
+    );
+
+    expect(result, isA<EqmonitorMapCameraActionHypocenterUnavailable>());
+    expect(host.commands, isEmpty);
+  });
+
+  test('非finiteまたは範囲外の震源はtyped invalidでcommandを送らない', () async {
+    for (final coordinate in const [
+      (longitude: double.nan, latitude: 36.2),
+      (longitude: 140.1, latitude: double.infinity),
+      (longitude: 180.1, latitude: 36.2),
+      (longitude: 140.1, latitude: -90.1),
+    ]) {
+      final controller = MapViewCameraController();
+      final host = RecordingCameraHost();
+      controller.attach(host: host, initialCamera: current);
+      controller.commitCameraFromHost(host: host, camera: current);
+
+      final result = await action.moveToHypocenter(
+        controller: controller,
+        longitude: coordinate.longitude,
+        latitude: coordinate.latitude,
+      );
+
+      expect(result, isA<EqmonitorMapCameraActionInvalidHypocenter>());
+      expect(host.commands, isEmpty);
+      controller.dispose();
+    }
+  });
+
+}

--- a/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action_test.dart
+++ b/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action_test.dart
@@ -94,4 +94,49 @@ void main() {
     }
   });
 
+  test('centerだけを置換しzoomを維持してexactly one commandを送る', () async {
+    final controller = MapViewCameraController();
+    final host = RecordingCameraHost();
+    addTearDown(controller.dispose);
+    controller.attach(host: host, initialCamera: current);
+    controller.commitCameraFromHost(host: host, camera: current);
+
+    final result = await action.moveToHypocenter(
+      controller: controller,
+      longitude: 140.1,
+      latitude: 36.2,
+    );
+
+    expect(result, isA<EqmonitorMapCameraActionSucceeded>());
+    expect(host.commands, const [
+      MapCamera(centerLongitude: 140.1, centerLatitude: 36.2, zoom: 7.25),
+    ]);
+  });
+
+  test('controller failureをtyped resultで返し再試行しない', () async {
+    const failure = MapCameraCommandRenderFailed(
+      reason: MapCameraCommandRenderFailureReason.sceneSubmissionRejected,
+    );
+    final controller = MapViewCameraController();
+    final host = RecordingCameraHost(failure: failure);
+    addTearDown(controller.dispose);
+    controller.attach(host: host, initialCamera: current);
+    controller.commitCameraFromHost(host: host, camera: current);
+
+    final result = await action.moveToHypocenter(
+      controller: controller,
+      longitude: 140.1,
+      latitude: 36.2,
+    );
+
+    expect(
+      result,
+      isA<EqmonitorMapCameraActionCommandFailed>().having(
+        (value) => value.failure,
+        'failure',
+        same(failure),
+      ),
+    );
+    expect(host.commands, hasLength(1));
+  });
 }


### PR DESCRIPTION
## 概要
- committed cameraと震源座標を検証するtyped Actionを追加
- camera centerだけを置換し、zoomを厳密に維持
- controller failureを型保持して返し、1 invocationあたりmoveToをexactly onceに制限

## 検証
- camera action unit tests: 5 passed
- scoped dart analyze: No issues found
- dart format: 3 files, 0 changed
- independent review: APPROVE, Critical/Important/Minor 0

Depends on #1769