### PR TITLE
fix: 推計震度archive取得の停止処理を強化

### DIFF
--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_download_guard.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_download_guard.dart
@@ -13,20 +13,29 @@ final class EstimatedIntensityArchiveDownloadGuard {
   }) : cancelled = cancellation?.isCancelled ?? false {
     cancellationSubscription = cancellation?.onCancel.listen((_) {
       cancelled = true;
+      if (!_stopRequested.isCompleted) {
+        _stopRequested.complete(.cancelled);
+      }
       operation.abort();
     });
     if (cancellation?.isCancelled ?? false) {
       cancelled = true;
+      _stopRequested.complete(.cancelled);
       operation.abort();
     }
     totalTimer = Timer(totalTimeout, () {
       timedOut = true;
+      if (!_stopRequested.isCompleted) {
+        _stopRequested.complete(.timeout);
+      }
       operation.abort();
     });
   }
 
   final EstimatedIntensityArchiveHttpOperation operation;
   late final Timer totalTimer;
+  final Completer<EstimatedIntensityArchiveStopReason> _stopRequested =
+      Completer<EstimatedIntensityArchiveStopReason>();
   StreamSubscription<void>? cancellationSubscription;
   bool cancelled;
   var timedOut = false;
@@ -37,8 +46,46 @@ final class EstimatedIntensityArchiveDownloadGuard {
       ? EstimatedIntensityArchiveStopReason.timeout
       : EstimatedIntensityArchiveStopReason.none;
 
+  Future<EstimatedIntensityArchiveStopReason> get stopRequested =>
+      _stopRequested.future;
+
+  /// 停止時はadapterを中断し、pending I/Oのsettle後にだけ呼出元へ戻す。
+  Future<T> settle<T>({
+    required Future<T> pending,
+    required Future<void> Function() abort,
+  }) async {
+    if (stopReason != EstimatedIntensityArchiveStopReason.none) {
+      try {
+        await abort();
+      } catch (_) {}
+      throw EstimatedIntensityArchiveStoppedException(stopReason);
+    }
+    try {
+      return await Future.any([
+        pending,
+        stopRequested.then<T>(
+          (reason) => throw EstimatedIntensityArchiveStoppedException(reason),
+        ),
+      ]);
+    } on EstimatedIntensityArchiveStoppedException {
+      try {
+        await abort();
+      } catch (_) {}
+      try {
+        await pending;
+      } catch (_) {}
+      rethrow;
+    }
+  }
+
   Future<void> close() async {
     totalTimer.cancel();
     await cancellationSubscription?.cancel();
   }
+}
+
+final class EstimatedIntensityArchiveStoppedException implements Exception {
+  const new(this.reason);
+
+  final EstimatedIntensityArchiveStopReason reason;
 }

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_download_guard.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_download_guard.dart
@@ -49,14 +49,19 @@ final class EstimatedIntensityArchiveDownloadGuard {
   Future<EstimatedIntensityArchiveStopReason> get stopRequested =>
       _stopRequested.future;
 
-  /// 停止時はadapterを中断し、pending I/Oのsettle後にだけ呼出元へ戻す。
+  /// 停止時はpending I/Oの収束後にだけ呼出元へ戻す。
+  ///
+  /// [abort]はHTTPなど安全に中断できるI/Oにのみ指定する。
   Future<T> settle<T>({
     required Future<T> pending,
-    required Future<void> Function() abort,
+    Future<void> Function()? abort,
   }) async {
     if (stopReason != EstimatedIntensityArchiveStopReason.none) {
       try {
-        await abort();
+        await abort?.call();
+      } catch (_) {}
+      try {
+        await pending;
       } catch (_) {}
       throw EstimatedIntensityArchiveStoppedException(stopReason);
     }
@@ -69,7 +74,7 @@ final class EstimatedIntensityArchiveDownloadGuard {
       ]);
     } on EstimatedIntensityArchiveStoppedException {
       try {
-        await abort();
+        await abort?.call();
       } catch (_) {}
       try {
         await pending;

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_file_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_file_verifier.dart
@@ -6,6 +6,7 @@ abstract interface class EstimatedIntensityArchiveFileVerifier {
     required EstimatedIntensityArchiveDescriptor descriptor,
     required File file,
     required Future<EstimatedIntensityArchiveStopReason> stopRequested,
+    required EstimatedIntensityArchiveDiagnosticReporter diagnosticReporter,
   });
 }
 
@@ -18,6 +19,7 @@ final class DartIoEstimatedIntensityArchiveFileVerifier
     required EstimatedIntensityArchiveDescriptor descriptor,
     required File file,
     required Future<EstimatedIntensityArchiveStopReason> stopRequested,
+    required EstimatedIntensityArchiveDiagnosticReporter diagnosticReporter,
   }) async {
     final actualLength = await file.length();
     if (actualLength != descriptor.sizeBytes) {
@@ -34,7 +36,12 @@ final class DartIoEstimatedIntensityArchiveFileVerifier
     if (outcome.stopped case final stopped?) {
       try {
         await digestIterator.cancel();
-      } catch (_) {}
+      } catch (_) {
+        reportEstimatedIntensityArchiveDiagnostic(
+          reporter: diagnosticReporter,
+          diagnostic: .hashStreamCancellationFailed,
+        );
+      }
       try {
         await moveNext;
       } catch (_) {}
@@ -46,7 +53,14 @@ final class DartIoEstimatedIntensityArchiveFileVerifier
       );
     }
     final actualSha256 = digestIterator.current.toString();
