### PR TITLE
docs: 推計震度GPU地図の実装仕様を定義

### DIFF
--- a/docs/knowledge/20260825_estimated_intensity_archive_identity.md
+++ b/docs/knowledge/20260825_estimated_intensity_archive_identity.md
@@ -1,0 +1,46 @@
+# 推計震度PMTilesのarchive identity確認
+
+## 前提
+
+推計震度PMTilesは、イベントIDだけのlegacy URLとcontent-addressed URLで同じbytesを返すとは
+限らない。Flutter GPU mapはlegacy URLからSHA-256、size、header zoomを推測せず、APIが返す
+immutable descriptorと取得後の実bytesを照合する。
+
+2026-08-25にevent `20260823020050`を確認した時点では、REST APIの
+`estimated_intensity_tile`はSHA-256をpathに含むURLを返した。一方、イベントIDだけの旧URLも
+HTTP 200だったが、両者はsize、SHA-256、PMTiles headerのmin zoomが異なる別archiveだった。
+
+- content-addressed URL: 1,013,133 bytes、path digestと実SHA-256が一致、PMTiles v3、MVT、
+  gzip、min zoom 0、max zoom 14
+- event-ID-only URL: 998,436 bytes、別SHA-256、PMTiles v3、MVT、gzip、min zoom 5、
+  max zoom 14
+
+このためevent-ID-only URLをfallbackやdescriptor validationへ使わない。実装とruntime gateは
+REST descriptorが指すcontent-addressed URLだけを、exact sizeとSHA-256の全件stream検証後に開く。
+
+## 再確認コマンド
+
+redirectを追わず、最初にheaderとsizeを確認する。
+
+```bash
+curl --fail --silent --show-error --max-redirs 0 --head \
+  "${ARCHIVE_URL}"
+```
+
+一時領域へ取得し、sizeとSHA-256を確認する。`ARCHIVE_URL`は実行時のAPI responseから取り、
+ソースコードへ固定しない。
+
+```bash
+ARCHIVE_FILE="$(mktemp /tmp/eqmonitor-estimated-intensity.XXXXXX)"
+curl --fail --silent --show-error --max-redirs 0 \
+  --output "${ARCHIVE_FILE}" "${ARCHIVE_URL}"
+stat -f '%z bytes' "${ARCHIVE_FILE}"
+shasum -a 256 "${ARCHIVE_FILE}"
+xxd -s 96 -l 32 "${ARCHIVE_FILE}"
+```
+
+PMTiles v3 headerのoffset 96以降はclustered、internal compression、tile compression、tile type、
+min zoom、max zoomの順である。raw byteの目視だけをproduction parserにせず、appでは
+`PmTilesV3Archive.open`のtyped header validationを使う。
+
+確認後はagentが作った一時fileだけを削除する。

