### PR TITLE
feat: GPUデバッグ地図の診断UIを強化

### DIFF
--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action.dart
@@ -40,6 +40,23 @@ final class EqmonitorMapCameraActionCommandFailed
   final MapCameraCommandFailure failure;
 }
 
+String eqmonitorMapCameraActionMessage(EqmonitorMapCameraActionResult result) =>
+    switch (result) {
+      EqmonitorMapCameraActionSucceeded() => '震源へ移動しました',
+      EqmonitorMapCameraActionNotReady() => '地図の準備が完了していません',
+      EqmonitorMapCameraActionHypocenterUnavailable() => '震源座標がありません',
+      EqmonitorMapCameraActionInvalidHypocenter() => '震源座標が不正です',
+      EqmonitorMapCameraActionCommandFailed(:final failure) =>
+        switch (failure) {
+          MapCameraCommandInvalidInput() => 'Camera入力が不正です',
+          MapCameraCommandNotAttached() => 'Camera controllerが未接続です',
+          MapCameraCommandNotReady() => 'Camera描画の準備が完了していません',
+          MapCameraCommandRenderFailed() => 'Camera描画に失敗しました',
+          MapCameraCommandDisposed() => 'Camera controllerは破棄済みです',
+          MapCameraCommandSuperseded() => 'Camera commandが更新されました',
+        },
+    };
+
 final class EqmonitorMapCameraAction {
   const new();
 

--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_overlay_layout.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_overlay_layout.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+/// 地図の操作面とデバッグ用overlayのhit-test順を一箇所で定義する。
+class EqmonitorMapDebugOverlayLayout extends StatelessWidget {
+  const new({
+    required this.map,
+    required this.banner,
+    required this.probePanel,
+    super.key,
+  });
+
+  final Widget map;
+  final Widget banner;
+  final Widget? probePanel;
+
+  @override
+  Widget build(BuildContext context) => Stack(
+    fit: StackFit.expand,
+    children: [
+      map,
+      Positioned.fill(
+        child: SafeArea(
+          minimum: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Flexible(
+                flex: 2,
+                child: Align(
+                  alignment: Alignment.topCenter,
+                  child: banner,
+                ),
+              ),
+              Expanded(
+                flex: probePanel == null ? 3 : 1,
+                child: const IgnorePointer(child: SizedBox.expand()),
+              ),
+              if (probePanel case final panel?)
+                Flexible(
+                  flex: 2,
+                  child: Align(
+                    alignment: Alignment.bottomRight,
+                    child: panel,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  );
+}

--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_page.dart
@@ -2,6 +2,9 @@ import 'package:eqmonitor/core/provider/clock/app_clock.dart';
 import 'package:eqmonitor/core/provider/clock/map_clock_source_identity_provider.dart';
 import 'package:eqmonitor/core/util/map/app_map_clock.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_overlay_layout.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_action.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_panel.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_source_provider.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_banner.dart';
@@ -26,11 +29,11 @@ class EqmonitorMapDebugPage extends StatelessWidget {
   };
 }
 
-class _EqmonitorMapGpuProbeDebugPage extends HookWidget {
+class _EqmonitorMapGpuProbeDebugPage extends HookConsumerWidget {
   const new();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final atlasFixture = useState(MapSpriteAtlasProbeFixture.production);
     final faultPoint = useState<MapGpuFaultPoint?>(null);
     final counterSnapshot = useState<MapGpuResourceCounterSnapshot?>(null);
@@ -55,14 +58,32 @@ class _EqmonitorMapGpuProbeDebugPage extends HookWidget {
         controller: probeController,
         counterSnapshot: counterSnapshot.value,
         onCounterChanged: counterCallbackGuard.publish,
-        onAtlasFixtureChanged: (value) => atlasFixture.value = value,
-        onFaultPointChanged: (value) => faultPoint.value = value,
+        onAtlasFixtureChanged: (value) {
+          final next = ref
+              .read(eqmonitorMapGpuProbeActionProvider)
+              .withAtlasFixture(
+                currentConfiguration: configuration,
+                atlasFixture: value,
+              );
+          atlasFixture.value = next.atlasFixture;
+        },
+        onFaultPointChanged: (value) {
+          final next = ref
+              .read(eqmonitorMapGpuProbeActionProvider)
+              .withFaultPoint(
+                currentConfiguration: configuration,
+                faultPoint: value,
+              );
+          faultPoint.value = next.faultPoint;
+        },
         onInvalidateRendererContextGeneration: () {
-          final didInvalidate = probeController
-              .invalidateRendererContextGeneration();
-          final message = switch (didInvalidate) {
-            true => 'Renderer generation を更新しました',
-            false => '地図の初期化完了後に再試行してください',
+          final result = ref
+              .read(eqmonitorMapGpuProbeActionProvider)
+              .invalidateRendererContextGeneration(controller: probeController);
+          final message = switch (result) {
+            EqmonitorMapGpuProbeInvalidationSucceeded() =>
+              'Renderer generation を更新しました',
+            EqmonitorMapGpuProbeInvalidationNotReady() => '地図の初期化完了後に再試行してください',
           };
           ScaffoldMessenger.of(context)
             ..hideCurrentSnackBar()
@@ -89,6 +110,9 @@ class _EqmonitorMapDebugContent extends HookConsumerWidget {
     useEffect(() {
       return mapSession.dispose;
     }, [mapSession]);
+    final committedCamera = useValueListenable(
+      mapSession.cameraController.committedCameraListenable,
+    );
     final mapClock = useMemoized(
       () => mapSession.clockFor(sourceIdentity: clockSourceIdentity),
       [mapSession, clockSourceIdentity],
@@ -101,8 +125,32 @@ class _EqmonitorMapDebugContent extends HookConsumerWidget {
     final presentation = EqmonitorMapOverlayPresentation.from(
       overlayState: overlayState,
       coverageSnapshot: coverageSnapshot.value,
+      committedCamera: committedCamera,
     );
     final overlay = presentation.overlay;
+    final hypocenter = presentation.hypocenter;
+    final onMoveToHypocenter =
+        presentation.canMoveToHypocenter && hypocenter != null
+        ? () async {
+            final result = await ref
+                .read(eqmonitorMapCameraActionProvider)
+                .moveToHypocenter(
+                  controller: mapSession.cameraController,
+                  longitude: hypocenter.longitude,
+                  latitude: hypocenter.latitude,
+                );
+            if (!context.mounted) {
+              return;
+            }
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(
+                SnackBar(
+                  content: Text(eqmonitorMapCameraActionMessage(result)),
+                ),
+              );
+          }
+        : null;
     final onCoverageChanged =
         useCallback<ValueChanged<EarthquakeOverlayCoverageSnapshot>>(
           (snapshot) => coverageSnapshot.value = snapshot,
@@ -110,47 +158,29 @@ class _EqmonitorMapDebugContent extends HookConsumerWidget {
         );
     return Scaffold(
       appBar: AppBar(title: const Text('EQMonitor Map (Flutter Scene)')),
-      body: Stack(
-        fit: StackFit.expand,
-        children: [
-          source.when(
-            data: (result) => Stack(
-              fit: StackFit.expand,
-              children: [
-                BaseMapView(
-                  source: result.source,
-                  initialCamera: EqmonitorMapDebugConfiguration.initialCamera,
-                  clock: mapClock,
-                  cameraController: mapSession.cameraController,
-                  limits: EqmonitorMapDebugConfiguration.limitsFor(
-                    minZoom: result.minZoom,
-                    maxZoom: result.maxZoom,
-                  ),
-                  earthquakeOverlay: overlay,
-                  onEarthquakeOverlayCoverageChanged: onCoverageChanged,
-                  gpuProbeConfiguration: probeBindings?.configuration,
-                  onGpuResourceCounterChanged: probeBindings?.onCounterChanged,
-                  gpuProbeController: probeBindings?.controller,
-                ),
-                Positioned(
-                  top: 12,
-                  left: 12,
-                  right: 12,
-                  child: SafeArea(
-                    child: EqmonitorMapOverlayBanner(
-                      presentation: presentation,
-                    ),
-                  ),
-                ),
-              ],
+      body: source.when(
+        data: (result) => EqmonitorMapDebugOverlayLayout(
+          map: BaseMapView(
+            source: result.source,
+            initialCamera: EqmonitorMapDebugConfiguration.initialCamera,
+            clock: mapClock,
+            cameraController: mapSession.cameraController,
+            limits: EqmonitorMapDebugConfiguration.limitsFor(
+              minZoom: result.minZoom,
+              maxZoom: result.maxZoom,
             ),
-            loading: () => const Center(
-              child: CircularProgressIndicator.adaptive(),
-            ),
-            error: (error, stackTrace) => const _EqmonitorMapDebugSourceError(),
+            earthquakeOverlay: overlay,
+            onEarthquakeOverlayCoverageChanged: onCoverageChanged,
+            gpuProbeConfiguration: probeBindings?.configuration,
+            onGpuResourceCounterChanged: probeBindings?.onCounterChanged,
+            gpuProbeController: probeBindings?.controller,
           ),
-          if (probeBindings case final bindings?)
-            EqmonitorMapGpuProbePanel(
+          banner: EqmonitorMapOverlayBanner(
+            presentation: presentation,
+            onMoveToHypocenter: onMoveToHypocenter,
+          ),
+          probePanel: switch (probeBindings) {
+            final bindings? => EqmonitorMapGpuProbePanel(
               atlasFixture: bindings.configuration.atlasFixture,
               faultPoint: bindings.configuration.faultPoint,
               counterSnapshot: bindings.counterSnapshot,
@@ -159,7 +189,12 @@ class _EqmonitorMapDebugContent extends HookConsumerWidget {
               onInvalidateRendererContextGeneration:
                   bindings.onInvalidateRendererContextGeneration,
             ),
-        ],
+            null => null,
+          },
+        ),
+        loading: () =>
+            const Center(child: CircularProgressIndicator.adaptive()),
+        error: (error, stackTrace) => const _EqmonitorMapDebugSourceError(),
       ),
     );
   }

--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_action.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_action.dart
@@ -1,0 +1,49 @@
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eqmonitor_map_gpu_probe_action.g.dart';
+
+@riverpod
+EqmonitorMapGpuProbeAction eqmonitorMapGpuProbeAction(Ref ref) =>
+    const EqmonitorMapGpuProbeAction();
+
+sealed class EqmonitorMapGpuProbeInvalidationResult {
+  const new();
+}
+
+final class EqmonitorMapGpuProbeInvalidationSucceeded
+    extends EqmonitorMapGpuProbeInvalidationResult {
+  const new();
+}
+
+final class EqmonitorMapGpuProbeInvalidationNotReady
+    extends EqmonitorMapGpuProbeInvalidationResult {
+  const new();
+}
+
+final class EqmonitorMapGpuProbeAction {
+  const new();
+
+  MapGpuProbeConfiguration withAtlasFixture({
+    required MapGpuProbeConfiguration currentConfiguration,
+    required MapSpriteAtlasProbeFixture atlasFixture,
+  }) => MapGpuProbeConfiguration(
+    faultPoint: currentConfiguration.faultPoint,
+    atlasFixture: atlasFixture,
+  );
+
+  MapGpuProbeConfiguration withFaultPoint({
+    required MapGpuProbeConfiguration currentConfiguration,
+    required MapGpuFaultPoint? faultPoint,
+  }) => MapGpuProbeConfiguration(
+    faultPoint: faultPoint,
+    atlasFixture: currentConfiguration.atlasFixture,
+  );
+
+  EqmonitorMapGpuProbeInvalidationResult invalidateRendererContextGeneration({
+    required MapGpuProbeController controller,
+  }) => switch (controller.invalidateRendererContextGeneration()) {
+    true => const EqmonitorMapGpuProbeInvalidationSucceeded(),
+    false => const EqmonitorMapGpuProbeInvalidationNotReady(),
+  };
+}

--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_action.g.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_action.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eqmonitor_map_gpu_probe_action.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eqmonitorMapGpuProbeAction)
+final eqmonitorMapGpuProbeActionProvider =
+    EqmonitorMapGpuProbeActionProvider._();
+
+final class EqmonitorMapGpuProbeActionProvider
+    extends
+        $FunctionalProvider<
+          EqmonitorMapGpuProbeAction,
+          EqmonitorMapGpuProbeAction,
+          EqmonitorMapGpuProbeAction
+        >
+    with $Provider<EqmonitorMapGpuProbeAction> {
+  EqmonitorMapGpuProbeActionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eqmonitorMapGpuProbeActionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eqmonitorMapGpuProbeActionHash();
+
+  @$internal
+  @override
+  $ProviderElement<EqmonitorMapGpuProbeAction> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EqmonitorMapGpuProbeAction create(Ref ref) {
+    return eqmonitorMapGpuProbeAction(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EqmonitorMapGpuProbeAction value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EqmonitorMapGpuProbeAction>(value),
+    );
+  }
+}
+
+String _$eqmonitorMapGpuProbeActionHash() =>
+    r'273a590c25e4c22b7b845d102c483f09fae6d675';

--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_panel.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_panel.dart
@@ -68,101 +68,111 @@ class EqmonitorMapGpuProbePanel extends StatelessWidget {
           constraints: const BoxConstraints(maxWidth: 420),
           child: Card(
             clipBehavior: Clip.antiAlias,
-            child: ExpansionTile(
-              title: const Text('GPU Probe'),
-              subtitle: Text(generationLabel),
-              childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: ListView(
+              primary: false,
+              shrinkWrap: true,
               children: [
-                DropdownButtonFormField<MapSpriteAtlasProbeFixture>(
-                  key: eqmonitorMapGpuProbeAtlasFixtureKey,
-                  initialValue: atlasFixture,
-                  decoration: const InputDecoration(
-                    labelText: 'Atlas fixture',
-                  ),
-                  items: MapSpriteAtlasProbeFixture.values
-                      .map(
-                        (fixture) => DropdownMenuItem(
-                          value: fixture,
-                          child: Text(
-                            switch (fixture) {
-                              MapSpriteAtlasProbeFixture.production =>
-                                'Production',
-                              MapSpriteAtlasProbeFixture.orientation2x2 =>
-                                '2x2 向き確認',
-                              MapSpriteAtlasProbeFixture.alphaHalf =>
-                                'Alpha 50%',
-                              MapSpriteAtlasProbeFixture.edgeBleed =>
-                                'Edge bleed',
-                            },
-                          ),
-                        ),
-                      )
-                      .toList(growable: false),
-                  onChanged: (value) {
-                    if (value != null) {
-                      onAtlasFixtureChanged(value);
-                    }
-                  },
-                ),
-                const SizedBox(height: 12),
-                DropdownButtonFormField<_MapGpuFaultSelection>(
-                  key: eqmonitorMapGpuProbeFaultPointKey,
-                  initialValue: selectedFault,
-                  decoration: const InputDecoration(labelText: 'Fault point'),
-                  items: _MapGpuFaultSelection.values
-                      .map(
-                        (selection) => DropdownMenuItem(
-                          value: selection,
-                          child: Text(
-                            switch (selection) {
-                              _MapGpuFaultSelection.none => 'なし',
-                              _MapGpuFaultSelection.atlasUpload =>
-                                'Atlas upload',
-                              _MapGpuFaultSelection.shaderInterface =>
-                                'Shader interface',
-                              _MapGpuFaultSelection.frameSubmit =>
-                                'Frame submit',
-                            },
-                          ),
-                        ),
-                      )
-                      .toList(growable: false),
-                  onChanged: (selection) {
-                    final nextFault = switch (selection) {
-                      null || _MapGpuFaultSelection.none => null,
-                      _MapGpuFaultSelection.atlasUpload =>
-                        MapGpuFaultPoint.atlasUpload,
-                      _MapGpuFaultSelection.shaderInterface =>
-                        MapGpuFaultPoint.shaderInterface,
-                      _MapGpuFaultSelection.frameSubmit =>
-                        MapGpuFaultPoint.frameSubmit,
-                    };
-                    onFaultPointChanged(nextFault);
-                  },
-                ),
-                const SizedBox(height: 12),
-                SizedBox(
-                  width: double.infinity,
-                  child: OutlinedButton.icon(
-                    key: eqmonitorMapGpuProbeInvalidateGenerationKey,
-                    onPressed: onInvalidateRendererContextGeneration,
-                    icon: const Icon(Icons.refresh),
-                    label: const Text('Renderer generation を無効化'),
-                  ),
-                ),
-                const Divider(height: 24),
-                if (counters.isEmpty)
-                  const Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text('Resource counter: 未取得'),
-                  )
-                else
-                  ...counters.map(
-                    (entry) => _EqmonitorMapGpuResourceCounterRow(
-                      label: entry.label,
-                      counter: entry.counter,
+                ExpansionTile(
+                  title: const Text('GPU Probe'),
+                  subtitle: Text(generationLabel),
+                  childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                  children: [
+                    DropdownButtonFormField<MapSpriteAtlasProbeFixture>(
+                      key: eqmonitorMapGpuProbeAtlasFixtureKey,
+                      initialValue: atlasFixture,
+                      isExpanded: true,
+                      decoration: const InputDecoration(
+                        labelText: 'Atlas fixture',
+                      ),
+                      items: MapSpriteAtlasProbeFixture.values
+                          .map(
+                            (fixture) => DropdownMenuItem(
+                              value: fixture,
+                              child: Text(
+                                switch (fixture) {
+                                  MapSpriteAtlasProbeFixture.production =>
+                                    'Production',
+                                  MapSpriteAtlasProbeFixture.orientation2x2 =>
+                                    '2x2 向き確認',
+                                  MapSpriteAtlasProbeFixture.alphaHalf =>
+                                    'Alpha 50%',
+                                  MapSpriteAtlasProbeFixture.edgeBleed =>
+                                    'Edge bleed',
+                                },
+                              ),
+                            ),
+                          )
+                          .toList(growable: false),
+                      onChanged: (value) {
+                        if (value != null) {
+                          onAtlasFixtureChanged(value);
+                        }
+                      },
                     ),
-                  ),
+                    const SizedBox(height: 12),
+                    DropdownButtonFormField<_MapGpuFaultSelection>(
+                      key: eqmonitorMapGpuProbeFaultPointKey,
+                      initialValue: selectedFault,
+                      isExpanded: true,
+                      decoration: const InputDecoration(
+                        labelText: 'Fault point',
+                      ),
+                      items: _MapGpuFaultSelection.values
+                          .map(
+                            (selection) => DropdownMenuItem(
+                              value: selection,
+                              child: Text(
+                                switch (selection) {
+                                  _MapGpuFaultSelection.none => 'なし',
+                                  _MapGpuFaultSelection.atlasUpload =>
+                                    'Atlas upload',
+                                  _MapGpuFaultSelection.shaderInterface =>
+                                    'Shader interface',
+                                  _MapGpuFaultSelection.frameSubmit =>
+                                    'Frame submit',
+                                },
+                              ),
+                            ),
+                          )
+                          .toList(growable: false),
+                      onChanged: (selection) {
+                        final nextFault = switch (selection) {
+                          null || _MapGpuFaultSelection.none => null,
+                          _MapGpuFaultSelection.atlasUpload =>
+                            MapGpuFaultPoint.atlasUpload,
+                          _MapGpuFaultSelection.shaderInterface =>
+                            MapGpuFaultPoint.shaderInterface,
+                          _MapGpuFaultSelection.frameSubmit =>
+                            MapGpuFaultPoint.frameSubmit,
+                        };
+                        onFaultPointChanged(nextFault);
+                      },
+                    ),
+                    const SizedBox(height: 12),
+                    SizedBox(
+                      width: double.infinity,
+                      child: OutlinedButton.icon(
+                        key: eqmonitorMapGpuProbeInvalidateGenerationKey,
+                        onPressed: onInvalidateRendererContextGeneration,
+                        icon: const Icon(Icons.refresh),
+                        label: const Text('Renderer generation を無効化'),
+                      ),
+                    ),
+                    const Divider(height: 24),
+                    if (counters.isEmpty)
+                      const Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text('Resource counter: 未取得'),
+                      )
+                    else
+                      ...counters.map(
+                        (entry) => _EqmonitorMapGpuResourceCounterRow(
+                          label: entry.label,
+                          counter: entry.counter,
+                        ),
+                      ),
+                  ],
+                ),
               ],
             ),
           ),

--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_banner.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_banner.dart
@@ -5,6 +5,27 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 
+const eqmonitorMapMoveToHypocenterKey = ValueKey(
+  'eqmonitor-map-move-to-hypocenter',
+);
+
+typedef EqmonitorMapOverlayInputCounts = ({
+  int regions,
+  int cities,
+  int stations,
+  int sprites,
+});
+
+typedef EqmonitorMapHypocenter = ({double longitude, double latitude});
+
+enum EqmonitorMapCoverageState {
+  unconfirmed,
+  hidden,
+  loading,
+  incomplete,
+  complete,
+}
+
 final class EqmonitorMapOverlayPresentation {
   const new({
     required this.eventIdLabel,
@@ -13,14 +34,24 @@ final class EqmonitorMapOverlayPresentation {
     required this.message,
     required this.overlay,
     required this.isError,
+    required this.dataSequence,
+    required this.renderGeneration,
+    required this.inputCounts,
+    required this.coverageState,
+    required this.coverageDiagnostic,
+    required this.currentZoom,
+    required this.hypocenter,
+    required this.canMoveToHypocenter,
   });
 
   factory from({
     required AsyncValue<LatestEarthquakeOverlayData> overlayState,
     required EarthquakeOverlayCoverageSnapshot? coverageSnapshot,
+    required MapCamera? committedCamera,
   }) => const EqmonitorMapOverlayPresentationBuilder().build(
     overlayState: overlayState,
     coverageSnapshot: coverageSnapshot,
+    committedCamera: committedCamera,
   );
 
   final String eventIdLabel;
@@ -29,6 +60,14 @@ final class EqmonitorMapOverlayPresentation {
   final String message;
   final EarthquakeMapOverlaySnapshot? overlay;
   final bool isError;
+  final int? dataSequence;
+  final int? renderGeneration;
+  final EqmonitorMapOverlayInputCounts? inputCounts;
+  final EqmonitorMapCoverageState coverageState;
+  final EarthquakeOverlayCoverageDiagnostic? coverageDiagnostic;
+  final double? currentZoom;
+  final EqmonitorMapHypocenter? hypocenter;
+  final bool canMoveToHypocenter;
 }
 
 final class EqmonitorMapOverlayPresentationBuilder {
@@ -37,39 +76,65 @@ final class EqmonitorMapOverlayPresentationBuilder {
   EqmonitorMapOverlayPresentation build({
     required AsyncValue<LatestEarthquakeOverlayData> overlayState,
     required EarthquakeOverlayCoverageSnapshot? coverageSnapshot,
+    required MapCamera? committedCamera,
   }) {
     if (overlayState.isLoading) {
-      return const EqmonitorMapOverlayPresentation(
+      return EqmonitorMapOverlayPresentation(
         eventIdLabel: '取得中',
         originTimeLabel: '取得中',
         statusLabel: '取得中',
         message: '最新の地震情報を取得中です',
         overlay: null,
         isError: false,
+        dataSequence: null,
+        renderGeneration: null,
+        inputCounts: null,
+        coverageState: .unconfirmed,
+        coverageDiagnostic: null,
+        currentZoom: committedCamera?.zoom,
+        hypocenter: null,
+        canMoveToHypocenter: false,
       );
     }
     if (overlayState.hasError) {
-      return const EqmonitorMapOverlayPresentation(
+      return EqmonitorMapOverlayPresentation(
         eventIdLabel: '取得失敗',
         originTimeLabel: '取得失敗',
         statusLabel: '取得失敗',
         message: '最新の地震情報を取得できませんでした',
         overlay: null,
         isError: true,
+        dataSequence: null,
+        renderGeneration: null,
+        inputCounts: null,
+        coverageState: .unconfirmed,
+        coverageDiagnostic: null,
+        currentZoom: committedCamera?.zoom,
+        hypocenter: null,
+        canMoveToHypocenter: false,
       );
     }
     return switch (overlayState) {
       AsyncData(:final value) => buildData(
         data: value,
         coverageSnapshot: coverageSnapshot,
+        committedCamera: committedCamera,
       ),
-      _ => const EqmonitorMapOverlayPresentation(
+      _ => EqmonitorMapOverlayPresentation(
         eventIdLabel: '取得中',
         originTimeLabel: '取得中',
         statusLabel: '取得中',
         message: '最新の地震情報を取得中です',
         overlay: null,
         isError: false,
+        dataSequence: null,
+        renderGeneration: null,
+        inputCounts: null,
+        coverageState: .unconfirmed,
+        coverageDiagnostic: null,
+        currentZoom: committedCamera?.zoom,
+        hypocenter: null,
+        canMoveToHypocenter: false,
       ),
     };
   }
@@ -77,15 +142,40 @@ final class EqmonitorMapOverlayPresentationBuilder {
   EqmonitorMapOverlayPresentation buildData({
     required LatestEarthquakeOverlayData data,
     required EarthquakeOverlayCoverageSnapshot? coverageSnapshot,
+    required MapCamera? committedCamera,
   }) {
     final originTime = data.originTime;
     final overlay = data.overlay;
-    final coverage =
-        overlay == null ||
-            coverageSnapshot == null ||
-            coverageSnapshot.versionStamp != overlay.versionStamp
-        ? const EarthquakeOverlayCoverage.hidden()
-        : coverageSnapshot.coverage;
+    final matchingCoverage =
+        overlay != null &&
+            coverageSnapshot?.versionStamp == overlay.versionStamp
+        ? coverageSnapshot
+        : null;
+    final coverageState = switch (matchingCoverage?.coverage) {
+      EarthquakeOverlayHidden() => EqmonitorMapCoverageState.hidden,
+      EarthquakeOverlayLoading() => EqmonitorMapCoverageState.loading,
+      EarthquakeOverlayIncomplete() => EqmonitorMapCoverageState.incomplete,
+      EarthquakeOverlayComplete() => EqmonitorMapCoverageState.complete,
+      null => EqmonitorMapCoverageState.unconfirmed,
+    };
+    MapPointSpriteFeature? hypocenterSprite;
+    final eventId = data.eventId;
+    if (eventId != null && overlay != null) {
+      final expectedId = 'hypocenter:$eventId';
+      for (final sprite in overlay.sprites) {
+        if (sprite.id == expectedId) {
+          hypocenterSprite = sprite;
+          break;
+        }
+      }
+    }
+    final hypocenter = switch (hypocenterSprite) {
+      final sprite? => (
+        longitude: sprite.longitude,
+        latitude: sprite.latitude,
+      ),
+      null => null,
+    };
     return EqmonitorMapOverlayPresentation(
       eventIdLabel: data.eventId ?? '対象なし',
       originTimeLabel: originTime == null
@@ -94,10 +184,25 @@ final class EqmonitorMapOverlayPresentationBuilder {
       statusLabel: statusLabel(data.telegramStatus),
       message: message(
         availability: data.availability,
-        coverage: coverage,
+        coverageState: coverageState,
       ),
       overlay: overlay,
       isError: false,
+      dataSequence: overlay?.versionStamp.dataSequence,
+      renderGeneration: overlay?.versionStamp.renderGeneration,
+      inputCounts: overlay == null
+          ? null
+          : (
+              regions: overlay.regionStyles.length,
+              cities: overlay.cityStyles.length,
+              stations: overlay.stations.length,
+              sprites: overlay.sprites.length,
+            ),
+      coverageState: coverageState,
+      coverageDiagnostic: matchingCoverage?.diagnostic,
+      currentZoom: committedCamera?.zoom,
+      hypocenter: hypocenter,
+      canMoveToHypocenter: committedCamera != null && hypocenter != null,
     );
   }
 
@@ -110,13 +215,14 @@ final class EqmonitorMapOverlayPresentationBuilder {
 
   String message({
     required LatestEarthquakeOverlayAvailability availability,
-    required EarthquakeOverlayCoverage coverage,
+    required EqmonitorMapCoverageState coverageState,
   }) => switch (availability) {
-    LatestEarthquakeOverlayAvailability.available => switch (coverage) {
-      EarthquakeOverlayIncomplete() => '表示範囲の震度情報は不完全です',
-      EarthquakeOverlayComplete() => '表示範囲の震度情報を表示中です',
-      EarthquakeOverlayHidden() ||
-      EarthquakeOverlayLoading() => '表示範囲の震度情報を準備中です',
+    LatestEarthquakeOverlayAvailability.available => switch (coverageState) {
+      EqmonitorMapCoverageState.unconfirmed => '表示範囲の震度情報は未確定です',
+      EqmonitorMapCoverageState.hidden => '表示範囲の震度情報は非表示です',
+      EqmonitorMapCoverageState.loading => '表示範囲の震度情報を準備中です',
+      EqmonitorMapCoverageState.incomplete => '表示範囲の震度情報は不完全です',
+      EqmonitorMapCoverageState.complete => '表示範囲の震度情報を表示中です',
     },
     LatestEarthquakeOverlayAvailability.noEarthquake => '震度1以上の地震はありません',
     LatestEarthquakeOverlayAvailability.noIntensity => '震度データがありません',
@@ -129,54 +235,82 @@ final class EqmonitorMapOverlayPresentationBuilder {
 class EqmonitorMapOverlayBanner extends StatelessWidget {
   const new({
     required this.presentation,
+    required this.onMoveToHypocenter,
     super.key,
   });
 
   final EqmonitorMapOverlayPresentation presentation;
+  final VoidCallback? onMoveToHypocenter;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final textStyle = Theme.of(context).textTheme.bodySmall;
+    final coverageLabel = switch (presentation.coverageState) {
+      EqmonitorMapCoverageState.unconfirmed => '未確定',
+      EqmonitorMapCoverageState.hidden => '非表示',
+      EqmonitorMapCoverageState.loading => '準備中',
+      EqmonitorMapCoverageState.incomplete => '不完全',
+      EqmonitorMapCoverageState.complete => '完了',
+    };
+    final inputCounts = presentation.inputCounts;
+    final diagnostic = presentation.coverageDiagnostic;
+    final labels = [
+      'イベント: ${presentation.eventIdLabel}',
+      '発生時刻: ${presentation.originTimeLabel}',
+      '電文状態: ${presentation.statusLabel}',
+      'Data sequence: ${presentation.dataSequence ?? '未確定'}',
+      'Render generation: ${presentation.renderGeneration ?? '未確定'}',
+      '現在 zoom: ${presentation.currentZoom?.toStringAsFixed(2) ?? '未取得'}',
+      if (inputCounts != null)
+        '入力数 Region ${inputCounts.regions} / City ${inputCounts.cities} / '
+            'Station ${inputCounts.stations} / Sprite ${inputCounts.sprites}',
+      'Coverage: $coverageLabel',
+      if (diagnostic != null) ...[
+        '描画診断 Tile 可視 ${diagnostic.visibleCanonicalTileCount} / '
+            '準備中 ${diagnostic.pendingTileCount} / '
+            '空 ${diagnostic.authoritativeEmptyTileCount}',
+        '描画診断 Layer欠損 ${diagnostic.sourceLayerAbsentTileCount} / '
+            'Property不正 ${diagnostic.missingOrInvalidPropertyFeatureCount} / '
+            'Decode ${diagnostic.decodeOrSchemaFailureTileCount} / '
+            'Code未解決 ${diagnostic.requiredCodeUnresolvedCount}',
+        '描画済み Station ${diagnostic.stationCount} / '
+            'Sprite ${diagnostic.spriteCount}',
+      ],
+    ];
     return Material(
       elevation: 2,
       color: colorScheme.surface.withValues(alpha: 0.92),
       borderRadius: BorderRadius.circular(12),
-      child: Padding(
+      clipBehavior: Clip.antiAlias,
+      child: ListView(
+        primary: false,
+        shrinkWrap: true,
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'イベント: ${presentation.eventIdLabel}',
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: textStyle,
+        children: [
+          Wrap(
+            spacing: 12,
+            runSpacing: 4,
+            children: [
+              for (final label in labels) Text(label, style: textStyle),
+            ],
+          ),
+          Text(
+            presentation.message,
+            style: textStyle?.copyWith(
+              color: presentation.isError ? colorScheme.error : null,
+              fontWeight: FontWeight.w600,
             ),
-            Text(
-              '発生時刻: ${presentation.originTimeLabel}',
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: textStyle,
-            ),
-            Text(
-              '電文状態: ${presentation.statusLabel}',
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: textStyle,
-            ),
-            Text(
-              presentation.message,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: textStyle?.copyWith(
-                color: presentation.isError ? colorScheme.error : null,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ],
-        ),
+          ),
+          OutlinedButton.icon(
+            key: eqmonitorMapMoveToHypocenterKey,
+            onPressed: presentation.canMoveToHypocenter
+                ? onMoveToHypocenter
+                : null,
+            icon: const Icon(Icons.my_location),
+            label: const Text('震源へ移動'),
+          ),
+        ],
       ),
     );
   }

--- a/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action_test.dart
+++ b/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_camera_action_test.dart
@@ -139,4 +139,33 @@ void main() {
     );
     expect(host.commands, hasLength(1));
   });
+
+  test('Action resultをraw detailなしの短い分類messageへ変換する', () {
+    final cases = <(EqmonitorMapCameraActionResult, String)>[
+      (
+        const EqmonitorMapCameraActionNotReady(),
+        '地図の準備が完了していません',
+      ),
+      (
+        const EqmonitorMapCameraActionHypocenterUnavailable(),
+        '震源座標がありません',
+      ),
+      (
+        const EqmonitorMapCameraActionInvalidHypocenter(),
+        '震源座標が不正です',
+      ),
+      (
+        const EqmonitorMapCameraActionCommandFailed(
+          failure: MapCameraCommandRenderFailed(
+            reason: MapCameraCommandRenderFailureReason.sceneSubmissionRejected,
+          ),
+        ),
+        'Camera描画に失敗しました',
+      ),
+    ];
+
+    for (final entry in cases) {
+      expect(eqmonitorMapCameraActionMessage(entry.$1), entry.$2);
+    }
+  });
 }

--- a/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_overlay_layout_test.dart
+++ b/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_overlay_layout_test.dart
@@ -1,0 +1,195 @@
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_overlay_layout.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_panel.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_banner.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'short large-text expanded diagnostics keep both controls and map usable',
+    (tester) async {
+      tester.view.physicalSize = const Size(320, 480);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      var mapPanCount = 0;
+      var moveCount = 0;
+      var invalidateCount = 0;
+      const bannerSurfaceKey = ValueKey('test-debug-banner-surface');
+      const panelSurfaceKey = ValueKey('test-debug-panel-surface');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(
+              context,
+            ).copyWith(textScaler: const TextScaler.linear(1.8)),
+            child: child ?? const SizedBox.shrink(),
+          ),
+          home: Scaffold(
+            body: EqmonitorMapDebugOverlayLayout(
+              map: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onPanUpdate: (_) => mapPanCount += 1,
+              ),
+              banner: KeyedSubtree(
+                key: bannerSurfaceKey,
+                child: EqmonitorMapOverlayBanner(
+                  presentation: _diagnosticPresentation(),
+                  onMoveToHypocenter: () => moveCount += 1,
+                ),
+              ),
+              probePanel: KeyedSubtree(
+                key: panelSurfaceKey,
+                child: EqmonitorMapGpuProbePanel(
+                  atlasFixture: MapSpriteAtlasProbeFixture.production,
+                  faultPoint: null,
+                  counterSnapshot: null,
+                  onAtlasFixtureChanged: (_) {},
+                  onFaultPointChanged: (_) {},
+                  onInvalidateRendererContextGeneration: () =>
+                      invalidateCount += 1,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('GPU Probe'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      final bannerRect = tester.getRect(find.byKey(bannerSurfaceKey));
+      final panelRect = tester.getRect(find.byKey(panelSurfaceKey));
+      expect(bannerRect.bottom, lessThan(panelRect.top));
+
+      final mapGestureStart = Offset(
+        16,
+        (bannerRect.bottom + panelRect.top) / 2,
+      );
+      await tester.dragFrom(mapGestureStart, const Offset(40, 20));
+      expect(mapPanCount, greaterThan(0));
+
+      await tester.drag(
+        find.descendant(
+          of: find.byKey(bannerSurfaceKey),
+          matching: find.byType(Scrollable),
+        ),
+        const Offset(0, -1000),
+      );
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(
+        find.byKey(eqmonitorMapMoveToHypocenterKey),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(eqmonitorMapMoveToHypocenterKey));
+      await tester.drag(
+        find.descendant(
+          of: find.byKey(panelSurfaceKey),
+          matching: find.byType(Scrollable),
+        ),
+        const Offset(0, -1000),
+      );
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(
+        find.byKey(eqmonitorMapGpuProbeInvalidateGenerationKey),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(eqmonitorMapGpuProbeInvalidateGenerationKey),
+      );
+
+      expect(moveCount, 1);
+      expect(invalidateCount, 1);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('bannerとpanel外のtap/dragだけをmapへ渡す', (tester) async {
+    var mapTapCount = 0;
+    var mapPanCount = 0;
+    var bannerTapCount = 0;
+    var panelTapCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EqmonitorMapDebugOverlayLayout(
+            map: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => mapTapCount += 1,
+              onPanUpdate: (_) => mapPanCount += 1,
+            ),
+            banner: SizedBox(
+              height: 96,
+              child: Material(
+                child: TextButton(
+                  onPressed: () => bannerTapCount += 1,
+                  child: const Text('Banner action'),
+                ),
+              ),
+            ),
+            probePanel: Align(
+              alignment: Alignment.bottomRight,
+              child: SizedBox(
+                width: 140,
+                height: 80,
+                child: Material(
+                  child: TextButton(
+                    onPressed: () => panelTapCount += 1,
+                    child: const Text('Probe action'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tapAt(const Offset(100, 300));
+    await tester.dragFrom(const Offset(100, 300), const Offset(40, 20));
+    await tester.tap(find.text('Banner action'));
+    await tester.tap(find.text('Probe action'));
+
+    expect(mapTapCount, 1);
+    expect(mapPanCount, greaterThan(0));
+    expect(bannerTapCount, 1);
+    expect(panelTapCount, 1);
+  });
+}
+
+EqmonitorMapOverlayPresentation _diagnosticPresentation() =>
+    EqmonitorMapOverlayPresentation(
+      eventIdLabel: '20260823020050',
+      originTimeLabel: '2026/08/23 02:00:50',
+      statusLabel: '通常',
+      message: '表示範囲の震度情報は不完全です',
+      overlay: null,
+      isError: false,
+      dataSequence: 7,
+      renderGeneration: 9,
+      inputCounts: const (
+        regions: 47,
+        cities: 1896,
+        stations: 4376,
+        sprites: 1,
+      ),
+      coverageState: .incomplete,
+      coverageDiagnostic: EarthquakeOverlayCoverageDiagnostic(
+        visibleCanonicalTileCount: 8,
+        pendingTileCount: 2,
+        authoritativeEmptyTileCount: 1,
+        sourceLayerAbsentTileCount: 1,
+        missingOrInvalidPropertyFeatureCount: 2,
+        decodeOrSchemaFailureTileCount: 1,
+        requiredCodeUnresolvedCount: 3,
+        stationCount: 4376,
+        spriteCount: 1,
+      ),
+      currentZoom: 6.75,
+      hypocenter: const (longitude: 140.1, latitude: 36.2),
+      canMoveToHypocenter: true,
+    );

--- a/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_action_test.dart
+++ b/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_action_test.dart
@@ -1,0 +1,69 @@
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_gpu_probe_action.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final class RecordingMapGpuProbeHost implements MapGpuProbeHost {
+  var invalidationCount = 0;
+
+  @override
+  void invalidateRendererContextGeneration() {
+    invalidationCount += 1;
+  }
+}
+
+void main() {
+  const action = EqmonitorMapGpuProbeAction();
+
+  test('atlas fixtureだけを置換して現在のfaultを維持する', () {
+    const current = MapGpuProbeConfiguration(
+      faultPoint: .shaderInterface,
+      atlasFixture: .production,
+    );
+
+    final next = action.withAtlasFixture(
+      currentConfiguration: current,
+      atlasFixture: .edgeBleed,
+    );
+
+    expect(next.atlasFixture, MapSpriteAtlasProbeFixture.edgeBleed);
+    expect(next.faultPoint, MapGpuFaultPoint.shaderInterface);
+  });
+
+  test('faultだけを置換して現在のatlas fixtureを維持する', () {
+    const current = MapGpuProbeConfiguration(
+      faultPoint: .frameSubmit,
+      atlasFixture: .alphaHalf,
+    );
+
+    final next = action.withFaultPoint(
+      currentConfiguration: current,
+      faultPoint: null,
+    );
+
+    expect(next.atlasFixture, MapSpriteAtlasProbeFixture.alphaHalf);
+    expect(next.faultPoint, isNull);
+  });
+
+  test('controller未接続時はtyped not-readyを返す', () {
+    final controller = MapGpuProbeController();
+
+    final result = action.invalidateRendererContextGeneration(
+      controller: controller,
+    );
+
+    expect(result, isA<EqmonitorMapGpuProbeInvalidationNotReady>());
+  });
+
+  test('接続済みcontrollerのgenerationを1回無効化してtyped successを返す', () {
+    final controller = MapGpuProbeController();
+    final host = RecordingMapGpuProbeHost();
+    controller.attach(host: host);
+
+    final result = action.invalidateRendererContextGeneration(
+      controller: controller,
+    );
+
+    expect(result, isA<EqmonitorMapGpuProbeInvalidationSucceeded>());
+    expect(host.invalidationCount, 1);
+  });
+}

--- a/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_banner_test.dart
+++ b/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_banner_test.dart
@@ -1,0 +1,107 @@
+import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_banner.dart';
+import 'package:eqmonitor_map/eqmonitor_map.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+EqmonitorMapOverlayPresentation presentation({required bool canMove}) =>
+    EqmonitorMapOverlayPresentation(
+      eventIdLabel: '20260823020050',
+      originTimeLabel: '2026/08/23 02:00:50',
+      statusLabel: '通常',
+      message: '表示範囲の震度情報は不完全です',
+      overlay: null,
+      isError: false,
+      dataSequence: 7,
+      renderGeneration: 9,
+      inputCounts: const (
+        regions: 1,
+        cities: 2,
+        stations: 3,
+        sprites: 1,
+      ),
+      coverageState: .incomplete,
+      coverageDiagnostic: EarthquakeOverlayCoverageDiagnostic(
+        visibleCanonicalTileCount: 5,
+        pendingTileCount: 0,
+        authoritativeEmptyTileCount: 1,
+        sourceLayerAbsentTileCount: 1,
+        missingOrInvalidPropertyFeatureCount: 2,
+        decodeOrSchemaFailureTileCount: 1,
+        requiredCodeUnresolvedCount: 3,
+        stationCount: 2,
+        spriteCount: 1,
+      ),
+      currentZoom: 6.75,
+      hypocenter: const (longitude: 140.1, latitude: 36.2),
+      canMoveToHypocenter: canMove,
+    );
+
+void main() {
+  testWidgets('version・入力数・描画診断・zoomを可変高で表示する', (tester) async {
+    tester.view.physicalSize = const Size(320, 760);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(1.6)),
+          child: Scaffold(
+            body: EqmonitorMapOverlayBanner(
+              presentation: presentation(canMove: false),
+              onMoveToHypocenter: null,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Data sequence: 7'), findsOneWidget);
+    expect(find.text('Render generation: 9'), findsOneWidget);
+    expect(find.text('現在 zoom: 6.75'), findsOneWidget);
+    expect(
+      find.text('入力数 Region 1 / City 2 / Station 3 / Sprite 1'),
+      findsOneWidget,
+    );
+    expect(find.text('Coverage: 不完全'), findsOneWidget);
+    expect(find.textContaining('描画済み Station 2 / Sprite 1'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('rebuildでは移動せず有効なbutton tap一回でcallback一回', (tester) async {
+    var invocationCount = 0;
+    final banner = EqmonitorMapOverlayBanner(
+      presentation: presentation(canMove: true),
+      onMoveToHypocenter: () => invocationCount += 1,
+    );
+
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: banner)));
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: banner)));
+
+    expect(invocationCount, 0);
+    await tester.tap(find.byKey(eqmonitorMapMoveToHypocenterKey));
+    await tester.pump();
+    expect(invocationCount, 1);
+  });
+
+  testWidgets('committed cameraまたは震源がない場合はbuttonを無効化する', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EqmonitorMapOverlayBanner(
+            presentation: presentation(canMove: false),
+            onMoveToHypocenter: () {},
+          ),
+        ),
+      ),
+    );
+
+    final button = tester.widget<OutlinedButton>(
+      find.byKey(eqmonitorMapMoveToHypocenterKey),
+    );
+    expect(button.onPressed, isNull);
+  });
+}

--- a/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_presentation_test.dart
+++ b/app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_presentation_test.dart
@@ -1,5 +1,8 @@
 // ignore_for_file: invalid_use_of_internal_member
 
+import 'dart:typed_data';
+import 'dart:ui';
+
 import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/provider/latest_earthquake_overlay_provider.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_overlay_banner.dart';
@@ -23,18 +26,63 @@ MapOverlayVersionStamp _versionStamp({
   renderDigest: renderDigest,
 );
 
-EarthquakeMapOverlaySnapshot _snapshot(MapOverlayVersionStamp versionStamp) =>
-    createEarthquakeMapOverlaySnapshot(
-      versionStamp: versionStamp,
-      regionToCityZoom: 6,
-      stationMinZoom: 6,
-      regionStyles: const [],
-      cityStyles: const [],
-      stations: const [],
-      spriteAtlas: null,
-      sprites: const [],
-      maxSpritePolicyBatches: 1,
-    );
+EarthquakeMapOverlaySnapshot _snapshot(
+  MapOverlayVersionStamp versionStamp, {
+  List<EarthquakeAreaStyle> regionStyles = const [],
+  List<EarthquakeAreaStyle> cityStyles = const [],
+  List<EarthquakeObservationPoint> stations = const [],
+  MapSpriteAtlas? spriteAtlas,
+  List<MapPointSpriteFeature> sprites = const [],
+}) => createEarthquakeMapOverlaySnapshot(
+  versionStamp: versionStamp,
+  regionToCityZoom: 6,
+  stationMinZoom: 6,
+  regionStyles: regionStyles,
+  cityStyles: cityStyles,
+  stations: stations,
+  spriteAtlas: spriteAtlas,
+  sprites: sprites,
+  maxSpritePolicyBatches: 1,
+);
+
+MapSpriteAtlas _atlas() => createMapSpriteAtlas(
+  identity: createMapSourceIdentity(value: 'atlas-a'),
+  width: 1,
+  height: 1,
+  rgbaBytes: Uint8List.fromList(const [255, 255, 255, 255]),
+  regions: const [
+    MapSpriteRegion(
+      id: 'normal',
+      normalizedUv: Rect.fromLTRB(0.5, 0.5, 0.5, 0.5),
+      logicalSize: Size(16, 16),
+    ),
+  ],
+  limits: const MapSpriteAtlasLimits(
+    maxWidth: 1,
+    maxHeight: 1,
+    maxPixelBytes: 4,
+    maxRegions: 1,
+  ),
+);
+
+MapPointSpriteFeature _hypocenter() => createMapPointSpriteFeature(
+  id: 'hypocenter:A',
+  longitude: 140.1,
+  latitude: 36.2,
+  spriteRegionId: 'normal',
+  sizeScale: createMapZoomLinearRange(
+    startZoom: 3,
+    startValue: 0.15,
+    endZoom: 20,
+    endValue: 0.4,
+  ),
+  opacity: createMapZoomStep(
+    thresholdZoom: 8,
+    belowValue: 1,
+    atOrAboveValue: 0.6,
+  ),
+  priority: 0,
+);
 
 LatestEarthquakeOverlayData _available(
   String eventId, {
@@ -56,6 +104,7 @@ void main() {
     final presentation = EqmonitorMapOverlayPresentation.from(
       overlayState: loading,
       coverageSnapshot: null,
+      committedCamera: null,
     );
 
     expect(presentation.overlay, isNull);
@@ -71,6 +120,7 @@ void main() {
     final presentation = EqmonitorMapOverlayPresentation.from(
       overlayState: error,
       coverageSnapshot: null,
+      committedCamera: null,
     );
 
     expect(presentation.overlay, isNull);
@@ -89,6 +139,7 @@ void main() {
     final presentation = EqmonitorMapOverlayPresentation.from(
       overlayState: const AsyncData(data),
       coverageSnapshot: null,
+      committedCamera: null,
     );
 
     expect(presentation.overlay, isNull);
@@ -101,6 +152,7 @@ void main() {
     final overlay = data.overlay as EarthquakeMapOverlaySnapshot;
     final presentation = EqmonitorMapOverlayPresentation.from(
       overlayState: AsyncData(data),
+      committedCamera: null,
       coverageSnapshot: EarthquakeOverlayCoverageSnapshot(
         versionStamp: overlay.versionStamp,
         coverage: const EarthquakeOverlayCoverage.incomplete(
@@ -118,6 +170,7 @@ void main() {
   test('旧sourceのcoverageをcurrent overlayへ適用しない', () {
     final presentation = EqmonitorMapOverlayPresentation.from(
       overlayState: AsyncData(_available('B')),
+      committedCamera: null,
       coverageSnapshot: EarthquakeOverlayCoverageSnapshot(
         versionStamp: _versionStamp(sourceIdentity: 'A'),
         coverage: const EarthquakeOverlayCoverage.complete(
@@ -126,12 +179,13 @@ void main() {
       ),
     );
 
-    expect(presentation.message, '表示範囲の震度情報を準備中です');
+    expect(presentation.message, '表示範囲の震度情報は未確定です');
   });
 
   test('同じsourceでもdata stampが異なるcoverageを適用しない', () {
     final presentation = EqmonitorMapOverlayPresentation.from(
       overlayState: AsyncData(_available('A')),
+      committedCamera: null,
       coverageSnapshot: EarthquakeOverlayCoverageSnapshot(
         versionStamp: _versionStamp(
           sourceIdentity: 'A',
@@ -146,12 +200,13 @@ void main() {
       ),
     );
 
-    expect(presentation.message, '表示範囲の震度情報を準備中です');
+    expect(presentation.message, '表示範囲の震度情報は未確定です');
   });
 
   test('同じdataでもrender stampが異なるcoverageを適用しない', () {
     final presentation = EqmonitorMapOverlayPresentation.from(
       overlayState: AsyncData(_available('A')),
+      committedCamera: null,
       coverageSnapshot: EarthquakeOverlayCoverageSnapshot(
         versionStamp: _versionStamp(
           sourceIdentity: 'A',
@@ -164,7 +219,7 @@ void main() {
       ),
     );
 
-    expect(presentation.message, '表示範囲の震度情報を準備中です');
+    expect(presentation.message, '表示範囲の震度情報は未確定です');
   });
 
   test('current overlayのloading coverageを準備中として扱う', () {
@@ -172,6 +227,7 @@ void main() {
     final overlay = data.overlay as EarthquakeMapOverlaySnapshot;
     final presentation = EqmonitorMapOverlayPresentation.from(
       overlayState: AsyncData(data),
+      committedCamera: null,
       coverageSnapshot: EarthquakeOverlayCoverageSnapshot(
         versionStamp: overlay.versionStamp,
         coverage: const EarthquakeOverlayCoverage.loading(),
@@ -179,5 +235,126 @@ void main() {
     );
 
     expect(presentation.message, '表示範囲の震度情報を準備中です');
+  });
+
+  test('versionと入力数を描画済みdiagnosticから分離して公開する', () {
+    final stamp = _versionStamp(
+      sourceIdentity: 'A',
+      dataSequence: 7,
+      renderGeneration: 9,
+    );
+    final atlas = _atlas();
+    final overlay = _snapshot(
+      stamp,
+      regionStyles: const [
+        EarthquakeAreaStyle(code: '01', color: Color(0xFF112233), opacity: 1),
+      ],
+      cityStyles: const [
+        EarthquakeAreaStyle(
+          code: '01100',
+          color: Color(0xFF223344),
+          opacity: 1,
+        ),
+        EarthquakeAreaStyle(
+          code: '01200',
+          color: Color(0xFF334455),
+          opacity: 1,
+        ),
+      ],
+      stations: const [
+        EarthquakeObservationPoint(
+          id: 'station-a',
+          longitude: 141,
+          latitude: 43,
+          color: Color(0xFF445566),
+          radiusLogicalPixels: 4,
+        ),
+      ],
+      spriteAtlas: atlas,
+      sprites: [_hypocenter()],
+    );
+    final diagnostic = EarthquakeOverlayCoverageDiagnostic(
+      visibleCanonicalTileCount: 5,
+      pendingTileCount: 0,
+      authoritativeEmptyTileCount: 1,
+      sourceLayerAbsentTileCount: 1,
+      missingOrInvalidPropertyFeatureCount: 2,
+      decodeOrSchemaFailureTileCount: 1,
+      requiredCodeUnresolvedCount: 3,
+      stationCount: 1,
+      spriteCount: 1,
+    );
+    final presentation = EqmonitorMapOverlayPresentation.from(
+      overlayState: AsyncData(
+        LatestEarthquakeOverlayData(
+          eventId: 'A',
+          originTime: DateTime.utc(2026, 8, 23),
+          telegramStatus: TelegramStatus.normal,
+          availability: LatestEarthquakeOverlayAvailability.available,
+          overlay: overlay,
+        ),
+      ),
+      coverageSnapshot: EarthquakeOverlayCoverageSnapshot(
+        versionStamp: stamp,
+        coverage: const EarthquakeOverlayCoverage.incomplete(
+          requestedTileCount: 5,
+          readyTileCount: 3,
+          missingOrInvalidCodeCount: 5,
+        ),
+        diagnostic: diagnostic,
+      ),
+      committedCamera: const MapCamera(
+        centerLongitude: 137.5,
+        centerLatitude: 36.5,
+        zoom: 6.75,
+      ),
+    );
+
+    expect(presentation.dataSequence, 7);
+    expect(presentation.renderGeneration, 9);
+    expect(
+      presentation.inputCounts,
+      const (regions: 1, cities: 2, stations: 1, sprites: 1),
+    );
+    expect(presentation.coverageState, EqmonitorMapCoverageState.incomplete);
+    expect(presentation.coverageDiagnostic, same(diagnostic));
+    expect(presentation.currentZoom, 6.75);
+    expect(
+      presentation.hypocenter,
+      const (longitude: 140.1, latitude: 36.2),
+    );
+    expect(presentation.canMoveToHypocenter, isTrue);
+  });
+
+  test('stale coverageは未確定としてdiagnosticを公開しない', () {
+    final presentation = EqmonitorMapOverlayPresentation.from(
+      overlayState: AsyncData(_available('A')),
+      coverageSnapshot: EarthquakeOverlayCoverageSnapshot(
+        versionStamp: _versionStamp(sourceIdentity: 'stale'),
+        coverage: const EarthquakeOverlayCoverage.complete(
+          requestedTileCount: 1,
+        ),
+        diagnostic: EarthquakeOverlayCoverageDiagnostic(
+          visibleCanonicalTileCount: 1,
+          pendingTileCount: 0,
+          authoritativeEmptyTileCount: 1,
+          sourceLayerAbsentTileCount: 0,
+          missingOrInvalidPropertyFeatureCount: 0,
+          decodeOrSchemaFailureTileCount: 0,
+          requiredCodeUnresolvedCount: 0,
+          stationCount: 99,
+          spriteCount: 99,
+        ),
+      ),
+      committedCamera: const MapCamera(
+        centerLongitude: 0,
+        centerLatitude: 0,
+        zoom: 4,
+      ),
+    );
+
+    expect(presentation.coverageState, EqmonitorMapCoverageState.unconfirmed);
+    expect(presentation.coverageDiagnostic, isNull);
+    expect(presentation.message, '表示範囲の震度情報は未確定です');
   });
 }

--- a/packages/eqmonitor_map/lib/src/flutter_scene/map_gpu_probe.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/map_gpu_probe.dart
@@ -23,6 +23,42 @@ final class MapGpuProbeConfiguration {
   final MapSpriteAtlasProbeFixture atlasFixture;
 }
 
+final class MapGpuProbeAtlasFixtureTransition {
+  const MapGpuProbeAtlasFixtureTransition._({
+    required this.previous,
+    required this.next,
+  });
+
+  final MapSpriteAtlasProbeFixture previous;
+  final MapSpriteAtlasProbeFixture next;
+}
+
+final class MapGpuProbeConfigurationUpdate {
+  const new({
+    required this.faultPointChanged,
+    required this.atlasTransitionToken,
+  });
+
+  final bool faultPointChanged;
+  final MapGpuProbeAtlasTransitionToken? atlasTransitionToken;
+}
+
+final class _MapGpuProbeRuntimeIdentity {
+  const new();
+}
+
+final class MapGpuProbeAtlasTransitionToken {
+  const MapGpuProbeAtlasTransitionToken._({
+    required this._owner,
+    required this._previous,
+    required this._next,
+  });
+
+  final _MapGpuProbeRuntimeIdentity _owner;
+  final MapSpriteAtlasProbeFixture _previous;
+  final MapSpriteAtlasProbeFixture _next;
+}
+
 final class MapGpuProbeFault implements Exception {
   const MapGpuProbeFault({required this.point});
 
@@ -34,15 +70,62 @@ final class MapGpuProbeFault implements Exception {
 
 /// Debug-only fault state. Production callers do not construct this object.
 final class MapGpuProbeRuntime {
-  MapGpuProbeRuntime({required this.configuration});
+  factory MapGpuProbeRuntime({
+    required MapGpuProbeConfiguration configuration,
+  }) => MapGpuProbeRuntime._(configuration);
 
-  final MapGpuProbeConfiguration configuration;
+  MapGpuProbeRuntime._(this._configuration);
+
+  MapGpuProbeConfiguration _configuration;
+  final _identity = const _MapGpuProbeRuntimeIdentity();
+  final _issuedAtlasTransitionTokens = <MapGpuProbeAtlasTransitionToken>{};
   var _didFire = false;
 
-  MapSpriteAtlasProbeFixture get atlasFixture => configuration.atlasFixture;
+  MapSpriteAtlasProbeFixture get atlasFixture => _configuration.atlasFixture;
+
+  MapGpuProbeConfigurationUpdate updateConfiguration(
+    MapGpuProbeConfiguration configuration,
+  ) {
+    final previous = _configuration;
+    final faultPointChanged = previous.faultPoint != configuration.faultPoint;
+    final atlasFixtureChanged =
+        previous.atlasFixture != configuration.atlasFixture;
+    _configuration = configuration;
+    if (faultPointChanged) {
+      _didFire = false;
+    }
+    final token = atlasFixtureChanged && mapGpuProbeCompileTimeEnabled
+        ? MapGpuProbeAtlasTransitionToken._(
+            owner: _identity,
+            previous: previous.atlasFixture,
+            next: configuration.atlasFixture,
+          )
+        : null;
+    if (token != null) {
+      _issuedAtlasTransitionTokens.add(token);
+    }
+    return MapGpuProbeConfigurationUpdate(
+      faultPointChanged: faultPointChanged,
+      atlasTransitionToken: token,
+    );
+  }
+
+  MapGpuProbeAtlasFixtureTransition? consumeAtlasTransition(
+    MapGpuProbeAtlasTransitionToken token,
+  ) {
+    if (!mapGpuProbeCompileTimeEnabled ||
+        !identical(token._owner, _identity) ||
+        !_issuedAtlasTransitionTokens.remove(token)) {
+      return null;
+    }
+    return MapGpuProbeAtlasFixtureTransition._(
+      previous: token._previous,
+      next: token._next,
+    );
+  }
 
   void throwIfRequested(MapGpuFaultPoint point) {
-    if (_didFire || configuration.faultPoint != point) {
+    if (_didFire || _configuration.faultPoint != point) {
       return;
     }
     _didFire = true;

--- a/packages/eqmonitor_map/lib/src/flutter_scene/map_gpu_probe_overlay.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/map_gpu_probe_overlay.dart
@@ -1,0 +1,233 @@
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
+import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
+import 'package:eqmonitor_map/src/overlay/earthquake_map_overlay_snapshot.dart';
+import 'package:eqmonitor_map/src/overlay/map_sprite_atlas.dart';
+import 'package:flutter/foundation.dart';
+
+EarthquakeMapOverlaySnapshot? resolveMapGpuProbeOverlay({
+  required EarthquakeMapOverlaySnapshot? overlay,
+  required MapGpuProbeRuntime? probeRuntime,
+}) {
+  if (overlay == null || probeRuntime == null) {
+    return overlay;
+  }
+  return applyMapGpuProbeAtlasFixture(
+    overlay: overlay,
+    fixture: probeRuntime.atlasFixture,
+  );
+}
+
+final class MapGpuProbeOverlayFrameResolver {
+  EarthquakeMapOverlaySnapshot? _cachedSourceOverlay;
+  EarthquakeMapOverlaySnapshot? _cachedResolvedOverlay;
+  final _pendingTokens = <MapGpuProbeAtlasTransitionToken>[];
+
+  void enqueue(MapGpuProbeAtlasTransitionToken token) {
+    _pendingTokens.add(token);
+    _cachedSourceOverlay = null;
+  }
+
+  void invalidateSource() {
+    _cachedSourceOverlay = null;
+    _cachedResolvedOverlay = null;
+  }
+
+  EarthquakeMapOverlaySnapshot resolve({
+    required EarthquakeMapOverlaySnapshot sourceOverlay,
+    required EarthquakeMapOverlaySnapshot? currentOverlay,
+    required MapGpuProbeRuntime? probeRuntime,
+  }) {
+    if (identical(_cachedSourceOverlay, sourceOverlay) &&
+        _pendingTokens.isEmpty) {
+      return _cachedResolvedOverlay ?? sourceOverlay;
+    }
+    var resolved = currentOverlay;
+    final canApplySameVersionTransition =
+        resolved != null &&
+        resolved.versionStamp == sourceOverlay.versionStamp &&
+        probeRuntime != null;
+    if (canApplySameVersionTransition) {
+      for (final token in _pendingTokens) {
+        final transition = probeRuntime.consumeAtlasTransition(token);
+        if (transition == null) {
+          continue;
+        }
+        final transitionCurrent = resolved;
+        if (transitionCurrent == null) {
+          break;
+        }
+        final next = applyMapGpuProbeAtlasFixtureTransition(
+          sourceOverlay: sourceOverlay,
+          currentOverlay: transitionCurrent,
+          transition: transition,
+        );
+        if (next == null) {
+          break;
+        }
+        resolved = next;
+      }
+    } else {
+      if (probeRuntime != null) {
+        _pendingTokens.forEach(probeRuntime.consumeAtlasTransition);
+      }
+      resolved = resolveMapGpuProbeOverlay(
+        overlay: sourceOverlay,
+        probeRuntime: probeRuntime,
+      );
+    }
+    _pendingTokens.clear();
+    _cachedSourceOverlay = sourceOverlay;
+    _cachedResolvedOverlay = resolved ?? sourceOverlay;
+    return _cachedResolvedOverlay ?? sourceOverlay;
+  }
+}
+
+EarthquakeMapOverlaySnapshot applyMapGpuProbeAtlasFixture({
+  required EarthquakeMapOverlaySnapshot overlay,
+  required MapSpriteAtlasProbeFixture fixture,
+}) {
+  final atlas = overlay.spriteAtlas;
+  if (fixture == MapSpriteAtlasProbeFixture.production || atlas == null) {
+    return overlay;
+  }
+  final fixtureAtlas = replaceMapSpriteAtlasTexture(
+    atlas: atlas,
+    identity: createMapSourceIdentity(
+      value: '${atlas.identity.value}:gpu-probe-${fixture.name}-v1',
+    ),
+    rgbaBytes: createMapGpuProbeAtlasFixtureBytes(
+      fixture: fixture,
+      atlas: atlas,
+    ),
+  );
+  return replaceEarthquakeMapOverlaySpriteAtlas(
+    snapshot: overlay,
+    spriteAtlas: fixtureAtlas,
+  );
+}
+
+EarthquakeMapOverlaySnapshot? applyMapGpuProbeAtlasFixtureTransition({
+  required EarthquakeMapOverlaySnapshot sourceOverlay,
+  required EarthquakeMapOverlaySnapshot currentOverlay,
+  required MapGpuProbeAtlasFixtureTransition transition,
+}) {
+  if (!mapGpuProbeCompileTimeEnabled) {
+    return null;
+  }
+  final expectedCurrent = applyMapGpuProbeAtlasFixture(
+    overlay: sourceOverlay,
+    fixture: transition.previous,
+  );
+  if (!mapGpuProbeOverlayMatchesExpected(
+    candidate: currentOverlay,
+    expected: expectedCurrent,
+  )) {
+    return null;
+  }
+  return applyMapGpuProbeAtlasFixture(
+    overlay: sourceOverlay,
+    fixture: transition.next,
+  );
+}
+
+bool mapGpuProbeOverlayMatchesExpected({
+  required EarthquakeMapOverlaySnapshot candidate,
+  required EarthquakeMapOverlaySnapshot expected,
+}) {
+  if (candidate.versionStamp != expected.versionStamp ||
+      candidate.regionToCityZoom != expected.regionToCityZoom ||
+      candidate.stationMinZoom != expected.stationMinZoom ||
+      candidate.maxSpritePolicyBatches != expected.maxSpritePolicyBatches ||
+      !identical(candidate.regionStyles, expected.regionStyles) ||
+      !identical(candidate.cityStyles, expected.cityStyles) ||
+      !identical(candidate.stations, expected.stations) ||
+      !identical(candidate.sprites, expected.sprites)) {
+    return false;
+  }
+  final candidateAtlas = candidate.spriteAtlas;
+  final expectedAtlas = expected.spriteAtlas;
+  if (candidateAtlas == null || expectedAtlas == null) {
+    return candidateAtlas == null && expectedAtlas == null;
+  }
+  return candidateAtlas.identity == expectedAtlas.identity &&
+      candidateAtlas.width == expectedAtlas.width &&
+      candidateAtlas.height == expectedAtlas.height &&
+      identical(candidateAtlas.regions, expectedAtlas.regions) &&
+      listEquals(candidateAtlas.rgbaBytes, expectedAtlas.rgbaBytes);
+}
+
+Uint8List createMapGpuProbeAtlasFixtureBytes({
+  required MapSpriteAtlasProbeFixture fixture,
+  required MapSpriteAtlas atlas,
+}) {
+  final bytes = Uint8List(atlas.rgbaBytes.length);
+  if (fixture == MapSpriteAtlasProbeFixture.edgeBleed) {
+    for (
+      var offset = 0;
+      offset < bytes.length;
+      offset += MapSpriteAtlas.bytesPerPixel
+    ) {
+      bytes.setRange(
+        offset,
+        offset + MapSpriteAtlas.bytesPerPixel,
+        const [255, 0, 255, 0],
+      );
+    }
+  }
+  for (var regionIndex = 0; regionIndex < atlas.regions.length; regionIndex++) {
+    final region = atlas.regions[regionIndex];
+    final contentLeft = (region.normalizedUv.left * atlas.width - 0.5).round();
+    final contentTop = (region.normalizedUv.top * atlas.height - 0.5).round();
+    final contentRight = (region.normalizedUv.right * atlas.width - 0.5)
+        .round();
+    final contentBottom = (region.normalizedUv.bottom * atlas.height - 0.5)
+        .round();
+    final cellLeft = (contentLeft - MapSpriteAtlas.regionExtrusionPixels).clamp(
+      0,
+      atlas.width - 1,
+    );
+    final cellTop = (contentTop - MapSpriteAtlas.regionExtrusionPixels).clamp(
+      0,
+      atlas.height - 1,
+    );
+    final cellRight = (contentRight + MapSpriteAtlas.regionExtrusionPixels)
+        .clamp(0, atlas.width - 1);
+    final cellBottom = (contentBottom + MapSpriteAtlas.regionExtrusionPixels)
+        .clamp(0, atlas.height - 1);
+    for (var y = cellTop; y <= cellBottom; y++) {
+      final sourceY = y < contentTop
+          ? 0
+          : y > contentBottom
+          ? contentBottom - contentTop
+          : y - contentTop;
+      for (var x = cellLeft; x <= cellRight; x++) {
+        final sourceX = x < contentLeft
+            ? 0
+            : x > contentRight
+            ? contentRight - contentLeft
+            : x - contentLeft;
+        final rgba = switch (fixture) {
+          MapSpriteAtlasProbeFixture.production => const [0, 0, 0, 0],
+          MapSpriteAtlasProbeFixture.orientation2x2 => switch ((
+            sourceX % 2,
+            sourceY % 2,
+          )) {
+            (0, 0) => const [255, 0, 0, 255],
+            (1, 0) => const [0, 255, 0, 255],
+            (0, 1) => const [0, 0, 255, 255],
+            (1, 1) => const [255, 255, 255, 255],
+            _ => const [0, 0, 0, 0],
+          },
+          MapSpriteAtlasProbeFixture.alphaHalf => const [255, 255, 255, 128],
+          MapSpriteAtlasProbeFixture.edgeBleed =>
+            regionIndex.isEven
+                ? const [0, 255, 255, 255]
+                : const [255, 255, 0, 255],
+        };
+        final offset = (y * atlas.width + x) * MapSpriteAtlas.bytesPerPixel;
+        bytes.setRange(offset, offset + MapSpriteAtlas.bytesPerPixel, rgba);
+      }
+    }
+  }
+  return bytes;
+}

--- a/packages/eqmonitor_map/lib/src/overlay/earthquake_map_overlay_snapshot.dart
+++ b/packages/eqmonitor_map/lib/src/overlay/earthquake_map_overlay_snapshot.dart
@@ -98,6 +98,29 @@ EarthquakeMapOverlaySnapshot createEarthquakeMapOverlaySnapshot({
   );
 }
 
+/// Replaces only the atlas while retaining every non-texture overlay input.
+EarthquakeMapOverlaySnapshot replaceEarthquakeMapOverlaySpriteAtlas({
+  required EarthquakeMapOverlaySnapshot snapshot,
+  required MapSpriteAtlas spriteAtlas,
+}) {
+  _validateSprites(
+    spriteAtlas: spriteAtlas,
+    sprites: snapshot.sprites,
+    maxSpritePolicyBatches: snapshot.maxSpritePolicyBatches,
+  );
+  return EarthquakeMapOverlaySnapshot._(
+    versionStamp: snapshot.versionStamp,
+    regionToCityZoom: snapshot.regionToCityZoom,
+    stationMinZoom: snapshot.stationMinZoom,
+    regionStyles: snapshot.regionStyles,
+    cityStyles: snapshot.cityStyles,
+    stations: snapshot.stations,
+    spriteAtlas: spriteAtlas,
+    sprites: snapshot.sprites,
+    maxSpritePolicyBatches: snapshot.maxSpritePolicyBatches,
+  );
+}
+
 void _validateSnapshotValues({
   required double regionToCityZoom,
   required double stationMinZoom,

--- a/packages/eqmonitor_map/lib/src/overlay/earthquake_overlay_controller.dart
+++ b/packages/eqmonitor_map/lib/src/overlay/earthquake_overlay_controller.dart
@@ -36,3 +36,17 @@ EarthquakeOverlayCommitResult commitEarthquakeOverlaySnapshot({
   }
   return EarthquakeOverlayCommitAccepted(next: next);
 }
+
+/// Rejects a separately-built input that reuses the current full version.
+///
+/// Exact same-version replacement is reserved for a typed GPU probe token;
+/// ordinary app input must advance its version or retain the same instance.
+EarthquakeOverlayCommitResult commitEarthquakeOverlayInputSnapshot({
+  required EarthquakeMapOverlaySnapshot? current,
+  required EarthquakeMapOverlaySnapshot next,
+}) {
+  if (current != null && current.versionStamp == next.versionStamp) {
+    return EarthquakeOverlayCommitRejected(current: current);
+  }
+  return commitEarthquakeOverlaySnapshot(current: current, next: next);
+}

--- a/packages/eqmonitor_map/lib/src/overlay/map_sprite_atlas.dart
+++ b/packages/eqmonitor_map/lib/src/overlay/map_sprite_atlas.dart
@@ -87,6 +87,24 @@ MapSpriteAtlas createMapSpriteAtlas({
   );
 }
 
+/// Replaces only immutable texture content while preserving atlas placement.
+MapSpriteAtlas replaceMapSpriteAtlasTexture({
+  required MapSpriteAtlas atlas,
+  required MapSourceIdentity identity,
+  required Uint8List rgbaBytes,
+}) {
+  if (rgbaBytes.length != atlas.rgbaBytes.length) {
+    throw ArgumentError.value(rgbaBytes.length, 'rgbaBytes');
+  }
+  return MapSpriteAtlas._(
+    identity: identity,
+    width: atlas.width,
+    height: atlas.height,
+    rgbaBytes: Uint8List.fromList(rgbaBytes).asUnmodifiableView(),
+    regions: atlas.regions,
+  );
+}
+
 void _validateLimits(MapSpriteAtlasLimits limits) {
   if (limits.maxWidth <= 0) {
     throw ArgumentError.value(limits.maxWidth, 'limits.maxWidth');

--- a/packages/eqmonitor_map/lib/src/renderer/map_sprite_batch.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/map_sprite_batch.dart
@@ -68,6 +68,20 @@ final class MapPointSpriteInstanceBatch implements MapSceneInstanceBatch {
     required MapFrameSnapshot frame,
     required MapOverlayVersionStamp versionStamp,
     required ByteData frameUniform,
+  }) => withAtlasAndFrame(
+    frame: frame,
+    versionStamp: versionStamp,
+    atlas: atlas,
+    frameUniform: frameUniform,
+    batchKey: batchKey,
+  );
+
+  MapPointSpriteInstanceBatch withAtlasAndFrame({
+    required MapFrameSnapshot frame,
+    required MapOverlayVersionStamp versionStamp,
+    required MapSpriteAtlas atlas,
+    required ByteData frameUniform,
+    required MapSceneBatchKey batchKey,
   }) {
     final ownedUniform = Uint8List.fromList(
       frameUniform.buffer.asUint8List(

--- a/packages/eqmonitor_map/lib/src/renderer/map_sprite_batch_builder.dart
+++ b/packages/eqmonitor_map/lib/src/renderer/map_sprite_batch_builder.dart
@@ -127,6 +127,25 @@ MapPointSpriteInstanceBatch _buildPolicyBatch({
       frameUniform: frameUniform,
     );
   }
+  MapPointSpriteInstanceBatch? textureReplacementReusable;
+  for (final batch in previousByDigest.values) {
+    if (identical(batch.atlas.regions, atlas.regions) &&
+        batch.sizePolicy == sizePolicy &&
+        batch.opacityPolicy == opacityPolicy &&
+        batch.instanceDigest == instanceDigest) {
+      textureReplacementReusable = batch;
+      break;
+    }
+  }
+  if (textureReplacementReusable != null) {
+    return textureReplacementReusable.withAtlasAndFrame(
+      frame: frame,
+      versionStamp: versionStamp,
+      atlas: atlas,
+      frameUniform: frameUniform,
+      batchKey: batchKey,
+    );
+  }
   return createMapPointSpriteInstanceBatch(
     frame: frame,
     versionStamp: versionStamp,

--- a/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
+++ b/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
@@ -6,6 +6,7 @@ import 'package:eqmonitor_map/src/flutter_scene/earthquake_overlay_material_owne
 import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_map_adapter.dart';
 import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_sprite_resource_owner.dart';
 import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe_overlay.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_revision.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
@@ -47,6 +48,26 @@ import 'package:pmtiles_v3/pmtiles_v3.dart';
 import 'package:vector_math/vector_math.dart' as scene_math;
 
 part 'base_map_view.freezed.dart';
+
+typedef BaseMapViewControllerLifecycleIdentity = ({
+  VerifiedPmTilesSource source,
+  MapBaseLayerLimits limits,
+  MapClock clock,
+  MapViewCameraController? cameraController,
+  ValueChanged<MapGpuResourceCounterSnapshot>? gpuCounterCallback,
+  MapGpuProbeController? gpuProbeController,
+});
+
+BaseMapViewControllerLifecycleIdentity baseMapViewControllerLifecycleIdentity(
+  BaseMapView view,
+) => (
+  source: view.source,
+  limits: view.limits,
+  clock: view.clock,
+  cameraController: view.cameraController,
+  gpuCounterCallback: view.onGpuResourceCounterChanged,
+  gpuProbeController: view.gpuProbeController,
+);
 
 /// [BaseMapView]がgestureとtile取得の両方を制限するために使う上限値一式。
 /// 呼び出し側(app)が明示し、widget内部に固定fallbackは置かない
@@ -191,6 +212,7 @@ class BaseMapView extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
+    final lifecycleIdentity = baseMapViewControllerLifecycleIdentity(this);
     final controller = useMemoized(
       () => _BaseMapController(
         source: source,
@@ -204,21 +226,17 @@ class BaseMapView extends HookWidget {
         onGpuResourceCounterChanged: onGpuResourceCounterChanged,
         gpuProbeController: gpuProbeController,
       ),
-      [
-        source,
-        limits,
-        clock,
-        cameraController,
-        gpuProbeConfiguration,
-        onGpuResourceCounterChanged,
-        gpuProbeController,
-      ],
+      [lifecycleIdentity],
     );
     useEffect(() {
       controller.attachCameraController();
       controller.attachGpuProbeController();
       return controller.dispose;
     }, [controller]);
+    useEffect(() {
+      controller.updateGpuProbeConfiguration(gpuProbeConfiguration);
+      return null;
+    }, [controller, gpuProbeConfiguration]);
     useListenable(controller);
 
     useEffect(() {
@@ -264,7 +282,7 @@ class BaseMapView extends HookWidget {
 
     final initError = controller.initError;
     if (initError != null) {
-      return _BaseMapViewError(error: initError);
+      return const BaseMapViewInitializationError();
     }
     if (!controller.isReady) {
       return const Center(child: CircularProgressIndicator());
@@ -302,13 +320,9 @@ class BaseMapView extends HookWidget {
   }
 }
 
-class _BaseMapViewError extends StatelessWidget {
-  const new({required this.error});
-
-  // privateなdebug表示専用のwidgetであり、Flutter Inspector越しの検査対象
-  // ではない。
-  // ignore: diagnostic_describe_all_properties
-  final Object error;
+/// 初期化例外の詳細をUIへ漏らさず、利用者向けの分類済み文言だけを表示する。
+class BaseMapViewInitializationError extends StatelessWidget {
+  const new({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -317,7 +331,7 @@ class _BaseMapViewError extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(24),
         child: Text(
-          'ベースレイヤーの初期化に失敗しました: $error',
+          'ベースレイヤーの初期化に失敗しました。',
           style: theme.textTheme.bodyMedium?.copyWith(
             color: theme.colorScheme.error,
           ),
@@ -380,11 +394,12 @@ class _BaseMapController extends ChangeNotifier
     required this.onGpuResourceCounterChanged,
     required this.gpuProbeController,
   }) : _cameraOwner = MapCameraCandidateOwner(initialCamera: initialCamera),
-       _inputOverlay = earthquakeOverlay,
-       _acceptedOverlay = earthquakeOverlay,
        _overlayFrameOwner = BaseMapOverlayFrameOwner(
          onCoverageChanged: onEarthquakeOverlayCoverageChanged,
-       );
+       ) {
+    _inputOverlay = earthquakeOverlay;
+    _acceptedOverlay = earthquakeOverlay;
+  }
 
   final VerifiedPmTilesSource source;
   final MapBaseLayerLimits limits;
@@ -462,6 +477,7 @@ class _BaseMapController extends ChangeNotifier
   EarthquakeMapOverlaySnapshot? _preparingOverlay;
   EarthquakeOverlayMaterialStage? _requestedMaterialStage;
   final BaseMapOverlayFrameOwner _overlayFrameOwner;
+  final _gpuProbeOverlayResolver = MapGpuProbeOverlayFrameResolver();
   var _overlayRequestGeneration = 0;
 
   var _frameNumber = 0;
@@ -541,6 +557,28 @@ class _BaseMapController extends ChangeNotifier
     if (!controller.attach(host: this)) {
       _initError = StateError('GPU probe controller is already attached');
       notifyListeners();
+    }
+  }
+
+  void updateGpuProbeConfiguration(
+    MapGpuProbeConfiguration? configuration,
+  ) {
+    if (_isDisposed || configuration == null) {
+      return;
+    }
+    final runtime = _gpuProbeRuntime;
+    if (runtime == null) {
+      return;
+    }
+    final update = runtime.updateConfiguration(configuration);
+    final token = update.atlasTransitionToken;
+    if (token != null) {
+      _gpuProbeOverlayResolver.enqueue(token);
+    }
+    if (token != null || update.faultPointChanged) {
+      _refresh();
+      notifyListeners();
+      WidgetsBinding.instance.ensureVisualUpdate();
     }
   }
 
@@ -784,6 +822,7 @@ class _BaseMapController extends ChangeNotifier
     if (overlay == null) {
       _inputOverlay = null;
       _acceptedOverlay = null;
+      _gpuProbeOverlayResolver.invalidateSource();
       _overlayRequestGeneration++;
       _requestedOverlay = null;
       _preparingOverlay = null;
@@ -793,7 +832,7 @@ class _BaseMapController extends ChangeNotifier
       notifyListeners();
       return;
     }
-    final commit = commitEarthquakeOverlaySnapshot(
+    final commit = commitEarthquakeOverlayInputSnapshot(
       current: _acceptedOverlay,
       next: overlay,
     );
@@ -802,11 +841,11 @@ class _BaseMapController extends ChangeNotifier
       EarthquakeOverlayCommitRejected(:final current) => current,
     };
     if (commit is EarthquakeOverlayCommitRejected) {
-      _inputOverlay = selected;
       return;
     }
     _inputOverlay = selected;
     _acceptedOverlay = selected;
+    _gpuProbeOverlayResolver.invalidateSource();
     final requestGeneration = ++_overlayRequestGeneration;
     _requestedOverlay = null;
     _preparingOverlay = selected;
@@ -1037,11 +1076,19 @@ class _BaseMapController extends ChangeNotifier
       ),
       lineHalfWidthLogicalPixels: _debugLineHalfWidthLogicalPixels,
     );
+    final requestedOverlay = switch (_requestedOverlay) {
+      final overlay? => _gpuProbeOverlayResolver.resolve(
+        sourceOverlay: overlay,
+        currentOverlay: _overlayFrameOwner.overlay,
+        probeRuntime: _gpuProbeRuntime,
+      ),
+      null => null,
+    };
     final result = buildBaseMapOverlayFrame(
       frame: frame,
       baseMap: baseMap,
       currentOverlay: _overlayFrameOwner.overlay,
-      requestedOverlay: _requestedOverlay,
+      requestedOverlay: requestedOverlay,
       previousObservationBatch: _overlayFrameOwner.previousObservationBatch,
       previousSpriteBatches: _overlayFrameOwner.previousSpriteBatches,
       requestedCover: cover,

--- a/packages/eqmonitor_map/test/flutter_scene/flutter_scene_sprite_resource_owner_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/flutter_scene_sprite_resource_owner_test.dart
@@ -512,6 +512,50 @@ void main() {
     },
   );
 
+  test('atlas fixture uploads only texture and preserves GPU geometry', () {
+    if (!mapGpuProbeCompileTimeEnabled) {
+      return;
+    }
+    final backend = _FakeSpriteBackend();
+    final owner = _owner(
+      backend: backend,
+      maxFramesInFlight: 2,
+      maxActiveAtlases: 1,
+      maxTopologyVariants: 1,
+      maxPolicyBatches: 1,
+      completions: [],
+    );
+    final productionAtlas = atlas('sha256:production');
+    final firstFrame = frame(number: 0);
+    final firstBatches = batches(
+      frame: firstFrame,
+      atlas: productionAtlas,
+      generation: 1,
+    );
+    owner.prepareFrame(frame: firstFrame, batches: firstBatches).commit();
+    final probeAtlas = replaceMapSpriteAtlasTexture(
+      atlas: productionAtlas,
+      identity: createMapSourceIdentity(value: 'sha256:probe'),
+      rgbaBytes: Uint8List.fromList(List.filled(64, 255)),
+    );
+    final secondFrame = frame(number: 1);
+    final secondBatches = batches(
+      frame: secondFrame,
+      atlas: probeAtlas,
+      generation: 1,
+      previous: firstBatches,
+    );
+
+    owner.prepareFrame(frame: secondFrame, batches: secondBatches).commit();
+
+    expect(backend.textureUploads, 2);
+    expect(backend.topologyPrepares, 1);
+    expect(backend.instancePrepares, 1);
+    expect(owner.snapshot.texture.uploads, 2);
+    expect(owner.snapshot.topology.uploads, 1);
+    expect(owner.snapshot.instance.uploads, 1);
+  });
+
   test('caller limits and frames in flight must be positive', () {
     for (final limits in [
       const MapSpriteRendererLimits(

--- a/packages/eqmonitor_map/test/flutter_scene/map_gpu_probe_overlay_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/map_gpu_probe_overlay_test.dart
@@ -1,0 +1,430 @@
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe_overlay.dart';
+import 'package:eqmonitor_map/src/foundation/revision/map_source_identity.dart';
+import 'package:eqmonitor_map/src/overlay/earthquake_map_overlay_snapshot.dart';
+import 'package:eqmonitor_map/src/overlay/map_overlay_version_stamp.dart';
+import 'package:eqmonitor_map/src/overlay/map_point_sprite_feature.dart';
+import 'package:eqmonitor_map/src/overlay/map_sprite_atlas.dart';
+import 'package:eqmonitor_map/src/overlay/map_zoom_scalar_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final overlay = _overlayFixture();
+
+  test('disabled runtime and production fixture preserve overlay identity', () {
+    final disabled = resolveMapGpuProbeOverlay(
+      overlay: overlay,
+      probeRuntime: null,
+    );
+    final production = resolveMapGpuProbeOverlay(
+      overlay: overlay,
+      probeRuntime: MapGpuProbeRuntime(
+        configuration: const MapGpuProbeConfiguration(
+          faultPoint: null,
+          atlasFixture: MapSpriteAtlasProbeFixture.production,
+        ),
+      ),
+    );
+
+    expect(disabled, same(overlay));
+    expect(production, same(overlay));
+  });
+
+  test('probe fixtures replace texture with literal straight RGBA bytes', () {
+    final expectedBytes = <MapSpriteAtlasProbeFixture, List<int>>{
+      MapSpriteAtlasProbeFixture.orientation2x2: const [
+        255,
+        0,
+        0,
+        255,
+        0,
+        255,
+        0,
+        255,
+        0,
+        0,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+      ],
+      MapSpriteAtlasProbeFixture.alphaHalf: const [
+        255,
+        255,
+        255,
+        128,
+        255,
+        255,
+        255,
+        128,
+        255,
+        255,
+        255,
+        128,
+        255,
+        255,
+        255,
+        128,
+      ],
+      MapSpriteAtlasProbeFixture.edgeBleed: const [
+        0,
+        255,
+        255,
+        255,
+        0,
+        255,
+        255,
+        255,
+        0,
+        255,
+        255,
+        255,
+        0,
+        255,
+        255,
+        255,
+      ],
+    };
+
+    for (final MapEntry(key: fixture, value: bytes) in expectedBytes.entries) {
+      final result = applyMapGpuProbeAtlasFixture(
+        overlay: overlay,
+        fixture: fixture,
+      );
+
+      expect(result.spriteAtlas?.rgbaBytes, bytes, reason: fixture.name);
+      expect(
+        result.spriteAtlas?.identity.value,
+        'atlas-production:gpu-probe-${fixture.name}-v1',
+      );
+    }
+  });
+
+  test('edge fixture extrudes each region and keeps the gap distinct', () {
+    final atlas = createMapSpriteAtlas(
+      identity: createMapSourceIdentity(value: 'atlas-edge'),
+      width: 11,
+      height: 5,
+      rgbaBytes: Uint8List(11 * 5 * 4),
+      regions: const [
+        MapSpriteRegion(
+          id: 'normal',
+          normalizedUv: Rect.fromLTRB(2.5 / 11, 0.5, 2.5 / 11, 0.5),
+          logicalSize: Size(1, 1),
+        ),
+        MapSpriteRegion(
+          id: 'low-precision',
+          normalizedUv: Rect.fromLTRB(8.5 / 11, 0.5, 8.5 / 11, 0.5),
+          logicalSize: Size(1, 1),
+        ),
+      ],
+      limits: const MapSpriteAtlasLimits(
+        maxWidth: 11,
+        maxHeight: 5,
+        maxPixelBytes: 11 * 5 * 4,
+        maxRegions: 2,
+      ),
+    );
+
+    final bytes = createMapGpuProbeAtlasFixtureBytes(
+      fixture: MapSpriteAtlasProbeFixture.edgeBleed,
+      atlas: atlas,
+    );
+
+    expect(_pixel(bytes: bytes, width: 11, x: 0, y: 2), [0, 255, 255, 255]);
+    expect(_pixel(bytes: bytes, width: 11, x: 4, y: 2), [0, 255, 255, 255]);
+    expect(_pixel(bytes: bytes, width: 11, x: 5, y: 2), [255, 0, 255, 0]);
+    expect(_pixel(bytes: bytes, width: 11, x: 6, y: 2), [255, 255, 0, 255]);
+    expect(_pixel(bytes: bytes, width: 11, x: 10, y: 2), [255, 255, 0, 255]);
+  });
+
+  test('fixture changes only atlas texture identity and bytes', () {
+    final result = applyMapGpuProbeAtlasFixture(
+      overlay: overlay,
+      fixture: MapSpriteAtlasProbeFixture.orientation2x2,
+    );
+    final sourceAtlas = overlay.spriteAtlas;
+    final resultAtlas = result.spriteAtlas;
+
+    expect(result, isNot(same(overlay)));
+    expect(result.versionStamp, same(overlay.versionStamp));
+    expect(result.regionStyles, same(overlay.regionStyles));
+    expect(result.cityStyles, same(overlay.cityStyles));
+    expect(result.stations, same(overlay.stations));
+    expect(result.sprites, same(overlay.sprites));
+    expect(result.regionToCityZoom, overlay.regionToCityZoom);
+    expect(result.stationMinZoom, overlay.stationMinZoom);
+    expect(result.maxSpritePolicyBatches, overlay.maxSpritePolicyBatches);
+    expect(resultAtlas?.width, sourceAtlas?.width);
+    expect(resultAtlas?.height, sourceAtlas?.height);
+    expect(resultAtlas?.regions, same(sourceAtlas?.regions));
+    expect(resultAtlas?.identity, isNot(sourceAtlas?.identity));
+    expect(resultAtlas?.rgbaBytes, isNot(sourceAtlas?.rgbaBytes));
+  });
+
+  test('fixture change produces a different texture identity', () {
+    final orientation = applyMapGpuProbeAtlasFixture(
+      overlay: overlay,
+      fixture: MapSpriteAtlasProbeFixture.orientation2x2,
+    );
+    final alpha = applyMapGpuProbeAtlasFixture(
+      overlay: overlay,
+      fixture: MapSpriteAtlasProbeFixture.alphaHalf,
+    );
+
+    expect(
+      orientation.spriteAtlas?.identity,
+      isNot(alpha.spriteAtlas?.identity),
+    );
+  });
+
+  test('consumed typed transition permits only the expected atlas change', () {
+    if (!mapGpuProbeCompileTimeEnabled) {
+      return;
+    }
+    final runtime = MapGpuProbeRuntime(
+      configuration: const MapGpuProbeConfiguration(
+        faultPoint: null,
+        atlasFixture: MapSpriteAtlasProbeFixture.production,
+      ),
+    );
+    final update = runtime.updateConfiguration(
+      const MapGpuProbeConfiguration(
+        faultPoint: null,
+        atlasFixture: MapSpriteAtlasProbeFixture.orientation2x2,
+      ),
+    );
+    final token = update.atlasTransitionToken;
+    if (token == null) {
+      fail('probe-enabled update must issue an atlas transition token');
+    }
+    final transition = runtime.consumeAtlasTransition(token);
+    if (transition == null) {
+      fail('fresh atlas transition token must be consumable');
+    }
+
+    final result = applyMapGpuProbeAtlasFixtureTransition(
+      sourceOverlay: overlay,
+      currentOverlay: overlay,
+      transition: transition,
+    );
+
+    expect(result, isNotNull);
+    expect(result?.versionStamp, same(overlay.versionStamp));
+    expect(result?.regionStyles, same(overlay.regionStyles));
+    expect(result?.cityStyles, same(overlay.cityStyles));
+    expect(result?.stations, same(overlay.stations));
+    expect(result?.sprites, same(overlay.sprites));
+    expect(result?.spriteAtlas?.regions, same(overlay.spriteAtlas?.regions));
+    expect(
+      result?.spriteAtlas?.identity.value,
+      'atlas-production:gpu-probe-orientation2x2-v1',
+    );
+  });
+
+  test('typed transition rejects same-version non-atlas input changes', () {
+    if (!mapGpuProbeCompileTimeEnabled) {
+      return;
+    }
+    final runtime = MapGpuProbeRuntime(
+      configuration: const MapGpuProbeConfiguration(
+        faultPoint: null,
+        atlasFixture: MapSpriteAtlasProbeFixture.production,
+      ),
+    );
+    final update = runtime.updateConfiguration(
+      const MapGpuProbeConfiguration(
+        faultPoint: null,
+        atlasFixture: MapSpriteAtlasProbeFixture.alphaHalf,
+      ),
+    );
+    final token = update.atlasTransitionToken;
+    if (token == null) {
+      fail('probe-enabled update must issue an atlas transition token');
+    }
+    final transition = runtime.consumeAtlasTransition(token);
+    if (transition == null) {
+      fail('fresh atlas transition token must be consumable');
+    }
+    final forged = createEarthquakeMapOverlaySnapshot(
+      versionStamp: overlay.versionStamp,
+      regionToCityZoom: overlay.regionToCityZoom,
+      stationMinZoom: overlay.stationMinZoom,
+      regionStyles: overlay.regionStyles,
+      cityStyles: overlay.cityStyles,
+      stations: const [
+        EarthquakeObservationPoint(
+          id: 'forged-station',
+          longitude: 140,
+          latitude: 36,
+          color: Color(0xffffffff),
+          radiusLogicalPixels: 4,
+        ),
+      ],
+      spriteAtlas: overlay.spriteAtlas,
+      sprites: overlay.sprites,
+      maxSpritePolicyBatches: overlay.maxSpritePolicyBatches,
+    );
+
+    final result = applyMapGpuProbeAtlasFixtureTransition(
+      sourceOverlay: overlay,
+      currentOverlay: forged,
+      transition: transition,
+    );
+
+    expect(result, isNull);
+  });
+
+  test(
+    'frame resolver consumes atlas token once and caches the transition',
+    () {
+      if (!mapGpuProbeCompileTimeEnabled) {
+        return;
+      }
+      final runtime = MapGpuProbeRuntime(
+        configuration: const MapGpuProbeConfiguration(
+          faultPoint: null,
+          atlasFixture: MapSpriteAtlasProbeFixture.production,
+        ),
+      );
+      final resolver = MapGpuProbeOverlayFrameResolver();
+      final initial = resolver.resolve(
+        sourceOverlay: overlay,
+        currentOverlay: null,
+        probeRuntime: runtime,
+      );
+      final update = runtime.updateConfiguration(
+        const MapGpuProbeConfiguration(
+          faultPoint: null,
+          atlasFixture: MapSpriteAtlasProbeFixture.edgeBleed,
+        ),
+      );
+      final token = update.atlasTransitionToken;
+      if (token == null) {
+        fail('probe-enabled update must issue an atlas transition token');
+      }
+      resolver.enqueue(token);
+
+      final transitioned = resolver.resolve(
+        sourceOverlay: overlay,
+        currentOverlay: initial,
+        probeRuntime: runtime,
+      );
+      final cached = resolver.resolve(
+        sourceOverlay: overlay,
+        currentOverlay: transitioned,
+        probeRuntime: runtime,
+      );
+
+      expect(transitioned.versionStamp, same(overlay.versionStamp));
+      expect(
+        transitioned.spriteAtlas?.identity.value,
+        'atlas-production:gpu-probe-edgeBleed-v1',
+      );
+      expect(cached, same(transitioned));
+      expect(runtime.consumeAtlasTransition(token), isNull);
+    },
+  );
+}
+
+List<int> _pixel({
+  required Uint8List bytes,
+  required int width,
+  required int x,
+  required int y,
+}) {
+  final offset = (y * width + x) * MapSpriteAtlas.bytesPerPixel;
+  return bytes.sublist(offset, offset + MapSpriteAtlas.bytesPerPixel);
+}
+
+EarthquakeMapOverlaySnapshot _overlayFixture() {
+  final atlas = createMapSpriteAtlas(
+    identity: createMapSourceIdentity(value: 'atlas-production'),
+    width: 2,
+    height: 2,
+    rgbaBytes: Uint8List.fromList(const [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+    ]),
+    regions: const [
+      MapSpriteRegion(
+        id: 'normal',
+        normalizedUv: Rect.fromLTRB(0.25, 0.25, 0.75, 0.75),
+        logicalSize: Size(2, 2),
+      ),
+    ],
+    limits: const MapSpriteAtlasLimits(
+      maxWidth: 2,
+      maxHeight: 2,
+      maxPixelBytes: 16,
+      maxRegions: 1,
+    ),
+  );
+  final sprite = createMapPointSpriteFeature(
+    id: 'hypocenter:event-a',
+    longitude: 139.7,
+    latitude: 35.7,
+    spriteRegionId: 'normal',
+    sizeScale: createMapZoomLinearRange(
+      startZoom: 3,
+      startValue: 0.15,
+      endZoom: 20,
+      endValue: 0.4,
+    ),
+    opacity: createMapZoomStep(
+      thresholdZoom: 8,
+      belowValue: 1,
+      atOrAboveValue: 0.6,
+    ),
+    priority: 10,
+  );
+  return createEarthquakeMapOverlaySnapshot(
+    versionStamp: createMapOverlayVersionStamp(
+      sourceIdentity: createMapSourceIdentity(value: 'event-a'),
+      sourceIncarnation: createMapSourceIncarnation(value: 'incarnation-a'),
+      dataSequence: 4,
+      dataDigest: 'data-a',
+      renderGeneration: 7,
+      renderDigest: 'render-a',
+    ),
+    regionToCityZoom: 6,
+    stationMinZoom: 6,
+    regionStyles: const [
+      EarthquakeAreaStyle(code: '100', color: Color(0xffff0000), opacity: 0.6),
+    ],
+    cityStyles: const [
+      EarthquakeAreaStyle(code: '101', color: Color(0xff00ff00), opacity: 0.7),
+    ],
+    stations: const [
+      EarthquakeObservationPoint(
+        id: 'station-a',
+        longitude: 139.8,
+        latitude: 35.8,
+        color: Color(0xff0000ff),
+        radiusLogicalPixels: 4,
+      ),
+    ],
+    spriteAtlas: atlas,
+    sprites: [sprite],
+    maxSpritePolicyBatches: 1,
+  );
+}

--- a/packages/eqmonitor_map/test/flutter_scene/map_gpu_probe_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/map_gpu_probe_test.dart
@@ -31,6 +31,78 @@ void main() {
     expect(runtime.atlasFixture, MapSpriteAtlasProbeFixture.alphaHalf);
   });
 
+  test(
+    'atlas-only update preserves fired fault state and yields one token',
+    () {
+      final runtime = MapGpuProbeRuntime(
+        configuration: const MapGpuProbeConfiguration(
+          faultPoint: MapGpuFaultPoint.atlasUpload,
+          atlasFixture: MapSpriteAtlasProbeFixture.production,
+        ),
+      );
+      expect(
+        () => runtime.throwIfRequested(MapGpuFaultPoint.atlasUpload),
+        throwsA(isA<MapGpuProbeFault>()),
+      );
+
+      final update = runtime.updateConfiguration(
+        const MapGpuProbeConfiguration(
+          faultPoint: MapGpuFaultPoint.atlasUpload,
+          atlasFixture: MapSpriteAtlasProbeFixture.alphaHalf,
+        ),
+      );
+
+      expect(update.faultPointChanged, isFalse);
+      expect(
+        update.atlasTransitionToken,
+        mapGpuProbeCompileTimeEnabled ? isNotNull : isNull,
+      );
+      expect(
+        () => runtime.throwIfRequested(MapGpuFaultPoint.atlasUpload),
+        returnsNormally,
+      );
+      final token = update.atlasTransitionToken;
+      if (token != null) {
+        final first = runtime.consumeAtlasTransition(token);
+        final second = runtime.consumeAtlasTransition(token);
+        expect(first?.previous, MapSpriteAtlasProbeFixture.production);
+        expect(first?.next, MapSpriteAtlasProbeFixture.alphaHalf);
+        expect(second, isNull);
+      }
+    },
+  );
+
+  test('fault change rearms one-shot without producing atlas token', () {
+    final runtime = MapGpuProbeRuntime(
+      configuration: const MapGpuProbeConfiguration(
+        faultPoint: MapGpuFaultPoint.atlasUpload,
+        atlasFixture: MapSpriteAtlasProbeFixture.production,
+      ),
+    );
+    expect(
+      () => runtime.throwIfRequested(MapGpuFaultPoint.atlasUpload),
+      throwsA(isA<MapGpuProbeFault>()),
+    );
+
+    final update = runtime.updateConfiguration(
+      const MapGpuProbeConfiguration(
+        faultPoint: MapGpuFaultPoint.shaderInterface,
+        atlasFixture: MapSpriteAtlasProbeFixture.production,
+      ),
+    );
+
+    expect(update.faultPointChanged, isTrue);
+    expect(update.atlasTransitionToken, isNull);
+    expect(
+      () => runtime.throwIfRequested(MapGpuFaultPoint.shaderInterface),
+      throwsA(isA<MapGpuProbeFault>()),
+    );
+    expect(
+      () => runtime.throwIfRequested(MapGpuFaultPoint.shaderInterface),
+      returnsNormally,
+    );
+  });
+
   test('controller invalidates only its currently attached renderer host', () {
     final controller = MapGpuProbeController();
     final first = _FakeProbeHost();

--- a/packages/eqmonitor_map/test/overlay/earthquake_overlay_controller_test.dart
+++ b/packages/eqmonitor_map/test/overlay/earthquake_overlay_controller_test.dart
@@ -181,6 +181,30 @@ void main() {
     );
   });
 
+  test('input gate rejects a distinct snapshot with the same stamp', () {
+    final stamp = versionStamp(
+      sourceIdentity: 'event-a',
+      dataSequence: 8,
+      renderGeneration: 8,
+    );
+    final current = snapshot(
+      versionStamp: stamp,
+      color: const Color(0xfff44336),
+    );
+    final conflictingInput = snapshot(
+      versionStamp: stamp,
+      color: const Color(0xff2196f3),
+    );
+
+    final result = commitEarthquakeOverlayInputSnapshot(
+      current: current,
+      next: conflictingInput,
+    );
+
+    expect(result, isA<EarthquakeOverlayCommitRejected>());
+    expect((result as EarthquakeOverlayCommitRejected).current, same(current));
+  });
+
   test('atomically replaces the current snapshot from another source', () {
     final current = snapshot(
       versionStamp: versionStamp(

--- a/packages/eqmonitor_map/test/renderer/map_sprite_batch_builder_test.dart
+++ b/packages/eqmonitor_map/test/renderer/map_sprite_batch_builder_test.dart
@@ -356,6 +356,35 @@ void main() {
     expect(second.frameUniform, isNot(same(first.frameUniform)));
   });
 
+  test('atlas texture replacement preserves instance geometry identity', () {
+    final first = buildMapPointSpriteBatches(
+      frame: frame(),
+      versionStamp: versionStamp(),
+      atlas: atlas,
+      features: [feature(id: 'a', priority: 0)],
+      maxPolicyBatches: 1,
+    ).single;
+    final replacementAtlas = replaceMapSpriteAtlasTexture(
+      atlas: atlas,
+      identity: createMapSourceIdentity(value: 'sha256:atlas-probe'),
+      rgbaBytes: Uint8List.fromList(List.filled(64, 255)),
+    );
+
+    final second = buildMapPointSpriteBatches(
+      frame: frame(frameNumber: 1),
+      versionStamp: versionStamp(),
+      atlas: replacementAtlas,
+      features: [feature(id: 'a', priority: 0)],
+      maxPolicyBatches: 1,
+      previous: [first],
+    ).single;
+
+    expect(second.atlas, same(replacementAtlas));
+    expect(second.batchKey, isNot(first.batchKey));
+    expect(second.instanceGeneration, same(first.instanceGeneration));
+    expect(second.instanceData, same(first.instanceData));
+  });
+
   test('different digest replaces instances', () {
     final first = buildMapPointSpriteBatches(
       frame: frame(),

--- a/packages/eqmonitor_map/test/widget/base_map_overlay_frame_builder_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_overlay_frame_builder_test.dart
@@ -4,6 +4,8 @@ import 'dart:ui';
 
 import 'package:eqmonitor_map/src/flutter_scene/earthquake_overlay_material_owner.dart';
 import 'package:eqmonitor_map/src/flutter_scene/flutter_scene_map_adapter.dart';
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe.dart';
+import 'package:eqmonitor_map/src/flutter_scene/map_gpu_probe_overlay.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_clock.dart';
 import 'package:eqmonitor_map/src/foundation/frame/map_frame_snapshot.dart';
 import 'package:eqmonitor_map/src/foundation/render/map_render_batch.dart';
@@ -454,6 +456,85 @@ void main() {
     );
 
     expect(frames.previousSpriteBatches, candidate.spriteBatchesForReuse);
+  });
+
+  test('atlas-only probe commit preserves complete coverage continuity', () {
+    if (!mapGpuProbeCompileTimeEnabled) {
+      return;
+    }
+    final coverages = <EarthquakeOverlayCoverageSnapshot>[];
+    final frames = BaseMapOverlayFrameOwner(
+      onCoverageChanged: coverages.add,
+    );
+    final runtime = MapGpuProbeRuntime(
+      configuration: const MapGpuProbeConfiguration(
+        faultPoint: null,
+        atlasFixture: MapSpriteAtlasProbeFixture.production,
+      ),
+    );
+    final resolver = MapGpuProbeOverlayFrameResolver();
+    final source = snapshot(atlas: spriteAtlas(), sprites: [sprite()]);
+    final initial = resolver.resolve(
+      sourceOverlay: source,
+      currentOverlay: null,
+      probeRuntime: runtime,
+    );
+    final first = build(frame: frameAt(6), requested: initial);
+    final fallback = build(
+      frame: frameAt(6),
+      current: initial,
+      requested: null,
+    );
+    frames.commit(
+      candidate: first,
+      baseOnlySubmission: fallback.submission!,
+      resources: null,
+      submitFrame: (_) {},
+      retireAllGpuResources: () {},
+      failClosedResources: () {},
+    );
+    expect(frames.coverage, isA<EarthquakeOverlayComplete>());
+    coverages.clear();
+
+    final update = runtime.updateConfiguration(
+      const MapGpuProbeConfiguration(
+        faultPoint: null,
+        atlasFixture: MapSpriteAtlasProbeFixture.orientation2x2,
+      ),
+    );
+    final token = update.atlasTransitionToken;
+    if (token == null) {
+      fail('probe-enabled update must issue an atlas transition token');
+    }
+    resolver.enqueue(token);
+    final transitioned = resolver.resolve(
+      sourceOverlay: source,
+      currentOverlay: frames.overlay,
+      probeRuntime: runtime,
+    );
+    final candidate = build(
+      frame: frameAt(6, frameNumber: 1),
+      current: frames.overlay,
+      requested: transitioned,
+      previousObservation: frames.previousObservationBatch,
+      previousSprites: frames.previousSpriteBatches,
+    );
+    frames.commit(
+      candidate: candidate,
+      baseOnlySubmission: fallback.submission!,
+      resources: null,
+      submitFrame: (_) {},
+      retireAllGpuResources: () {},
+      failClosedResources: () {},
+    );
+
+    expect(frames.overlay, same(transitioned));
+    expect(frames.coverage, isA<EarthquakeOverlayComplete>());
+    expect(
+      coverages,
+      isEmpty,
+      reason: 'same coverage must not publish loading or hidden transitions',
+    );
   });
 
   test('null snapshot atomically hides the previous overlay', () {

--- a/packages/eqmonitor_map/test/widget/base_map_view_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_view_test.dart
@@ -24,6 +24,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pmtiles_v3/pmtiles_v3.dart';
 
 void main() {
+  testWidgets('initialization error view never renders raw error details', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: BaseMapViewInitializationError(),
+      ),
+    );
+
+    expect(find.text('ベースレイヤーの初期化に失敗しました。'), findsOneWidget);
+    expect(find.textContaining('/private/secret.pmtiles'), findsNothing);
+    expect(find.textContaining('https://tiles.example.invalid'), findsNothing);
+    expect(find.textContaining('sha256:'), findsNothing);
+    expect(find.textContaining('Exception'), findsNothing);
+  });
+
   test(
     'typed sprite initialization failure disables only sprite resources',
     () async {
@@ -145,6 +162,28 @@ void main() {
     expect(view.gpuProbeConfiguration, same(gpuProbeConfiguration));
     expect(view.onGpuResourceCounterChanged, same(gpuCounterCallback));
     expect(view.gpuProbeController, same(gpuProbeController));
+
+    final changedProbe = BaseMapView(
+      source: view.source,
+      initialCamera: view.initialCamera,
+      limits: view.limits,
+      clock: view.clock,
+      cameraController: view.cameraController,
+      earthquakeOverlay: view.earthquakeOverlay,
+      onEarthquakeOverlayCoverageChanged:
+          view.onEarthquakeOverlayCoverageChanged,
+      gpuProbeConfiguration: const MapGpuProbeConfiguration(
+        faultPoint: MapGpuFaultPoint.frameSubmit,
+        atlasFixture: MapSpriteAtlasProbeFixture.edgeBleed,
+      ),
+      onGpuResourceCounterChanged: view.onGpuResourceCounterChanged,
+      gpuProbeController: view.gpuProbeController,
+    );
+    expect(
+      baseMapViewControllerLifecycleIdentity(view),
+      baseMapViewControllerLifecycleIdentity(changedProbe),
+      reason: 'probe configuration is an in-place runtime update',
+    );
   });
 
   group('cameraAfterGestureUpdate', () {


### PR DESCRIPTION
## 概要
- GPUデバッグ地図へversion・入力数・coverage診断・現在zoomを表示
- 震源へ移動するtyped Actionとexactly-once操作を接続
- GPU probe設定をcontroller再生成なしで更新し、atlas差替えではtextureのみ再upload
- 初期化エラーを固定文言へredact
- 短高viewport・large text・GPU panel同時表示でも操作可能なbounded layoutへ変更

## 検証
- eqmonitor_map focused: probe無効 65 passed / probe有効 65 passed
- coverage continuity: probe無効 24 passed / probe有効 24 passed
- app focused: 27 passed
- package/app scoped analyze: 0 issues
- dart format: 28 files, 0 changed
- build_runner target生成一致
- git diff --check
- 独立レビュー: Critical/Important 0

既知のAsset Pack未staging warningは出ますが、focused testsは成功しています。