### PR TITLE
fix: Stacked PRでFlutter CIを起動

### DIFF
--- a/.github/workflows/actonlint.yaml
+++ b/.github/workflows/actonlint.yaml
@@ -6,7 +6,7 @@ on:
      - '*'
   pull_request:
     branches:
-     - '*'
+     - '**'
     types:
       - opened
       - synchronize

--- a/.github/workflows/check-github-actions.yaml
+++ b/.github/workflows/check-github-actions.yaml
@@ -6,7 +6,7 @@ on:
       - "*"
   pull_request:
     branches:
-      - "*"
+      - "**"
     types:
       - opened
       - synchronize

--- a/.github/workflows/pr-flutter-check.yaml
+++ b/.github/workflows/pr-flutter-check.yaml
@@ -3,7 +3,7 @@ name: PR Flutter Check
 on:
   pull_request:
     branches:
-      - "*"
+      - "**"
   merge_group:
 
 permissions:

--- a/docs/knowledge/20260826_github_actions_stacked_pr_branch_glob.md
+++ b/docs/knowledge/20260826_github_actions_stacked_pr_branch_glob.md
@@ -1,0 +1,39 @@
+# Stacked PRでGitHub Actionsを起動するbranch filter
+
+## 事象
+
+`pull_request.branches`に`"*"`だけを指定すると、base branch名に`/`を含む
+Stacked PRでworkflowが起動しない。
+
+EQMonitorでは最下段のbaseは`develop`なのでworkflowが起動する一方、上段のbaseは
+`codex/gpu-map-...`となるため、filterなしのworkflowだけが起動していた。
+
+## 原因
+
+`pull_request.branches`はPRのbase branchへ適用される。GitHub Actionsのglobでは
+`*`は`/`を跨がず、`**`は`/`を含むbranch名にも一致する。
+
+## 対応
+
+Stacked PRを許可するworkflowでは次のように指定する。
+
+```yaml
+on:
+  pull_request:
+    branches:
+      - "**"
+```
+
+`push.branches`は別の起動ポリシーなので、Stacked PR対応だけを目的とする変更では
+不用意に変更しない。
+
+## 確認
+
+```bash
+mise exec -- actionlint -color
+gh run list --repo YumNumm/EQMonitor --branch <head-branch>
+gh pr checks <number> --repo YumNumm/EQMonitor
+```
+
+最下段だけでなく、base branchに`/`を含む上段PRで`PR Flutter Check`、
+`Check GitHub Actions`、`ActionLint`が作成されることを確認する。


### PR DESCRIPTION
## 概要
- pull_request branch filterをslashを含むbase branchにも一致させる
- PR Flutter Check、Check GitHub Actions、ActionLintをStack上段でも起動する
- push branch filterは変更しない
- 再現・確認手順をknowledgeへ記録

## 原因
- pull_request.branchesの*はslashを跨がず、baseがcodex/gpu-map-...の上段PRに一致していなかった
- baseがdevelopの最下段だけCIが起動する実状態と一致

## 検証
- mise exec -- actionlint -color
- commit hooks: gitleaks、pinact、zizmorほか成功
- git diff --check成功