--- a/docs/superpowers/plans/2026-08-25-estimated-intensity-flutter-gpu-map.md
+++ b/docs/superpowers/plans/2026-08-25-estimated-intensity-flutter-gpu-map.md
@@ -1,0 +1,800 @@
+# Estimated Intensity Flutter GPU Map Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** event `20260823020050` を最初の production data gate として、API が返す
+immutable descriptor から検証済み PMTiles を取得し、Flutter Scene / Flutter GPU の
+デバッグ地図へ推計震度 Fill / Line と同一 event の震源を原子的に表示する。
+
+**Architecture:** backend は URL・exact size・SHA-256 を一体化した immutable descriptor
+を公開する。app は URL と response を fail closed で検証し、archive 全体の size / hash /
+PMTiles header を確認した local lease だけを package へ渡す。package は base map と独立した
+exact-cover pipeline で strict MVT decode を行い、visible cover が完全な場合だけ Fill / Line
+pair を Scene frame へ publish する。observed と estimated は full display candidate 単位で排他し、
+estimated candidate は同一 event の震源 sprite を含む。
+
+**Tech Stack:** TypeScript backend/OpenAPI（P0、current source audit 後）、Dart/Flutter、
+Riverpod、Freezed、`eqmonitor_api` generator、PMTiles v3、MVT、Flutter Scene、Flutter GPU、
+`package:test` / `flutter_test`。
+
+**Design reference:**
+`docs/superpowers/specs/2026-08-25-estimated-intensity-flutter-gpu-map-design.md`
+
+## Execution Rules
+
+- Flutter / Dart command は必ず `mise exec --` 経由で実行する。
+- production code に event `20260823020050` の URL、size、SHA-256 を埋め込まない。event ID は
+  fixture、debug input、runtime verification input に限る。
+- legacy `estimated_intensity_tile` から descriptor を合成せず、新 field 欠落時は fail closed にする。
+- Task 7 / 8 の既存 worktree を再利用・変更しない。各 PR は直前 branch から新しい worktree を作る。
+- 1 commit はおおむね30〜100行に保つ。生成物や機械的 fixture 更新は、対応する contract commit
+  へまとめてもよい。
+- commit message は英語1単語 prefix + 簡潔な日本語説明にする。
+- PR / Issue は YumNumm org にだけ作成する。`gh pr create` / `gh issue create` では必ず
+  `--repo YumNumm/EQMonitor` または `--repo YumNumm/eqmonitor-backend` を明示する。
+- EQMonitor のstack rootだけを`develop`に置く。この推計震度stackは既存GPU map stack上へ続けるため、
+  P1以降のPR baseは必ず直前branchにする。
+- 各 PR は RED の失敗理由、GREEN の成功出力、focused analyze、diff review を PR 本文へ記録する。
+- MapLibre layer はこの stack で削除しない。
+
+## Stack and Dependency Order
+
+P0 は別 repository の backend prerequisite で、EQMonitor の gh-stack には含めない。backend の
+default branch、ownership、test script は source audit 前に決め打ちしない。P0 が merge され、
+EQMonitor の `backend` submodule がその contract commit を参照できる状態になり、既存GPU map stackの
+`codex/gpu-map-13-estimated-intensity-spec`がreadyになってから P1 を開始する。
+
+| PR | Repository / branch | Base | Public outcome |
+| --- | --- | --- | --- |
+| S0 | `YumNumm/EQMonitor` / `codex/gpu-map-13-estimated-intensity-spec` | `codex/gpu-map-12-debug-ui` | approved design and implementation plan |
+| P0 | `YumNumm/eqmonitor-backend` / audit 後に命名 | backend の live default branch | immutable descriptor と event fixture |
+| P1 | `YumNumm/EQMonitor` / `codex/gpu-map-14-estimated-api-client` | `codex/gpu-map-13-estimated-intensity-spec` | generated Dart contract |
+| P2 | `codex/gpu-map-15-estimated-source-contract` | P1 branch | app validator と純粋 model |
+| P3 | `codex/gpu-map-16-estimated-download` | P2 branch | verified download / lease repository |
+| P4 | `codex/gpu-map-17-estimated-pmtiles` | P3 branch | independent exact PMTiles source |
+| P5 | `codex/gpu-map-18-estimated-mvt` | P4 branch | strict estimated MVT decoder |
+| P6 | `codex/gpu-map-19-estimated-renderer` | P5 branch | typed Fill / Line renderer |
+| P7 | `codex/gpu-map-20-estimated-pipeline` | P6 branch | coverage / generation / publication barrier |
+| P8 | `codex/gpu-map-21-estimated-app` | P7 branch | atomic app/debug-map integration |
+| P9 | `codex/gpu-map-22-estimated-runtime` | P8 branch | event fixture、lifecycle、iOS / Android gate |
+
+S0はdocsだけを持ち、branch 12へのrebaseとreview完了後に既存Stack #1756へlinkする。P1〜P9は
+その上へ順にreview / mergeする。上位branchのsyncは直前baseのmerge後に行い、
+unrelated `develop` の取り込みと feature commit を同じ commit に混ぜない。
+
+## P0: Publish the Backend Immutable Archive Descriptor
+
+P0 は backend repository の現在 source を未監査である。この task の最初の成果物は file ownership と
+実行コマンドの確認であり、次の Files 欄にない backend 実装 path や job 名を推測して変更しない。
+
+**Files:**
+
+- Inspect: backend repository の `AGENTS.md`、package manager manifest、default branch
+- Inspect: `estimated_intensity_tile` / `estimated_intensity_key` / `ixac41` / `pmtiles` の owner
+- Modify: audit で特定した OpenAPI schema source、REST serializer、realtime serializer、archive publisher
+- Modify: audit で特定した contract fixture generator と tests
+- Generated consumer outputs: `api/api/openapi.json`
+- Generated consumer outputs: `api/api-stub/generated/contract-fixtures/**`
+
+### P0.1 Audit before edit
+
+- [ ] backend repository の clean worktree を作り、default branch と project instructions を確認する。
+
+```bash
+git remote -v
+git status --short
+gh repo view YumNumm/eqmonitor-backend --json defaultBranchRef
+rg -n "estimated_intensity_tile|estimated_intensity_key|ixac41|pmtiles" api service packages
+rg -n "openapi|contract-fixture|realtime" api service packages
+rg -n '"scripts"|packageManager|pnpm|bun|npm' package.json pnpm-workspace.yaml bun.lock package-lock.json
+```
+
+- [ ] schema owner、archive writer、object-key builder、response handler、realtime producer、fixture generator、
+  test runner を監査メモへ列挙する。
+- [ ] package script に存在しない command を実行計画へ追加しない。
+
+**Verification:** immutable object key が現在どう作られ、REST と realtime がどの record を読むかを
+同じ event まで追跡できること。追跡できない場合は P0 を止め、backend-local design review を行う。
+
+### P0.2 RED: lock the public contract
+
+- [ ] audit で特定した schema/serializer test に、descriptor がない現実装では失敗する assertion を追加する。
+- [ ] event `20260823020050` の fixture に、legacy URL と並べて次の shape を要求する。
+
+```json
+{
+  "estimated_intensity_tile_archive": {
+    "url": "https://<allowed-host>/ixac41/20260823020050/<sha256>.pmtiles",
+    "size_bytes": "<exact-positive-byte-count>",
+    "sha256": "<sha256>"
+  }
+}
+```
+
+上は field 関係を示す schema notation で、copyable fixture JSON ではない。実 fixture では publisher が
+出した数値型の exact size と、archive bytes から得た有効な64文字 lowercase hex SHA-256を使う。URL末尾の
+digestと`sha256` fieldを完全一致させる。
+
+- [ ] P0.1 で確認した最小 test script を実行する。
+
+```bash
+# P0.1 で確認した package manager の test scriptを、引数を変えずに実行する。
+# 期待結果: descriptor field または fixture assertion が未実装のため FAIL。
+```
+
+**RED verification:** failure が新しい descriptor assertion に限定され、既存 unrelated test failure では
+ないこと。
+
+### P0.3 GREEN: publish one immutable identity
+
+- [ ] reusable descriptor schema を追加し、`Earthquake` と `EarthquakePartial` が同じ型を参照する。
+- [ ] publisher が archive bytes の exact size と lowercase SHA-256 を確定してから immutable object key
+  `/ixac41/{eventId}/{sha256}.pmtiles` を publish する。
+- [ ] URL は redirect endpoint ではなく bytes を直接返し、content change 時は URL も変える。
+- [ ] REST detail/list が URL、size、SHA-256 を同一 database/storage record から組み立てる。
+- [ ] legacy `estimated_intensity_tile` は MapLibre migration のため残す。
+- [ ] realtime key は immutable path identity を含め、client が REST descriptor と照合できるようにする。
+- [ ] size が0、digest不正、object未確定、または descriptor record と object metadata が不一致なら
+  descriptor を出さない。非content-addressedなlegacy URLとの差はdescriptor trust判定に使わない。
+- [ ] event fixture と OpenAPI artifact を regeneration する。
+- [ ] P0.1 で確認した focused test、typecheck、OpenAPI drift check を実行する。
+
+**GREEN verification:** event fixture の URL path digest、`sha256`、実 archive digest が一致し、実 byte size が
+`size_bytes` と一致すること。descriptor URL に対する HEAD/GET semantics と redirect 無しを integration test
+で確認する。
+
+**Commit sequence:**
+
+1. `test: 推計震度archive descriptor契約を固定`
+2. `feat: 推計震度archive descriptorを公開`
+3. `test: 推計震度event fixtureを追加`
+
+**PR verification:** GitHub 操作前に backend の live default branch を再確認し、PR は
+`gh pr create --repo YumNumm/eqmonitor-backend` を明示する。P0 が merge されるまで P1 の generated
+artifact を手編集しない。
+
+## P1: Synchronize the Generated API Client
+
+**Files:**
+
+- Modify: `backend` gitlink
+- Regenerate ignored transient input: `packages/eqmonitor_api/openapi/openapi.json`
+- Modify: generator が列挙した `packages/eqmonitor_api/lib/src/models/**`
+- Modify: generator が同期する `packages/eqmonitor_api/test/fixtures/contract/**`
+- Verify: `packages/eqmonitor_api/test/contract_drift_test.dart`
+- Create: `packages/eqmonitor_api/test/generated_contract_fixture_test.dart`
+
+### P1.1 RED
+
+- [ ] P0 merge commit を `backend` submodule へ checkoutする。既存`contract_drift_test.dart`はbackend sourceを
+  直接比較しないため、このgitlink更新だけでREDになるとはみなさない。
+- [ ] `generated_contract_fixture_test.dart`へdescriptor JSONのdecodeと生成modelの
+  `estimatedIntensityTileArchive` property accessを追加し、generator実行前のmodelでcompile failureになることを
+  確認する。descriptor値はtest内の有効なschema fixtureで、production treeへ置かない。
+
+```bash
+cd packages/eqmonitor_api
+mise exec -- dart test test/generated_contract_fixture_test.dart
+```
+
+**Expected:** generated Dart modelに新field/typeがなく、新property accessでcompile failure。
+
+### P1.2 GREEN
+
+- [ ] repository の generator だけを使い、OpenAPI、Dart model、Freezed/JSON、contract fixture を同期する。
+
+```bash
+cd packages/eqmonitor_api
+mise exec -- dart run bin/generate.dart
+mise exec -- dart format lib test
+mise exec -- dart test test/contract_drift_test.dart
+mise exec -- dart test test/generated_contract_fixture_test.dart
+mise exec -- dart analyze
+```
+
+- [ ] `Earthquake` と `EarthquakePartial` が同じ generated descriptor model を nullable field として持つことを
+  diff で確認する。
+- [ ] generatorが同期したevent `20260823020050` fixtureを同testでdecodeし、URL path digest、positive size、
+  lowercase SHA-256の関係を確認する。
+- [ ] legacy field が消えていないことを fixture decode test で固定する。
+
+**Commit sequence:**
+
+1. `test: 推計震度descriptor contract fixtureを固定`
+2. `gen: 推計震度descriptor API clientを同期`
+
+**Verification:**
+
+```bash
+git --no-pager diff --check
+git status --short
+```
+
+P1 の PR は
+`gh pr create --repo YumNumm/EQMonitor --base codex/gpu-map-13-estimated-intensity-spec`
+を使う。
+
+## P2: Validate the Descriptor at the App Boundary
+
+**Files:**
+
+- Create: `app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart`
+- Create: `app/lib/feature/earthquake_history/data/logic/estimated_intensity_archive_descriptor_validator.dart`
+- Create: `app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_failure.dart`
+- Modify: `app/lib/feature/earthquake_history/data/model/earthquake.dart`
+- Modify: `app/lib/feature/earthquake_history/data/model/earthquake_partial.dart`
+- Modify: auditで特定した realtime earthquake mapper / notifier / detail refetch owner
+- Create: `app/test/feature/earthquake_history/data/estimated_intensity_archive_descriptor_validator_test.dart`
+- Modify: `app/test/feature/earthquake_history/earthquake_model_test.dart`
+- Modify: `app/test/feature/earthquake_history/data/earthquake_partial_converter_test.dart`
+- Create: auditで特定した realtime key / detail refetch generation test
+
+### P2.1 RED
+
+- [ ] table-driven validator test を追加し、valid descriptor と全拒否条件を固定する。
+
+Cases: non-HTTPS、userinfo、query、fragment、non-default port、allowlist外host、suffix spoof、二重slash、
+trailing slash、dot segment、encoded slash、wrong event、invalid event ID、uppercase/short hash、URL/field
+hash mismatch、size 0、negative、caller cap超過。
+
+```bash
+cd app
+mise exec -- flutter test test/feature/earthquake_history/data/estimated_intensity_archive_descriptor_validator_test.dart
+```
+
+**Expected:** validator/model 未実装で compile FAIL。
+
+- [ ] converter test で new descriptor の正常変換、null、legacy-onlyを固定する。legacy URLが異なる
+  pathでもdescriptor自身がvalidなら結果が変わらないことを固定する。
+- [ ] realtime key受信後、detail refetchが同じevent/generation/immutable pathを返すまでsource candidateを
+  作らず、stale responseとkey mismatchを拒否するtestを追加する。
+
+### P2.2 GREEN
+
+- [ ] `EstimatedIntensityArchiveDescriptor` は `eventId`、canonical `Uri`、`sizeBytes`、`sha256` を持つ
+  package-neutral immutable value にする。
+- [ ] `EstimatedIntensityArchiveUrlPolicy` は exact `allowedHosts` と `maxArchiveBytes` を caller 必須にする。
+- [ ] validator は raw URL semantics を canonicalization 前後で照合し、decoded path 3 segments と event/hash
+  equality を検証する。
+- [ ] converter は generated API descriptor を pure validator input へ写し、failure を typed value で返す。
+- [ ] legacy-only では descriptor を作らず、legacy URL から size/hash を推測しない。
+- [ ] realtime mapper/notifierはkeyをtrust inputへ直接変換せず、request generation付きdetail refetchを行う。
+  同じevent/generation/pathを確認したREST descriptorだけをdownload requestへ進める。
+- [ ] app model の full URL/hash を `toString` や user-facing error に含めない。
+
+```bash
+cd app
+mise exec -- dart format lib/feature/earthquake_history test/feature/earthquake_history
+mise exec -- flutter test test/feature/earthquake_history/data/estimated_intensity_archive_descriptor_validator_test.dart
+mise exec -- flutter test test/feature/earthquake_history/earthquake_model_test.dart
+mise exec -- flutter test test/feature/earthquake_history/data/earthquake_partial_converter_test.dart
+mise exec -- flutter analyze lib/feature/earthquake_history test/feature/earthquake_history
+```
+
+**Commit sequence:**
+
+1. `test: 推計震度descriptor検証境界を固定`
+2. `feat: 推計震度descriptor validatorを追加`
+3. `feat: 地震modelへ検証済みdescriptorを接続`
+
+**Verification:** malformed descriptor はすべて fail closed、valid descriptor だけが download request へ進める。
+
+## P3: Download, Verify, and Lease the Archive
+
+**Files:**
+
+- Create: `app/lib/feature/earthquake_history/data/repository/estimated_intensity_archive_repository.dart`
+- Create: `app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart`
+- Create: `app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_lease.dart`
+- Create: `app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_limits.dart`
+- Create: `app/lib/feature/earthquake_history/data/provider/estimated_intensity_archive_repository_provider.dart`
+- Create: `app/lib/feature/earthquake_history/data/provider/estimated_intensity_archive_repository_provider.g.dart`
+- Create: `app/test/feature/earthquake_history/data/estimated_intensity_archive_repository_test.dart`
+- Create: `app/test/feature/earthquake_history/data/estimated_intensity_archive_http_data_source_test.dart`
+
+### P3.1 RED
+
+- [ ] injected transport と temporary directory を使う test を追加する。
+- [ ] 200/identity/exact length/exact SHA の success と、3xx、non-200、content-encoding、declared length mismatch、
+  short/long/no-length body、stream cap、SHA mismatch、cancel、timeout、late completion を固定する。
+- [ ] real `HttpClient` transport testで`autoUncompress=false`を固定し、gzip等のbodyが自動展開されて
+  header/size/hash検査を通過しないことを確認する。
+- [ ] coalescing、active lease pin、LRU、count/byte cap、all-leased failure、`.part` cleanup を固定する。
+
+```bash
+cd app
+mise exec -- flutter test test/feature/earthquake_history/data/estimated_intensity_archive_http_data_source_test.dart
+mise exec -- flutter test test/feature/earthquake_history/data/estimated_intensity_archive_repository_test.dart
+```
+
+**Expected:** repository/data source 未実装で compile FAIL。
+
+### P3.2 GREEN
+
+- [ ] `HttpClient.autoUncompress=false`、redirects disabled、status 200 only、
+  `Accept-Encoding: identity` の transport を実装し、bodyを読む前にstatus/headerを検査する。
+- [ ] response body を unique `.part` へ streaming write し、descriptor size と caller cap の小さい方を超えた
+  時点で cancel する。
+- [ ] EOF 後に exact byte count と SHA-256 を検証し、成功前に verified file を publish しない。
+- [ ] destination は `estimated-intensity/{eventId}/{sha256}.pmtiles` とし、同一 filesystem 上で atomic rename する。
+- [ ] 同一 content identity の concurrent request を coalesce し、open consumer ごとに lease を返す。
+- [ ] source switch/dispose 後に close を await して lease を release し、unleased file だけを LRU eviction する。
+- [ ] temp path、URL、hash、response body、raw exception を利用者向け error/logへ出さない。
+
+```bash
+cd app
+mise exec -- dart run build_runner build --delete-conflicting-outputs
+mise exec -- dart format lib/feature/earthquake_history test/feature/earthquake_history
+mise exec -- flutter test test/feature/earthquake_history/data/estimated_intensity_archive_http_data_source_test.dart
+mise exec -- flutter test test/feature/earthquake_history/data/estimated_intensity_archive_repository_test.dart
+mise exec -- flutter analyze lib/feature/earthquake_history test/feature/earthquake_history
+```
+
+**Commit sequence:**
+
+1. `test: 推計震度archive transport制約を固定`
+2. `feat: 推計震度archiveをstream検証`
+3. `test: 推計震度archive lease制約を固定`
+4. `feat: 検証済みarchive leaseを管理`
+
+**Verification:** failure/cancel/supersede 後に verified source が発行されず、`.part` と lease count が残らない。
+
+## P4: Build an Independent Exact PMTiles Source
+
+**Files:**
+
+- Create: `packages/eqmonitor_map/lib/src/tile/estimated_intensity_pmtiles_source.dart`
+- Create: `packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_repository.dart`
+- Create: `packages/eqmonitor_map/lib/src/tile/estimated_intensity_exact_tile_cache.dart`
+- Create: `packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_cover_planner.dart`
+- Modify: `packages/eqmonitor_map/lib/eqmonitor_map.dart`
+- Modify: `packages/eqmonitor_map/test/support/minimal_pmtiles_archive_builder.dart`
+- Create: `packages/eqmonitor_map/test/source/estimated_intensity_pmtiles_source_test.dart`
+- Create: `packages/eqmonitor_map/test/tile/estimated_intensity_tile_cover_planner_test.dart`
+- Create: `packages/eqmonitor_map/test/tile/estimated_intensity_exact_tile_cache_test.dart`
+
+### P4.1 RED
+
+- [ ] minimal PMTiles fixtures で v3/MVT/gzip/min0/max14 と synthetic min5/max14/bounds を受理し、wrong
+  version/type/compression/zoom/bounds を拒否する test を追加する。
+- [ ] event-shape min0 fixtureはz0/z14をexact、z15をcanonical z14 + overscaledZ15とする。synthetic
+  min5 fixtureはz0でtile request 0 + `belowSourceMinZoom`、z5 exactとし、bounds外/absent entryは
+  authoritative emptyへ固定する。
+- [ ] visible canonical count cap 超過は partial cover ではなく full failure になることを固定する。
+
+```bash
+cd packages/eqmonitor_map
+mise exec -- flutter test test/source/estimated_intensity_pmtiles_source_test.dart
+mise exec -- flutter test test/tile/estimated_intensity_tile_cover_planner_test.dart
+mise exec -- flutter test test/tile/estimated_intensity_exact_tile_cache_test.dart
+```
+
+**Expected:** source/planner/cache 未実装で compile FAIL。
+
+### P4.2 GREEN
+
+- [ ] app が検証した `VerifiedPmTilesSource` だけを受け取り、file random-access reader と header snapshot を開く。
+- [ ] base source と repository/cache/scheduler/coverage/generation を共有しない event source を作る。
+- [ ] `camera.floorZoom < minZoom` を cover calculator 呼び出し前に判定し、min zoom tileへ clampしない。
+- [ ] max zoom 超過だけ visual transform の overscale を許し、canonical lookup は max zoom に固定する。
+- [ ] exact cache は parent/child fallback を持たず、ready/authoritative empty/failure を区別する。
+- [ ] boundsとworld wrapを考慮して canonical lookupをdeduplicateし、render transformはunwrapped tileを保持する。
+
+```bash
+cd packages/eqmonitor_map
+mise exec -- dart format lib test
+mise exec -- flutter test test/source/estimated_intensity_pmtiles_source_test.dart
+mise exec -- flutter test test/tile/estimated_intensity_tile_cover_planner_test.dart
+mise exec -- flutter test test/tile/estimated_intensity_exact_tile_cache_test.dart
+mise exec -- flutter analyze
+```
+
+**Commit sequence:**
+
+1. `test: 推計震度PMTiles header制約を固定`
+2. `feat: 推計震度PMTiles event sourceを追加`
+3. `test: 推計震度exact cover制約を固定`
+4. `feat: 推計震度exact tile pipelineを追加`
+
+**Verification:** min0 fixtureはz0を読み、synthetic min5 fixtureはz0 request 0、どちらもz14超で異なる
+canonical sourceを読まない。
+
+## P5: Decode Only the Estimated-intensity MVT Schema
+
+**Files:**
+
+- Create: `packages/eqmonitor_map/lib/src/tile/estimated_intensity_class.dart`
+- Create: `packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_geometry.dart`
+- Create: `packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_decoder.dart`
+- Create: `packages/eqmonitor_map/lib/src/tile/mvt/polygon_boundary_builder.dart`
+- Modify: `packages/eqmonitor_map/lib/src/tile/base_map_tile_decoder.dart`
+- Modify: `packages/eqmonitor_map/lib/eqmonitor_map.dart`
+- Modify: `packages/eqmonitor_map/test/tile/mvt/support/mvt_fixture_builder.dart`
+- Create: `packages/eqmonitor_map/test/tile/estimated_intensity_tile_decoder_test.dart`
+- Create: `packages/eqmonitor_map/test/tile/mvt/polygon_boundary_builder_test.dart`
+
+### P5.1 RED
+
+- [ ] `seismic_intensity` Polygon + `name` の6 classを accepted tableで固定する。
+- [ ] source layer missing、wrong case、Point/LineString、missing/non-string name、unknown class、duplicate conflicting
+  property、invalid ring、MVT limit超過は tile全体 invalid になる test を追加する。
+- [ ] required layer present + feature zero は authoritative empty、directory absent は repository authoritative empty と
+  別 result になることを固定する。
+- [ ] Polygon ringからclosed LineMeshを作る共有 helperの winding/closure testを追加する。
+
+```bash
+cd packages/eqmonitor_map
+mise exec -- flutter test test/tile/estimated_intensity_tile_decoder_test.dart
+mise exec -- flutter test test/tile/mvt/polygon_boundary_builder_test.dart
+```
+
+**Expected:** decoder/helper 未実装で compile FAIL。
+
+### P5.2 GREEN
+
+- [ ] enum/parser は exact class string だけを受理し、近似、default、tile `fill` property fallback を持たない。
+- [ ] layer内に1 featureでもinvalidがあれば既知featureもpublishせずtyped schema failureを返す。
+- [ ] Fill geometryとboundary Line geometryをclassごとに返し、theme/colorをdecoderへ渡さない。
+- [ ] base decoderのprivate polygon boundary logicをpackage-neutral helperへ移し、両decoderで同じ閉路規則を使う。
+- [ ] existing `MvtDecodeLimits` と caller mesh limitsを全pathで適用する。
+
+```bash
+cd packages/eqmonitor_map
+mise exec -- dart format lib test
+mise exec -- flutter test test/tile/estimated_intensity_tile_decoder_test.dart
+mise exec -- flutter test test/tile/mvt/polygon_boundary_builder_test.dart
+mise exec -- flutter test test/tile/base_map_tile_decoder_test.dart
+mise exec -- flutter analyze
+```
+
+**Commit sequence:**
+
+1. `test: 推計震度MVT schemaを固定`
+2. `refactor: polygon境界mesh生成を共通化`
+3. `feat: 推計震度MVT decoderを追加`
+
+**Verification:** unknown classを含むtileでFill/Lineが1件も生成されず、既知6 classはgeometryのみを返す。
+
+## P6: Add Typed Fill and Line Rendering
+
+**Files:**
+
+- Create: `packages/eqmonitor_map/lib/src/renderer/estimated_intensity_render_resources.dart`
+- Create: `packages/eqmonitor_map/lib/src/renderer/estimated_intensity_render_submission_builder.dart`
+- Create: `packages/eqmonitor_map/lib/src/renderer/estimated_intensity_packed_mesh_cache.dart`
+- Modify: `packages/eqmonitor_map/lib/src/renderer/map_scene_frame_submission.dart`
+- Modify: `packages/eqmonitor_map/lib/src/renderer/map_scene_render_phase_policy.dart`
+- Modify: `packages/eqmonitor_map/lib/src/foundation/map_scene.dart`
+- Create: `packages/eqmonitor_map/lib/src/flutter_scene/estimated_intensity_material_owner.dart`
+- Modify: `packages/eqmonitor_map/lib/src/flutter_scene/flutter_scene_base_map_adapter.dart`
+- Modify: `packages/eqmonitor_map/lib/eqmonitor_map.dart`
+- Create: `packages/eqmonitor_map/test/renderer/estimated_intensity_render_submission_builder_test.dart`
+- Create: `packages/eqmonitor_map/test/renderer/estimated_intensity_packed_mesh_cache_test.dart`
+- Create: `packages/eqmonitor_map/test/renderer/map_scene_frame_submission_test.dart`
+- Modify: `packages/eqmonitor_map/test/flutter_scene/flutter_scene_base_map_adapter_test.dart`
+
+### P6.1 RED
+
+- [ ] `estimatedIntensityFill` / `estimatedIntensityLine` kindとcomponent key、hazard underlay phaseを固定する。
+- [ ] Fill/Line pair、同一 version stamp、同一 event/source identity、行政境界線より下をvalidator testへ追加する。
+- [ ] observed region/city、station、estimated pairの違法共存をScene mutation前に拒否するtestを追加する。
+- [ ] class色、opacity 1、Line width 0.5 logical pixel、既存fmat ABIをparameter testで固定する。
+
+```bash
+cd packages/eqmonitor_map
+mise exec -- flutter test test/renderer/estimated_intensity_render_submission_builder_test.dart
+mise exec -- flutter test test/flutter_scene/flutter_scene_base_map_adapter_test.dart
+```
+
+**Expected:** typed kind/component/material 未実装で compile または validation FAIL。
+
+### P6.2 GREEN
+
+- [ ] Fill / Line packed mesh layoutとfmat ABIは既存実装を再利用し、semantic key/material ownerはestimated専用にする。
+- [ ] classごとのimmutable render styleをsubmission builderへ渡し、全class色が揃わない場合はcandidateを拒否する。
+- [ ] Fill/Lineは `mapSceneEarthquakeHistorySourceKey` を使い、hypocenterとのversion混在を検知可能にする。
+- [ ] preflight後にだけScene node/materialをcommitし、partial pairを一度もvisibleにしない。
+- [ ] failure/retirementがbase map、observed overlay、hypocenter atlasのresourceを解放しないようownerを分離する。
+
+```bash
+cd packages/eqmonitor_map
+mise exec -- dart format lib test
+mise exec -- flutter test test/renderer/estimated_intensity_render_submission_builder_test.dart
+mise exec -- flutter test test/renderer/estimated_intensity_packed_mesh_cache_test.dart
+mise exec -- flutter test test/flutter_scene/flutter_scene_base_map_adapter_test.dart
+mise exec -- flutter test test/renderer/map_scene_frame_submission_test.dart
+mise exec -- flutter analyze
+```
+
+**Commit sequence:**
+
+1. `test: 推計震度Scene taxonomyを固定`
+2. `feat: 推計震度Fill Line submissionを追加`
+3. `feat: 推計震度material lifecycleを追加`
+
+**Verification:** valid pairのphase順が base polygon → estimated Fill → estimated Line → administrative line、
+invalid pairではScene mutation countが0。
+
+## P7: Enforce Coverage and Generation Ownership
+
+**Files:**
+
+- Create: `packages/eqmonitor_map/lib/src/overlay/estimated_intensity_source_snapshot.dart`
+- Create: `packages/eqmonitor_map/lib/src/overlay/estimated_intensity_coverage.dart`
+- Create: `packages/eqmonitor_map/lib/src/overlay/estimated_intensity_source_controller.dart`
+- Create: `packages/eqmonitor_map/lib/src/renderer/estimated_intensity_frame_builder.dart`
+- Modify: `packages/eqmonitor_map/lib/src/renderer/base_map_overlay_frame_builder.dart`
+- Modify: `packages/eqmonitor_map/lib/src/widget/base_map_view.dart`
+- Modify: `packages/eqmonitor_map/lib/eqmonitor_map.dart`
+- Create: `packages/eqmonitor_map/test/overlay/estimated_intensity_source_controller_test.dart`
+- Create: `packages/eqmonitor_map/test/overlay/estimated_intensity_coverage_test.dart`
+- Create: `packages/eqmonitor_map/test/renderer/estimated_intensity_frame_builder_test.dart`
+- Modify: `packages/eqmonitor_map/test/widget/base_map_view_test.dart`
+
+### P7.1 RED
+
+- [ ] visible canonical tileが全てready/authoritative emptyになるまでpacket 0であることを固定する。
+- [ ] pending 1件、schema/decode/source/resource failure 1件、cover cap超過でpartial publishしないことを固定する。
+- [ ] event A→B、same event hash change、viewport cover change、dispose、background、context recreation後のlate completionを
+  cache put/coverage/Scene commitの各境界で拒否するtestを追加する。
+- [ ] same canonical cover内のpan/fractional zoomとtheme-only changeはdecode generation/data identityを変えないことを固定する。
+
+```bash
+cd packages/eqmonitor_map
+mise exec -- flutter test test/overlay/estimated_intensity_source_controller_test.dart
+mise exec -- flutter test test/overlay/estimated_intensity_coverage_test.dart
+mise exec -- flutter test test/renderer/estimated_intensity_frame_builder_test.dart
+```
+
+**Expected:** coverage/controller/frame builder 未実装で compile FAIL。
+
+### P7.2 GREEN
+
+- [ ] coverage stateをhidden/loading/complete/authoritative empty/below min/invalid/source failure/resource limit/
+  suspendedへtyped化し、countsをbounded diagnosticとして保持する。
+- [ ] source/data/render/context generationを別ownerで管理し、async completionごとにcurrent tokenを検証する。
+- [ ] content identity `estimated:{eventId}:{verifiedSha256}` をsource identityとdata digestへ入れる。
+- [ ] theme-only changeはrender digestだけを進め、geometryをdecode/repackしない。
+- [ ] source switch時はold estimated Fill/Lineを即時clearし、new full cover complete前にold viewportを出さない。
+- [ ] backgroundでdownload/decode/upload/frameを止め、foregroundでdescriptor/lease/file/header/coverを再評価する。
+- [ ] context recreation後はCPU verified geometryだけを再利用し、old GPU resourcesを再利用しない。
+
+```bash
+cd packages/eqmonitor_map
+mise exec -- dart format lib test
+mise exec -- flutter test test/overlay/estimated_intensity_source_controller_test.dart
+mise exec -- flutter test test/overlay/estimated_intensity_coverage_test.dart
+mise exec -- flutter test test/renderer/estimated_intensity_frame_builder_test.dart
+mise exec -- flutter test test/widget/base_map_view_test.dart
+mise exec -- flutter analyze
+```
+
+**Commit sequence:**
+
+1. `test: 推計震度coverage barrierを固定`
+2. `feat: 推計震度source generationを管理`
+3. `feat: 推計震度frame publicationを原子化`
+
+**Verification:** source/mode/lifecycle switchを各100回繰り返し、late commit、negative lease、double retireが0。
+
+## P8: Integrate Atomic Display Mode into the Debug Map
+
+**Files:**
+
+- Create: `app/lib/feature/earthquake_history/data/model/earthquake_map_display_candidate.dart`
+- Create: `app/lib/feature/earthquake_history/data/logic/estimated_intensity_map_candidate_builder.dart`
+- Create: `app/lib/feature/earthquake_history/data/provider/estimated_intensity_map_candidate_provider.dart`
+- Create: `app/lib/feature/earthquake_history/data/provider/estimated_intensity_map_candidate_provider.g.dart`
+- Create: `app/lib/feature/earthquake_history/data/logic/estimated_intensity_map_digest_builder.dart`
+- Modify: `app/lib/feature/earthquake_history/data/logic/earthquake_map_overlay_builder.dart`
+- Modify: `app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_source_provider.dart`
+- Modify: `app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_page.dart`
+- Create: `app/test/feature/earthquake_history/data/estimated_intensity_map_candidate_builder_test.dart`
+- Create: `app/test/feature/earthquake_history/data/earthquake_map_display_candidate_test.dart`
+- Modify: `app/test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_configuration_test.dart`
+
+### P8.1 RED
+
+- [ ] observed candidateはregion/city/station、estimated candidateはFill/Line sourceとsame-event hypocenterだけを持つtestを追加する。
+- [ ] mode switch中にobservedとestimatedが共存せず、descriptor loading/errorでもobservedへのsilent fallbackがないことを固定する。
+- [ ] different-event hypocenter、version mismatch、legacy-only descriptor、invalid descriptorを拒否する。
+- [ ] descriptor未検証中はestimated full candidateを作らず、同event震源だけを
+  `base+hypocenter:<eventId>:<requestGeneration>` candidateとして表示する。verification成功時にだけ
+  `estimated:<eventId>:<verifiedSha>`へFill/Line/hypocenterを原子的に昇格するtestを追加する。
+- [ ] realtime key受信後のdetail refetchでgeneration/pathが一致するまでcandidateを作らず、stale応答を
+  Scene commitしないことを固定する。
+- [ ] debug state文言とdiagnostic redactionをpure model testで固定する。
+
+```bash
+cd app
+mise exec -- flutter test test/feature/earthquake_history/data/estimated_intensity_map_candidate_builder_test.dart
+mise exec -- flutter test test/feature/earthquake_history/data/earthquake_map_display_candidate_test.dart
+mise exec -- flutter test test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_configuration_test.dart
+```
+
+**Expected:** display candidate/provider 未実装で compile FAIL。
+
+### P8.2 GREEN
+
+- [ ] sealed full display candidateを導入し、one-event one-modeをbuilder/provider境界で強制する。
+- [ ] estimated candidateへverified source snapshot、class theme、same-event hypocenter sprite、共通version stampを渡す。
+- [ ] archive未検証中はbase+hypocenter-only candidateを使い、estimated full candidateのidentity/stampを
+  捏造しない。verified archive publication時にだけfull candidateへ切り替える。
+- [ ] `EstimatedIntensityColors` の6 classをrender styleへ明示変換し、unknown/default branchを持たない。
+- [ ] debug pageはevent ID入力からAPI detailを取得し、URL/hash/sizeをproduction定数へ持たない。
+- [ ] UIは準備中/表示中/below min/表示不可の短い文言だけを出し、raw URL/hash/path/exceptionを出さない。
+- [ ] diagnostic panelは分類値とcountだけを表示し、full identityをredactする。
+- [ ] provider dispose/mode switchをawait可能なclose flowへ接続し、active leaseをreleaseする。
+
+```bash
+cd app
+mise exec -- dart run build_runner build --delete-conflicting-outputs
+mise exec -- dart format lib/feature/earthquake_history lib/feature/settings test/feature/earthquake_history test/feature/settings
+mise exec -- flutter test test/feature/earthquake_history/data/estimated_intensity_map_candidate_builder_test.dart
+mise exec -- flutter test test/feature/earthquake_history/data/earthquake_map_display_candidate_test.dart
+mise exec -- flutter test test/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_configuration_test.dart
+mise exec -- flutter analyze lib/feature/earthquake_history lib/feature/settings
+```
+
+**Commit sequence:**
+
+1. `test: 地震map display mode排他を固定`
+2. `feat: 推計震度full candidateを追加`
+3. `feat: デバッグ地図へ推計震度を接続`
+
+**Verification:** event ID入力だけで descriptor pathが開始され、legacy-only/error/loading時に観測Fill/stationや旧estimated
+geometryが表示されない。同一eventの震源はbase+hypocenter-only stampで表示され、archive verification成功時だけ
+Fill/Lineと同じestimated full candidate stampへ切り替わる。
+
+## P9: Pin the Event Fixture and Pass Runtime Gates
+
+**Files:**
+
+- Create: `packages/eqmonitor_map/test/fixtures/estimated_intensity/20260823020050_manifest.json`
+- Create: `packages/eqmonitor_map/test/integration/estimated_intensity_event_fixture_test.dart`
+- Create: `packages/eqmonitor_map/test/integration/estimated_intensity_lifecycle_test.dart`
+- Create: `app/test/feature/settings/children/config/debug/eqmonitor_map/estimated_intensity_runtime_configuration_test.dart`
+- Modify after runtime discovery: `docs/knowledge/20260825_estimated_intensity_archive_identity.md`
+
+manifest は actual archive bytes を repositoryへ固定埋め込みするものではない。通常CIでは同じschemaと
+identity関係を持つrepository内deterministic archive fixtureを使う。API contract fixtureが指すactual bytesとの
+照合は、credential付きの明示的opt-in integration laneでP3 trust boundaryを通して実行する。
+
+### P9.1 RED
+
+- [ ] hermetic event manifest testを追加し、deterministic fixtureのevent/URL digest/SHA/sizeとverified source
+  identityの一致を要求する。
+- [ ] content-addressed event archiveにPMTiles v3/MVT/gzip/min0/max14、representative canonical tiles、
+  class 4/5-/5+を要求する。
+- [ ] lifecycle harnessでbackground/foreground、context recreation、event/hash/theme/mode switch、resource capsを固定する。
+- [ ] event fixtureのz0 exactとz14超overscale、synthetic min5 fixtureのz0 request/packet 0 +
+  `belowSourceMinZoom`を固定する。
+
+```bash
+cd packages/eqmonitor_map
+mise exec -- flutter test test/integration/estimated_intensity_event_fixture_test.dart
+mise exec -- flutter test test/integration/estimated_intensity_lifecycle_test.dart
+```
+
+**Expected:** manifest/runtime harness未実装のためFAIL。通常testはnetwork/credentialを要求しない。actual
+descriptor/archiveを検証するopt-in integration lane内ではnetwork unavailableをpass/skipへ変換しない。
+
+### P9.2 GREEN automated gates
+
+- [ ] 通常CI用にdeterministic local archive fixtureを生成し、P3以降の全trust/decoder/lifecycle pathをhermeticに通す。
+- [ ] test専用credential/configuration経路の明示的opt-in laneでP0 contract fixtureのactual descriptorを供給し、
+  P3 repository経由でfull verificationする。
+- [ ] actual archive manifestをopt-in laneで生成してreviewし、event-specific値はtest treeの外へexportしない。
+- [ ] lifecycle testでdownload/decode/upload/Scene countersとlease/resource retirementを検証する。
+- [ ] runtimeで判明した再現可能なplatform制約と操作commandだけをknowledge documentへ残す。
+
+```bash
+cd packages/eqmonitor_map
+mise exec -- dart format lib test
+mise exec -- flutter test test/integration/estimated_intensity_event_fixture_test.dart
+mise exec -- flutter test test/integration/estimated_intensity_lifecycle_test.dart
+mise exec -- flutter test
+mise exec -- flutter analyze
+
+cd ../../app
+mise exec -- flutter test test/feature/settings/children/config/debug/eqmonitor_map/estimated_intensity_runtime_configuration_test.dart
+mise exec -- flutter test
+mise exec -- flutter analyze
+```
+
+actual network verificationは上の無条件suiteへ混ぜず、auditで確認したcredential secretと専用workflow/inputが
+そろったopt-in laneだけで実行する。lane名とcommandは実装時にrepository workflowを監査して確定し、推測した
+script名をこの計画へ固定しない。
+
+### P9.3 GREEN iOS / Android runtime gates
+
+- [ ] `mise exec -- flutter devices` で実在する iOS Simulator、physical iOS device、Android emulator、
+  physical Android deviceのdevice IDとsupport modeを記録する。
+- [ ] ユーザーへ操作開始を通知してから、generic platform selectorを使わず、各targetのactual device IDを
+  `-d`へ明示してdebug mapを起動する。
+- [ ] iOS Simulator debugとAndroid emulator debugでvisual/gesture/mode/lifecycle smokeを実行する。
+- [ ] physical iOS device profileでperformance、memory、renderer context、OS lifecycle gateを実行する。
+- [ ] Androidはprofileをsupportするactual emulatorまたはphysical deviceでperformance/lifecycle gateを実行する。
+- [ ] debug inputへ `20260823020050` を入力し、次を画面・diagnostic counter・log分類で確認する。
+
+Runtime checklist:
+
+- actual descriptor download、exact size、SHA-256、PMTiles header gate
+- class 4 / 5- / 5+ のtheme色とFill/Line pair
+- administrative lineより下の描画順
+- observed Fill/station非表示、archive未検証中のbase+hypocenter-only表示、verified後のsame-event
+  hypocenter再stamp
+- pan/pinch、z0、z14、z14超、bounds edge
+- event/hash/theme/mode switch
+- background/foreground、renderer context recreation
+- cap超過時のpacket 0と利用者向けredacted error
+- continuous Scene/GPU error、late commit、double retire、leaked leaseが0
+
+```bash
+cd app
+mise exec -- flutter devices
+```
+
+この出力からactual device IDをrun sheetへ転記し、次の4 commandをそのIDで具体化してから実行する。
+run sheetに未解決placeholderが残る間は実行しない。
+
+```text
+mise exec -- flutter run --debug -d ACTUAL_IOS_SIMULATOR_DEVICE_ID
+mise exec -- flutter run --profile -d ACTUAL_PHYSICAL_IOS_DEVICE_ID
+mise exec -- flutter run --debug -d ACTUAL_ANDROID_EMULATOR_DEVICE_ID
+mise exec -- flutter run --profile -d ACTUAL_PROFILE_CAPABLE_ANDROID_DEVICE_ID
+```
+
+大文字のdevice IDはproduction commandの固定値ではなく、実行前run sheetで `flutter devices` の出力へ
+置換する明示placeholderである。iOS Simulatorにはprofile commandを実行しない。physical deviceが利用不能なら
+該当profile gateをpass/skip扱いせずblockedとして記録する。runtime evidenceにはdevice名、OS、renderer backend、
+commit SHA、実行mode、操作、結果を残す。
+終了時はagentが起動したprocessを停止し、Simulator/emulatorの入力をユーザーへ解放する。
+
+**Commit sequence:**
+
+1. `test: 推計震度event fixtureを固定`
+2. `test: 推計震度lifecycle gateを追加`
+3. `docs: 推計震度runtime検証を記録`
+
+**Verification:** iOS Simulator debug、physical iOS profile、Android emulator debug、profile-capable Android
+targetの4 gateがgreenになるまで P9 をmerge-readyとしない。Simulator/emulator testだけで
+real-device/OS lifecycle provenとは表現しない。
+
+## Final Stack Verification
+
+- [ ] stack rootから各branchのbase/headを確認し、P1→P9に飛び越しや逆依存がないことを確認する。
+- [ ] 各PRで `git --no-pager diff --check`、focused tests、package/app analyzeを再実行する。
+- [ ] generated OpenAPI/client/fixtureとbackend submodule commitがP0 contractに一致する。
+- [ ] production treeに event URL/hash/sizeの固定値やlegacy fallbackがないことを検索する。
+
+```bash
+rg -n "20260823020050|estimated_intensity_tile_archive" app/lib packages/eqmonitor_map/lib
+rg -n "estimatedIntensityTileUrl.*fallback|estimated_intensity_tile.*fallback" app/lib packages/eqmonitor_map/lib
+git --no-pager diff --check
+```
+
+最初の `rg` は production treeでevent IDが0件であることを期待する。descriptor field名はcontract accessとして
+存在してよいが、URL/hash/size literalは存在してはならない。
+
+- [ ] `gh pr view --repo YumNumm/EQMonitor` と `gh pr checks --repo YumNumm/EQMonitor` で各PRのbase、head、
+  review、required checksをlive確認する。
+- [ ] mergeはP1から順番に行い、下位PR merge後は次PRのbase syncとfocused regressionを終えてから次へ進む。
+- [ ] debug-map gate完了後もMapLibre removalを別issue/stackとして残す。
+
+## Done Definition
+
+- P0 descriptorがURL/size/SHAを一つのimmutable identityとして公開する。
+- P1 generated clientがlegacy fieldとdescriptorを併存してdecodeする。
+- malformed/legacy-only/redirect/oversize/hash mismatch/archive mismatchは全てfail closed。
+- PMTiles header由来のmin0/max14をevent fixtureで使い、synthetic min5 fixtureでもunderzoom fallbackを行わない。
+- strict `seismic_intensity` Polygonと既知6 classだけを受理する。
+- visible exact cover complete前はFill/Line packetが0。
+- observed/estimatedは原子的に排他で、estimatedはsame-event hypocenterを維持する。
+- event/hash/viewport/theme/lifecycle/contextのlate workがSceneへcommitされない。
+- event `20260823020050` がtest fixtureとiOS/Android runtime gateを通る。
+- production codeに固定URL/hash/size、unknown-class fallback、legacy descriptor合成がない。
+- MapLibre layerは残り、削除判断に必要なparity evidenceが保存されている。

