### PR TITLE
feat: 推計震度descriptor検証境界を追加

### DIFF
--- a/app/lib/feature/earthquake_history/data/logic/estimated_intensity_archive_descriptor_validator.dart
+++ b/app/lib/feature/earthquake_history/data/logic/estimated_intensity_archive_descriptor_validator.dart
@@ -1,0 +1,63 @@
+part of '../model/estimated_intensity_archive_descriptor.dart';
+
+final class EarthquakeEventIdValidator {
+  const new();
+
+  bool validate(String eventId) =>
+      _estimatedIntensityEventIdPattern.hasMatch(eventId);
+}
+
+/// API descriptor を package-neutral な検証済み値へ変換する pure boundary。
+final class EstimatedIntensityArchiveDescriptorValidator {
+  const new();
+
+  EstimatedIntensityArchiveValidationResult validate({
+    required String eventId,
+    required EstimatedIntensityArchiveDescriptorInput? input,
+    required EstimatedIntensityArchiveUrlPolicy policy,
+  }) {
+    if (!const EarthquakeEventIdValidator().validate(eventId)) {
+      return const EstimatedIntensityArchiveValidationInvalid(
+        .invalidEventId,
+      );
+    }
+    if (input == null) {
+      return const EstimatedIntensityArchiveValidationMissing();
+    }
+    if (input.sizeBytes <= 0) {
+      return const EstimatedIntensityArchiveValidationInvalid(.invalidSize);
+    }
+    if (input.sizeBytes > policy.maxArchiveBytes) {
+      return const EstimatedIntensityArchiveValidationInvalid(
+        .archiveTooLarge,
+      );
+    }
+    if (!_estimatedIntensitySha256Pattern.hasMatch(input.sha256)) {
+      return const EstimatedIntensityArchiveValidationInvalid(.invalidSha256);
+    }
+
+    final uri = Uri.tryParse(input.url);
+    if (uri == null) {
+      return const EstimatedIntensityArchiveValidationInvalid(.invalidUrl);
+    }
+    final urlFailure = const EstimatedIntensityArchiveUrlValidator().validate(
+      rawUrl: input.url,
+      uri: uri,
+      eventId: eventId,
+      sha256: input.sha256,
+      policy: policy,
+    );
+    if (urlFailure != null) {
+      return EstimatedIntensityArchiveValidationInvalid(urlFailure);
+    }
+
+    return EstimatedIntensityArchiveValidationValid(
+      EstimatedIntensityArchiveDescriptor._(
+        eventId: eventId,
+        url: uri,
+        sizeBytes: input.sizeBytes,
+        sha256: input.sha256,
+      ),
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/data/logic/estimated_intensity_archive_url_path_validator.dart
+++ b/app/lib/feature/earthquake_history/data/logic/estimated_intensity_archive_url_path_validator.dart
@@ -1,0 +1,49 @@
+part of '../model/estimated_intensity_archive_descriptor.dart';
+
+final _encodedSeparatorPattern = RegExp('%(?:2f|5c)', caseSensitive: false);
+
+/// Decoded segment と raw path の両方を照合し、URI alias を拒否する。
+final class EstimatedIntensityArchiveUrlPathValidator {
+  const new();
+
+  EstimatedIntensityArchiveFailure? validate({
+    required String rawUrl,
+    required Uri uri,
+    required String eventId,
+    required String sha256,
+  }) {
+    final pathStart = rawUrl.indexOf('/', rawUrl.indexOf('://') + 3);
+    final rawPath = pathStart < 0 ? '' : rawUrl.substring(pathStart);
+    if (rawPath.contains('//') || rawPath.endsWith('/')) {
+      return .invalidPath;
+    }
+    if (_encodedSeparatorPattern.hasMatch(rawPath)) {
+      return .invalidPath;
+    }
+
+    final segments = uri.pathSegments;
+    if (segments.length != 3 || segments.first != 'ixac41') {
+      return .invalidPath;
+    }
+    if (segments[1] != eventId) {
+      return _estimatedIntensityEventIdPattern.hasMatch(segments[1])
+          ? .eventIdMismatch
+          : .invalidEventId;
+    }
+
+    final filename = segments[2];
+    if (!filename.endsWith('.pmtiles')) {
+      return .invalidPath;
+    }
+    final urlSha256 = filename.substring(0, filename.length - 8);
+    if (!_estimatedIntensitySha256Pattern.hasMatch(urlSha256)) {
+      return .invalidSha256;
+    }
+    if (urlSha256 != sha256) {
+      return .sha256Mismatch;
+    }
+
+    final expectedPath = '/ixac41/$eventId/$sha256.pmtiles';
+    return rawPath == expectedPath ? null : .nonCanonicalUrl;
+  }
+}

--- a/app/lib/feature/earthquake_history/data/logic/estimated_intensity_archive_url_validator.dart
+++ b/app/lib/feature/earthquake_history/data/logic/estimated_intensity_archive_url_validator.dart
@@ -1,0 +1,53 @@
+part of '../model/estimated_intensity_archive_descriptor.dart';
+
+/// Descriptor URL の authority と content-addressed path を検証する。
+final class EstimatedIntensityArchiveUrlValidator {
+  const new();
+
+  EstimatedIntensityArchiveFailure? validate({
+    required String rawUrl,
+    required Uri uri,
+    required String eventId,
+    required String sha256,
+    required EstimatedIntensityArchiveUrlPolicy policy,
+  }) {
+    if (uri.scheme != 'https') {
+      return .insecureScheme;
+    }
+    if (!uri.hasAuthority) {
+      return .missingAuthority;
+    }
+    if (uri.host.isEmpty) {
+      return .invalidUrl;
+    }
+    if (uri.authority.contains('@')) {
+      return .userInfoNotAllowed;
+    }
+    if (uri.hasQuery) {
+      return .queryNotAllowed;
+    }
+    if (uri.hasFragment) {
+      return .fragmentNotAllowed;
+    }
+    if (uri.hasPort && uri.port != 443) {
+      return .nonDefaultPort;
+    }
+    if (!policy.allowedHosts.contains(uri.host)) {
+      return .disallowedHost;
+    }
+
+    final pathFailure = const EstimatedIntensityArchiveUrlPathValidator()
+        .validate(rawUrl: rawUrl, uri: uri, eventId: eventId, sha256: sha256);
+    if (pathFailure != null) {
+      return pathFailure;
+    }
+
+    final canonicalHost = uri.host.contains(':') ? '[${uri.host}]' : uri.host;
+    final canonicalPath = '/ixac41/$eventId/$sha256.pmtiles';
+    final canonicalUrl = 'https://$canonicalHost$canonicalPath';
+    final canonicalUrlWithPort = 'https://$canonicalHost:443$canonicalPath';
+    return rawUrl == canonicalUrl || rawUrl == canonicalUrlWithPort
+        ? null
+        : .nonCanonicalUrl;
+  }
+}

--- a/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart
+++ b/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart
@@ -1,0 +1,92 @@
+part 'estimated_intensity_archive_failure.dart';
+part '../logic/estimated_intensity_archive_descriptor_validator.dart';
+part '../logic/estimated_intensity_archive_url_path_validator.dart';
+part '../logic/estimated_intensity_archive_url_validator.dart';
+
+final _estimatedIntensityEventIdPattern = RegExp(r'^[0-9]{14}$');
+final _estimatedIntensitySha256Pattern = RegExp(r'^[0-9a-f]{64}$');
+
+/// Generated API model から pure validator へ渡す package-neutral input。
+///
+/// 未検証のため、download や map package へ直接渡してはならない。
+final class EstimatedIntensityArchiveDescriptorInput {
+  const new({
+    required this.url,
+    required this.sizeBytes,
+    required this.sha256,
+  });
+
+  final String url;
+  final int sizeBytes;
+  final String sha256;
+
+  @override
+  String toString() =>
+      'EstimatedIntensityArchiveDescriptorInput('
+      'sizeBytes: $sizeBytes, identity: redacted)';
+}
+
+/// URL、event、size、digest の整合を検証済みの archive descriptor。
+///
+/// `EstimatedIntensityArchiveDescriptorValidator` が検証後に生成し、downstream は
+/// この値を未検証 API input の代わりに使用する。
+final class EstimatedIntensityArchiveDescriptor {
+  // ignore: unnecessary_type_name_in_constructor
+  const EstimatedIntensityArchiveDescriptor._({
+    required this.eventId,
+    required this.url,
+    required this.sizeBytes,
+    required this.sha256,
+  });
+
+  final String eventId;
+  final Uri url;
+  final int sizeBytes;
+  final String sha256;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EstimatedIntensityArchiveDescriptor &&
+          eventId == other.eventId &&
+          url == other.url &&
+          sizeBytes == other.sizeBytes &&
+          sha256 == other.sha256;
+
+  @override
+  int get hashCode => Object.hash(eventId, url, sizeBytes, sha256);
+
+  @override
+  String toString() =>
+      'EstimatedIntensityArchiveDescriptor('
+      'eventId: $eventId, sizeBytes: $sizeBytes, identity: redacted)';
+}
+
+/// Descriptor URL と archive size に対する caller-owned policy。
+final class EstimatedIntensityArchiveUrlPolicy {
+  new({
+    required Set<String> allowedHosts,
+    required this.maxArchiveBytes,
+  }) : allowedHosts = Set.unmodifiable(allowedHosts) {
+    if (allowedHosts.isEmpty) {
+      throw ArgumentError.value(
+        allowedHosts,
+        'allowedHosts',
+        'must not be empty',
+      );
+    }
+    if (maxArchiveBytes <= 0) {
+      throw ArgumentError.value(
+        maxArchiveBytes,
+        'maxArchiveBytes',
+        'must be positive',
+      );
+    }
+  }
+
+  /// `Uri.host` と suffix ではなく完全一致で比較する hostname の集合。
+  final Set<String> allowedHosts;
+
+  /// Descriptor が宣言できる archive size の上限。既定値は持たない。
+  final int maxArchiveBytes;
+}

--- a/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_failure.dart
+++ b/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_failure.dart
@@ -1,0 +1,57 @@
+part of 'estimated_intensity_archive_descriptor.dart';
+
+/// Untrusted descriptor の値を保持しない fail-closed reason。
+enum EstimatedIntensityArchiveFailure {
+  invalidEventId,
+  invalidUrl,
+  insecureScheme,
+  missingAuthority,
+  userInfoNotAllowed,
+  queryNotAllowed,
+  fragmentNotAllowed,
+  nonDefaultPort,
+  disallowedHost,
+  invalidPath,
+  nonCanonicalUrl,
+  eventIdMismatch,
+  invalidSha256,
+  sha256Mismatch,
+  invalidSize,
+  archiveTooLarge,
+}
+
+/// API field の欠落、検証成功、検証失敗を区別する結果。
+sealed class EstimatedIntensityArchiveValidationResult {
+  const new();
+}
+
+final class EstimatedIntensityArchiveValidationMissing
+    extends EstimatedIntensityArchiveValidationResult {
+  const new();
+
+  @override
+  String toString() => 'EstimatedIntensityArchiveValidationResult.missing()';
+}
+
+final class EstimatedIntensityArchiveValidationValid
+    extends EstimatedIntensityArchiveValidationResult {
+  const new(this.descriptor);
+
+  final EstimatedIntensityArchiveDescriptor descriptor;
+
+  @override
+  String toString() =>
+      'EstimatedIntensityArchiveValidationResult.valid($descriptor)';
+}
+
+final class EstimatedIntensityArchiveValidationInvalid
+    extends EstimatedIntensityArchiveValidationResult {
+  const new(this.failure);
+
+  final EstimatedIntensityArchiveFailure failure;
+
+  @override
+  String toString() =>
+      'EstimatedIntensityArchiveValidationResult.invalid('
+      'failure: $failure)';
+}

--- a/app/test/feature/earthquake_history/data/dart_api_compiler_test_support.dart
+++ b/app/test/feature/earthquake_history/data/dart_api_compiler_test_support.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+
+final class DartApiCompiler {
+  const new({
+    required this.dartExecutable,
+    required this.packageConfig,
+  });
+
+  static DartApiCompiler resolve() {
+    var workspace = Directory.current;
+    while (!File(
+      '${workspace.path}/.dart_tool/package_config.json',
+    ).existsSync()) {
+      final parent = workspace.parent;
+      if (parent.path == workspace.path) {
+        throw StateError('Could not locate workspace package_config.json');
+      }
+      workspace = parent;
+    }
+
+    var flutterSdkDirectory = File(Platform.resolvedExecutable).parent;
+    while (!File(
+      '${flutterSdkDirectory.path}/dart-sdk/bin/dart',
+    ).existsSync()) {
+      final parent = flutterSdkDirectory.parent;
+      if (parent.path == flutterSdkDirectory.path) {
+        throw StateError(
+          'Could not locate Dart SDK from Platform.resolvedExecutable',
+        );
+      }
+      flutterSdkDirectory = parent;
+    }
+
+    return DartApiCompiler(
+      dartExecutable: '${flutterSdkDirectory.path}/dart-sdk/bin/dart',
+      packageConfig: '${workspace.path}/.dart_tool/package_config.json',
+    );
+  }
+
+  final String dartExecutable;
+  final String packageConfig;
+
+  Future<ProcessResult> compile({
+    required Directory directory,
+    required String name,
+    required String source,
+  }) async {
+    final sourceFile = File('${directory.path}/$name.dart');
+    await sourceFile.writeAsString(source);
+    return Process.run(dartExecutable, [
+      'compile',
+      'kernel',
+      '--packages=$packageConfig',
+      '--output=${directory.path}/$name.dill',
+      sourceFile.path,
+    ]);
+  }
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_descriptor_api_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_descriptor_api_test.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'dart_api_compiler_test_support.dart';
+
+void main() {
+  test(
+    'unchecked descriptor construction is not part of the public API',
+    () async {
+      final temporaryDirectory = await Directory.systemTemp.createTemp(
+        'estimated_intensity_descriptor_api_',
+      );
+      addTearDown(() => temporaryDirectory.delete(recursive: true));
+      final compiler = DartApiCompiler.resolve();
+      final controlResult = await compiler.compile(
+        directory: temporaryDirectory,
+        name: 'control',
+        source: '''
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+
+void main() {
+  const validator = EstimatedIntensityArchiveDescriptorValidator();
+  final result = validator.validate(
+    eventId: '20260823020050',
+    input: null,
+    policy: EstimatedIntensityArchiveUrlPolicy(
+      allowedHosts: const {'tiles.example.test'},
+      maxArchiveBytes: 1,
+    ),
+  );
+  if (result is! EstimatedIntensityArchiveValidationMissing) {
+    throw StateError('unexpected public API result');
+  }
+}
+''',
+      );
+      final controlDiagnostics =
+          '${controlResult.stdout}\n${controlResult.stderr}';
+      expect(controlResult.exitCode, 0, reason: controlDiagnostics);
+
+      final result = await compiler.compile(
+        directory: temporaryDirectory,
+        name: 'unchecked',
+        source:
+            '''
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+
+void main() {
+  EstimatedIntensityArchiveDescriptor(
+    eventId: '20260823020050',
+    url: Uri.parse(
+      'https://tiles.example.test/ixac41/20260823020050/'
+      '${'a' * 64}.pmtiles',
+    ),
+    sizeBytes: 1,
+    sha256: '${'a' * 64}',
+  );
+}
+''',
+      );
+      final diagnostics = '${result.stdout}\n${result.stderr}';
+
+      expect(result.exitCode, isNot(0), reason: diagnostics);
+      expect(
+        diagnostics,
+        anyOf(
+          contains(
+            "Couldn't find constructor 'EstimatedIntensityArchiveDescriptor'",
+          ),
+          contains(
+            "Member not found: 'EstimatedIntensityArchiveDescriptor.new'",
+          ),
+        ),
+      );
+    },
+  );
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_descriptor_test_support.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_descriptor_test_support.dart
@@ -1,0 +1,28 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+
+final class EstimatedIntensityArchiveDescriptorTestSupport {
+  const new();
+
+  static const eventId = '20260823020050';
+  static const allowedHost = 'tiles.example.test';
+  static const validator = EstimatedIntensityArchiveDescriptorValidator();
+
+  String get sha256 => 'a' * 64;
+  String get otherSha256 => 'b' * 64;
+  String get validUrl => 'https://$allowedHost/ixac41/$eventId/$sha256.pmtiles';
+  EstimatedIntensityArchiveUrlPolicy get policy =>
+      EstimatedIntensityArchiveUrlPolicy(
+        allowedHosts: const {allowedHost},
+        maxArchiveBytes: 2_000_000,
+      );
+
+  EstimatedIntensityArchiveDescriptorInput input({
+    String? url,
+    int sizeBytes = 1_000_000,
+    String? digest,
+  }) => EstimatedIntensityArchiveDescriptorInput(
+    url: url ?? validUrl,
+    sizeBytes: sizeBytes,
+    sha256: digest ?? sha256,
+  );
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_descriptor_validator_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_descriptor_validator_test.dart
@@ -1,0 +1,68 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_descriptor_test_support.dart';
+
+void main() {
+  const support = EstimatedIntensityArchiveDescriptorTestSupport();
+
+  test('accepts a canonical descriptor', () {
+    final result = EstimatedIntensityArchiveDescriptorTestSupport.validator
+        .validate(
+          eventId: EstimatedIntensityArchiveDescriptorTestSupport.eventId,
+          input: support.input(),
+          policy: support.policy,
+        );
+
+    expect(result, isA<EstimatedIntensityArchiveValidationValid>());
+    final valid = result as EstimatedIntensityArchiveValidationValid;
+    expect(
+      valid.descriptor.eventId,
+      EstimatedIntensityArchiveDescriptorTestSupport.eventId,
+    );
+    expect(valid.descriptor.url, Uri.parse(support.validUrl));
+    expect(valid.descriptor.sizeBytes, 1_000_000);
+    expect(valid.descriptor.sha256, support.sha256);
+  });
+
+  test('accepts explicit HTTPS port 443', () {
+    final url =
+        'https://${EstimatedIntensityArchiveDescriptorTestSupport.allowedHost}:443/'
+        'ixac41/${EstimatedIntensityArchiveDescriptorTestSupport.eventId}/'
+        '${support.sha256}.pmtiles';
+    final result = EstimatedIntensityArchiveDescriptorTestSupport.validator
+        .validate(
+          eventId: EstimatedIntensityArchiveDescriptorTestSupport.eventId,
+          input: support.input(url: url),
+          policy: support.policy,
+        );
+
+    final descriptor =
+        (result as EstimatedIntensityArchiveValidationValid).descriptor;
+    expect(descriptor.url, Uri.parse(url));
+  });
+
+  test('distinguishes an absent API descriptor from an invalid one', () {
+    final result = EstimatedIntensityArchiveDescriptorTestSupport.validator
+        .validate(
+          eventId: EstimatedIntensityArchiveDescriptorTestSupport.eventId,
+          input: null,
+          policy: support.policy,
+        );
+
+    expect(result, isA<EstimatedIntensityArchiveValidationMissing>());
+  });
+
+  test('failure text retains neither the raw URL nor SHA-256', () {
+    final rawUrl = '${support.validUrl}?secret=value';
+    final result = EstimatedIntensityArchiveDescriptorTestSupport.validator
+        .validate(
+          eventId: EstimatedIntensityArchiveDescriptorTestSupport.eventId,
+          input: support.input(url: rawUrl),
+          policy: support.policy,
+        );
+
+    expect(result.toString(), isNot(contains(rawUrl)));
+    expect(result.toString(), isNot(contains(support.sha256)));
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_identity_validator_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_identity_validator_test.dart
@@ -1,0 +1,83 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_descriptor_test_support.dart';
+
+void main() {
+  const support = EstimatedIntensityArchiveDescriptorTestSupport();
+  final eventId = EstimatedIntensityArchiveDescriptorTestSupport.eventId;
+  final host = EstimatedIntensityArchiveDescriptorTestSupport.allowedHost;
+
+  for (final invalidEventId in [
+    '2026082302005',
+    '202608230200500',
+    '２０２６０８２３０２００５０',
+    '2026082302005A',
+  ]) {
+    test('rejects non-ASCII-14 event ID $invalidEventId', () {
+      final result = EstimatedIntensityArchiveDescriptorTestSupport.validator
+          .validate(
+            eventId: invalidEventId,
+            input: support.input(),
+            policy: support.policy,
+          );
+
+      expect(
+        (result as EstimatedIntensityArchiveValidationInvalid).failure,
+        EstimatedIntensityArchiveFailure.invalidEventId,
+      );
+    });
+  }
+
+  final hashCases =
+      <
+        ({
+          String name,
+          String url,
+          String digest,
+          EstimatedIntensityArchiveFailure failure,
+        })
+      >[
+        (
+          name: 'uppercase URL hash',
+          url:
+              'https://$host/ixac41/$eventId/${support.sha256.toUpperCase()}.pmtiles',
+          digest: support.sha256,
+          failure: EstimatedIntensityArchiveFailure.invalidSha256,
+        ),
+        (
+          name: 'short URL hash',
+          url: 'https://$host/ixac41/$eventId/${'a' * 63}.pmtiles',
+          digest: support.sha256,
+          failure: EstimatedIntensityArchiveFailure.invalidSha256,
+        ),
+        (
+          name: 'uppercase descriptor hash',
+          url: support.validUrl,
+          digest: support.sha256.toUpperCase(),
+          failure: EstimatedIntensityArchiveFailure.invalidSha256,
+        ),
+        (
+          name: 'URL and descriptor hash mismatch',
+          url: 'https://$host/ixac41/$eventId/${support.otherSha256}.pmtiles',
+          digest: support.sha256,
+          failure: EstimatedIntensityArchiveFailure.sha256Mismatch,
+        ),
+      ];
+
+  for (final testCase in hashCases) {
+    test('rejects ${testCase.name}', () {
+      final result = EstimatedIntensityArchiveDescriptorTestSupport.validator
+          .validate(
+            eventId: eventId,
+            input: support.input(url: testCase.url, digest: testCase.digest),
+            policy: support.policy,
+          );
+
+      expect(
+        (result as EstimatedIntensityArchiveValidationInvalid).failure,
+        testCase.failure,
+      );
+    });
+  }
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_size_policy_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_size_policy_test.dart
@@ -1,0 +1,75 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_descriptor_test_support.dart';
+
+void main() {
+  const support = EstimatedIntensityArchiveDescriptorTestSupport();
+
+  for (final invalidSize in [0, -1]) {
+    test('rejects non-positive size $invalidSize', () {
+      final result = EstimatedIntensityArchiveDescriptorTestSupport.validator
+          .validate(
+            eventId: EstimatedIntensityArchiveDescriptorTestSupport.eventId,
+            input: support.input(sizeBytes: invalidSize),
+            policy: support.policy,
+          );
+
+      expect(
+        (result as EstimatedIntensityArchiveValidationInvalid).failure,
+        EstimatedIntensityArchiveFailure.invalidSize,
+      );
+    });
+  }
+
+  test('rejects a size above the caller cap', () {
+    final result = EstimatedIntensityArchiveDescriptorTestSupport.validator
+        .validate(
+          eventId: EstimatedIntensityArchiveDescriptorTestSupport.eventId,
+          input: support.input(sizeBytes: 2_000_001),
+          policy: support.policy,
+        );
+
+    expect(
+      (result as EstimatedIntensityArchiveValidationInvalid).failure,
+      EstimatedIntensityArchiveFailure.archiveTooLarge,
+    );
+  });
+
+  test('takes a defensive copy of the exact host allowlist', () {
+    final hosts = {EstimatedIntensityArchiveDescriptorTestSupport.allowedHost};
+    final policy = EstimatedIntensityArchiveUrlPolicy(
+      allowedHosts: hosts,
+      maxArchiveBytes: 1,
+    );
+
+    hosts.add('attacker.test');
+
+    expect(policy.allowedHosts, {
+      EstimatedIntensityArchiveDescriptorTestSupport.allowedHost,
+    });
+    expect(
+      () => policy.allowedHosts.add('attacker.test'),
+      throwsUnsupportedError,
+    );
+  });
+
+  test('rejects an empty allowlist and non-positive byte cap', () {
+    expect(
+      () => EstimatedIntensityArchiveUrlPolicy(
+        allowedHosts: const {},
+        maxArchiveBytes: 1,
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => EstimatedIntensityArchiveUrlPolicy(
+        allowedHosts: const {
+          EstimatedIntensityArchiveDescriptorTestSupport.allowedHost,
+        },
+        maxArchiveBytes: 0,
+      ),
+      throwsArgumentError,
+    );
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_url_authority_validator_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_url_authority_validator_test.dart
@@ -1,0 +1,77 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_descriptor_test_support.dart';
+
+void main() {
+  const support = EstimatedIntensityArchiveDescriptorTestSupport();
+  final eventId = EstimatedIntensityArchiveDescriptorTestSupport.eventId;
+  final host = EstimatedIntensityArchiveDescriptorTestSupport.allowedHost;
+
+  final cases = <({String name, String url, EstimatedIntensityArchiveFailure failure})>[
+    (
+      name: 'non-HTTPS scheme',
+      url: 'http://$host/ixac41/$eventId/${support.sha256}.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.insecureScheme,
+    ),
+    (
+      name: 'userinfo',
+      url: 'https://user@$host/ixac41/$eventId/${support.sha256}.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.userInfoNotAllowed,
+    ),
+    (
+      name: 'query',
+      url: '${support.validUrl}?token=value',
+      failure: EstimatedIntensityArchiveFailure.queryNotAllowed,
+    ),
+    (
+      name: 'fragment',
+      url: '${support.validUrl}#fragment',
+      failure: EstimatedIntensityArchiveFailure.fragmentNotAllowed,
+    ),
+    (
+      name: 'non-default port',
+      url: 'https://$host:8443/ixac41/$eventId/${support.sha256}.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.nonDefaultPort,
+    ),
+    (
+      name: 'host outside allowlist',
+      url:
+          'https://other.example.test/ixac41/$eventId/${support.sha256}.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.disallowedHost,
+    ),
+    (
+      name: 'allowlist suffix spoof',
+      url:
+          'https://$host.attacker.test/ixac41/$eventId/${support.sha256}.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.disallowedHost,
+    ),
+    (
+      name: 'malformed absolute URL',
+      url: 'https://',
+      failure: EstimatedIntensityArchiveFailure.invalidUrl,
+    ),
+    (
+      name: 'missing authority',
+      url: 'https:ixac41/$eventId/${support.sha256}.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.missingAuthority,
+    ),
+  ];
+
+  for (final testCase in cases) {
+    test('rejects ${testCase.name}', () {
+      final result = EstimatedIntensityArchiveDescriptorTestSupport.validator
+          .validate(
+            eventId: eventId,
+            input: support.input(url: testCase.url),
+            policy: support.policy,
+          );
+
+      expect(result, isA<EstimatedIntensityArchiveValidationInvalid>());
+      expect(
+        (result as EstimatedIntensityArchiveValidationInvalid).failure,
+        testCase.failure,
+      );
+    });
+  }
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_url_path_validator_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_url_path_validator_test.dart
@@ -1,0 +1,79 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_descriptor_test_support.dart';
+
+void main() {
+  const support = EstimatedIntensityArchiveDescriptorTestSupport();
+  final eventId = EstimatedIntensityArchiveDescriptorTestSupport.eventId;
+  final host = EstimatedIntensityArchiveDescriptorTestSupport.allowedHost;
+  final sha256 = support.sha256;
+
+  final cases = <({String name, String url, EstimatedIntensityArchiveFailure failure})>[
+    (
+      name: 'double slash',
+      url: 'https://$host/ixac41//$eventId/$sha256.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.invalidPath,
+    ),
+    (
+      name: 'trailing slash',
+      url: '${support.validUrl}/',
+      failure: EstimatedIntensityArchiveFailure.invalidPath,
+    ),
+    (
+      name: 'dot segment',
+      url: 'https://$host/ixac41/./$eventId/$sha256.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.nonCanonicalUrl,
+    ),
+    (
+      name: 'encoded slash',
+      url:
+          'https://$host/ixac41/${eventId.substring(0, 13)}%2F0/$sha256.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.invalidPath,
+    ),
+    (
+      name: 'encoded backslash',
+      url:
+          'https://$host/ixac41/${eventId.substring(0, 13)}%5C0/$sha256.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.invalidPath,
+    ),
+    (
+      name: 'lowercase encoded separator',
+      url:
+          'https://$host/ixac41/${eventId.substring(0, 13)}%5c0/$sha256.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.invalidPath,
+    ),
+    (
+      name: 'unreserved percent alias',
+      url: 'https://$host/%69xac41/$eventId/$sha256.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.nonCanonicalUrl,
+    ),
+    (
+      name: 'wrong event',
+      url: 'https://$host/ixac41/20260823020051/$sha256.pmtiles',
+      failure: EstimatedIntensityArchiveFailure.eventIdMismatch,
+    ),
+    (
+      name: 'extra path segment',
+      url: 'https://$host/ixac41/$eventId/$sha256.pmtiles/extra',
+      failure: EstimatedIntensityArchiveFailure.invalidPath,
+    ),
+  ];
+
+  for (final testCase in cases) {
+    test('rejects ${testCase.name}', () {
+      final result = EstimatedIntensityArchiveDescriptorTestSupport.validator
+          .validate(
+            eventId: eventId,
+            input: support.input(url: testCase.url),
+            policy: support.policy,
+          );
+
+      expect(result, isA<EstimatedIntensityArchiveValidationInvalid>());
+      expect(
+        (result as EstimatedIntensityArchiveValidationInvalid).failure,
+        testCase.failure,
+      );
+    });
+  }
+}


### PR DESCRIPTION
## 概要

- 推計震度archive descriptorをpackage-neutralなdomain型へ変換
- event ID、HTTPS authority、exact host、canonical path、SHA-256、size上限をfail closedで検証
- descriptor欠落・正常・不正をtyped resultで区別
- raw URL/hashをfailureや文字列表示へ残さない
- 検証済みdescriptorのconstructorをlibrary-privateにし、validator迂回をcompile testで防止
- production byte capは暗黙に決めずcaller必須policyとする

## 検証

- focused Flutter tests 36件成功
- scoped `dart analyze --fatal-infos`: No issues
- format check: 13 files、変更なし
- `git diff --check`
- 独立再レビュー: Critical / Important / Minor 0

## Scope

このPRは純粋なsource contractのみです。Earthquake model/repository/realtime統合は後続PRへ分離します。

## Stack

- Stack issue: #1756
- Parent: #1773