-    await digestIterator.cancel();
+    try {
+      await digestIterator.cancel();
+    } catch (_) {
+      reportEstimatedIntensityArchiveDiagnostic(
+        reporter: diagnosticReporter,
+        diagnostic: .hashStreamCancellationFailed,
+      );
+    }
     if (actualSha256 != descriptor.sha256) {
       return const EstimatedIntensityArchiveDownloadRejected(
         EstimatedIntensityArchiveDownloadFailure.sha256Mismatch,

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_file_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_file_verifier.dart
@@ -73,7 +73,7 @@ final class DartIoEstimatedIntensityArchiveFileVerifier
       try {
         await digestIterator.cancel();
       } catch (_) {
-        reportEstimatedIntensityArchiveDiagnostic(
+        EstimatedIntensityArchiveDiagnostics.report(
           reporter: diagnosticReporter,
           diagnostic: .hashStreamCancellationFailed,
         );
@@ -92,7 +92,7 @@ final class DartIoEstimatedIntensityArchiveFileVerifier
     try {
       await digestIterator.cancel();
     } catch (_) {
-      reportEstimatedIntensityArchiveDiagnostic(
+      EstimatedIntensityArchiveDiagnostics.report(
         reporter: diagnosticReporter,
         diagnostic: .hashStreamCancellationFailed,
       );

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_file_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_file_verifier.dart
@@ -5,6 +5,7 @@ abstract interface class EstimatedIntensityArchiveFileVerifier {
   Future<EstimatedIntensityArchiveDownloadResult> verify({
     required EstimatedIntensityArchiveDescriptor descriptor,
     required File file,
+    required Future<EstimatedIntensityArchiveStopReason> stopRequested,
   });
 }
 
@@ -16,6 +17,7 @@ final class DartIoEstimatedIntensityArchiveFileVerifier
   Future<EstimatedIntensityArchiveDownloadResult> verify({
     required EstimatedIntensityArchiveDescriptor descriptor,
     required File file,
+    required Future<EstimatedIntensityArchiveStopReason> stopRequested,
   }) async {
     final actualLength = await file.length();
     if (actualLength != descriptor.sizeBytes) {
@@ -23,7 +25,28 @@ final class DartIoEstimatedIntensityArchiveFileVerifier
         EstimatedIntensityArchiveDownloadFailure.sizeMismatch,
       );
     }
-    final actualSha256 = (await sha256.bind(file.openRead()).first).toString();
+    final digestIterator = StreamIterator(sha256.bind(file.openRead()));
+    final moveNext = digestIterator.moveNext();
+    final outcome = await Future.any([
+      moveNext.then((moved) => (moved: moved, stopped: null)),
+      stopRequested.then((stopped) => (moved: false, stopped: stopped)),
+    ]);
+    if (outcome.stopped case final stopped?) {
+      try {
+        await digestIterator.cancel();
+      } catch (_) {}
+      try {
+        await moveNext;
+      } catch (_) {}
+      return const EstimatedIntensityArchiveStopResultMapper().map(stopped);
+    }
+    if (!outcome.moved) {
+      return const EstimatedIntensityArchiveDownloadRejected(
+        EstimatedIntensityArchiveDownloadFailure.requestFailed,
+      );
+    }
+    final actualSha256 = digestIterator.current.toString();
+    await digestIterator.cancel();
     if (actualSha256 != descriptor.sha256) {
       return const EstimatedIntensityArchiveDownloadRejected(
         EstimatedIntensityArchiveDownloadFailure.sha256Mismatch,

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_file_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_file_verifier.dart
@@ -10,9 +10,26 @@ abstract interface class EstimatedIntensityArchiveFileVerifier {
   });
 }
 
+abstract interface class EstimatedIntensityArchiveFileLengthReader {
+  Future<int> read({required File file});
+}
+
+final class DartIoEstimatedIntensityArchiveFileLengthReader
+    implements EstimatedIntensityArchiveFileLengthReader {
+  const new();
+
+  @override
+  Future<int> read({required File file}) => file.length();
+}
+
 final class DartIoEstimatedIntensityArchiveFileVerifier
     implements EstimatedIntensityArchiveFileVerifier {
-  const new();
+  const new({
+    this.fileLengthReader =
+        const DartIoEstimatedIntensityArchiveFileLengthReader(),
+  });
+
+  final EstimatedIntensityArchiveFileLengthReader fileLengthReader;
 
   @override
   Future<EstimatedIntensityArchiveDownloadResult> verify({
@@ -21,7 +38,26 @@ final class DartIoEstimatedIntensityArchiveFileVerifier
     required Future<EstimatedIntensityArchiveStopReason> stopRequested,
     required EstimatedIntensityArchiveDiagnosticReporter diagnosticReporter,
   }) async {
-    final actualLength = await file.length();
+    final pendingLength = fileLengthReader.read(file: file);
+    final lengthOutcome =
+        await Future.any<
+          ({int? length, EstimatedIntensityArchiveStopReason? stopped})
+        >([
+          pendingLength.then((length) => (length: length, stopped: null)),
+          stopRequested.then((stopped) => (length: null, stopped: stopped)),
+        ]);
+    if (lengthOutcome.stopped case final stopped?) {
+      try {
+        await pendingLength;
+      } catch (_) {}
+      return const EstimatedIntensityArchiveStopResultMapper().map(stopped);
+    }
+    final actualLength = lengthOutcome.length;
+    if (actualLength == null) {
+      return const EstimatedIntensityArchiveDownloadRejected(
+        EstimatedIntensityArchiveDownloadFailure.requestFailed,
+      );
+    }
     if (actualLength != descriptor.sizeBytes) {
       return const EstimatedIntensityArchiveDownloadRejected(
         EstimatedIntensityArchiveDownloadFailure.sizeMismatch,

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart
@@ -64,7 +64,7 @@ final class EstimatedIntensityArchiveHttpDataSource {
         descriptor: descriptor,
         limits: limits,
         partFile: File('${stagingDirectory.path}/archive.part'),
-        stopReason: () => guard.stopReason,
+        guard: guard,
       );
       succeeded = result is EstimatedIntensityArchiveDownloadSuccess;
       return result;

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart
@@ -15,7 +15,7 @@ final class EstimatedIntensityArchiveHttpDataSource {
         EstimatedIntensityArchiveHttpOperationFactory.create,
     this.responseValidator = const EstimatedIntensityArchiveResponseValidator(),
     this.streamVerifier = const EstimatedIntensityArchiveStreamVerifier(),
-    this.diagnosticReporter = ignoreEstimatedIntensityArchiveDiagnostic,
+    this.diagnosticReporter = EstimatedIntensityArchiveDiagnostics.ignore,
   });
   final EstimatedIntensityArchiveHttpOperationCreator operationFactory;
   final EstimatedIntensityArchiveResponseValidator responseValidator;
@@ -92,7 +92,7 @@ final class EstimatedIntensityArchiveHttpDataSource {
       try {
         await guard.close();
       } catch (_) {
-        reportEstimatedIntensityArchiveDiagnostic(
+        EstimatedIntensityArchiveDiagnostics.report(
           reporter: diagnosticReporter,
           diagnostic: .guardCloseFailed,
         );
@@ -101,7 +101,7 @@ final class EstimatedIntensityArchiveHttpDataSource {
         try {
           operation.abort();
         } catch (_) {
-          reportEstimatedIntensityArchiveDiagnostic(
+          EstimatedIntensityArchiveDiagnostics.report(
             reporter: diagnosticReporter,
             diagnostic: .httpAbortFailed,
           );
@@ -110,7 +110,7 @@ final class EstimatedIntensityArchiveHttpDataSource {
           try {
             await directory.delete(recursive: true);
           } catch (_) {
-            reportEstimatedIntensityArchiveDiagnostic(
+            EstimatedIntensityArchiveDiagnostics.report(
               reporter: diagnosticReporter,
               diagnostic: .stagingDirectoryDeleteFailed,
             );
@@ -120,7 +120,7 @@ final class EstimatedIntensityArchiveHttpDataSource {
       try {
         operation.close();
       } catch (_) {
-        reportEstimatedIntensityArchiveDiagnostic(
+        EstimatedIntensityArchiveDiagnostics.report(
           reporter: diagnosticReporter,
           diagnostic: .httpCloseFailed,
         );

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart
@@ -89,16 +89,42 @@ final class EstimatedIntensityArchiveHttpDataSource {
             : EstimatedIntensityArchiveDownloadFailure.requestFailed,
       );
     } finally {
-      await guard.close();
+      try {
+        await guard.close();
+      } catch (_) {
+        reportEstimatedIntensityArchiveDiagnostic(
+          reporter: diagnosticReporter,
+          diagnostic: .guardCloseFailed,
+        );
+      }
       if (!succeeded) {
-        operation.abort();
+        try {
+          operation.abort();
+        } catch (_) {
+          reportEstimatedIntensityArchiveDiagnostic(
+            reporter: diagnosticReporter,
+            diagnostic: .httpAbortFailed,
+          );
+        }
         if (stagingDirectory case final directory?) {
           try {
             await directory.delete(recursive: true);
-          } catch (_) {}
+          } catch (_) {
+            reportEstimatedIntensityArchiveDiagnostic(
+              reporter: diagnosticReporter,
+              diagnostic: .stagingDirectoryDeleteFailed,
+            );
+          }
         }
       }
-      operation.close();
+      try {
+        operation.close();
+      } catch (_) {
+        reportEstimatedIntensityArchiveDiagnostic(
+          reporter: diagnosticReporter,
+          diagnostic: .httpCloseFailed,
+        );
+      }
     }
   }
 }

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart
@@ -6,6 +6,7 @@ import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_response_validator.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_cleanup_diagnostic.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
 
 final class EstimatedIntensityArchiveHttpDataSource {
@@ -14,10 +15,12 @@ final class EstimatedIntensityArchiveHttpDataSource {
         EstimatedIntensityArchiveHttpOperationFactory.create,
     this.responseValidator = const EstimatedIntensityArchiveResponseValidator(),
     this.streamVerifier = const EstimatedIntensityArchiveStreamVerifier(),
+    this.diagnosticReporter = ignoreEstimatedIntensityArchiveDiagnostic,
   });
   final EstimatedIntensityArchiveHttpOperationCreator operationFactory;
   final EstimatedIntensityArchiveResponseValidator responseValidator;
   final EstimatedIntensityArchiveStreamVerifier streamVerifier;
+  final EstimatedIntensityArchiveDiagnosticReporter diagnosticReporter;
   Future<EstimatedIntensityArchiveDownloadResult> download({
     required EstimatedIntensityArchiveDescriptor descriptor,
     required Directory temporaryDirectory,
@@ -65,6 +68,7 @@ final class EstimatedIntensityArchiveHttpDataSource {
         limits: limits,
         partFile: File('${stagingDirectory.path}/archive.part'),
         guard: guard,
+        diagnosticReporter: diagnosticReporter,
       );
       succeeded = result is EstimatedIntensityArchiveDownloadSuccess;
       return result;

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_part_writer.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_part_writer.dart
@@ -5,9 +5,9 @@ abstract interface class EstimatedIntensityArchivePartWriter {
 
   Future<void> flushAndClose();
 
-  /// Pending write/flushをsettleさせてから完了する。
+  /// Pending write/flushがない状態で呼び出し、handleをcloseする。
   ///
-  /// 停止後の一時file削除は、このFutureの完了後にだけ実行される。
+  /// 呼出元は開始済みI/Oを収束させた後にcleanupする。
   Future<void> close();
 }
 

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_part_writer.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_part_writer.dart
@@ -5,6 +5,9 @@ abstract interface class EstimatedIntensityArchivePartWriter {
 
   Future<void> flushAndClose();
 
+  /// Pending write/flushをsettleさせてから完了する。
+  ///
+  /// 停止後の一時file削除は、このFutureの完了後にだけ実行される。
   Future<void> close();
 }
 

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
@@ -68,16 +68,6 @@ final class EstimatedIntensityArchiveStreamVerifier {
         }
         await guard.settle(
           pending: output.write(chunk),
-          abort: () async {
-            try {
-              await output?.close();
-            } catch (_) {
-              reportEstimatedIntensityArchiveDiagnostic(
-                reporter: diagnosticReporter,
-                diagnostic: .partWriterCloseFailed,
-              );
-            }
-          },
         );
         receivedBytes = nextBytes;
       }
@@ -88,16 +78,6 @@ final class EstimatedIntensityArchiveStreamVerifier {
       }
       await guard.settle(
         pending: output.flushAndClose(),
-        abort: () async {
-          try {
-            await output?.close();
-          } catch (_) {
-            reportEstimatedIntensityArchiveDiagnostic(
-              reporter: diagnosticReporter,
-              diagnostic: .partWriterCloseFailed,
-            );
-          }
-        },
       );
       if (receivedBytes != descriptor.sizeBytes) {
         return const EstimatedIntensityArchiveDownloadRejected(

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
@@ -107,7 +107,8 @@ final class EstimatedIntensityArchiveStreamVerifier {
       final verified = await fileVerifier.verify(
         descriptor: descriptor,
         file: partFile,
-        stopRequested: guard.stopRequested.future,
+        stopRequested: guard.stopRequested,
+        diagnosticReporter: diagnosticReporter,
       );
       final finalStop = guard.stopReason;
       if (finalStop != EstimatedIntensityArchiveStopReason.none) {

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
@@ -78,6 +78,7 @@ final class EstimatedIntensityArchiveStreamVerifier {
       final verified = await fileVerifier.verify(
         descriptor: descriptor,
         file: partFile,
+        stopRequested: guard.stopRequested.future,
       );
       final finalStop = guard.stopReason;
       if (finalStop != EstimatedIntensityArchiveStopReason.none) {

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
@@ -43,7 +43,7 @@ final class EstimatedIntensityArchiveStreamVerifier {
           try {
             await bodyIterator?.cancel();
           } catch (_) {
-            reportEstimatedIntensityArchiveDiagnostic(
+            EstimatedIntensityArchiveDiagnostics.report(
               reporter: diagnosticReporter,
               diagnostic: .bodyCancellationFailed,
             );
@@ -123,7 +123,7 @@ final class EstimatedIntensityArchiveStreamVerifier {
       try {
         await bodyIterator?.cancel();
       } catch (_) {
-        reportEstimatedIntensityArchiveDiagnostic(
+        EstimatedIntensityArchiveDiagnostics.report(
           reporter: diagnosticReporter,
           diagnostic: .bodyCancellationFailed,
         );
@@ -131,7 +131,7 @@ final class EstimatedIntensityArchiveStreamVerifier {
       try {
         await output?.close();
       } catch (_) {
-        reportEstimatedIntensityArchiveDiagnostic(
+        EstimatedIntensityArchiveDiagnostics.report(
           reporter: diagnosticReporter,
           diagnostic: .partWriterCloseFailed,
         );

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_attestation_binder.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_download_guard.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_part_writer.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
@@ -26,7 +27,7 @@ final class EstimatedIntensityArchiveStreamVerifier {
     required EstimatedIntensityArchiveDescriptor descriptor,
     required EstimatedIntensityArchiveDownloadLimits limits,
     required File partFile,
-    required EstimatedIntensityArchiveStopReasonReader stopReason,
+    required EstimatedIntensityArchiveDownloadGuard guard,
   }) async {
     EstimatedIntensityArchivePartWriter? output;
     StreamIterator<List<int>>? bodyIterator;
@@ -34,30 +35,41 @@ final class EstimatedIntensityArchiveStreamVerifier {
       output = await partWriterFactory(partFile);
       var receivedBytes = 0;
       bodyIterator = StreamIterator(response.body.timeout(limits.idleTimeout));
-      while (await bodyIterator.moveNext()) {
-        final stopped = stopReason();
+      while (await guard.settle(
+        pending: bodyIterator.moveNext(),
+        abort: bodyIterator.cancel,
+      )) {
+        final stopped = guard.stopReason;
         if (stopped != EstimatedIntensityArchiveStopReason.none) {
           return stopResultMapper.map(stopped);
         }
         final chunk = bodyIterator.current;
         final nextBytes = receivedBytes + chunk.length;
         if (nextBytes > limits.maxArchiveBytes) {
-          return const EstimatedIntensityArchiveDownloadRejected(.archiveTooLarge);
+          return const EstimatedIntensityArchiveDownloadRejected(
+            .archiveTooLarge,
+          );
         }
         if (nextBytes > descriptor.sizeBytes) {
           return const EstimatedIntensityArchiveDownloadRejected(
             EstimatedIntensityArchiveDownloadFailure.sizeMismatch,
           );
         }
-        await output.write(chunk);
+        await guard.settle(
+          pending: output.write(chunk),
+          abort: output.close,
+        );
         receivedBytes = nextBytes;
       }
 
-      final stopped = stopReason();
+      final stopped = guard.stopReason;
       if (stopped != EstimatedIntensityArchiveStopReason.none) {
         return stopResultMapper.map(stopped);
       }
-      await output.flushAndClose();
+      await guard.settle(
+        pending: output.flushAndClose(),
+        abort: output.close,
+      );
       if (receivedBytes != descriptor.sizeBytes) {
         return const EstimatedIntensityArchiveDownloadRejected(
           EstimatedIntensityArchiveDownloadFailure.sizeMismatch,
@@ -67,7 +79,7 @@ final class EstimatedIntensityArchiveStreamVerifier {
         descriptor: descriptor,
         file: partFile,
       );
-      final finalStop = stopReason();
+      final finalStop = guard.stopReason;
       if (finalStop != EstimatedIntensityArchiveStopReason.none) {
         return stopResultMapper.map(finalStop);
       }
@@ -77,7 +89,7 @@ final class EstimatedIntensityArchiveStreamVerifier {
         partFile: partFile,
       );
     } on TimeoutException {
-      final stopped = stopReason();
+      final stopped = guard.stopReason;
       if (stopped != EstimatedIntensityArchiveStopReason.none) {
         return stopResultMapper.map(stopped);
       }
@@ -89,7 +101,7 @@ final class EstimatedIntensityArchiveStreamVerifier {
         EstimatedIntensityArchiveDownloadFailure.storageFailure,
       );
     } catch (_) {
-      final stopped = stopReason();
+      final stopped = guard.stopReason;
       if (stopped != EstimatedIntensityArchiveStopReason.none) {
         return stopResultMapper.map(stopped);
       }

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_download_guard.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_part_writer.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_cleanup_diagnostic.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_stop_reason.dart';
@@ -28,6 +29,7 @@ final class EstimatedIntensityArchiveStreamVerifier {
     required EstimatedIntensityArchiveDownloadLimits limits,
     required File partFile,
     required EstimatedIntensityArchiveDownloadGuard guard,
+    required EstimatedIntensityArchiveDiagnosticReporter diagnosticReporter,
   }) async {
     EstimatedIntensityArchivePartWriter? output;
     StreamIterator<List<int>>? bodyIterator;
@@ -37,7 +39,16 @@ final class EstimatedIntensityArchiveStreamVerifier {
       bodyIterator = StreamIterator(response.body.timeout(limits.idleTimeout));
       while (await guard.settle(
         pending: bodyIterator.moveNext(),
-        abort: bodyIterator.cancel,
+        abort: () async {
+          try {
+            await bodyIterator?.cancel();
+          } catch (_) {
+            reportEstimatedIntensityArchiveDiagnostic(
+              reporter: diagnosticReporter,
+              diagnostic: .bodyCancellationFailed,
+            );
+          }
+        },
       )) {
         final stopped = guard.stopReason;
         if (stopped != EstimatedIntensityArchiveStopReason.none) {
@@ -57,7 +68,16 @@ final class EstimatedIntensityArchiveStreamVerifier {
         }
         await guard.settle(
           pending: output.write(chunk),
-          abort: output.close,
+          abort: () async {
+            try {
+              await output?.close();
+            } catch (_) {
+              reportEstimatedIntensityArchiveDiagnostic(
+                reporter: diagnosticReporter,
+                diagnostic: .partWriterCloseFailed,
+              );
+            }
+          },
         );
         receivedBytes = nextBytes;
       }
@@ -68,7 +88,16 @@ final class EstimatedIntensityArchiveStreamVerifier {
       }
       await guard.settle(
         pending: output.flushAndClose(),
-        abort: output.close,
+        abort: () async {
+          try {
+            await output?.close();
+          } catch (_) {
+            reportEstimatedIntensityArchiveDiagnostic(
+              reporter: diagnosticReporter,
+              diagnostic: .partWriterCloseFailed,
+            );
+          }
+        },
       );
       if (receivedBytes != descriptor.sizeBytes) {
         return const EstimatedIntensityArchiveDownloadRejected(
@@ -110,10 +139,22 @@ final class EstimatedIntensityArchiveStreamVerifier {
         EstimatedIntensityArchiveDownloadFailure.requestFailed,
       );
     } finally {
-      await bodyIterator?.cancel();
+      try {
+        await bodyIterator?.cancel();
+      } catch (_) {
+        reportEstimatedIntensityArchiveDiagnostic(
+          reporter: diagnosticReporter,
+          diagnostic: .bodyCancellationFailed,
+        );
+      }
       try {
         await output?.close();
-      } catch (_) {}
+      } catch (_) {
+        reportEstimatedIntensityArchiveDiagnostic(
+          reporter: diagnosticReporter,
+          diagnostic: .partWriterCloseFailed,
+        );
+      }
     }
   }
 }

--- a/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_cleanup_diagnostic.dart
+++ b/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_cleanup_diagnostic.dart
@@ -12,16 +12,16 @@ typedef EstimatedIntensityArchiveDiagnosticReporter = void Function(
   EstimatedIntensityArchiveCleanupDiagnostic diagnostic,
 );
 
-void ignoreEstimatedIntensityArchiveDiagnostic(
-  EstimatedIntensityArchiveCleanupDiagnostic diagnostic,
-) {}
+abstract final class EstimatedIntensityArchiveDiagnostics {
+  static void ignore(EstimatedIntensityArchiveCleanupDiagnostic diagnostic) {}
 
-/// Reporter failureもdownload resultを変更しない。
-void reportEstimatedIntensityArchiveDiagnostic({
-  required EstimatedIntensityArchiveDiagnosticReporter reporter,
-  required EstimatedIntensityArchiveCleanupDiagnostic diagnostic,
-}) {
-  try {
-    reporter(diagnostic);
-  } catch (_) {}
+  /// Reporter failureもdownload resultを変更しない。
+  static void report({
+    required EstimatedIntensityArchiveDiagnosticReporter reporter,
+    required EstimatedIntensityArchiveCleanupDiagnostic diagnostic,
+  }) {
+    try {
+      reporter(diagnostic);
+    } catch (_) {}
+  }
 }

--- a/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_cleanup_diagnostic.dart
+++ b/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_cleanup_diagnostic.dart
@@ -1,0 +1,27 @@
+enum EstimatedIntensityArchiveCleanupDiagnostic {
+  bodyCancellationFailed,
+  partWriterCloseFailed,
+  hashStreamCancellationFailed,
+  guardCloseFailed,
+  httpAbortFailed,
+  stagingDirectoryDeleteFailed,
+  httpCloseFailed,
+}
+
+typedef EstimatedIntensityArchiveDiagnosticReporter = void Function(
+  EstimatedIntensityArchiveCleanupDiagnostic diagnostic,
+);
+
+void ignoreEstimatedIntensityArchiveDiagnostic(
+  EstimatedIntensityArchiveCleanupDiagnostic diagnostic,
+) {}
+
+/// Reporter failureもdownload resultを変更しない。
+void reportEstimatedIntensityArchiveDiagnostic({
+  required EstimatedIntensityArchiveDiagnosticReporter reporter,
+  required EstimatedIntensityArchiveCleanupDiagnostic diagnostic,
+}) {
+  try {
+    reporter(diagnostic);
+  } catch (_) {}
+}

--- a/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart
+++ b/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart
@@ -1,7 +1,9 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_stop_reason.dart';
 
 export 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_limits.dart';
 

--- a/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart
+++ b/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_cleanup_diagnostic.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_stop_reason.dart';
 
 export 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_limits.dart';

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_abort_settlement_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_abort_settlement_test.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_download_guard.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_stop_reason.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'estimated_intensity_archive_abort_test_support.dart';
@@ -55,4 +58,43 @@ void main() {
     expect(temporaryDirectory.listSync(recursive: true), isEmpty);
   });
 
+  test('停止済みguardは開始済み処理の完了後に例外を返す', () async {
+    final cancellation = EstimatedIntensityArchiveDownloadCancellation();
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: Completer<EstimatedIntensityArchiveHttpResponse>().future,
+    );
+    final guard = EstimatedIntensityArchiveDownloadGuard(
+      operation: operation,
+      totalTimeout: const Duration(seconds: 1),
+      cancellation: cancellation,
+    );
+    final pending = Completer<void>();
+    await cancellation.cancel();
+
+    final settlement = guard.settle(
+      pending: pending.future,
+      abort: () async {},
+    );
+    final earlyResult = await Future.any([
+      settlement.then(
+        (_) => 'completed',
+        onError: (_) => 'failed',
+      ),
+      Future<void>.delayed(Duration.zero).then((_) => 'waiting'),
+    ]);
+    expect(earlyResult, 'waiting');
+
+    pending.complete();
+    await expectLater(
+      settlement,
+      throwsA(
+        isA<EstimatedIntensityArchiveStoppedException>().having(
+          (error) => error.reason,
+          'reason',
+          EstimatedIntensityArchiveStopReason.cancelled,
+        ),
+      ),
+    );
+    await guard.close();
+  });
 }

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_attestation_binding_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_attestation_binding_test.dart
@@ -4,6 +4,7 @@ import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_stop_reason.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'estimated_intensity_archive_transport_test_support.dart';
@@ -80,5 +81,6 @@ final class ReplayEstimatedIntensityArchiveFileVerifier
   Future<EstimatedIntensityArchiveDownloadResult> verify({
     required EstimatedIntensityArchiveDescriptor descriptor,
     required File file,
+    required Future<EstimatedIntensityArchiveStopReason> stopRequested,
   }) async => result;
 }

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_attestation_binding_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_attestation_binding_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_cleanup_diagnostic.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_stop_reason.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -82,5 +83,6 @@ final class ReplayEstimatedIntensityArchiveFileVerifier
     required EstimatedIntensityArchiveDescriptor descriptor,
     required File file,
     required Future<EstimatedIntensityArchiveStopReason> stopRequested,
+    required EstimatedIntensityArchiveDiagnosticReporter diagnosticReporter,
   }) async => result;
 }

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_backpressure_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_backpressure_test.dart
@@ -17,13 +17,13 @@ void main() {
     addTearDown(() => temporaryDirectory.delete(recursive: true));
     final firstWriteStarted = Completer<void>();
     final releaseFirstWrite = Completer<void>();
-    GatedEstimatedIntensityArchivePartWriter? writer;
+    PausedEstimatedIntensityArchivePartWriter? writer;
     final verifier = EstimatedIntensityArchiveStreamVerifier(
       partWriterFactory: (file) async {
         final delegate = await DartIoEstimatedIntensityArchivePartWriter.open(
           file,
         );
-        final created = GatedEstimatedIntensityArchivePartWriter(
+        final created = PausedEstimatedIntensityArchivePartWriter(
           delegate: delegate,
           firstWriteStarted: firstWriteStarted,
           releaseFirstWrite: releaseFirstWrite,
@@ -60,9 +60,66 @@ void main() {
     expect(writer?.writeCount, 2);
     expect(writer?.maxConcurrentWrites, 1);
   });
+
+  test('total timeoutは待機中のwriteをcloseしてpartをcleanupする', () async {
+    final temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_write_timeout_test_',
+    );
+    addTearDown(() => temporaryDirectory.delete(recursive: true));
+    final writeStarted = Completer<void>();
+    final releaseWrite = Completer<void>();
+    addTearDown(() {
+      if (!releaseWrite.isCompleted) {
+        releaseWrite.complete();
+      }
+    });
+    PausedEstimatedIntensityArchivePartWriter? writer;
+    final verifier = EstimatedIntensityArchiveStreamVerifier(
+      partWriterFactory: (file) async {
+        final created = PausedEstimatedIntensityArchivePartWriter(
+          delegate: await DartIoEstimatedIntensityArchivePartWriter.open(file),
+          firstWriteStarted: writeStarted,
+          releaseFirstWrite: releaseWrite,
+        );
+        writer = created;
+        return created;
+      },
+    );
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: Future.value(estimatedIntensityTestResponse()),
+    );
+    final limits = EstimatedIntensityArchiveDownloadLimits(
+      maxArchiveBytes: 1024,
+      connectTimeout: const Duration(seconds: 1),
+      headerTimeout: const Duration(seconds: 1),
+      idleTimeout: const Duration(seconds: 1),
+      totalTimeout: const Duration(milliseconds: 10),
+    );
+
+    final resultFuture =
+        EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () => operation,
+          streamVerifier: verifier,
+        ).download(
+          descriptor: estimatedIntensityTestDescriptor(),
+          temporaryDirectory: temporaryDirectory,
+          limits: limits,
+        );
+    await writeStarted.future;
+    final result = await resultFuture.timeout(
+      const Duration(milliseconds: 200),
+    );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.timeout,
+    );
+    expect(writer?.closeCount, 1);
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
 }
 
-final class GatedEstimatedIntensityArchivePartWriter
+final class PausedEstimatedIntensityArchivePartWriter
     implements EstimatedIntensityArchivePartWriter {
   new({
     required this.delegate,
@@ -76,6 +133,8 @@ final class GatedEstimatedIntensityArchivePartWriter
   var writeCount = 0;
   var concurrentWrites = 0;
   var maxConcurrentWrites = 0;
+  var closeCount = 0;
+  var closed = false;
 
   @override
   Future<void> write(List<int> bytes) async {
@@ -96,5 +155,15 @@ final class GatedEstimatedIntensityArchivePartWriter
   Future<void> flushAndClose() => delegate.flushAndClose();
 
   @override
-  Future<void> close() => delegate.close();
+  Future<void> close() async {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    closeCount += 1;
+    if (!releaseFirstWrite.isCompleted) {
+      releaseFirstWrite.completeError(StateError('writer closed'));
+    }
+    await delegate.close();
+  }
 }

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_backpressure_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_backpressure_test.dart
@@ -61,13 +61,14 @@ void main() {
     expect(writer?.maxConcurrentWrites, 1);
   });
 
-  test('total timeoutは待機中のwriteをcloseしてpartをcleanupする', () async {
+  test('total timeoutは待機中のwrite収束後にpartをcleanupする', () async {
     final temporaryDirectory = await Directory.systemTemp.createTemp(
       'estimated_intensity_write_timeout_test_',
     );
     addTearDown(() => temporaryDirectory.delete(recursive: true));
     final writeStarted = Completer<void>();
     final releaseWrite = Completer<void>();
+    final stopNotified = Completer<void>();
     addTearDown(() {
       if (!releaseWrite.isCompleted) {
         releaseWrite.complete();
@@ -85,9 +86,15 @@ void main() {
         return created;
       },
     );
-    final operation = TestEstimatedIntensityArchiveHttpOperation(
-      openResponse: Future.value(estimatedIntensityTestResponse()),
-    );
+    final operation =
+        TestEstimatedIntensityArchiveHttpOperation(
+            openResponse: Future.value(estimatedIntensityTestResponse()),
+          )
+          ..onAbort = () {
+            if (!stopNotified.isCompleted) {
+              stopNotified.complete();
+            }
+          };
     final limits = EstimatedIntensityArchiveDownloadLimits(
       maxArchiveBytes: 1024,
       connectTimeout: const Duration(seconds: 1),
@@ -106,6 +113,10 @@ void main() {
           limits: limits,
         );
     await writeStarted.future;
+    await stopNotified.future;
+    await Future<void>.delayed(Duration.zero);
+    final closeOverlappedWrite = writer?.closeOverlappedWrite;
+    releaseWrite.complete();
     final result = await resultFuture.timeout(
       const Duration(milliseconds: 200),
     );
@@ -114,6 +125,9 @@ void main() {
       result: result,
       failure: EstimatedIntensityArchiveDownloadFailure.timeout,
     );
+    expect(closeOverlappedWrite, isFalse);
+    expect(writer?.writeCount, 1);
+    expect(writer?.maxConcurrentWrites, 1);
     expect(writer?.closeCount, 1);
     expect(temporaryDirectory.listSync(recursive: true), isEmpty);
   });
@@ -134,6 +148,7 @@ final class PausedEstimatedIntensityArchivePartWriter
   var concurrentWrites = 0;
   var maxConcurrentWrites = 0;
   var closeCount = 0;
+  var closeOverlappedWrite = false;
   var closed = false;
 
   @override
@@ -159,11 +174,12 @@ final class PausedEstimatedIntensityArchivePartWriter
     if (closed) {
       return;
     }
-    closed = true;
     closeCount += 1;
-    if (!releaseFirstWrite.isCompleted) {
-      releaseFirstWrite.completeError(StateError('writer closed'));
+    if (concurrentWrites > 0) {
+      closeOverlappedWrite = true;
+      return;
     }
+    closed = true;
     await delegate.close();
   }
 }

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_failure_cleanup_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_failure_cleanup_test.dart
@@ -3,6 +3,9 @@ import 'dart:io';
 
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_operation.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_part_writer.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_cleanup_diagnostic.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -68,4 +71,67 @@ void main() {
     expect(operation.abortCount, 1);
     expect(operation.closeCount, 1);
   });
+
+  test('part close失敗はprimary failureを保ちsanitized diagnosticへ記録する', () async {
+    final temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_cleanup_diagnostic_test_',
+    );
+    addTearDown(() => temporaryDirectory.delete(recursive: true));
+    final diagnostics = <EstimatedIntensityArchiveCleanupDiagnostic>[];
+    final operation = TestEstimatedIntensityArchiveHttpOperation(
+      openResponse: Future.value(
+        estimatedIntensityTestResponse(
+          body: Stream.error(StateError('private response body')),
+        ),
+      ),
+    );
+    final verifier = EstimatedIntensityArchiveStreamVerifier(
+      partWriterFactory: (file) async => CloseFailingPartWriter(
+        delegate: await DartIoEstimatedIntensityArchivePartWriter.open(file),
+      ),
+    );
+
+    final result =
+        await EstimatedIntensityArchiveHttpDataSource(
+          operationFactory: () => operation,
+          streamVerifier: verifier,
+          diagnosticReporter: diagnostics.add,
+        ).download(
+          descriptor: estimatedIntensityTestDescriptor(),
+          temporaryDirectory: temporaryDirectory,
+          limits: estimatedIntensityTransportTestLimits,
+        );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.requestFailed,
+    );
+    expect(
+      diagnostics,
+      contains(
+        EstimatedIntensityArchiveCleanupDiagnostic.partWriterCloseFailed,
+      ),
+    );
+    expect(diagnostics.join(), isNot(contains('private response body')));
+    expect(temporaryDirectory.listSync(recursive: true), isEmpty);
+  });
+}
+
+final class CloseFailingPartWriter
+    implements EstimatedIntensityArchivePartWriter {
+  const new({required this.delegate});
+
+  final EstimatedIntensityArchivePartWriter delegate;
+
+  @override
+  Future<void> write(List<int> bytes) => delegate.write(bytes);
+
+  @override
+  Future<void> flushAndClose() => delegate.flushAndClose();
+
+  @override
+  Future<void> close() async {
+    await delegate.close();
+    throw const FileSystemException('private cleanup failure');
+  }
 }

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_hash_timeout_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_hash_timeout_test.dart
@@ -5,22 +5,20 @@ import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_stop_reason.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'estimated_intensity_archive_transport_test_support.dart';
 
 void main() {
-  test('hash中のtotal timeoutはhash終了後にrejectしてからpartを消す', () async {
+  test('hash中のtotal timeoutはhashをcancelしてpartを消す', () async {
     final temporaryDirectory = await Directory.systemTemp.createTemp(
       'estimated_intensity_hash_timeout_test_',
     );
     addTearDown(() => temporaryDirectory.delete(recursive: true));
     final hashStarted = Completer<void>();
-    final releaseHash = Completer<void>();
-    final fileVerifier = GatedEstimatedIntensityArchiveFileVerifier(
-      delegate: const DartIoEstimatedIntensityArchiveFileVerifier(),
+    final fileVerifier = PausedEstimatedIntensityArchiveFileVerifier(
       hashStarted: hashStarted,
-      releaseHash: releaseHash,
     );
     final operation = TestEstimatedIntensityArchiveHttpOperation(
       openResponse: Future.value(estimatedIntensityTestResponse()),
@@ -45,15 +43,9 @@ void main() {
         );
     await hashStarted.future;
 
-    final firstCompletion = await Future.any<String>([
-      resultFuture.then((_) => 'completed'),
-      Future.delayed(const Duration(milliseconds: 30), () => 'pending'),
-    ]);
-    expect(firstCompletion, 'pending');
-    expect(temporaryDirectory.listSync(recursive: true), isNotEmpty);
-
-    releaseHash.complete();
-    final result = await resultFuture;
+    final result = await resultFuture.timeout(
+      const Duration(milliseconds: 200),
+    );
 
     expectEstimatedIntensityDownloadFailure(
       result: result,
@@ -61,27 +53,45 @@ void main() {
     );
     expect(temporaryDirectory.listSync(recursive: true), isEmpty);
   });
+
+  test('停止済みfile verifierはhashをpublishしない', () async {
+    final temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_stopped_hash_test_',
+    );
+    addTearDown(() => temporaryDirectory.delete(recursive: true));
+    final file = File('${temporaryDirectory.path}/archive.part');
+    await file.writeAsBytes('hello world'.codeUnits);
+
+    final result = await const DartIoEstimatedIntensityArchiveFileVerifier()
+        .verify(
+          descriptor: estimatedIntensityTestDescriptor(),
+          file: file,
+          stopRequested: Future.value(
+            EstimatedIntensityArchiveStopReason.cancelled,
+          ),
+        );
+
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.cancelled,
+    );
+  });
 }
 
-final class GatedEstimatedIntensityArchiveFileVerifier
+final class PausedEstimatedIntensityArchiveFileVerifier
     implements EstimatedIntensityArchiveFileVerifier {
-  new({
-    required this.delegate,
-    required this.hashStarted,
-    required this.releaseHash,
-  });
+  new({required this.hashStarted});
 
-  final EstimatedIntensityArchiveFileVerifier delegate;
   final Completer<void> hashStarted;
-  final Completer<void> releaseHash;
 
   @override
   Future<EstimatedIntensityArchiveDownloadResult> verify({
     required EstimatedIntensityArchiveDescriptor descriptor,
     required File file,
+    required Future<EstimatedIntensityArchiveStopReason> stopRequested,
   }) async {
     hashStarted.complete();
-    await releaseHash.future;
-    return delegate.verify(descriptor: descriptor, file: file);
+    final stopped = await stopRequested;
+    return const EstimatedIntensityArchiveStopResultMapper().map(stopped);
   }
 }

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_hash_timeout_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_hash_timeout_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_http_data_source.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_stream_verifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_cleanup_diagnostic.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_descriptor.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_stop_reason.dart';
@@ -69,6 +70,7 @@ void main() {
           stopRequested: Future.value(
             EstimatedIntensityArchiveStopReason.cancelled,
           ),
+          diagnosticReporter: ignoreEstimatedIntensityArchiveDiagnostic,
         );
 
     expectEstimatedIntensityDownloadFailure(
@@ -89,6 +91,7 @@ final class PausedEstimatedIntensityArchiveFileVerifier
     required EstimatedIntensityArchiveDescriptor descriptor,
     required File file,
     required Future<EstimatedIntensityArchiveStopReason> stopRequested,
+    required EstimatedIntensityArchiveDiagnosticReporter diagnosticReporter,
   }) async {
     hashStarted.complete();
     final stopped = await stopRequested;

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_hash_timeout_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_hash_timeout_test.dart
@@ -78,6 +78,45 @@ void main() {
       failure: EstimatedIntensityArchiveDownloadFailure.cancelled,
     );
   });
+
+  test('file length待機中の停止は取得の収束後に戻る', () async {
+    final temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_length_timeout_test_',
+    );
+    addTearDown(() => temporaryDirectory.delete(recursive: true));
+    final file = File('${temporaryDirectory.path}/archive.part');
+    await file.writeAsBytes('hello world'.codeUnits);
+    final lengthStarted = Completer<void>();
+    final releaseLength = Completer<int>();
+    final stopRequested = Completer<EstimatedIntensityArchiveStopReason>();
+    final verifier = DartIoEstimatedIntensityArchiveFileVerifier(
+      fileLengthReader: (_) {
+        lengthStarted.complete();
+        return releaseLength.future;
+      },
+    );
+
+    final resultFuture = verifier.verify(
+      descriptor: estimatedIntensityTestDescriptor(),
+      file: file,
+      stopRequested: stopRequested.future,
+      diagnosticReporter: ignoreEstimatedIntensityArchiveDiagnostic,
+    );
+    await lengthStarted.future;
+    stopRequested.complete(EstimatedIntensityArchiveStopReason.timeout);
+    final earlyResult = await Future.any([
+      resultFuture.then((_) => 'completed'),
+      Future<void>.delayed(Duration.zero).then((_) => 'waiting'),
+    ]);
+    expect(earlyResult, 'waiting');
+
+    releaseLength.complete(11);
+    final result = await resultFuture;
+    expectEstimatedIntensityDownloadFailure(
+      result: result,
+      failure: EstimatedIntensityArchiveDownloadFailure.timeout,
+    );
+  });
 }
 
 final class PausedEstimatedIntensityArchiveFileVerifier

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_hash_timeout_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_hash_timeout_test.dart
@@ -70,7 +70,7 @@ void main() {
           stopRequested: Future.value(
             EstimatedIntensityArchiveStopReason.cancelled,
           ),
-          diagnosticReporter: ignoreEstimatedIntensityArchiveDiagnostic,
+          diagnosticReporter: EstimatedIntensityArchiveDiagnostics.ignore,
         );
 
     expectEstimatedIntensityDownloadFailure(
@@ -100,7 +100,7 @@ void main() {
       descriptor: estimatedIntensityTestDescriptor(),
       file: file,
       stopRequested: stopRequested.future,
-      diagnosticReporter: ignoreEstimatedIntensityArchiveDiagnostic,
+      diagnosticReporter: EstimatedIntensityArchiveDiagnostics.ignore,
     );
     await lengthStarted.future;
     stopRequested.complete(EstimatedIntensityArchiveStopReason.timeout);

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_hash_timeout_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_hash_timeout_test.dart
@@ -90,10 +90,10 @@ void main() {
     final releaseLength = Completer<int>();
     final stopRequested = Completer<EstimatedIntensityArchiveStopReason>();
     final verifier = DartIoEstimatedIntensityArchiveFileVerifier(
-      fileLengthReader: (_) {
-        lengthStarted.complete();
-        return releaseLength.future;
-      },
+      fileLengthReader: PausedEstimatedIntensityArchiveFileLengthReader(
+        started: lengthStarted,
+        release: releaseLength,
+      ),
     );
 
     final resultFuture = verifier.verify(
@@ -117,6 +117,20 @@ void main() {
       failure: EstimatedIntensityArchiveDownloadFailure.timeout,
     );
   });
+}
+
+final class PausedEstimatedIntensityArchiveFileLengthReader
+    implements EstimatedIntensityArchiveFileLengthReader {
+  const new({required this.started, required this.release});
+
+  final Completer<void> started;
+  final Completer<int> release;
+
+  @override
+  Future<int> read({required File file}) {
+    started.complete();
+    return release.future;
+  }
 }
 
 final class PausedEstimatedIntensityArchiveFileVerifier

--- a/docs/superpowers/plans/2026-08-25-estimated-intensity-flutter-gpu-map.md
+++ b/docs/superpowers/plans/2026-08-25-estimated-intensity-flutter-gpu-map.md
@@ -5,7 +5,8 @@
 > superpowers:executing-plans to implement this plan task-by-task. Steps use
 > checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** event `20260823020050` を最初の production data gate として、API が返す
+**Goal:** event `20260823020050` を最初のproduction data検証対象として、
+API が返す
 immutable descriptor から検証済み PMTiles を取得し、Flutter Scene / Flutter GPU の
 デバッグ地図へ推計震度 Fill / Line と同一 event の震源を原子的に表示する。
 
@@ -59,7 +60,7 @@ EQMonitor の `backend` submodule がその contract commit を参照できる�
 | P6 | `codex/gpu-map-19-estimated-renderer` | P5 branch | typed Fill / Line renderer |
 | P7 | `codex/gpu-map-20-estimated-pipeline` | P6 branch | coverage / generation / publication barrier |
 | P8 | `codex/gpu-map-21-estimated-app` | P7 branch | atomic app/debug-map integration |
-| P9 | `codex/gpu-map-22-estimated-runtime` | P8 branch | event fixture、lifecycle、iOS / Android gate |
+| P9 | `codex/gpu-map-22-estimated-runtime` | P8 branch | event fixture、lifecycle、iOS / Android実機検証 |
 
 S0はdocsだけを持ち、branch 12へのrebaseとreview完了後に既存Stack #1756へlinkする。P1〜P9は
 その上へ順にreview / mergeする。上位branchのsyncは直前baseのmerge後に行い、
@@ -722,7 +723,8 @@ script名をこの計画へ固定しない。
 
 Runtime checklist:
 
-- actual descriptor download、exact size、SHA-256、PMTiles header gate
+- actual descriptor download、exact size、SHA-256、
+  PMTiles header確認
 - class 4 / 5- / 5+ のtheme色とFill/Line pair
 - administrative lineより下の描画順
 - observed Fill/station非表示、archive未検証中のbase+hypocenter-only表示、verified後のsame-event

--- a/docs/superpowers/specs/2026-08-25-estimated-intensity-flutter-gpu-map-design.md
+++ b/docs/superpowers/specs/2026-08-25-estimated-intensity-flutter-gpu-map-design.md
@@ -268,6 +268,11 @@ HTTP contract:
 - timeout、cancel、socket failure を source failure として typed に保持
 - response body、例外、URL に auth token や local path を user-facing message へ出さない
 
+total timeout と cancel は request open、body read、part write、flush、exact size、SHA-256
+確認までを一つの停止signalで制御する。停止時はHTTP request、body subscription、part writer、
+hash subscriptionを中断し、各adapterのpending I/Oがsettleしてから `.part` cleanupへ進む。
+cleanup失敗の診断は固定enumだけを渡し、URL、local path、hash、元例外を渡さない。
+
 ### 7.2 Full-content verification
 
 response は unique `.part` file へ stream する。write と同時に SHA-256 を更新してよいが、

--- a/docs/superpowers/specs/2026-08-25-estimated-intensity-flutter-gpu-map-design.md
+++ b/docs/superpowers/specs/2026-08-25-estimated-intensity-flutter-gpu-map-design.md
@@ -271,8 +271,9 @@ HTTP contract:
 - response body、例外、URL に auth token や local path を user-facing message へ出さない
 
 total timeout と cancel は request open、body read、part write、flush、exact size、SHA-256
-確認までを一つの停止signalで制御する。停止時はHTTP request、body subscription、part writer、
-hash subscriptionを中断し、各adapterのpending I/Oがsettleしてから `.part` cleanupへ進む。
+確認までを一つの停止signalで制御する。停止時はHTTP request、body subscription、
+hash subscriptionを中断する。part write、flush、file lengthは同一handleを並行closeせず、
+開始済みI/Oの収束後に `.part` cleanupへ進む。
 cleanup失敗の診断は固定enumだけを渡し、URL、local path、hash、元例外を渡さない。
 
 ### 7.2 Full-content verification

--- a/docs/superpowers/specs/2026-08-25-estimated-intensity-flutter-gpu-map-design.md
+++ b/docs/superpowers/specs/2026-08-25-estimated-intensity-flutter-gpu-map-design.md
@@ -5,7 +5,8 @@
 地震履歴の推計震度分布図を、既存 MapLibre 表示を正本として残したまま、
 Flutter Scene / Flutter GPU のデバッグ地図へ production-grade に実装する。
 
-最初の実データ gate は event `20260823020050` とする。この event ID は contract
+最初の実データ検証対象は event `20260823020050` とする。
+この event ID は contract
 fixture、integration test、runtime verification の入力であり、production code が
 参照する固定 URL、固定 SHA-256、fallback source にはしない。
 
@@ -38,7 +39,8 @@ backend immutable archive descriptor
 - observed / estimated mode の full candidate 排他
 - estimated mode で同一 event の震源 sprite を維持すること
 - event、hash、viewport、theme、lifecycle、renderer context の世代管理
-- event `20260823020050` の deterministic contract fixture と iOS / Android gate
+- event `20260823020050` の deterministic contract fixture と
+  iOS / Android 実機検証
 
 ### 2.2 Out of scope
 
@@ -596,7 +598,8 @@ fixture の URL / hash / size は test input であり production code から im
 
 unit test は repository に巨大な production archive を無条件に複製せず、既存
 `MinimalPmTilesArchiveBuilder` と MVT fixture builder で deterministic minimal archive を作る。
-実 archive manifest の drift test と iOS / Android runtime gate は API descriptor が指す bytes
+実 archive manifest の drift test と iOS / Android runtime検証は、
+API descriptor が指す bytes
 を full verificationした後に実行する。
 
 ## 14. Limits and Performance
@@ -672,10 +675,11 @@ event `20260823020050` は target ごとに次の mode で検証する。
 - Android emulator debug: visual、gesture、mode switch、background / foreground
 - profile を support する Android target: performance、memory、renderer context、lifecycle
 
-iOS Simulator を profile gate として扱わない。各実行では `flutter devices` が返した実在 device ID
+iOS Simulator をprofile判定基準として扱わない。各実行では
+`flutter devices` が返した実在 device ID
 を使い、generic `-d ios` / `-d android` を使わない。
 
-- actual descriptor download / size / SHA / header gate
+- actual descriptor download / size / SHA / header確認
 - class 4 / 5- / 5+ の theme 色
 - Fill / Line と administrative line の順序
 - observed Fill / station 非表示、same-event hypocenter 表示
@@ -688,11 +692,13 @@ iOS Simulator を profile gate として扱わない。各実行では `flutter 
 
 Simulator / emulator を agent が操作する場合、開始前にユーザーへ通知し、終了時に入力を解放する。
 
-## 17. Rollout and Removal Gate
+## 17. Rollout and Removal Criteria
 
 実装は backend P0、client P1、app/package P2-P9 の Stacked PR とする。各 PR は前段の public
-contractだけに依存し、独立した RED/GREEN、focused analyze、review gate を持つ。
+contractだけに依存し、独立したRED/GREEN、focused analyze、
+review checkpointを持つ。
 
-debug map gate が green でも MapLibre layer は削除しない。地震履歴詳細とライブモニタの
+debug map検証が完了してもMapLibre layerは削除しない。
+地震履歴詳細とライブモニタの
 各 surface へ接続し、同じ data / mode / lifecycle gateを通した後、別 PR で MapLibre source / layer
 を除去する。


### PR DESCRIPTION
## 概要
- timeoutとcancelをbody読込・part書込・flush・size・SHA処理まで伝播
- 停止時も開始済みI/Oの収束後に一時ファイルを削除
- write/flush中の同一file handleへcloseを並行実行しない
- cleanup失敗を機密情報を含まない固定分類で診断先へ通知
- cleanup診断を専用classへ集約

## 検証
- archive関連86テスト成功
- 変更範囲の静的解析成功
- 実RandomAccessFile delegateの停止中writeを確認
- 独立レビューで指摘なし
- diff-check成功

## CI補足
- 全体解析は既存flutter_hooks_lint_pluginのRangeErrorで失敗
- 今回差分由来だったトップレベル関数警告2件は修正済み