--- a/docs/superpowers/specs/2026-08-25-estimated-intensity-flutter-gpu-map-design.md
+++ b/docs/superpowers/specs/2026-08-25-estimated-intensity-flutter-gpu-map-design.md
@@ -1,0 +1,693 @@
+# Estimated Intensity Flutter GPU Map Design
+
+## 1. Purpose
+
+地震履歴の推計震度分布図を、既存 MapLibre 表示を正本として残したまま、
+Flutter Scene / Flutter GPU のデバッグ地図へ production-grade に実装する。
+
+最初の実データ gate は event `20260823020050` とする。この event ID は contract
+fixture、integration test、runtime verification の入力であり、production code が
+参照する固定 URL、固定 SHA-256、fallback source にはしない。
+
+本設計は次を一つの信頼境界として扱う。
+
+```text
+backend immutable archive descriptor
+  -> generated client contract
+  -> app URL / response / full-content verification
+  -> verified local PMTiles lease
+  -> independent event tile pipeline
+  -> strict estimated-intensity MVT decode
+  -> complete visible cover candidate
+  -> observed / estimated atomic Scene frame
+```
+
+## 2. Scope
+
+### 2.1 In scope
+
+- backend/API の immutable archive descriptor 契約
+- legacy `estimated_intensity_tile` との移行期間中の併存
+- app の URL、host、event path、digest、size、redirect 検証
+- caller-owned byte cap 内の archive 全体 download と SHA-256 検証
+- verified local file の lease、bounded cache、cleanup
+- PMTiles v3 header、zoom range、bounds、tile type、compression の検証
+- base source と独立した event source の repository、cache、scheduler、coverage
+- `seismic_intensity` Polygon と既知 `name` class のみを受理する MVT decoder
+- theme 色の Fill / Line を行政境界線より下へ描画する typed submission
+- observed / estimated mode の full candidate 排他
+- estimated mode で同一 event の震源 sprite を維持すること
+- event、hash、viewport、theme、lifecycle、renderer context の世代管理
+- event `20260823020050` の deterministic contract fixture と iOS / Android gate
+
+### 2.2 Out of scope
+
+- Home、地震履歴詳細、ライブモニタの MapLibre layer 削除
+- remote range reader を使った初回描画
+- per-chunk digest、Merkle proof、署名済み range response
+- 既存 archive の min zoom を下げる backend generator 改修と過去 archive 再生成
+- EEW、強震モニタ、station label の GPU 実装
+- production code への target event URL、SHA-256、archive size の埋め込み
+
+MapLibre 削除は、同一 surface の全 display mode と error / loading / lifecycle parity を
+iOS / Android で確認した別 task とする。
+
+## 3. Current Baseline and Confirmed Gaps
+
+### 3.1 Existing MapLibre behavior
+
+`EarthquakeHistoryDetailsEstimatedIntensityLayer` は API の full URL を
+`pmtiles://` source として直接開き、source layer `seismic_intensity` を Fill と Line
+の両方へ使う。
+
+- Fill opacity: `1`
+- Line opacity: `1`
+- Line width: `0.5` logical pixel
+- Fill / Line ともに base administrative line より下
+- known class: `intensity:4`, `5-`, `5+`, `6-`, `6+`, `7`
+- known class は `activeColorSet.estimatedIntensity` の背景色
+- estimated mode は観測 Fill と観測点を隠す
+- 震源 layer は mode 分岐の外にあり、同一 event の震源を残す
+
+現行 MapLibre expression は unknown class で tile の `fill` property へ fallback する。
+GPU 実装ではこの fallback を禁止する。焼き込み色、近い震度階級、観測 Fill、古い
+archive のいずれにも置き換えず、schema failure として推計震度を描画しない。
+
+### 3.2 Existing API contract
+
+生成済み client では `Earthquake.estimatedIntensityTile` と
+`EarthquakePartial.estimatedIntensityTile` は nullable URL string であり、app model は
+それを `estimatedIntensityTileUrl` へ無検証でコピーする。現在の contract fixture は
+event ID を filename に持つ URL だけを含み、content size と SHA-256 を持たない。
+
+この legacy field だけでは URL digest と download 後 SHA-256 を照合できない。
+GPU code は legacy URL から digest、size、immutable revision を推測してはならない。
+
+### 3.3 Existing package contracts
+
+再利用する既存 contract は次のとおりである。
+
+- `VerifiedPmTilesSource`: app が検証済みの local path / size / SHA-256
+- `PmTilesV3Archive` / `PmTilesV3FileRandomAccessReader`
+- `MvtDecoder` / `MvtDecodeLimits`
+- `FillMeshBuilder` / `LineMeshBuilder`
+- `MapTileScheduler`
+- `MapTileFallbackPolicy.hazard`
+- `MapOverlayVersionStamp`
+- `MapSceneFrameSubmission`
+- `mapSceneUnderlayHazardFillPhaseId`
+- `mapSceneUnderlayHazardLinePhaseId`
+- existing Fill / Line packed mesh layout and fmat ABI
+
+`MapRemotePmTilesRandomAccessReader` の SHA-256 field は cache identity であり、range
+response 全体と digest を照合しない。strong ETag は range 間の snapshot consistency
+を保証するだけで、expected archive との content attestation にはならない。このため
+estimated source の初回描画には使わない。
+
+### 3.4 Backend evidence boundary
+
+EQMonitor checkout から確認できるのは generated OpenAPI、generated Dart model、contract
+fixture、および backend submodule の消費経路である。backend repository の現在の
+IXAC41 generator、object key publication、R2 response header、realtime payload producer、
+schema source file の実装位置と挙動は、本設計起草時点では live source audit を行って
+いない。
+
+したがって backend P0 は変更前に対象 repository で次を read-only に確認する。
+
+```bash
+rg -n "estimated_intensity_tile|estimated_intensity_key|ixac41|pmtiles" api service packages
+rg -n "openapi|contract-fixture|realtime" api service packages
+```
+
+本設計は public descriptor の意味と検証規則を固定するが、未確認の backend file path、
+generator class、storage library、deployment job 名を決め打ちしない。
+
+## 4. Chosen Approach
+
+### 4.1 Adopted: immutable descriptor and full local verification
+
+backend は URL、exact byte size、SHA-256 を一つの immutable descriptor として返す。
+URL 自体にも event ID と digest を含め、redirect なしで同一 bytes を返す。app は archive
+全体を一時領域へ download し、size と SHA-256 を照合した local bytes だけを package へ
+渡す。
+
+この方式は network round-trip と一時 disk を必要とするが、既存 package contract を
+壊さず、初回描画前に content identity を証明できる唯一の現行方式である。
+
+### 4.2 Rejected: legacy URL plus ETag
+
+legacy URL は digest と expected size を持たない。ETag は producer が選ぶ validator で、
+SHA-256 と同値とは限らない。同一 ETag で異なる content が配られる障害も検出できない。
+この案は採用しない。
+
+### 4.3 Deferred: verified range access
+
+署名済み total size と per-chunk digest、Merkle proof、または同等の content binding が
+backend contract に追加された場合だけ、全体 download を range reader へ置換できる。
+現段階で range reader を estimated source の trust boundary にしない。
+
+## 5. Backend and API Contract
+
+### 5.1 Additive descriptor
+
+移行期間は既存 `estimated_intensity_tile` を MapLibre consumer のために残し、GPU consumer
+向けに additive field `estimated_intensity_tile_archive` を追加する。
+
+```json
+{
+  "estimated_intensity_tile": "<legacy full URL>",
+  "estimated_intensity_tile_archive": {
+    "url": "https://<allowed-host>/ixac41/<eventId>/<sha256>.pmtiles",
+    "size_bytes": 123456,
+    "sha256": "<64 lowercase hex>"
+  }
+}
+```
+
+上記 URL、size、hash は schema shape の説明であり、production 定数ではない。
+
+descriptor の不変条件:
+
+- `url` は absolute HTTPS URL
+- path は decoded segment 単位で `ixac41`, event ID, `<sha256>.pmtiles`
+- URL digest と `sha256` field は lowercase で完全一致
+- `size_bytes` は正数
+- URL は redirect endpoint ではなく archive bytes を直接返す
+- 同一 URL は常に同一 bytes
+- content が変わる場合は同一 event でも digest、URL、descriptor を変える
+
+`Earthquake` と `EarthquakePartial` の両方へ同じ descriptor 型を使う。detail と list の
+descriptor が同一 event で異なる場合、detail の新しい canonical record を採用し、古い
+async result は generation で拒否する。
+
+### 5.2 Realtime contract
+
+最小移行では realtime の `estimated_intensity_key` を immutable URL path と同じ key にし、
+hash を含ませる。client は realtime を受信したら detail API を再取得し、identifier と
+descriptor URL path が一致した場合だけ新 source candidate を作る。
+
+realtime mapper / notifier は key を source candidate として直接採用しない。key 受信時に
+request generation を進め、detail refetch の応答が同じ event、同じ generation、同じ immutable
+path の descriptor を返した場合だけ download へ進む。古い refetch、異なる key、descriptor
+未取得の状態は `base+hypocenter` までに留める。
+
+backend audit で realtime record が descriptor object を安全に同梱できることが確認できた
+場合は、同じ descriptor schema を再利用できる。ただし REST と realtime で別の digest / size
+定義を作らない。
+
+### 5.3 Legacy coexistence and fail-closed behavior
+
+- MapLibre consumer は移行完了まで legacy field を使用できる。
+- GPU consumer は新 descriptor だけを使用する。
+- descriptor が null または不正な場合、GPU estimated source は `disabled` または
+  `invalidInput` とする。
+- legacy URL は content-addressed identity ではないため、新 descriptor の trust 判定や
+  invalid 判定へ使わない。両 field の path が異なっても、それだけで valid descriptor を
+  拒否しない。
+- GPU consumer は legacy URL へ fallback しない。
+- API migration 中に descriptor がない event で observed mode を自動選択することは UI の
+  初期 mode 決定として可能だが、ユーザーが estimated mode を選んだ後に observed Fill を
+  silent fallback として描画してはならない。
+
+## 6. App Descriptor Validation
+
+app は API model を package-neutral download request へ変換する前に、pure validator で
+次を検証する。
+
+```dart
+final class EstimatedIntensityArchiveDescriptor {
+  final String eventId;
+  final Uri url;
+  final int sizeBytes;
+  final String sha256;
+}
+
+final class EstimatedIntensityArchiveUrlPolicy {
+  final Set<String> allowedHosts;
+  final int maxArchiveBytes;
+}
+```
+
+policy は caller 必須であり、production code に full URL や target event hash を持たない。
+host allowlist は exact hostname matching とし、suffix matching を使わない。
+
+拒否条件:
+
+- scheme が HTTPS 以外
+- authority または host がない
+- host が exact allowlist 外
+- user info、fragment、query、non-default port がある
+- decoded path segment が厳密な3 segment構造と異なる
+- empty segment、dot segment、encoded separator、二重 slash、trailing slash
+- event ID segment が要求 event ID と異なる
+- event ID が既存 earthquake event ID validator を通らない
+- URL digest が64文字 lowercase hexでない
+- URL digest と descriptor SHA-256 が異なる
+- size が正数でない、または caller `maxArchiveBytes` を超える
+
+URI canonicalization で異なる入力を同一とみなして受理しない。検証前 raw URL と検証後 URI
+の path semantics が一致しない場合は拒否する。
+
+## 7. Download, Verification, and Lease
+
+### 7.1 Transport contract
+
+download は app data layer の専用 repository が所有する。Asset Pack の background
+downloader は redirect と streaming cap の検証面が異なるため直接再利用しない。
+
+HTTP contract:
+
+- `HttpClient.autoUncompress = false` とし、header 検査前に response body を自動展開しない
+- redirect follow を無効化し、全 3xx を拒否
+- status `200` だけを受理
+- `Accept-Encoding: identity`
+- `Content-Encoding` は未指定または `identity` だけを受理
+- `Content-Length` があれば descriptor size と完全一致し、byte cap 以下
+- `Content-Length` がなくても stream 中の累積 byte 数で cap を強制
+- EOF 時の実 byte 数が descriptor size と完全一致
+- timeout、cancel、socket failure を source failure として typed に保持
+- response body、例外、URL に auth token や local path を user-facing message へ出さない
+
+### 7.2 Full-content verification
+
+response は unique `.part` file へ stream する。write と同時に SHA-256 を更新してよいが、
+EOF、exact size、digest の全確認前に verified source として publish しない。
+
+確認順:
+
+1. descriptor と caller policy
+2. response status / headers
+3. streaming byte cap
+4. exact final size
+5. SHA-256
+6. PMTiles archive header
+7. content-addressed cache への atomic rename
+8. `VerifiedPmTilesSource` publication
+
+SHA mismatch、size mismatch、header failure、cancel、supersede では `.part` を削除する。
+cleanup failure は verified source を publishする理由にせず、diagnosticへ記録する。
+
+### 7.3 Lease and bounded local cache
+
+verified file は temporary/cache directory の content-addressed path に置く。
+
+```text
+estimated-intensity/<eventId>/<sha256>.pmtiles
+```
+
+同じ content identity の concurrent request は一つへ coalesce する。active repository が
+file を開いている間は lease で pin し、source switch / widget dispose / package repository
+close 完了後に release する。unleased file だけを LRU cleanup 対象にする。
+
+caller は少なくとも次の上限を渡す。
+
+- `maxArchiveBytes`
+- `maxRetainedArchiveBytes`
+- `maxRetainedArchiveCount`
+- connect / idle / total timeout
+
+上限内に収めるため active lease を強制削除してはならない。全 file が leased で新 archive
+を保持できない場合は新 candidate を fail closed にする。
+
+## 8. Verified PMTiles Event Source
+
+### 8.1 Header validation
+
+`VerifiedPmTilesSource` を file reader で開き、実 header から次を取得・検証する。
+
+- PMTiles spec version 3
+- tile type MVT
+- supported internal compression
+- tile compression gzip
+- `0 <= minZoom <= maxZoom <= PMTiles maximum`
+- finite WGS84 bounds
+- longitude / latitude の順序と範囲
+- archive section bounds と overlap は既存 `PmTilesV3Archive.open` の検証を利用
+
+event `20260823020050` fixture はcontent-addressed URLが指す実 archiveの検証済みmanifestを持ち、
+少なくともPMTiles v3、MVT、gzip、`minZoom=0`、`maxZoom=14`、class 4 / 5- / 5+をpinする。
+値は test fixture にのみ置き、production limit や fallback として転記しない。
+
+### 8.2 Independent source pipeline
+
+base source と estimated event source は同じ camera / viewport capture を共有するが、次を
+共有しない。
+
+- header-derived zoom range
+- bounds
+- canonical cover
+- repository
+- decoded geometry cache
+- packed mesh cache
+- scheduler / in-flight set
+- decode failure owner
+- source generation
+- coverage
+
+`BaseMapTileRepository` の archive/readTile contract は汎用化して再利用できるが、base map
+cache は `BaseMapTileGeometry` と visual parent/child fallback に密結合している。estimated
+source は exact hazard tile 専用 cache を持つ。
+
+### 8.3 Cover and zoom policy
+
+estimated cover は camera zoom の floor と event header を使う。
+
+- `camera.floorZoom < header.minZoom`: `belowSourceMinZoom`、tile request 0、描画なし
+- `header.minZoom <= floorZoom <= header.maxZoom`: exact canonical tile
+- `floorZoom > header.maxZoom`: canonical z=`header.maxZoom`、overscaledZ は camera floor
+- header bounds 外: authoritative empty
+- bounds 内で PMTiles directory entry がない: authoritative empty
+
+min zoom 未満を min zoom tile へ clamp しない。これは MapLibre に存在しない underzoom を
+捏造し、hazard geometry の exactness と resource budget を壊すためである。
+
+event `20260823020050` のcontent-addressed archiveはheader由来のmin zoom 0を持つため、z0を
+exact canonical tileとして扱う。generic underzoom policyはmin zoom 5のdeterministic synthetic
+fixtureを別に用意し、z0でrequest 0 + `belowSourceMinZoom`になることを固定する。いずれもheaderを
+唯一のzoom sourceとし、event IDやlegacy archiveの既知値をproduction fallbackへ使わない。
+
+bounds と cover の canonical tile は world wrap を除いて deduplicate する。描画 transform は
+unwrapped tile を保持する。cover が caller `maxVisibleCanonicalTiles` を超える場合は一部だけ
+描かず、candidate 全体を resource-limit failure とする。
+
+## 9. Estimated Intensity MVT Contract
+
+### 9.1 Accepted schema
+
+source layer は大文字小文字を含め `seismic_intensity` 完全一致とする。
+
+受理する feature:
+
+- geometry type: Polygon
+- property `name`: non-empty String
+- exact class:
+  - `intensity:4`
+  - `intensity:5-`
+  - `intensity:5+`
+  - `intensity:6-`
+  - `intensity:6+`
+  - `intensity:7`
+
+`fill` property は読まず、render style の入力にしない。Point、LineString、missing name、
+unknown class、duplicate conflicting property、invalid geometry、decoder limit 超過は schema
+failure とする。既知 feature と未知 feature が同じ tile に混在する場合も tile 全体を拒否し、
+既知 feature だけを部分表示しない。
+
+### 9.2 Tile result distinction
+
+- PMTiles directory entry absent: authoritative empty
+- tile bytes present、required layer absent: invalid schema
+- required layer present、feature zero: authoritative empty
+- required layer present、全 feature valid: ready
+- required layer present、1件でも invalid: invalid schema
+- archive read / decompress / MVT decode failure: source or decode failure
+
+### 9.3 Geometry and style separation
+
+decoder は app theme に依存せず、class ごとの FillMesh と closed polygon boundary LineMesh を
+返す。Polygon ring を LineString に変換する helper は package-neutral な公開 unit とし、
+base map decoder と estimated decoder が同じ閉路規則を使う。
+
+app は `EstimatedIntensityColors` を class ごとの immutable style へ変換する。class が全て
+theme に対応しない限り render candidate を作らない。Fill / Line の色は同じ class theme
+背景色、opacity は1、Line width は0.5 logical pixelとする。
+
+## 10. Scene Rendering and Atomic Display Mode
+
+### 10.1 Typed layers
+
+次の component と kind を追加する。
+
+```text
+component estimated-intensity-fill
+  kind estimatedIntensityFill
+  phase underlayHazardFill
+
+component estimated-intensity-line
+  kind estimatedIntensityLine
+  phase underlayHazardLine
+```
+
+Fill、Line、hypocenter sprite は `mapSceneEarthquakeHistorySourceKey` を共有する。estimated
+専用 logical source key を別に作ると、frame validator が震源との version 混在を検知できない
+ためである。
+
+既存 Fill / Line fmat ABI、material parameter encoder、packed mesh layout は再利用する。
+semantic pipeline key と material owner は estimated 用に分け、base map material cache や
+observed earthquake material stage を誤って commit / retire しない。
+
+### 10.2 Full display candidate
+
+app は一 event について observed または estimated のどちらか一つを選び、package へ full
+candidate として渡す。
+
+```dart
+sealed class EarthquakeMapDisplayCandidate {
+  MapOverlayVersionStamp get versionStamp;
+  String get eventId;
+}
+
+final class ObservedEarthquakeMapDisplayCandidate
+    extends EarthquakeMapDisplayCandidate {
+  final EarthquakeMapOverlaySnapshot snapshot;
+}
+
+final class HypocenterOnlyEarthquakeMapDisplayCandidate
+    extends EarthquakeMapDisplayCandidate {
+  final int requestGeneration;
+  final MapSpriteAtlas spriteAtlas;
+  final List<MapPointSpriteFeature> hypocenterSprites;
+}
+
+final class EstimatedEarthquakeMapDisplayCandidate
+    extends EarthquakeMapDisplayCandidate {
+  final EstimatedIntensitySourceSnapshot source;
+  final MapSpriteAtlas? spriteAtlas;
+  final List<MapPointSpriteFeature> hypocenterSprites;
+}
+```
+
+estimated content identity は
+`estimated:<eventId>:<verifiedSha256>`。これを `MapSourceIdentity` と data digest の入力へ
+含める。同一 event でも hash が変われば source switch とし、旧 estimated Fill / Line を
+即時 clear する。
+
+descriptor が null、loading、invalid、source failure、または archive verification 前の間は
+estimated full candidate とその content identity を作らない。同一 event の検証済み
+hypocenter sprite だけを残す場合は、archive と独立した
+`base+hypocenter:<eventId>:<requestGeneration>` candidate を使う。archive の full verification
+成功時にだけ `estimated:<eventId>:<verifiedSha256>` candidate へ原子的に昇格し、hypocenter も
+新 stamp へ付け替える。
+
+theme-only 変更は source identity、data sequence、data digest を変えず、render generation
+と render digest だけを進める。render digest は全 class 色、opacity、Line width、sprite
+render input を含む。
+
+### 10.3 Frame invariants
+
+`MapSceneFrameSubmission` は次を Scene mutation 前に拒否する。
+
+- observed region/city Fill と estimated Fill / Line の共存
+- observation point と estimated Fill / Line の共存
+- estimated Fill だけ、または Line だけの partial pair
+- Fill / Line / hypocenter の overlay version mismatch
+- 異なる event の hypocenter
+- wrong phase / pipeline / component combination
+- node count、material ABI、geometry ABI の上限超過
+
+estimated source が loading、invalid、source failure、below min zoom の場合、observed Fill / station
+や旧 estimated geometryを描かない。同一 event の検証済み hypocenter sprite は base map 上に
+残せるが、estimated full candidate の stamp を捏造せず、
+`base+hypocenter:<eventId>:<requestGeneration>` candidate として単独 commit する。verified archive
+が利用可能になったときだけ Fill / Line / hypocenter を同じ estimated stamp へ原子的に切り替える。
+
+## 11. Coverage and Publication Barrier
+
+estimated coverage は少なくとも次を区別する。
+
+- hidden
+- loading archive
+- validating archive
+- loading visible tiles
+- complete
+- authoritative empty
+- below source min zoom
+- invalid input / schema
+- source / decode failure
+- resource limit exceeded
+- lifecycle suspended
+
+debug diagnostic は event ID、content identity、header zoom / bounds、visible canonical count、
+ready、authoritative empty、pending、missing layer、unknown class、decode failure を持つ。利用者向け
+message は短い分類文だけを表示し、URL、hash、local path、例外全文を表示しない。
+
+publication rule:
+
+```text
+all unique visible canonical tiles are
+  ready OR authoritative empty
+AND invalid/schema/decode/resource failures are zero
+=> Fill and Line pair may be submitted
+```
+
+pending が1件でもある、または invalid が1件でもある場合は estimated Fill / Line packet を0件
+にする。前 viewport の complete coverを新 viewportへ last-good として使わない。
+
+## 12. Generation, Switching, and Lifecycle
+
+次の操作は async generation を進め、旧 work の cache put、coverage publish、Scene commit を
+拒否する。
+
+- event A -> B
+- same event SHA-256 change
+- descriptor invalidation
+- display mode switch
+- viewport canonical cover change
+- provider dispose
+- background transition
+- clock / replay source incarnation change
+- renderer context generation change
+
+camera の fractional zoom や pan で canonical cover が変わらない場合は decode generation を
+不要に進めない。camera-only update は既存 geometry の model transform / uniform だけを更新する。
+
+background では download、decode、upload、continuous frame を停止し、uncommitted candidate を
+破棄する。foreground では API descriptor、active lease、file existence / size、header、current
+viewport cover を再評価する。renderer context が再生成された場合は CPU verified geometry を
+再利用できるが、旧 context の GPU material / geometry / node を再利用しない。
+
+resource retirement は existing completion fence 後に一度だけ行う。candidate preflight failure は
+committed base map resource や hypocenter atlas の pin を誤って解放しない。
+
+## 13. Event-specific Fixture
+
+event `20260823020050` は二層の fixture で検証する。
+
+### 13.1 API contract fixture
+
+backend が生成し EQMonitor に同期する fixture は次を含む。
+
+- event ID
+- legacy URL
+- immutable descriptor URL
+- exact size
+- SHA-256
+- URL digest と SHA-256 の一致
+- realtime immutable key
+
+fixture の URL / hash / size は test input であり production code から import しない。
+
+### 13.2 Archive manifest and deterministic MVT fixtures
+
+実 archive の検証 manifest は次を pin する。
+
+- PMTiles v3
+- MVT / gzip
+- content-addressed archiveのmin zoom 0 / max zoom 14
+- bounds
+- representative canonical tiles
+- `seismic_intensity`
+- class 4 / 5- / 5+
+
+unit test は repository に巨大な production archive を無条件に複製せず、既存
+`MinimalPmTilesArchiveBuilder` と MVT fixture builder で deterministic minimal archive を作る。
+実 archive manifest の drift test と iOS / Android runtime gate は API descriptor が指す bytes
+を full verificationした後に実行する。
+
+## 14. Limits and Performance
+
+全上限は caller が明示し、package に hidden fallback を置かない。
+
+- archive byte cap
+- retained archive byte / count cap
+- PMTiles directory depth / window cap
+- MVT layer / feature / property / ring / vertex / command cap
+- Fill / Line mesh vertex cap
+- visible canonical tile cap
+- in-flight decode cap
+- decoded geometry count / retained byte cap
+- packed CPU / GPU byte cap
+- Scene node cap
+- max frames in flight
+
+同じ content identity、canonical tile、class、mesh ordinal は packed geometry を再利用する。
+theme change は geometryを再decode / repackしない。viewport complete barrier のために visible tile
+を pin する場合、pin count / bytes は caller budget 内でなければならない。
+
+runtime diagnostic は download bytes / duration、hash duration、tile read/decode p50/p95、cache
+entries / bytes、in-flight count、GPU upload count / bytes、Scene node / batch count を bounded
+collectorへ送る。生 URL、hash、座標を通常ログへ出さない。
+
+## 15. User-facing and Debug Integration
+
+最初の consumer は `EqmonitorMapDebugPage` とする。event ID は route parameter、debug input、
+または test injection から渡し、production code に固定 URL / hash を置かない。
+
+表示状態:
+
+- descriptor fetch中: 推計震度データを確認中
+- archive download / hash中: 推計震度分布図を準備中
+- visible cover loading: 表示範囲の推計震度を準備中
+- complete: 推計震度分布図を表示中
+- below min zoom: この縮尺では推計震度分布図を表示できない
+- invalid/schema/source failure: 推計震度分布図を表示できない
+
+error object、stack trace、URL、hash、local path は UI に表示しない。debug details は明示的に
+開く diagnostic panelだけへ分類値と count を表示する。
+
+## 16. Verification Gates
+
+### 16.1 Automated
+
+通常CIとpackage/appの無条件test suiteはrepository内のdeterministic fixtureだけを使い、network、
+credential、live objectの可用性へ依存しない。event `20260823020050` のactual descriptor/archive
+照合はcredential付きの明示的opt-in integration laneで実行する。このlane内のnetwork failureは
+skip/passへ変換せずfailureとする。
+
+- descriptor parse / legacy coexistence / contract drift
+- host、scheme、port、userinfo、query、fragment、path、event、URL hash
+- redirect、status、encoding、Content-Length、stream cap、short / long body
+- SHA mismatch、same URL replacement、temp cleanup、lease pin / eviction
+- PMTiles header、tile type、compression、min/max、bounds
+- event fixtureのz0 exact、synthetic min5 fixtureのz0 no-underzoom、z14 exact、z14超 overscale、bounds edge
+- absent tile と present-but-layer-missing の区別
+- known class全種、unknown / missing name / wrong geometry 拒否
+- Fill / Line underlay phase、theme color、0.5px Line
+- visible cover complete前 packet 0
+- event A -> B、same event hash、late download / decode
+- observed / estimated 排他、same-event hypocenter
+- lifecycle / context recreation / resource retirement
+
+### 16.2 Runtime
+
+event `20260823020050` は target ごとに次の mode で検証する。
+
+- iOS Simulator debug: visual、gesture、mode switch、background / foreground
+- physical iOS device profile: performance、memory、renderer context、OS lifecycle
+- Android emulator debug: visual、gesture、mode switch、background / foreground
+- profile を support する Android target: performance、memory、renderer context、lifecycle
+
+iOS Simulator を profile gate として扱わない。各実行では `flutter devices` が返した実在 device ID
+を使い、generic `-d ios` / `-d android` を使わない。
+
+- actual descriptor download / size / SHA / header gate
+- class 4 / 5- / 5+ の theme 色
+- Fill / Line と administrative line の順序
+- observed Fill / station 非表示、same-event hypocenter 表示
+- pan / pinch、z0、z14、z14超、bounds edge
+- event/hash/theme/mode switch
+- background / foreground
+- renderer context recreation
+- resource / upload / node cap
+- 連続 Scene / GPU error がないこと
+
+Simulator / emulator を agent が操作する場合、開始前にユーザーへ通知し、終了時に入力を解放する。
+
+## 17. Rollout and Removal Gate
+
+実装は backend P0、client P1、app/package P2-P9 の Stacked PR とする。各 PR は前段の public
+contractだけに依存し、独立した RED/GREEN、focused analyze、review gate を持つ。
+
+debug map gate が green でも MapLibre layer は削除しない。地震履歴詳細とライブモニタの
+各 surface へ接続し、同じ data / mode / lifecycle gateを通した後、別 PR で MapLibre source / layer
+を除去する。


### PR DESCRIPTION
## 概要
- event 20260823020050を最初のproduction data gateとする推計震度GPU地図仕様を定義
- immutable archive descriptor、HTTPS/size/SHA-256全件検証、lease/LRU、PMTiles v3/MVT strict decodeを設計
- observed/estimated排他、base+hypocenter段階表示、coverage/generation/lifecycle境界を固定
- P0からP9までのsubagent-driven Stacked PR実装計画を追加
- legacy URLとcontent-addressed URLが別archiveだった実データ知見を記録

## 検証
- Markdown fence数 70で偶数
- git diff --check
- production treeへのevent URL/hash/size固定禁止を仕様化
- actual network検証はcredential付きopt-in lane、通常CIはdeterministic fixtureと明記
- iOS/Android runtime gateとMapLibre削除判断を分離

バックエンドP0AはYumNumm/eqmonitor-backend#1138で並行実装中です。