### PR TITLE
feat: 推計震度archive取得を検証

### DIFF
--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_attestation_binder.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_attestation_binder.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+
+/// Verifier resultを現在のdescriptorと一時fileへ再bindし、replayを拒否する。
+final class EstimatedIntensityArchiveAttestationBinder {
+  const new();
+
+  EstimatedIntensityArchiveDownloadResult bind({
+    required EstimatedIntensityArchiveDownloadResult result,
+    required EstimatedIntensityArchiveDescriptor descriptor,
+    required File partFile,
+  }) {
+    if (result case EstimatedIntensityArchiveDownloadSuccess(:final archive)) {
+      final matchesCurrentDownload =
+          archive.eventId == descriptor.eventId &&
+          archive.sha256 == descriptor.sha256 &&
+          archive.sizeBytes == descriptor.sizeBytes &&
+          identical(archive.file, partFile);
+      if (!matchesCurrentDownload) {
+        return const EstimatedIntensityArchiveDownloadRejected(
+          EstimatedIntensityArchiveDownloadFailure.requestFailed,
+        );
+      }
+    }
+    return result;
+  }
+}

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_download_guard.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_download_guard.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_stop_reason.dart';
+
+/// 一回のHTTP操作にcancel/total timeoutを結び付けるlifecycle owner。
+final class EstimatedIntensityArchiveDownloadGuard {
+  new({
+    required this.operation,
+    required Duration totalTimeout,
+    EstimatedIntensityArchiveDownloadCancellation? cancellation,
+  }) : cancelled = cancellation?.isCancelled ?? false {
+    cancellationSubscription = cancellation?.onCancel.listen((_) {
+      cancelled = true;
+      operation.abort();
+    });
+    if (cancellation?.isCancelled ?? false) {
+      cancelled = true;
+      operation.abort();
+    }
+    totalTimer = Timer(totalTimeout, () {
+      timedOut = true;
+      operation.abort();
+    });
+  }
+
+  final EstimatedIntensityArchiveHttpOperation operation;
+  late final Timer totalTimer;
+  StreamSubscription<void>? cancellationSubscription;
+  bool cancelled;
+  var timedOut = false;
+
+  EstimatedIntensityArchiveStopReason get stopReason => cancelled
+      ? EstimatedIntensityArchiveStopReason.cancelled
+      : timedOut
+      ? EstimatedIntensityArchiveStopReason.timeout
+      : EstimatedIntensityArchiveStopReason.none;
+
+  Future<void> close() async {
+    totalTimer.cancel();
+    await cancellationSubscription?.cancel();
+  }
+}

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_file_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_file_verifier.dart
@@ -1,0 +1,41 @@
+part of '../model/estimated_intensity_archive_download.dart';
+
+/// Close済み一時fileを再読込し、exact sizeとSHA-256をattestする。
+abstract interface class EstimatedIntensityArchiveFileVerifier {
+  Future<EstimatedIntensityArchiveDownloadResult> verify({
+    required EstimatedIntensityArchiveDescriptor descriptor,
+    required File file,
+  });
+}
+
+final class DartIoEstimatedIntensityArchiveFileVerifier
+    implements EstimatedIntensityArchiveFileVerifier {
+  const new();
+
+  @override
+  Future<EstimatedIntensityArchiveDownloadResult> verify({
+    required EstimatedIntensityArchiveDescriptor descriptor,
+    required File file,
+  }) async {
+    final actualLength = await file.length();
+    if (actualLength != descriptor.sizeBytes) {
+      return const EstimatedIntensityArchiveDownloadRejected(
+        EstimatedIntensityArchiveDownloadFailure.sizeMismatch,
+      );
+    }
+    final actualSha256 = (await sha256.bind(file.openRead()).first).toString();
+    if (actualSha256 != descriptor.sha256) {
+      return const EstimatedIntensityArchiveDownloadRejected(
+        EstimatedIntensityArchiveDownloadFailure.sha256Mismatch,
+      );
+    }
+    return EstimatedIntensityArchiveDownloadSuccess(
+      VerifiedEstimatedIntensityArchiveDownload._(
+        eventId: descriptor.eventId,
+        sha256: descriptor.sha256,
+        file: file,
+        sizeBytes: actualLength,
+      ),
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart
@@ -1,0 +1,100 @@
+import 'dart:async' show TimeoutException;
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_download_guard.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_response_validator.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+
+final class EstimatedIntensityArchiveHttpDataSource {
+  const new({
+    this.operationFactory =
+        EstimatedIntensityArchiveHttpOperationFactory.create,
+    this.responseValidator = const EstimatedIntensityArchiveResponseValidator(),
+    this.streamVerifier = const EstimatedIntensityArchiveStreamVerifier(),
+  });
+  final EstimatedIntensityArchiveHttpOperationCreator operationFactory;
+  final EstimatedIntensityArchiveResponseValidator responseValidator;
+  final EstimatedIntensityArchiveStreamVerifier streamVerifier;
+  Future<EstimatedIntensityArchiveDownloadResult> download({
+    required EstimatedIntensityArchiveDescriptor descriptor,
+    required Directory temporaryDirectory,
+    required EstimatedIntensityArchiveDownloadLimits limits,
+    EstimatedIntensityArchiveDownloadCancellation? cancellation,
+  }) async {
+    if (descriptor.sizeBytes > limits.maxArchiveBytes) {
+      return const EstimatedIntensityArchiveDownloadRejected(
+        EstimatedIntensityArchiveDownloadFailure.archiveTooLarge,
+      );
+    }
+    if (cancellation?.isCancelled ?? false) {
+      return const EstimatedIntensityArchiveDownloadRejected(
+        EstimatedIntensityArchiveDownloadFailure.cancelled,
+      );
+    }
+    final operation = operationFactory();
+    Directory? stagingDirectory;
+    var succeeded = false;
+    final guard = EstimatedIntensityArchiveDownloadGuard(
+      operation: operation,
+      totalTimeout: limits.totalTimeout,
+      cancellation: cancellation,
+    );
+    try {
+      stagingDirectory = await temporaryDirectory.createTemp(
+        'estimated-intensity-',
+      );
+      final response = await operation.open(
+        url: descriptor.url,
+        connectTimeout: limits.connectTimeout,
+        headerTimeout: limits.headerTimeout,
+      );
+      final responseFailure = responseValidator.validate(
+        response: response,
+        descriptor: descriptor,
+        maxArchiveBytes: limits.maxArchiveBytes,
+      );
+      if (responseFailure case final failure?) {
+        return EstimatedIntensityArchiveDownloadRejected(failure);
+      }
+      final result = await streamVerifier.verify(
+        response: response,
+        descriptor: descriptor,
+        limits: limits,
+        partFile: File('${stagingDirectory.path}/archive.part'),
+        stopReason: () => guard.stopReason,
+      );
+      succeeded = result is EstimatedIntensityArchiveDownloadSuccess;
+      return result;
+    } on TimeoutException {
+      return const EstimatedIntensityArchiveDownloadRejected(
+        EstimatedIntensityArchiveDownloadFailure.timeout,
+      );
+    } on FileSystemException {
+      return const EstimatedIntensityArchiveDownloadRejected(
+        EstimatedIntensityArchiveDownloadFailure.storageFailure,
+      );
+    } catch (_) {
+      return EstimatedIntensityArchiveDownloadRejected(
+        guard.cancelled
+            ? EstimatedIntensityArchiveDownloadFailure.cancelled
+            : guard.timedOut
+            ? EstimatedIntensityArchiveDownloadFailure.timeout
+            : EstimatedIntensityArchiveDownloadFailure.requestFailed,
+      );
+    } finally {
+      await guard.close();
+      if (!succeeded) {
+        operation.abort();
+        if (stagingDirectory case final directory?) {
+          try {
+            await directory.delete(recursive: true);
+          } catch (_) {}
+        }
+      }
+      operation.close();
+    }
+  }
+}

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart
@@ -1,0 +1,93 @@
+import 'dart:io';
+
+final class EstimatedIntensityArchiveHttpResponse {
+  const new({
+    required this.statusCode,
+    required this.contentEncodings,
+    required this.contentLength,
+    required this.body,
+  });
+
+  final int statusCode;
+  final List<String> contentEncodings;
+  final int contentLength;
+  final Stream<List<int>> body;
+
+  @override
+  String toString() =>
+      'EstimatedIntensityArchiveHttpResponse('
+      'statusCode: $statusCode, headers: redacted)';
+}
+
+abstract interface class EstimatedIntensityArchiveHttpOperation {
+  Future<EstimatedIntensityArchiveHttpResponse> open({
+    required Uri url,
+    required Duration connectTimeout,
+    required Duration headerTimeout,
+  });
+
+  /// Pending `open`/bodyを必ずsettleさせる。cleanupはsettle後にだけ実行される。
+  void abort();
+
+  void close();
+}
+
+typedef EstimatedIntensityArchiveHttpOperationCreator =
+    EstimatedIntensityArchiveHttpOperation Function();
+
+final class EstimatedIntensityArchiveHttpOperationFactory {
+  const new();
+
+  static EstimatedIntensityArchiveHttpOperation create() =>
+      DartIoEstimatedIntensityArchiveHttpOperation(client: HttpClient());
+}
+
+/// 一回のdownloadだけを所有する`dart:io` HTTP adapter。
+final class DartIoEstimatedIntensityArchiveHttpOperation
+    implements EstimatedIntensityArchiveHttpOperation {
+  new({required this.client});
+
+  final HttpClient client;
+  HttpClientRequest? activeRequest;
+  var aborted = false;
+
+  @override
+  Future<EstimatedIntensityArchiveHttpResponse> open({
+    required Uri url,
+    required Duration connectTimeout,
+    required Duration headerTimeout,
+  }) async {
+    client
+      ..autoUncompress = false
+      ..connectionTimeout = connectTimeout;
+    final request = await client.openUrl('GET', url).timeout(connectTimeout);
+    activeRequest = request;
+    request
+      ..followRedirects = false
+      ..maxRedirects = 0;
+    request.headers.set(HttpHeaders.acceptEncodingHeader, 'identity');
+    final response = await request.close().timeout(headerTimeout);
+    return EstimatedIntensityArchiveHttpResponse(
+      statusCode: response.statusCode,
+      contentEncodings:
+          response.headers[HttpHeaders.contentEncodingHeader] ?? const [],
+      contentLength: response.contentLength,
+      body: response,
+    );
+  }
+
+  @override
+  void abort() {
+    if (aborted) {
+      return;
+    }
+    aborted = true;
+    activeRequest?.abort();
+    client.close(force: true);
+  }
+
+  @override
+  void close() {
+    client.close(force: true);
+  }
+}

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_part_writer.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_part_writer.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+abstract interface class EstimatedIntensityArchivePartWriter {
+  Future<void> write(List<int> bytes);
+
+  Future<void> flushAndClose();
+
+  Future<void> close();
+}
+
+typedef EstimatedIntensityArchivePartWriterCreator =
+    Future<EstimatedIntensityArchivePartWriter> Function(File file);
+
+final class EstimatedIntensityArchivePartWriterFactory {
+  const new();
+
+  static Future<EstimatedIntensityArchivePartWriter> create(File file) =>
+      DartIoEstimatedIntensityArchivePartWriter.open(file);
+}
+
+/// `RandomAccessFile.writeFrom`をawaitし、socketへのbackpressureを保つwriter。
+final class DartIoEstimatedIntensityArchivePartWriter
+    implements EstimatedIntensityArchivePartWriter {
+  new({required RandomAccessFile file}) : _file = file;
+
+  static Future<DartIoEstimatedIntensityArchivePartWriter> open(
+    File file,
+  ) async => DartIoEstimatedIntensityArchivePartWriter(
+    file: await file.open(mode: FileMode.writeOnly),
+  );
+
+  final RandomAccessFile _file;
+  var _closed = false;
+
+  @override
+  Future<void> write(List<int> bytes) => _file.writeFrom(bytes);
+
+  @override
+  Future<void> flushAndClose() async {
+    if (_closed) {
+      return;
+    }
+    await _file.flush();
+    await _file.close();
+    _closed = true;
+  }
+
+  @override
+  Future<void> close() async {
+    if (_closed) {
+      return;
+    }
+    await _file.close();
+    _closed = true;
+  }
+}

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_response_validator.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_response_validator.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+
+final class EstimatedIntensityArchiveResponseValidator {
+  const new();
+
+  EstimatedIntensityArchiveDownloadFailure? validate({
+    required EstimatedIntensityArchiveHttpResponse response,
+    required EstimatedIntensityArchiveDescriptor descriptor,
+    required int maxArchiveBytes,
+  }) {
+    if (response.statusCode != HttpStatus.ok) {
+      return EstimatedIntensityArchiveDownloadFailure.invalidStatus;
+    }
+    final encodings = response.contentEncodings;
+    if (encodings.length > 1) {
+      return EstimatedIntensityArchiveDownloadFailure.invalidContentEncoding;
+    }
+    if (encodings case [final encoding]) {
+      if (encoding.trim().toLowerCase() != 'identity') {
+        return EstimatedIntensityArchiveDownloadFailure.invalidContentEncoding;
+      }
+    }
+    final contentLength = response.contentLength;
+    if (contentLength >= 0 &&
+        (contentLength != descriptor.sizeBytes ||
+            contentLength > maxArchiveBytes)) {
+      return EstimatedIntensityArchiveDownloadFailure.invalidContentLength;
+    }
+    return null;
+  }
+}

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_attestation_binder.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_part_writer.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
@@ -12,11 +13,13 @@ final class EstimatedIntensityArchiveStreamVerifier {
     this.stopResultMapper = const EstimatedIntensityArchiveStopResultMapper(),
     this.fileVerifier = const DartIoEstimatedIntensityArchiveFileVerifier(),
     this.partWriterFactory = EstimatedIntensityArchivePartWriterFactory.create,
+    this.attestationBinder = const EstimatedIntensityArchiveAttestationBinder(),
   });
 
   final EstimatedIntensityArchiveStopResultMapper stopResultMapper;
   final EstimatedIntensityArchiveFileVerifier fileVerifier;
   final EstimatedIntensityArchivePartWriterCreator partWriterFactory;
+  final EstimatedIntensityArchiveAttestationBinder attestationBinder;
 
   Future<EstimatedIntensityArchiveDownloadResult> verify({
     required EstimatedIntensityArchiveHttpResponse response,
@@ -68,7 +71,11 @@ final class EstimatedIntensityArchiveStreamVerifier {
       if (finalStop != EstimatedIntensityArchiveStopReason.none) {
         return stopResultMapper.map(finalStop);
       }
-      return verified;
+      return attestationBinder.bind(
+        result: verified,
+        descriptor: descriptor,
+        partFile: partFile,
+      );
     } on TimeoutException {
       final stopped = stopReason();
       if (stopped != EstimatedIntensityArchiveStopReason.none) {

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_part_writer.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_stop_reason.dart';
+
+final class EstimatedIntensityArchiveStreamVerifier {
+  const new({
+    this.stopResultMapper = const EstimatedIntensityArchiveStopResultMapper(),
+    this.fileVerifier = const DartIoEstimatedIntensityArchiveFileVerifier(),
+    this.partWriterFactory = EstimatedIntensityArchivePartWriterFactory.create,
+  });
+
+  final EstimatedIntensityArchiveStopResultMapper stopResultMapper;
+  final EstimatedIntensityArchiveFileVerifier fileVerifier;
+  final EstimatedIntensityArchivePartWriterCreator partWriterFactory;
+
+  Future<EstimatedIntensityArchiveDownloadResult> verify({
+    required EstimatedIntensityArchiveHttpResponse response,
+    required EstimatedIntensityArchiveDescriptor descriptor,
+    required EstimatedIntensityArchiveDownloadLimits limits,
+    required File partFile,
+    required EstimatedIntensityArchiveStopReasonReader stopReason,
+  }) async {
+    EstimatedIntensityArchivePartWriter? output;
+    StreamIterator<List<int>>? bodyIterator;
+    try {
+      output = await partWriterFactory(partFile);
+      var receivedBytes = 0;
+      bodyIterator = StreamIterator(response.body.timeout(limits.idleTimeout));
+      while (await bodyIterator.moveNext()) {
+        final stopped = stopReason();
+        if (stopped != EstimatedIntensityArchiveStopReason.none) {
+          return stopResultMapper.map(stopped);
+        }
+        final chunk = bodyIterator.current;
+        final nextBytes = receivedBytes + chunk.length;
+        if (nextBytes > limits.maxArchiveBytes) {
+          return const EstimatedIntensityArchiveDownloadRejected(.archiveTooLarge);
+        }
+        if (nextBytes > descriptor.sizeBytes) {
+          return const EstimatedIntensityArchiveDownloadRejected(
+            EstimatedIntensityArchiveDownloadFailure.sizeMismatch,
+          );
+        }
+        await output.write(chunk);
+        receivedBytes = nextBytes;
+      }
+
+      final stopped = stopReason();
+      if (stopped != EstimatedIntensityArchiveStopReason.none) {
+        return stopResultMapper.map(stopped);
+      }
+      await output.flushAndClose();
+      if (receivedBytes != descriptor.sizeBytes) {
+        return const EstimatedIntensityArchiveDownloadRejected(
+          EstimatedIntensityArchiveDownloadFailure.sizeMismatch,
+        );
+      }
+      final verified = await fileVerifier.verify(
+        descriptor: descriptor,
+        file: partFile,
+      );
+      final finalStop = stopReason();
+      if (finalStop != EstimatedIntensityArchiveStopReason.none) {
+        return stopResultMapper.map(finalStop);
+      }
+      return verified;
+    } on TimeoutException {
+      final stopped = stopReason();
+      if (stopped != EstimatedIntensityArchiveStopReason.none) {
+        return stopResultMapper.map(stopped);
+      }
+      return const EstimatedIntensityArchiveDownloadRejected(
+        EstimatedIntensityArchiveDownloadFailure.timeout,
+      );
+    } on FileSystemException {
+      return const EstimatedIntensityArchiveDownloadRejected(
+        EstimatedIntensityArchiveDownloadFailure.storageFailure,
+      );
+    } catch (_) {
+      final stopped = stopReason();
+      if (stopped != EstimatedIntensityArchiveStopReason.none) {
+        return stopResultMapper.map(stopped);
+      }
+      return const EstimatedIntensityArchiveDownloadRejected(
+        EstimatedIntensityArchiveDownloadFailure.requestFailed,
+      );
+    } finally {
+      await bodyIterator?.cancel();
+      try {
+        await output?.close();
+      } catch (_) {}
+    }
+  }
+}

--- a/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart
+++ b/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+
+export 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_limits.dart';
+
+part '../data_source/estimated_intensity_archive_file_verifier.dart';
+
+/// Untrusted responseや例外の内容を保持しないfail-closed reason。
+enum EstimatedIntensityArchiveDownloadFailure {
+  cancelled,
+  timeout,
+  requestFailed,
+  invalidStatus,
+  invalidContentEncoding,
+  invalidContentLength,
+  archiveTooLarge,
+  sizeMismatch,
+  sha256Mismatch,
+  storageFailure,
+}
+
+sealed class EstimatedIntensityArchiveDownloadResult {
+  const new();
+}
+
+final class EstimatedIntensityArchiveDownloadSuccess
+    extends EstimatedIntensityArchiveDownloadResult {
+  const new(this.archive);
+
+  final VerifiedEstimatedIntensityArchiveDownload archive;
+
+  @override
+  String toString() =>
+      'EstimatedIntensityArchiveDownloadResult.success(identity: redacted)';
+}
+
+final class EstimatedIntensityArchiveDownloadRejected
+    extends EstimatedIntensityArchiveDownloadResult {
+  const new(this.failure);
+
+  final EstimatedIntensityArchiveDownloadFailure failure;
+
+  @override
+  String toString() =>
+      'EstimatedIntensityArchiveDownloadResult.rejected(failure: $failure)';
+}
+
+/// Exact sizeとSHA-256検証を完了した、未publishの一時archive。
+final class VerifiedEstimatedIntensityArchiveDownload {
+  // ignore: unnecessary_type_name_in_constructor
+  const VerifiedEstimatedIntensityArchiveDownload._({
+    required this.eventId,
+    required this.sha256,
+    required this.file,
+    required this.sizeBytes,
+  });
+
+  final String eventId;
+  final String sha256;
+  final File file;
+  final int sizeBytes;
+
+  @override
+  String toString() =>
+      'VerifiedEstimatedIntensityArchiveDownload('
+      'eventId: $eventId, sizeBytes: $sizeBytes, identity: redacted)';
+}

--- a/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_limits.dart
+++ b/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_limits.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+/// Archive取得時のcaller-owned上限。安全上の既定値は持たない。
+final class EstimatedIntensityArchiveDownloadLimits {
+  new({
+    required this.maxArchiveBytes,
+    required this.connectTimeout,
+    required this.headerTimeout,
+    required this.idleTimeout,
+    required this.totalTimeout,
+  }) {
+    if (maxArchiveBytes <= 0) {
+      throw ArgumentError.value(maxArchiveBytes, 'maxArchiveBytes');
+    }
+    for (final timeout in {
+      'connectTimeout': connectTimeout,
+      'headerTimeout': headerTimeout,
+      'idleTimeout': idleTimeout,
+      'totalTimeout': totalTimeout,
+    }.entries) {
+      if (timeout.value <= Duration.zero) {
+        throw ArgumentError.value(timeout.value, timeout.key);
+      }
+    }
+  }
+
+  final int maxArchiveBytes;
+  final Duration connectTimeout;
+  final Duration headerTimeout;
+  final Duration idleTimeout;
+  final Duration totalTimeout;
+}
+
+/// Lifecycle ownerが一回のdownload停止を通知するためのsignal。
+final class EstimatedIntensityArchiveDownloadCancellation {
+  final StreamController<void> _controller = StreamController<void>.broadcast(
+    sync: true,
+  );
+  var _isCancelled = false;
+
+  bool get isCancelled => _isCancelled;
+
+  Stream<void> get onCancel => _controller.stream;
+
+  Future<void> cancel() async {
+    if (!_isCancelled) {
+      _isCancelled = true;
+      _controller.add(null);
+      await _controller.close();
+    }
+  }
+}

--- a/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_stop_reason.dart
+++ b/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_stop_reason.dart
@@ -1,0 +1,23 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+
+enum EstimatedIntensityArchiveStopReason { none, cancelled, timeout }
+
+typedef EstimatedIntensityArchiveStopReasonReader =
+    EstimatedIntensityArchiveStopReason Function();
+
+final class EstimatedIntensityArchiveStopResultMapper {
+  const new();
+
+  EstimatedIntensityArchiveDownloadRejected map(
+    EstimatedIntensityArchiveStopReason reason,
+  ) => EstimatedIntensityArchiveDownloadRejected(
+    switch (reason) {
+      EstimatedIntensityArchiveStopReason.none =>
+        EstimatedIntensityArchiveDownloadFailure.requestFailed,
+      EstimatedIntensityArchiveStopReason.cancelled =>
+        EstimatedIntensityArchiveDownloadFailure.cancelled,
+      EstimatedIntensityArchiveStopReason.timeout =>
+        EstimatedIntensityArchiveDownloadFailure.timeout,
+    },
+  );
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_abort_settlement_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_abort_settlement_test.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_abort_test_support.dart';
+import 'estimated_intensity_archive_io_test_support.dart';
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_abort_settlement_test_',
+    );
+  });
+
+  tearDown(() async {
+    if (temporaryDirectory.existsSync()) {
+      await temporaryDirectory.delete(recursive: true);
+    }
+  });
+
+  test('dart:io open待機中cancelはclient closeでsettleしてcleanupする', () async {
+    final openResponse = Completer<HttpClientRequest>();
+    final response = RecordingEstimatedIntensityHttpResponse();
+    final request = RecordingEstimatedIntensityHttpRequest(response: response);
+    final client = RecordingEstimatedIntensityHttpClient(
+      request: request,
+      openResponse: openResponse.future,
+      onClose: () {
+        if (!openResponse.isCompleted) {
+          openResponse.completeError(const HttpException('aborted'));
+        }
+      },
+    );
+    final cancellation = EstimatedIntensityArchiveDownloadCancellation();
+    final resultFuture = downloadWithCancellation(
+      temporaryDirectory: temporaryDirectory,
+      client: client,
+      cancellation: cancellation,
+    );
+    await client.opened.future;
+
+    await cancellation.cancel();
+    final result = await resultFuture;
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.cancelled,
+    );
+    expect(client.closeForce, isTrue);
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_abort_test_support.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_abort_test_support.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+
+import 'estimated_intensity_archive_io_test_support.dart';
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+Future<EstimatedIntensityArchiveDownloadResult> downloadWithCancellation({
+  required Directory temporaryDirectory,
+  required RecordingEstimatedIntensityHttpClient client,
+  required EstimatedIntensityArchiveDownloadCancellation cancellation,
+}) =>
+    EstimatedIntensityArchiveHttpDataSource(
+      operationFactory: () =>
+          DartIoEstimatedIntensityArchiveHttpOperation(client: client),
+    ).download(
+      descriptor: estimatedIntensityTestDescriptor(),
+      temporaryDirectory: temporaryDirectory,
+      limits: EstimatedIntensityArchiveDownloadLimits(
+        maxArchiveBytes: estimatedIntensityTransportTestLimits.maxArchiveBytes,
+        connectTimeout: const Duration(seconds: 10),
+        headerTimeout: const Duration(seconds: 10),
+        idleTimeout: const Duration(seconds: 10),
+        totalTimeout: const Duration(seconds: 20),
+      ),
+      cancellation: cancellation,
+    );

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_attestation_binding_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_attestation_binding_test.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_attestation_test_',
+    );
+  });
+
+  tearDown(() async {
+    if (temporaryDirectory.existsSync()) {
+      await temporaryDirectory.delete(recursive: true);
+    }
+  });
+
+  test('別downloadのverified resultを現在のpartとしてreplayできない', () async {
+    final first = await downloadWithVerifier(
+      temporaryDirectory: temporaryDirectory,
+      fileVerifier: const DartIoEstimatedIntensityArchiveFileVerifier(),
+    );
+    expect(first, isA<EstimatedIntensityArchiveDownloadSuccess>());
+    final beforeReplay = temporaryDirectory
+        .listSync(recursive: true)
+        .map((entity) => entity.path)
+        .toSet();
+
+    final replay = await downloadWithVerifier(
+      temporaryDirectory: temporaryDirectory,
+      fileVerifier: ReplayEstimatedIntensityArchiveFileVerifier(first),
+    );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: replay,
+      failure: EstimatedIntensityArchiveDownloadFailure.requestFailed,
+    );
+    expect(
+      temporaryDirectory
+          .listSync(recursive: true)
+          .map((entity) => entity.path)
+          .toSet(),
+      beforeReplay,
+    );
+  });
+}
+
+Future<EstimatedIntensityArchiveDownloadResult> downloadWithVerifier({
+  required Directory temporaryDirectory,
+  required EstimatedIntensityArchiveFileVerifier fileVerifier,
+}) =>
+    EstimatedIntensityArchiveHttpDataSource(
+      operationFactory: () => TestEstimatedIntensityArchiveHttpOperation(
+        openResponse: Future.value(estimatedIntensityTestResponse()),
+      ),
+      streamVerifier: EstimatedIntensityArchiveStreamVerifier(
+        fileVerifier: fileVerifier,
+      ),
+    ).download(
+      descriptor: estimatedIntensityTestDescriptor(),
+      temporaryDirectory: temporaryDirectory,
+      limits: estimatedIntensityTransportTestLimits,
+    );
+
+final class ReplayEstimatedIntensityArchiveFileVerifier
+    implements EstimatedIntensityArchiveFileVerifier {
+  const new(this.result);
+
+  final EstimatedIntensityArchiveDownloadResult result;
+
+  @override
+  Future<EstimatedIntensityArchiveDownloadResult> verify({
+    required EstimatedIntensityArchiveDescriptor descriptor,
+    required File file,
+  }) async => result;
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_backpressure_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_backpressure_test.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_part_writer.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  test('chunk write完了まで次のbody chunkを消費しない', () async {
+    final temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_backpressure_test_',
+    );
+    addTearDown(() => temporaryDirectory.delete(recursive: true));
+    final firstWriteStarted = Completer<void>();
+    final releaseFirstWrite = Completer<void>();
+    GatedEstimatedIntensityArchivePartWriter? writer;
+    final verifier = EstimatedIntensityArchiveStreamVerifier(
+      partWriterFactory: (file) async {
+        final delegate = await DartIoEstimatedIntensityArchivePartWriter.open(
+          file,
+        );
+        final created = GatedEstimatedIntensityArchivePartWriter(
+          delegate: delegate,
+          firstWriteStarted: firstWriteStarted,
+          releaseFirstWrite: releaseFirstWrite,
+        );
+        writer = created;
+        return created;
+      },
+    );
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: Future.value(
+        estimatedIntensityTestResponse(
+          body: Stream.fromIterable([
+            'hello'.codeUnits,
+            ' world'.codeUnits,
+          ]),
+        ),
+      ),
+    );
+    final resultFuture =
+        EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () => operation,
+          streamVerifier: verifier,
+        ).download(
+          descriptor: estimatedIntensityTestDescriptor(),
+          temporaryDirectory: temporaryDirectory,
+          limits: estimatedIntensityTransportTestLimits,
+        );
+    await firstWriteStarted.future;
+    expect(writer?.writeCount, 1);
+    releaseFirstWrite.complete();
+    final result = await resultFuture;
+
+    expect(result, isA<EstimatedIntensityArchiveDownloadSuccess>());
+    expect(writer?.writeCount, 2);
+    expect(writer?.maxConcurrentWrites, 1);
+  });
+}
+
+final class GatedEstimatedIntensityArchivePartWriter
+    implements EstimatedIntensityArchivePartWriter {
+  new({
+    required this.delegate,
+    required this.firstWriteStarted,
+    required this.releaseFirstWrite,
+  });
+
+  final EstimatedIntensityArchivePartWriter delegate;
+  final Completer<void> firstWriteStarted;
+  final Completer<void> releaseFirstWrite;
+  var writeCount = 0;
+  var concurrentWrites = 0;
+  var maxConcurrentWrites = 0;
+
+  @override
+  Future<void> write(List<int> bytes) async {
+    writeCount += 1;
+    concurrentWrites += 1;
+    maxConcurrentWrites = maxConcurrentWrites < concurrentWrites
+        ? concurrentWrites
+        : maxConcurrentWrites;
+    if (writeCount == 1) {
+      firstWriteStarted.complete();
+      await releaseFirstWrite.future;
+    }
+    await delegate.write(bytes);
+    concurrentWrites -= 1;
+  }
+
+  @override
+  Future<void> flushAndClose() => delegate.flushAndClose();
+
+  @override
+  Future<void> close() => delegate.close();
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_body_abort_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_body_abort_test.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_abort_test_support.dart';
+import 'estimated_intensity_archive_io_test_support.dart';
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_body_abort_test_',
+    );
+  });
+
+  tearDown(() async {
+    if (temporaryDirectory.existsSync()) {
+      await temporaryDirectory.delete(recursive: true);
+    }
+  });
+
+  test('dart:io body待機中cancelはrequest abortでsettleしてcleanupする', () async {
+    final listened = Completer<void>();
+    final body = StreamController<List<int>>(
+      onListen: listened.complete,
+    );
+    Future<void>? bodyClosed;
+    final response = RecordingEstimatedIntensityHttpResponse(body: body.stream);
+    final request = RecordingEstimatedIntensityHttpRequest(
+      response: response,
+      onAbort: () {
+        if (!body.isClosed) {
+          body.addError(const HttpException('aborted'));
+          bodyClosed = body.close();
+        }
+      },
+    );
+    final client = RecordingEstimatedIntensityHttpClient(request: request);
+    final cancellation = EstimatedIntensityArchiveDownloadCancellation();
+    final resultFuture = downloadWithCancellation(
+      temporaryDirectory: temporaryDirectory,
+      client: client,
+      cancellation: cancellation,
+    );
+    await listened.future.timeout(
+      const Duration(seconds: 2),
+      onTimeout: () => throw StateError('body was not listened'),
+    );
+    await cancellation.cancel().timeout(
+      const Duration(seconds: 2),
+      onTimeout: () => throw StateError('cancel did not settle'),
+    );
+    final result = await resultFuture.timeout(
+      const Duration(seconds: 2),
+      onTimeout: () => throw StateError('download did not settle'),
+    );
+    await bodyClosed?.timeout(
+      const Duration(seconds: 2),
+      onTimeout: () => throw StateError('body close did not settle'),
+    );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.cancelled,
+    );
+    expect(request.abortCount, 1);
+    expect(client.closeForce, isTrue);
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_cancellation_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_cancellation_test.dart
@@ -1,0 +1,98 @@
+import 'dart:async' show StreamController;
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  test('cancelは一度だけ通知してawait可能にcloseする', () async {
+    final cancellation = EstimatedIntensityArchiveDownloadCancellation();
+    var events = 0;
+    var completed = false;
+    cancellation.onCancel.listen(
+      (_) => events += 1,
+      onDone: () => completed = true,
+    );
+
+    await cancellation.cancel();
+    await cancellation.cancel();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(cancellation.isCancelled, isTrue);
+    expect(events, 1);
+    expect(completed, isTrue);
+    await expectLater(cancellation.onCancel, emitsDone);
+  });
+
+  test('開始前cancelはHTTP operationもpartも作らない', () async {
+    final temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_precancel_test_',
+    );
+    addTearDown(() => temporaryDirectory.delete(recursive: true));
+    final cancellation = EstimatedIntensityArchiveDownloadCancellation();
+    await cancellation.cancel();
+    var operationCreated = false;
+
+    final result =
+        await EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () {
+            operationCreated = true;
+            return TestEstimatedIntensityArchiveHttpOperation(
+              openResponse: Future.value(estimatedIntensityTestResponse()),
+            );
+          },
+        ).download(
+          descriptor: estimatedIntensityTestDescriptor(),
+          temporaryDirectory: temporaryDirectory,
+          limits: estimatedIntensityTransportTestLimits,
+          cancellation: cancellation,
+        );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.cancelled,
+    );
+    expect(operationCreated, isFalse);
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+
+  test('stream中cancelはrequestをabortしてpartを消す', () async {
+    final temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_cancel_test_',
+    );
+    addTearDown(() => temporaryDirectory.delete(recursive: true));
+    final body = StreamController<List<int>>();
+    addTearDown(body.close);
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: Future.value(
+        estimatedIntensityTestResponse(contentLength: -1, body: body.stream),
+      ),
+    );
+    operation.onAbort = () => body.addError(StateError('aborted'));
+    final cancellation = EstimatedIntensityArchiveDownloadCancellation();
+    final resultFuture =
+        EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () => operation,
+        ).download(
+          descriptor: estimatedIntensityTestDescriptor(),
+          temporaryDirectory: temporaryDirectory,
+          limits: estimatedIntensityTransportTestLimits,
+          cancellation: cancellation,
+        );
+    body.add('hello'.codeUnits);
+
+    await cancellation.cancel();
+    final result = await resultFuture;
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.cancelled,
+    );
+    expect(operation.abortCount, greaterThanOrEqualTo(1));
+    expect(operation.closeCount, 1);
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_compile_test_support.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_compile_test_support.dart
@@ -1,0 +1,36 @@
+const downloadApiControlSource = '''
+import 'dart:io';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+
+Future<EstimatedIntensityArchiveDownloadResult> download(
+  EstimatedIntensityArchiveDescriptor descriptor,
+) => const EstimatedIntensityArchiveHttpDataSource().download(
+  descriptor: descriptor,
+  temporaryDirectory: Directory.systemTemp,
+  limits: EstimatedIntensityArchiveDownloadLimits(
+    maxArchiveBytes: 1,
+    connectTimeout: const Duration(seconds: 1),
+    headerTimeout: const Duration(seconds: 1),
+    idleTimeout: const Duration(seconds: 1),
+    totalTimeout: const Duration(seconds: 1),
+  ),
+);
+
+void main() {}
+''';
+
+const uncheckedVerifiedConstructorSource = '''
+import 'dart:io';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+
+void main() {
+  VerifiedEstimatedIntensityArchiveDownload(
+    eventId: '20260823020050',
+    sha256: 'forged',
+    file: File('forged.part'),
+    sizeBytes: 1,
+  );
+}
+''';

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_content_length_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_content_length_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_download_test_support.dart';
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_content_length_test_',
+    );
+  });
+
+  tearDown(() async {
+    if (temporaryDirectory.existsSync()) {
+      await temporaryDirectory.delete(recursive: true);
+    }
+  });
+
+  for (final contentLength in [10, 12, 2048]) {
+    test('Content-Length $contentLengthをdescriptor不一致で拒否する', () async {
+      final result = await downloadResponse(
+        temporaryDirectory: temporaryDirectory,
+        response: estimatedIntensityTestResponse(
+          contentLength: contentLength,
+        ),
+      );
+
+      expectEstimatedIntensityDownloadFailure(
+        result: result,
+        failure: EstimatedIntensityArchiveDownloadFailure.invalidContentLength,
+      );
+      expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+    });
+  }
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_download_test_support.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_download_test_support.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+Future<EstimatedIntensityArchiveDownloadResult> downloadResponse({
+  required Directory temporaryDirectory,
+  required EstimatedIntensityArchiveHttpResponse response,
+}) =>
+    EstimatedIntensityArchiveHttpDataSource(
+      operationFactory: () => TestEstimatedIntensityArchiveHttpOperation(
+        openResponse: Future.value(response),
+      ),
+    ).download(
+      descriptor: estimatedIntensityTestDescriptor(),
+      temporaryDirectory: temporaryDirectory,
+      limits: estimatedIntensityTransportTestLimits,
+    );
+
+Future<EstimatedIntensityArchiveDownloadResult> downloadBody({
+  required Directory temporaryDirectory,
+  required int contentLength,
+  required List<int> body,
+}) => downloadResponse(
+  temporaryDirectory: temporaryDirectory,
+  response: estimatedIntensityTestResponse(
+    contentLength: contentLength,
+    body: Stream.value(body),
+  ),
+);

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_failure_cleanup_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_failure_cleanup_test.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  test('request例外の本文を保持せずclientとpartをcleanupする', () async {
+    const secret =
+        'https://secret.example/token/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    final temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_request_failure_test_',
+    );
+    addTearDown(() => temporaryDirectory.delete(recursive: true));
+    final response = Completer<EstimatedIntensityArchiveHttpResponse>();
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: response.future,
+    );
+
+    final resultFuture =
+        EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () => operation,
+        ).download(
+          descriptor: estimatedIntensityTestDescriptor(),
+          temporaryDirectory: temporaryDirectory,
+          limits: estimatedIntensityTransportTestLimits,
+        );
+    await operation.opened.future;
+    response.completeError(StateError(secret));
+    final result = await resultFuture;
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.requestFailed,
+    );
+    expect(result.toString(), isNot(contains(secret)));
+    expect(operation.abortCount, 1);
+    expect(operation.closeCount, 1);
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+
+  test('書込先作成失敗はpathや例外を保持しないstorage failureにする', () async {
+    final missingRoot = Directory(
+      '${Directory.systemTemp.path}/missing-estimated-intensity-root/child',
+    );
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: Future.value(estimatedIntensityTestResponse()),
+    );
+
+    final result =
+        await EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () => operation,
+        ).download(
+          descriptor: estimatedIntensityTestDescriptor(),
+          temporaryDirectory: missingRoot,
+          limits: estimatedIntensityTransportTestLimits,
+        );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.storageFailure,
+    );
+    expect(result.toString(), isNot(contains(missingRoot.path)));
+    expect(operation.abortCount, 1);
+    expect(operation.closeCount, 1);
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_handshake_timeout_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_handshake_timeout_test.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_io_test_support.dart';
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_handshake_timeout_test_',
+    );
+  });
+
+  tearDown(() async {
+    if (temporaryDirectory.existsSync()) {
+      await temporaryDirectory.delete(recursive: true);
+    }
+  });
+
+  test('connect timeoutはtyped failureにしてclientとpartをcleanupする', () async {
+    final response = RecordingEstimatedIntensityHttpResponse();
+    final request = RecordingEstimatedIntensityHttpRequest(response: response);
+    final client = RecordingEstimatedIntensityHttpClient(
+      request: request,
+      openResponse: Completer<HttpClientRequest>().future,
+    );
+
+    final result = await downloadWithIoClient(
+      temporaryDirectory: temporaryDirectory,
+      client: client,
+      connectTimeout: const Duration(milliseconds: 10),
+      headerTimeout: const Duration(seconds: 1),
+    );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.timeout,
+    );
+    expect(client.closeForce, isTrue);
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+
+  test('header timeoutはrequestをabortしてclientとpartをcleanupする', () async {
+    final response = RecordingEstimatedIntensityHttpResponse();
+    final request = RecordingEstimatedIntensityHttpRequest(
+      response: response,
+      closeResponse: Completer<HttpClientResponse>().future,
+    );
+    final client = RecordingEstimatedIntensityHttpClient(request: request);
+
+    final result = await downloadWithIoClient(
+      temporaryDirectory: temporaryDirectory,
+      client: client,
+      connectTimeout: const Duration(seconds: 1),
+      headerTimeout: const Duration(milliseconds: 10),
+    );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.timeout,
+    );
+    expect(request.abortCount, 1);
+    expect(client.closeForce, isTrue);
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+}
+
+Future<EstimatedIntensityArchiveDownloadResult> downloadWithIoClient({
+  required Directory temporaryDirectory,
+  required RecordingEstimatedIntensityHttpClient client,
+  required Duration connectTimeout,
+  required Duration headerTimeout,
+}) =>
+    EstimatedIntensityArchiveHttpDataSource(
+      operationFactory: () =>
+          DartIoEstimatedIntensityArchiveHttpOperation(client: client),
+    ).download(
+      descriptor: estimatedIntensityTestDescriptor(),
+      temporaryDirectory: temporaryDirectory,
+      limits: EstimatedIntensityArchiveDownloadLimits(
+        maxArchiveBytes: 1024,
+        connectTimeout: connectTimeout,
+        headerTimeout: headerTimeout,
+        idleTimeout: const Duration(seconds: 1),
+        totalTimeout: const Duration(seconds: 2),
+      ),
+    );

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_hash_timeout_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_hash_timeout_test.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  test('hash中のtotal timeoutはhash終了後にrejectしてからpartを消す', () async {
+    final temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_hash_timeout_test_',
+    );
+    addTearDown(() => temporaryDirectory.delete(recursive: true));
+    final hashStarted = Completer<void>();
+    final releaseHash = Completer<void>();
+    final fileVerifier = GatedEstimatedIntensityArchiveFileVerifier(
+      delegate: const DartIoEstimatedIntensityArchiveFileVerifier(),
+      hashStarted: hashStarted,
+      releaseHash: releaseHash,
+    );
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: Future.value(estimatedIntensityTestResponse()),
+    );
+    final limits = EstimatedIntensityArchiveDownloadLimits(
+      maxArchiveBytes: 1024,
+      connectTimeout: const Duration(seconds: 1),
+      headerTimeout: const Duration(seconds: 1),
+      idleTimeout: const Duration(seconds: 1),
+      totalTimeout: const Duration(milliseconds: 10),
+    );
+    final resultFuture =
+        EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () => operation,
+          streamVerifier: EstimatedIntensityArchiveStreamVerifier(
+            fileVerifier: fileVerifier,
+          ),
+        ).download(
+          descriptor: estimatedIntensityTestDescriptor(),
+          temporaryDirectory: temporaryDirectory,
+          limits: limits,
+        );
+    await hashStarted.future;
+
+    final firstCompletion = await Future.any<String>([
+      resultFuture.then((_) => 'completed'),
+      Future.delayed(const Duration(milliseconds: 30), () => 'pending'),
+    ]);
+    expect(firstCompletion, 'pending');
+    expect(temporaryDirectory.listSync(recursive: true), isNotEmpty);
+
+    releaseHash.complete();
+    final result = await resultFuture;
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.timeout,
+    );
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+}
+
+final class GatedEstimatedIntensityArchiveFileVerifier
+    implements EstimatedIntensityArchiveFileVerifier {
+  new({
+    required this.delegate,
+    required this.hashStarted,
+    required this.releaseHash,
+  });
+
+  final EstimatedIntensityArchiveFileVerifier delegate;
+  final Completer<void> hashStarted;
+  final Completer<void> releaseHash;
+
+  @override
+  Future<EstimatedIntensityArchiveDownloadResult> verify({
+    required EstimatedIntensityArchiveDescriptor descriptor,
+    required File file,
+  }) async {
+    hashStarted.complete();
+    await releaseHash.future;
+    return delegate.verify(descriptor: descriptor, file: file);
+  }
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_http_data_source_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_http_data_source_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_transport_test_',
+    );
+  });
+
+  tearDown(() async {
+    if (temporaryDirectory.existsSync()) {
+      await temporaryDirectory.delete(recursive: true);
+    }
+  });
+
+  test('exact bodyだけを検証済みidentity付き一時fileとして返す', () async {
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: Future.value(estimatedIntensityTestResponse()),
+    );
+    final descriptor = estimatedIntensityTestDescriptor();
+    final result =
+        await EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () => operation,
+        ).download(
+          descriptor: descriptor,
+          temporaryDirectory: temporaryDirectory,
+          limits: estimatedIntensityTransportTestLimits,
+        );
+
+    final verified = switch (result) {
+      EstimatedIntensityArchiveDownloadSuccess(:final archive) => archive,
+      EstimatedIntensityArchiveDownloadRejected(:final failure) =>
+        throw TestFailure('unexpected failure: $failure'),
+    };
+    expect(await verified.file.readAsString(), 'hello world');
+    expect(verified.eventId, estimatedIntensityTestEventId);
+    expect(verified.sha256, helloWorldSha256);
+    expect(verified.sizeBytes, 11);
+    expect(verified.toString(), isNot(contains(verified.file.path)));
+    expect(verified.toString(), isNot(contains(verified.sha256)));
+    expect(operation.openedUrl, descriptor.url);
+    expect(operation.abortCount, 0);
+    expect(operation.closeCount, 1);
+  });
+
+  test('同時に成功した一時fileはuniqueなpart pathを持つ', () async {
+    Future<VerifiedEstimatedIntensityArchiveDownload> download() async {
+      final result =
+          await EstimatedIntensityArchiveHttpDataSource(
+            operationFactory: () => TestEstimatedIntensityArchiveHttpOperation(
+              openResponse: Future.value(estimatedIntensityTestResponse()),
+            ),
+          ).download(
+            descriptor: estimatedIntensityTestDescriptor(),
+            temporaryDirectory: temporaryDirectory,
+            limits: estimatedIntensityTransportTestLimits,
+          );
+      return switch (result) {
+        EstimatedIntensityArchiveDownloadSuccess(:final archive) => archive,
+        EstimatedIntensityArchiveDownloadRejected(:final failure) =>
+          throw TestFailure('unexpected failure: $failure'),
+      };
+    }
+
+    final archives = await Future.wait([download(), download()]);
+    expect(archives[0].file.path, isNot(archives[1].file.path));
+    expect(
+      archives.every((archive) => archive.file.path.endsWith('.part')),
+      isTrue,
+    );
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_http_operation_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_http_operation_test.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_io_test_support.dart';
+
+void main() {
+  test('dart:io adapterは自動展開とredirectを無効化しidentityを要求する', () async {
+    final response = RecordingEstimatedIntensityHttpResponse();
+    final request = RecordingEstimatedIntensityHttpRequest(response: response);
+    final client = RecordingEstimatedIntensityHttpClient(request: request);
+    final operation = DartIoEstimatedIntensityArchiveHttpOperation(
+      client: client,
+    );
+    final url = Uri.parse('https://tiles.example.test/archive.pmtiles');
+
+    final opened = await operation.open(
+      url: url,
+      connectTimeout: const Duration(seconds: 2),
+      headerTimeout: const Duration(seconds: 3),
+    );
+
+    expect(client.recordedAutoUncompress, isFalse);
+    expect(client.recordedConnectionTimeout, const Duration(seconds: 2));
+    expect(client.openedMethod, 'GET');
+    expect(client.openedUrl, url);
+    expect(request.recordedFollowRedirects, isFalse);
+    expect(request.recordedMaxRedirects, 0);
+    expect(
+      request.requestHeaders.values[HttpHeaders.acceptEncodingHeader],
+      ['identity'],
+    );
+    expect(opened.statusCode, HttpStatus.ok);
+
+    operation.close();
+    expect(client.closeForce, isTrue);
+  });
+
+  test('response encodingを自動展開前のheader値のまま渡す', () async {
+    final response = RecordingEstimatedIntensityHttpResponse();
+    response.responseHeaders.values[HttpHeaders.contentEncodingHeader] = [
+      'gzip',
+    ];
+    final request = RecordingEstimatedIntensityHttpRequest(response: response);
+    final operation = DartIoEstimatedIntensityArchiveHttpOperation(
+      client: RecordingEstimatedIntensityHttpClient(request: request),
+    );
+
+    final opened = await operation.open(
+      url: Uri.parse('https://tiles.example.test/archive.pmtiles'),
+      connectTimeout: const Duration(seconds: 1),
+      headerTimeout: const Duration(seconds: 1),
+    );
+
+    expect(opened.contentEncodings, ['gzip']);
+  });
+
+  test('connect timeoutをcaller指定値で強制する', () async {
+    final response = RecordingEstimatedIntensityHttpResponse();
+    final request = RecordingEstimatedIntensityHttpRequest(response: response);
+    final client = RecordingEstimatedIntensityHttpClient(
+      request: request,
+      openResponse: Completer<HttpClientRequest>().future,
+    );
+    final operation = DartIoEstimatedIntensityArchiveHttpOperation(
+      client: client,
+    );
+
+    await expectLater(
+      operation.open(
+        url: Uri.parse('https://tiles.example.test/archive.pmtiles'),
+        connectTimeout: const Duration(milliseconds: 10),
+        headerTimeout: const Duration(seconds: 1),
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+  });
+
+  test('header timeoutをcaller指定値で強制する', () async {
+    final response = RecordingEstimatedIntensityHttpResponse();
+    final request = RecordingEstimatedIntensityHttpRequest(
+      response: response,
+      closeResponse: Completer<HttpClientResponse>().future,
+    );
+    final operation = DartIoEstimatedIntensityArchiveHttpOperation(
+      client: RecordingEstimatedIntensityHttpClient(request: request),
+    );
+
+    await expectLater(
+      operation.open(
+        url: Uri.parse('https://tiles.example.test/archive.pmtiles'),
+        connectTimeout: const Duration(seconds: 1),
+        headerTimeout: const Duration(milliseconds: 10),
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_http_response_test_support.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_http_response_test_support.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+final class RecordingEstimatedIntensityHttpHeaders extends Fake
+    implements HttpHeaders {
+  final Map<String, List<String>> values = {};
+
+  @override
+  List<String>? operator [](String name) => values[name];
+
+  @override
+  void set(
+    String name,
+    covariant String value, {
+    bool preserveHeaderCase = false,
+  }) {
+    values[name] = [value];
+  }
+}
+
+final class RecordingEstimatedIntensityHttpResponse
+    extends StreamView<List<int>>
+    implements HttpClientResponse {
+  // ignore: unnecessary_type_name_in_constructor
+  factory RecordingEstimatedIntensityHttpResponse({
+    int responseStatusCode = HttpStatus.ok,
+    int responseContentLength = 11,
+    Stream<List<int>>? body,
+  }) => RecordingEstimatedIntensityHttpResponse._(
+    responseStatusCode: responseStatusCode,
+    responseContentLength: responseContentLength,
+    body: body ?? const Stream.empty(),
+  );
+
+  // ignore: unnecessary_type_name_in_constructor
+  RecordingEstimatedIntensityHttpResponse._({
+    required this.responseStatusCode,
+    required this.responseContentLength,
+    required Stream<List<int>> body,
+  }) : super(body);
+
+  final responseHeaders = RecordingEstimatedIntensityHttpHeaders();
+  final int responseStatusCode;
+  final int responseContentLength;
+
+  @override
+  HttpHeaders get headers => responseHeaders;
+
+  @override
+  int get statusCode => responseStatusCode;
+
+  @override
+  int get contentLength => responseContentLength;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_integrity_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_integrity_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'dart_api_compiler_test_support.dart';
+import 'estimated_intensity_archive_compile_test_support.dart';
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_integrity_test_',
+    );
+  });
+
+  tearDown(() async {
+    if (temporaryDirectory.existsSync()) {
+      await temporaryDirectory.delete(recursive: true);
+    }
+  });
+
+  test('SHA-256不一致ではverified resultを発行せずpartを消す', () async {
+    const wrongSha256 =
+        '0000000000000000000000000000000000000000000000000000000000000000';
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: Future.value(estimatedIntensityTestResponse()),
+    );
+
+    final result =
+        await EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () => operation,
+        ).download(
+          descriptor: estimatedIntensityTestDescriptor(sha256: wrongSha256),
+          temporaryDirectory: temporaryDirectory,
+          limits: estimatedIntensityTransportTestLimits,
+        );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.sha256Mismatch,
+    );
+    expect(result.toString(), isNot(contains(wrongSha256)));
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+
+  test('外部libraryからverified resultをunchecked生成できない', () async {
+    final compiler = DartApiCompiler.resolve();
+    final controlResult = await compiler.compile(
+      directory: temporaryDirectory,
+      name: 'control',
+      source: downloadApiControlSource,
+    );
+    final controlDiagnostics =
+        '${controlResult.stdout}\n${controlResult.stderr}';
+    expect(controlResult.exitCode, 0, reason: controlDiagnostics);
+
+    final result = await compiler.compile(
+      directory: temporaryDirectory,
+      name: 'unchecked',
+      source: uncheckedVerifiedConstructorSource,
+    );
+    final diagnostics = '${result.stdout}\n${result.stderr}';
+
+    expect(result.exitCode, isNot(0), reason: diagnostics);
+    expect(
+      diagnostics,
+      anyOf(
+        contains(
+          "Couldn't find constructor "
+          "'VerifiedEstimatedIntensityArchiveDownload'",
+        ),
+        contains(
+          "Member not found: "
+          "'VerifiedEstimatedIntensityArchiveDownload.new'",
+        ),
+      ),
+    );
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_io_test_support.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_io_test_support.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+export 'estimated_intensity_archive_http_response_test_support.dart';
+import 'estimated_intensity_archive_http_response_test_support.dart';
+
+final class RecordingEstimatedIntensityHttpRequest extends Fake
+    implements HttpClientRequest {
+  new({
+    required RecordingEstimatedIntensityHttpResponse response,
+    Future<HttpClientResponse>? closeResponse,
+    this.onAbort,
+  }) : closeResponse = closeResponse ?? Future.value(response);
+
+  final Future<HttpClientResponse> closeResponse;
+  final void Function()? onAbort;
+  final requestHeaders = RecordingEstimatedIntensityHttpHeaders();
+  bool? recordedFollowRedirects;
+  int? recordedMaxRedirects;
+  var abortCount = 0;
+
+  @override
+  HttpHeaders get headers => requestHeaders;
+
+  @override
+  set followRedirects(bool value) => recordedFollowRedirects = value;
+
+  @override
+  set maxRedirects(int value) => recordedMaxRedirects = value;
+
+  @override
+  Future<HttpClientResponse> close() => closeResponse;
+
+  @override
+  void abort([
+    covariant String? exception,
+    StackTrace? stackTrace,
+  ]) {
+    abortCount += 1;
+    onAbort?.call();
+  }
+}
+
+final class RecordingEstimatedIntensityHttpClient extends Fake
+    implements HttpClient {
+  new({
+    required RecordingEstimatedIntensityHttpRequest request,
+    Future<HttpClientRequest>? openResponse,
+    this.onClose,
+  }) : openResponse = openResponse ?? Future.value(request);
+
+  final Future<HttpClientRequest> openResponse;
+  final void Function()? onClose;
+  final Completer<void> opened = Completer<void>();
+  bool? recordedAutoUncompress;
+  Duration? recordedConnectionTimeout;
+  String? openedMethod;
+  Uri? openedUrl;
+  bool? closeForce;
+
+  @override
+  set autoUncompress(bool value) => recordedAutoUncompress = value;
+
+  @override
+  set connectionTimeout(Duration? value) => recordedConnectionTimeout = value;
+
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) async {
+    openedMethod = method;
+    openedUrl = url;
+    if (!opened.isCompleted) {
+      opened.complete();
+    }
+    return openResponse;
+  }
+
+  @override
+  void close({bool force = false}) {
+    closeForce = force;
+    onClose?.call();
+  }
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_limits_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_limits_test.dart
@@ -1,0 +1,43 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('archive capは正数をcallerが必ず指定する', () {
+    expect(
+      () => limits(maxArchiveBytes: 0),
+      throwsArgumentError,
+    );
+    expect(
+      () => limits(maxArchiveBytes: -1),
+      throwsArgumentError,
+    );
+  });
+
+  for (final field in ['connect', 'header', 'idle', 'total']) {
+    test('$field timeoutは正のDurationをcallerが必ず指定する', () {
+      expect(
+        () => limits(zeroTimeoutField: field),
+        throwsArgumentError,
+      );
+    });
+  }
+}
+
+EstimatedIntensityArchiveDownloadLimits limits({
+  int maxArchiveBytes = 1,
+  String? zeroTimeoutField,
+}) => EstimatedIntensityArchiveDownloadLimits(
+  maxArchiveBytes: maxArchiveBytes,
+  connectTimeout: zeroTimeoutField == 'connect'
+      ? Duration.zero
+      : const Duration(seconds: 1),
+  headerTimeout: zeroTimeoutField == 'header'
+      ? Duration.zero
+      : const Duration(seconds: 1),
+  idleTimeout: zeroTimeoutField == 'idle'
+      ? Duration.zero
+      : const Duration(seconds: 1),
+  totalTimeout: zeroTimeoutField == 'total'
+      ? Duration.zero
+      : const Duration(seconds: 1),
+);

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_response_policy_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_response_policy_test.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_download_test_support.dart';
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_response_test_',
+    );
+  });
+
+  tearDown(() async {
+    if (temporaryDirectory.existsSync()) {
+      await temporaryDirectory.delete(recursive: true);
+    }
+  });
+
+  for (final statusCode in [206, 301, 302, 404, 500]) {
+    test('status $statusCodeをbodyをpublishせず拒否する', () async {
+      final result = await downloadResponse(
+        temporaryDirectory: temporaryDirectory,
+        response: estimatedIntensityTestResponse(statusCode: statusCode),
+      );
+
+      expectEstimatedIntensityDownloadFailure(
+        result: result,
+        failure: EstimatedIntensityArchiveDownloadFailure.invalidStatus,
+      );
+      expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+    });
+  }
+
+  test('redirect responseはbodyを購読する前に拒否する', () async {
+    var bodyListened = false;
+    final body = Stream<List<int>>.multi(
+      (controller) {
+        bodyListened = true;
+        controller.close();
+      },
+    );
+
+    final result = await downloadResponse(
+      temporaryDirectory: temporaryDirectory,
+      response: estimatedIntensityTestResponse(
+        statusCode: 302,
+        body: body,
+      ),
+    );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.invalidStatus,
+    );
+    expect(bodyListened, isFalse);
+  });
+
+  for (final encodings in [
+    ['gzip'],
+    ['br'],
+    ['identity, gzip'],
+    ['identity', 'gzip'],
+  ]) {
+    test('Content-Encoding $encodingsを拒否する', () async {
+      final result = await downloadResponse(
+        temporaryDirectory: temporaryDirectory,
+        response: estimatedIntensityTestResponse(
+          contentEncodings: encodings,
+        ),
+      );
+
+      expectEstimatedIntensityDownloadFailure(
+        result: result,
+        failure:
+            EstimatedIntensityArchiveDownloadFailure.invalidContentEncoding,
+      );
+      expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+    });
+  }
+
+  test('単一identity encodingは受理する', () async {
+    final result = await downloadResponse(
+      temporaryDirectory: temporaryDirectory,
+      response: estimatedIntensityTestResponse(
+        contentEncodings: const ['identity'],
+      ),
+    );
+
+    expect(result, isA<EstimatedIntensityArchiveDownloadSuccess>());
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_stream_size_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_stream_size_test.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_download_test_support.dart';
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_size_test_',
+    );
+  });
+
+  tearDown(() async {
+    if (temporaryDirectory.existsSync()) {
+      await temporaryDirectory.delete(recursive: true);
+    }
+  });
+
+  test('Content-Lengthがなくてもexact bodyを受理する', () async {
+    final result = await downloadBody(
+      temporaryDirectory: temporaryDirectory,
+      contentLength: -1,
+      body: 'hello world'.codeUnits,
+    );
+
+    expect(result, isA<EstimatedIntensityArchiveDownloadSuccess>());
+  });
+
+  test('Content-Lengthなしのshort bodyをEOFで拒否してpartを消す', () async {
+    final result = await downloadBody(
+      temporaryDirectory: temporaryDirectory,
+      contentLength: -1,
+      body: 'hello worl'.codeUnits,
+    );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.sizeMismatch,
+    );
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+
+  test('descriptor sizeを超えるbodyを途中で拒否してpartを消す', () async {
+    final result = await downloadBody(
+      temporaryDirectory: temporaryDirectory,
+      contentLength: -1,
+      body: 'hello world!'.codeUnits,
+    );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.sizeMismatch,
+    );
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+
+  test('caller capを超えるstreamを途中で拒否する', () async {
+    final descriptor = estimatedIntensityTestDescriptor(sizeBytes: 20);
+    final limits = EstimatedIntensityArchiveDownloadLimits(
+      maxArchiveBytes: 20,
+      connectTimeout: const Duration(seconds: 1),
+      headerTimeout: const Duration(seconds: 1),
+      idleTimeout: const Duration(seconds: 1),
+      totalTimeout: const Duration(seconds: 2),
+    );
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: Future.value(
+        estimatedIntensityTestResponse(
+          contentLength: -1,
+          body: Stream.value(List.filled(21, 1)),
+        ),
+      ),
+    );
+
+    final result =
+        await EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () => operation,
+        ).download(
+          descriptor: descriptor,
+          temporaryDirectory: temporaryDirectory,
+          limits: limits,
+        );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.archiveTooLarge,
+    );
+    expect(operation.abortCount, 1);
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_timeout_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_timeout_test.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'estimated_intensity_archive_transport_test_support.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_timeout_test_',
+    );
+  });
+
+  tearDown(() async {
+    if (temporaryDirectory.existsSync()) {
+      await temporaryDirectory.delete(recursive: true);
+    }
+  });
+
+  test('idle timeoutはstreamをcancelしてpartを消す', () async {
+    final body = StreamController<List<int>>();
+    addTearDown(body.close);
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: Future.value(
+        estimatedIntensityTestResponse(contentLength: -1, body: body.stream),
+      ),
+    );
+    final limits = EstimatedIntensityArchiveDownloadLimits(
+      maxArchiveBytes: 1024,
+      connectTimeout: const Duration(seconds: 1),
+      headerTimeout: const Duration(seconds: 1),
+      idleTimeout: const Duration(milliseconds: 20),
+      totalTimeout: const Duration(seconds: 1),
+    );
+
+    final result =
+        await EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () => operation,
+        ).download(
+          descriptor: estimatedIntensityTestDescriptor(),
+          temporaryDirectory: temporaryDirectory,
+          limits: limits,
+        );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.timeout,
+    );
+    expect(operation.abortCount, 1);
+    expect(operation.closeCount, 1);
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+
+  test('total timeoutはrequestをabortしてlate streamをpublishしない', () async {
+    final body = StreamController<List<int>>();
+    addTearDown(body.close);
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: Future.value(
+        estimatedIntensityTestResponse(contentLength: -1, body: body.stream),
+      ),
+    );
+    operation.onAbort = () => body.addError(StateError('aborted'));
+    final limits = EstimatedIntensityArchiveDownloadLimits(
+      maxArchiveBytes: 1024,
+      connectTimeout: const Duration(seconds: 1),
+      headerTimeout: const Duration(seconds: 1),
+      idleTimeout: const Duration(seconds: 1),
+      totalTimeout: const Duration(milliseconds: 20),
+    );
+
+    final result =
+        await EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () => operation,
+        ).download(
+          descriptor: estimatedIntensityTestDescriptor(),
+          temporaryDirectory: temporaryDirectory,
+          limits: limits,
+        );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.timeout,
+    );
+    expect(operation.abortCount, greaterThanOrEqualTo(1));
+    expect(operation.closeCount, 1);
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_transport_descriptor_test_support.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_transport_descriptor_test_support.dart
@@ -1,0 +1,45 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const estimatedIntensityTestEventId = '20260823020050';
+const estimatedIntensityTestHost = 'tiles.example.test';
+const helloWorldSha256 =
+    'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9';
+final estimatedIntensityTransportTestLimits =
+    EstimatedIntensityArchiveDownloadLimits(
+      maxArchiveBytes: 1024,
+      connectTimeout: const Duration(milliseconds: 100),
+      headerTimeout: const Duration(milliseconds: 100),
+      idleTimeout: const Duration(milliseconds: 100),
+      totalTimeout: const Duration(seconds: 1),
+    );
+
+EstimatedIntensityArchiveDescriptor estimatedIntensityTestDescriptor({
+  int sizeBytes = 11,
+  String sha256 = helloWorldSha256,
+}) {
+  final input = EstimatedIntensityArchiveDescriptorInput(
+    url:
+        'https://$estimatedIntensityTestHost/ixac41/'
+        '$estimatedIntensityTestEventId/$sha256.pmtiles',
+    sizeBytes: sizeBytes,
+    sha256: sha256,
+  );
+  final result = const EstimatedIntensityArchiveDescriptorValidator().validate(
+    eventId: estimatedIntensityTestEventId,
+    input: input,
+    policy: EstimatedIntensityArchiveUrlPolicy(
+      allowedHosts: const {estimatedIntensityTestHost},
+      maxArchiveBytes: 4096,
+    ),
+  );
+  return switch (result) {
+    EstimatedIntensityArchiveValidationValid(:final descriptor) => descriptor,
+    EstimatedIntensityArchiveValidationMissing() => throw TestFailure(
+      'descriptor must not be missing',
+    ),
+    EstimatedIntensityArchiveValidationInvalid(:final failure) =>
+      throw TestFailure('unexpected descriptor failure: $failure'),
+  };
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_transport_test_support.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_transport_test_support.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+export 'estimated_intensity_archive_transport_descriptor_test_support.dart';
+
+EstimatedIntensityArchiveHttpResponse estimatedIntensityTestResponse({
+  int statusCode = 200,
+  List<String> contentEncodings = const [],
+  int contentLength = 11,
+  Stream<List<int>>? body,
+}) => EstimatedIntensityArchiveHttpResponse(
+  statusCode: statusCode,
+  contentEncodings: contentEncodings,
+  contentLength: contentLength,
+  body: body ?? Stream.value('hello world'.codeUnits),
+);
+
+final class TestEstimatedIntensityArchiveHttpOperation
+    implements EstimatedIntensityArchiveHttpOperation {
+  new({required this.openResponse});
+
+  final Future<EstimatedIntensityArchiveHttpResponse> openResponse;
+  final Completer<void> opened = Completer<void>();
+  Uri? openedUrl;
+  Duration? connectTimeout;
+  Duration? headerTimeout;
+  var abortCount = 0;
+  var closeCount = 0;
+  void Function()? onAbort;
+
+  @override
+  Future<EstimatedIntensityArchiveHttpResponse> open({
+    required Uri url,
+    required Duration connectTimeout,
+    required Duration headerTimeout,
+  }) {
+    openedUrl = url;
+    this.connectTimeout = connectTimeout;
+    this.headerTimeout = headerTimeout;
+    if (!opened.isCompleted) {
+      opened.complete();
+    }
+    return openResponse;
+  }
+
+  @override
+  void abort() {
+    abortCount += 1;
+    onAbort?.call();
+  }
+
+  @override
+  void close() {
+    closeCount += 1;
+  }
+}
+
+void expectEstimatedIntensityDownloadFailure({
+  required EstimatedIntensityArchiveDownloadResult result,
+  required EstimatedIntensityArchiveDownloadFailure failure,
+}) {
+  expect(
+    result,
+    isA<EstimatedIntensityArchiveDownloadRejected>().having(
+      (value) => value.failure,
+      'failure',
+      failure,
+    ),
+  );
+}


### PR DESCRIPTION
## 概要
- redirectなし・identity encoding・HTTP 200の取得契約を追加
- caller必須のbyte上限とconnect/header/idle/total timeoutを適用
- unique一時fileへstreamし、exact sizeとSHA-256を検証
- cancel・timeout・失敗時にabortとcleanupを実施
- verified attestationの別download replayを拒否

## 検証
- 推計震度P2/P3契約テスト 81件成功
- 変更対象11ファイルのflutter analyze --fatal-infos成功
- unawaited 0件
- git diff --check成功

## 後続
- cache/LRU/lease/PMTiles header/decode/UIは後続Stacked PRで実装
- production archive capは未確定のため固定値を持たない