### PR TITLE
feat: 推計震度MVTをclass別meshへ変換

### DIFF
--- a/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/eqmonitor_map/eqmonitor_map_debug_page.dart
@@ -300,6 +300,9 @@ final class EqmonitorMapDebugConfiguration {
         maxHolesPerPolygon: 500,
         maxVerticesPerFeature: 65536,
         maxVerticesPerSegment: 65536,
+        // X範囲が重なる辺ペアを約100万件まで検査し、通常の複雑な境界を
+        // 受理しつつ、悪意ある形状の比較処理を有限化する。
+        maxIntersectionChecks: 1 << 20,
       ),
       lineLimits: LineMeshBuilderLimits(maxVerticesPerSegment: 65536),
       lineMiterLimit: 4,

--- a/docs/knowledge/20260826_polygon_self_intersection_validation.md
+++ b/docs/knowledge/20260826_polygon_self_intersection_validation.md
@@ -1,0 +1,27 @@
+# Polygon mesh の自己交差検証
+
+## 原則
+
+`dart_earcut` は自己交差Polygonを入力エラーとして拒否するvalidatorではない。
+実用的な三角形化を試みるため、戻り値が得られても入力geometryが有効とは限らない。
+信頼できないMVTを描画する前に、`FillMeshBuilder`側で境界の自己交差を検証する。
+
+## 実装上の制約
+
+- 辺を`minX`順に処理し、`maxX`が現在位置より小さい辺を比較対象から外す。
+- 同一ringの隣接辺は比較しない。
+- X範囲が重なる非隣接辺だけをcaller必須の`maxIntersectionChecks`で数える。
+- Y範囲が重なる場合だけ整数orientationで接触・交差・重複を判定する。
+- 上限超過は`FillMeshLimitExceededException`、交差は
+  `FillMeshSelfIntersectionException`として返す。
+
+debug地図の基図policyは、最大65,536頂点の通常形状を受理しながら比較処理を
+有限化する値として、1 feature群あたり約100万件を明示する。
+
+## 確認コマンド
+
+```sh
+mise exec -- flutter test test/mesh/polygon_self_intersection_validator_test.dart
+mise exec -- flutter test test/mesh/fill_mesh_builder_test.dart
+mise exec -- flutter test test/tile/estimated_intensity_tile_decoder_test.dart
+```

--- a/docs/knowledge/20260826_polygon_self_intersection_validation.md
+++ b/docs/knowledge/20260826_polygon_self_intersection_validation.md
@@ -14,8 +14,11 @@
 - Y範囲が重なる場合だけ整数orientationで接触・交差・重複を判定する。
   Int64の積差が安全な範囲は通常の整数演算を使い、それを外れる座標だけ
   `BigInt`で符号を正確に求める。
+- winding分類の符号付き面積は64bit整数で積算し、累積が範囲を外れる場合
+  だけ`BigInt`へ切り替える。
 - 境界交差がなくても、外形外の穴、穴同士の包含、外形同士の包含は
-  `FillMeshInvalidTopologyException`として拒否する。
+  `FillMeshInvalidTopologyException`として拒否する。ただし、別polygonの
+  外形がhole内へ完全に収まる島は有効とする。
 - `maxIntersectionChecks`は、境界交差候補と包含判定を合計し、tileごとに
   生成する1つの`FillMeshBuilder`の全`build`呼び出しで共有する。
 - 上限超過は`FillMeshLimitExceededException`、交差は

--- a/docs/knowledge/20260826_polygon_self_intersection_validation.md
+++ b/docs/knowledge/20260826_polygon_self_intersection_validation.md
@@ -12,11 +12,17 @@
 - 同一ringの隣接辺は比較しない。
 - X範囲が重なる非隣接辺だけをcaller必須の`maxIntersectionChecks`で数える。
 - Y範囲が重なる場合だけ整数orientationで接触・交差・重複を判定する。
+  Int64の積差が安全な範囲は通常の整数演算を使い、それを外れる座標だけ
+  `BigInt`で符号を正確に求める。
+- 境界交差がなくても、外形外の穴、穴同士の包含、外形同士の包含は
+  `FillMeshInvalidTopologyException`として拒否する。
+- `maxIntersectionChecks`は、境界交差候補と包含判定を合計し、tileごとに
+  生成する1つの`FillMeshBuilder`の全`build`呼び出しで共有する。
 - 上限超過は`FillMeshLimitExceededException`、交差は
   `FillMeshSelfIntersectionException`として返す。
 
 debug地図の基図policyは、最大65,536頂点の通常形状を受理しながら比較処理を
-有限化する値として、1 feature群あたり約100万件を明示する。
+有限化する値として、1 tileあたり約100万件を明示する。
 
 ## 確認コマンド
 

--- a/packages/eqmonitor_map/lib/eqmonitor_map.dart
+++ b/packages/eqmonitor_map/lib/eqmonitor_map.dart
@@ -60,6 +60,11 @@ export 'src/renderer/map_render_batch_adapter.dart';
 export 'src/renderer/map_scene_renderer_adapter.dart';
 export 'src/renderer/spike_mesh_frame.dart';
 export 'src/tile/base_map_tile_decoder.dart' show BaseMapTileDecodeLimits;
+export 'src/tile/estimated_intensity_tile_decode_exception.dart';
+export 'src/tile/estimated_intensity_tile_decode_limits.dart';
+export 'src/tile/estimated_intensity_tile_decoder.dart'
+    show EstimatedIntensityTileDecoder, estimatedIntensitySourceLayerName;
+export 'src/tile/estimated_intensity_tile_geometry.dart';
 export 'src/tile/map_tile_fallback_policy.dart';
 export 'src/tile/map_tile_pipeline_budget.dart';
 export 'src/tile/mvt/mvt_decode_limits.dart';

--- a/packages/eqmonitor_map/lib/src/mesh/fill_mesh_build_exception.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/fill_mesh_build_exception.dart
@@ -30,6 +30,11 @@ sealed class FillMeshBuildException
     required String reason,
   }) = FillMeshSelfIntersectionException;
 
+  /// ringの包含関係がPolygon topologyとして不正な場合。
+  const factory invalidTopology({
+    required String reason,
+  }) = FillMeshInvalidTopologyException;
+
   /// 呼び出し側が渡した`FillMeshBuilderLimits`を超過した場合
   /// (穴数超過、feature内頂点数超過、1つのfeatureがsegment容量に収まらない
   /// など)。

--- a/packages/eqmonitor_map/lib/src/mesh/fill_mesh_build_exception.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/fill_mesh_build_exception.dart
@@ -25,6 +25,11 @@ sealed class FillMeshBuildException
     required String reason,
   }) = FillMeshHoleBeforeExteriorException;
 
+  /// 同一ringの非隣接辺、または異なるringの辺が接触・交差・重複する場合。
+  const factory selfIntersection({
+    required String reason,
+  }) = FillMeshSelfIntersectionException;
+
   /// 呼び出し側が渡した`FillMeshBuilderLimits`を超過した場合
   /// (穴数超過、feature内頂点数超過、1つのfeatureがsegment容量に収まらない
   /// など)。

--- a/packages/eqmonitor_map/lib/src/mesh/fill_mesh_build_exception.freezed.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/fill_mesh_build_exception.freezed.dart
@@ -87,12 +87,13 @@ extension FillMeshBuildExceptionPatterns on FillMeshBuildException {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( FillMeshDegenerateRingException value)?  degenerateRing,TResult Function( FillMeshHoleBeforeExteriorException value)?  holeBeforeExterior,TResult Function( FillMeshLimitExceededException value)?  limitExceeded,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( FillMeshDegenerateRingException value)?  degenerateRing,TResult Function( FillMeshHoleBeforeExteriorException value)?  holeBeforeExterior,TResult Function( FillMeshSelfIntersectionException value)?  selfIntersection,TResult Function( FillMeshLimitExceededException value)?  limitExceeded,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case FillMeshDegenerateRingException() when degenerateRing != null:
 return degenerateRing(_that);case FillMeshHoleBeforeExteriorException() when holeBeforeExterior != null:
-return holeBeforeExterior(_that);case FillMeshLimitExceededException() when limitExceeded != null:
+return holeBeforeExterior(_that);case FillMeshSelfIntersectionException() when selfIntersection != null:
+return selfIntersection(_that);case FillMeshLimitExceededException() when limitExceeded != null:
 return limitExceeded(_that);case _:
   return orElse();
 
@@ -111,12 +112,13 @@ return limitExceeded(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( FillMeshDegenerateRingException value)  degenerateRing,required TResult Function( FillMeshHoleBeforeExteriorException value)  holeBeforeExterior,required TResult Function( FillMeshLimitExceededException value)  limitExceeded,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( FillMeshDegenerateRingException value)  degenerateRing,required TResult Function( FillMeshHoleBeforeExteriorException value)  holeBeforeExterior,required TResult Function( FillMeshSelfIntersectionException value)  selfIntersection,required TResult Function( FillMeshLimitExceededException value)  limitExceeded,}){
 final _that = this;
 switch (_that) {
 case FillMeshDegenerateRingException():
 return degenerateRing(_that);case FillMeshHoleBeforeExteriorException():
-return holeBeforeExterior(_that);case FillMeshLimitExceededException():
+return holeBeforeExterior(_that);case FillMeshSelfIntersectionException():
+return selfIntersection(_that);case FillMeshLimitExceededException():
 return limitExceeded(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
@@ -131,12 +133,13 @@ return limitExceeded(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( FillMeshDegenerateRingException value)?  degenerateRing,TResult? Function( FillMeshHoleBeforeExteriorException value)?  holeBeforeExterior,TResult? Function( FillMeshLimitExceededException value)?  limitExceeded,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( FillMeshDegenerateRingException value)?  degenerateRing,TResult? Function( FillMeshHoleBeforeExteriorException value)?  holeBeforeExterior,TResult? Function( FillMeshSelfIntersectionException value)?  selfIntersection,TResult? Function( FillMeshLimitExceededException value)?  limitExceeded,}){
 final _that = this;
 switch (_that) {
 case FillMeshDegenerateRingException() when degenerateRing != null:
 return degenerateRing(_that);case FillMeshHoleBeforeExteriorException() when holeBeforeExterior != null:
-return holeBeforeExterior(_that);case FillMeshLimitExceededException() when limitExceeded != null:
+return holeBeforeExterior(_that);case FillMeshSelfIntersectionException() when selfIntersection != null:
+return selfIntersection(_that);case FillMeshLimitExceededException() when limitExceeded != null:
 return limitExceeded(_that);case _:
   return null;
 
@@ -154,11 +157,12 @@ return limitExceeded(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String reason)?  degenerateRing,TResult Function( String reason)?  holeBeforeExterior,TResult Function( String reason)?  limitExceeded,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String reason)?  degenerateRing,TResult Function( String reason)?  holeBeforeExterior,TResult Function( String reason)?  selfIntersection,TResult Function( String reason)?  limitExceeded,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case FillMeshDegenerateRingException() when degenerateRing != null:
 return degenerateRing(_that.reason);case FillMeshHoleBeforeExteriorException() when holeBeforeExterior != null:
-return holeBeforeExterior(_that.reason);case FillMeshLimitExceededException() when limitExceeded != null:
+return holeBeforeExterior(_that.reason);case FillMeshSelfIntersectionException() when selfIntersection != null:
+return selfIntersection(_that.reason);case FillMeshLimitExceededException() when limitExceeded != null:
 return limitExceeded(_that.reason);case _:
   return orElse();
 
@@ -177,11 +181,12 @@ return limitExceeded(_that.reason);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String reason)  degenerateRing,required TResult Function( String reason)  holeBeforeExterior,required TResult Function( String reason)  limitExceeded,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String reason)  degenerateRing,required TResult Function( String reason)  holeBeforeExterior,required TResult Function( String reason)  selfIntersection,required TResult Function( String reason)  limitExceeded,}) {final _that = this;
 switch (_that) {
 case FillMeshDegenerateRingException():
 return degenerateRing(_that.reason);case FillMeshHoleBeforeExteriorException():
-return holeBeforeExterior(_that.reason);case FillMeshLimitExceededException():
+return holeBeforeExterior(_that.reason);case FillMeshSelfIntersectionException():
+return selfIntersection(_that.reason);case FillMeshLimitExceededException():
 return limitExceeded(_that.reason);}
 }
 /// A variant of `when` that fallback to returning `null`
@@ -196,11 +201,12 @@ return limitExceeded(_that.reason);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String reason)?  degenerateRing,TResult? Function( String reason)?  holeBeforeExterior,TResult? Function( String reason)?  limitExceeded,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String reason)?  degenerateRing,TResult? Function( String reason)?  holeBeforeExterior,TResult? Function( String reason)?  selfIntersection,TResult? Function( String reason)?  limitExceeded,}) {final _that = this;
 switch (_that) {
 case FillMeshDegenerateRingException() when degenerateRing != null:
 return degenerateRing(_that.reason);case FillMeshHoleBeforeExteriorException() when holeBeforeExterior != null:
-return holeBeforeExterior(_that.reason);case FillMeshLimitExceededException() when limitExceeded != null:
+return holeBeforeExterior(_that.reason);case FillMeshSelfIntersectionException() when selfIntersection != null:
+return selfIntersection(_that.reason);case FillMeshLimitExceededException() when limitExceeded != null:
 return limitExceeded(_that.reason);case _:
   return null;
 
@@ -333,6 +339,72 @@ class _$FillMeshHoleBeforeExteriorExceptionCopyWithImpl<$Res>
 /// with the given fields replaced by the non-null parameter values.
 @override @pragma('vm:prefer-inline') $Res call({Object? reason = null,}) {
   return _then(FillMeshHoleBeforeExteriorException(
+reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class FillMeshSelfIntersectionException implements FillMeshBuildException {
+  const FillMeshSelfIntersectionException({required this.reason});
+
+
+@override final  String reason;
+
+/// Create a copy of FillMeshBuildException
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FillMeshSelfIntersectionExceptionCopyWith<FillMeshSelfIntersectionException> get copyWith => _$FillMeshSelfIntersectionExceptionCopyWithImpl<FillMeshSelfIntersectionException>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FillMeshSelfIntersectionException&&(identical(other.reason, reason) || other.reason == reason));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,reason);
+
+@override
+String toString() {
+  return 'FillMeshBuildException.selfIntersection(reason: $reason)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $FillMeshSelfIntersectionExceptionCopyWith<$Res> implements $FillMeshBuildExceptionCopyWith<$Res> {
+  factory $FillMeshSelfIntersectionExceptionCopyWith(FillMeshSelfIntersectionException value, $Res Function(FillMeshSelfIntersectionException) _then) = _$FillMeshSelfIntersectionExceptionCopyWithImpl;
+@override @useResult
+$Res call({
+ String reason
+});
+
+
+
+
+}
+/// @nodoc
+class _$FillMeshSelfIntersectionExceptionCopyWithImpl<$Res>
+    implements $FillMeshSelfIntersectionExceptionCopyWith<$Res> {
+  _$FillMeshSelfIntersectionExceptionCopyWithImpl(this._self, this._then);
+
+  final FillMeshSelfIntersectionException _self;
+  final $Res Function(FillMeshSelfIntersectionException) _then;
+
+/// Create a copy of FillMeshBuildException
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? reason = null,}) {
+  return _then(FillMeshSelfIntersectionException(
 reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
 as String,
   ));

--- a/packages/eqmonitor_map/lib/src/mesh/fill_mesh_build_exception.freezed.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/fill_mesh_build_exception.freezed.dart
@@ -87,13 +87,14 @@ extension FillMeshBuildExceptionPatterns on FillMeshBuildException {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( FillMeshDegenerateRingException value)?  degenerateRing,TResult Function( FillMeshHoleBeforeExteriorException value)?  holeBeforeExterior,TResult Function( FillMeshSelfIntersectionException value)?  selfIntersection,TResult Function( FillMeshLimitExceededException value)?  limitExceeded,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( FillMeshDegenerateRingException value)?  degenerateRing,TResult Function( FillMeshHoleBeforeExteriorException value)?  holeBeforeExterior,TResult Function( FillMeshSelfIntersectionException value)?  selfIntersection,TResult Function( FillMeshInvalidTopologyException value)?  invalidTopology,TResult Function( FillMeshLimitExceededException value)?  limitExceeded,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case FillMeshDegenerateRingException() when degenerateRing != null:
 return degenerateRing(_that);case FillMeshHoleBeforeExteriorException() when holeBeforeExterior != null:
 return holeBeforeExterior(_that);case FillMeshSelfIntersectionException() when selfIntersection != null:
-return selfIntersection(_that);case FillMeshLimitExceededException() when limitExceeded != null:
+return selfIntersection(_that);case FillMeshInvalidTopologyException() when invalidTopology != null:
+return invalidTopology(_that);case FillMeshLimitExceededException() when limitExceeded != null:
 return limitExceeded(_that);case _:
   return orElse();
 
@@ -112,13 +113,14 @@ return limitExceeded(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( FillMeshDegenerateRingException value)  degenerateRing,required TResult Function( FillMeshHoleBeforeExteriorException value)  holeBeforeExterior,required TResult Function( FillMeshSelfIntersectionException value)  selfIntersection,required TResult Function( FillMeshLimitExceededException value)  limitExceeded,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( FillMeshDegenerateRingException value)  degenerateRing,required TResult Function( FillMeshHoleBeforeExteriorException value)  holeBeforeExterior,required TResult Function( FillMeshSelfIntersectionException value)  selfIntersection,required TResult Function( FillMeshInvalidTopologyException value)  invalidTopology,required TResult Function( FillMeshLimitExceededException value)  limitExceeded,}){
 final _that = this;
 switch (_that) {
 case FillMeshDegenerateRingException():
 return degenerateRing(_that);case FillMeshHoleBeforeExteriorException():
 return holeBeforeExterior(_that);case FillMeshSelfIntersectionException():
-return selfIntersection(_that);case FillMeshLimitExceededException():
+return selfIntersection(_that);case FillMeshInvalidTopologyException():
+return invalidTopology(_that);case FillMeshLimitExceededException():
 return limitExceeded(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
@@ -133,13 +135,14 @@ return limitExceeded(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( FillMeshDegenerateRingException value)?  degenerateRing,TResult? Function( FillMeshHoleBeforeExteriorException value)?  holeBeforeExterior,TResult? Function( FillMeshSelfIntersectionException value)?  selfIntersection,TResult? Function( FillMeshLimitExceededException value)?  limitExceeded,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( FillMeshDegenerateRingException value)?  degenerateRing,TResult? Function( FillMeshHoleBeforeExteriorException value)?  holeBeforeExterior,TResult? Function( FillMeshSelfIntersectionException value)?  selfIntersection,TResult? Function( FillMeshInvalidTopologyException value)?  invalidTopology,TResult? Function( FillMeshLimitExceededException value)?  limitExceeded,}){
 final _that = this;
 switch (_that) {
 case FillMeshDegenerateRingException() when degenerateRing != null:
 return degenerateRing(_that);case FillMeshHoleBeforeExteriorException() when holeBeforeExterior != null:
 return holeBeforeExterior(_that);case FillMeshSelfIntersectionException() when selfIntersection != null:
-return selfIntersection(_that);case FillMeshLimitExceededException() when limitExceeded != null:
+return selfIntersection(_that);case FillMeshInvalidTopologyException() when invalidTopology != null:
+return invalidTopology(_that);case FillMeshLimitExceededException() when limitExceeded != null:
 return limitExceeded(_that);case _:
   return null;
 
@@ -157,12 +160,13 @@ return limitExceeded(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String reason)?  degenerateRing,TResult Function( String reason)?  holeBeforeExterior,TResult Function( String reason)?  selfIntersection,TResult Function( String reason)?  limitExceeded,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String reason)?  degenerateRing,TResult Function( String reason)?  holeBeforeExterior,TResult Function( String reason)?  selfIntersection,TResult Function( String reason)?  invalidTopology,TResult Function( String reason)?  limitExceeded,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case FillMeshDegenerateRingException() when degenerateRing != null:
 return degenerateRing(_that.reason);case FillMeshHoleBeforeExteriorException() when holeBeforeExterior != null:
 return holeBeforeExterior(_that.reason);case FillMeshSelfIntersectionException() when selfIntersection != null:
-return selfIntersection(_that.reason);case FillMeshLimitExceededException() when limitExceeded != null:
+return selfIntersection(_that.reason);case FillMeshInvalidTopologyException() when invalidTopology != null:
+return invalidTopology(_that.reason);case FillMeshLimitExceededException() when limitExceeded != null:
 return limitExceeded(_that.reason);case _:
   return orElse();
 
@@ -181,12 +185,13 @@ return limitExceeded(_that.reason);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String reason)  degenerateRing,required TResult Function( String reason)  holeBeforeExterior,required TResult Function( String reason)  selfIntersection,required TResult Function( String reason)  limitExceeded,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String reason)  degenerateRing,required TResult Function( String reason)  holeBeforeExterior,required TResult Function( String reason)  selfIntersection,required TResult Function( String reason)  invalidTopology,required TResult Function( String reason)  limitExceeded,}) {final _that = this;
 switch (_that) {
 case FillMeshDegenerateRingException():
 return degenerateRing(_that.reason);case FillMeshHoleBeforeExteriorException():
 return holeBeforeExterior(_that.reason);case FillMeshSelfIntersectionException():
-return selfIntersection(_that.reason);case FillMeshLimitExceededException():
+return selfIntersection(_that.reason);case FillMeshInvalidTopologyException():
+return invalidTopology(_that.reason);case FillMeshLimitExceededException():
 return limitExceeded(_that.reason);}
 }
 /// A variant of `when` that fallback to returning `null`
@@ -201,12 +206,13 @@ return limitExceeded(_that.reason);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String reason)?  degenerateRing,TResult? Function( String reason)?  holeBeforeExterior,TResult? Function( String reason)?  selfIntersection,TResult? Function( String reason)?  limitExceeded,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String reason)?  degenerateRing,TResult? Function( String reason)?  holeBeforeExterior,TResult? Function( String reason)?  selfIntersection,TResult? Function( String reason)?  invalidTopology,TResult? Function( String reason)?  limitExceeded,}) {final _that = this;
 switch (_that) {
 case FillMeshDegenerateRingException() when degenerateRing != null:
 return degenerateRing(_that.reason);case FillMeshHoleBeforeExteriorException() when holeBeforeExterior != null:
 return holeBeforeExterior(_that.reason);case FillMeshSelfIntersectionException() when selfIntersection != null:
-return selfIntersection(_that.reason);case FillMeshLimitExceededException() when limitExceeded != null:
+return selfIntersection(_that.reason);case FillMeshInvalidTopologyException() when invalidTopology != null:
+return invalidTopology(_that.reason);case FillMeshLimitExceededException() when limitExceeded != null:
 return limitExceeded(_that.reason);case _:
   return null;
 
@@ -405,6 +411,72 @@ class _$FillMeshSelfIntersectionExceptionCopyWithImpl<$Res>
 /// with the given fields replaced by the non-null parameter values.
 @override @pragma('vm:prefer-inline') $Res call({Object? reason = null,}) {
   return _then(FillMeshSelfIntersectionException(
+reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class FillMeshInvalidTopologyException implements FillMeshBuildException {
+  const FillMeshInvalidTopologyException({required this.reason});
+
+
+@override final  String reason;
+
+/// Create a copy of FillMeshBuildException
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FillMeshInvalidTopologyExceptionCopyWith<FillMeshInvalidTopologyException> get copyWith => _$FillMeshInvalidTopologyExceptionCopyWithImpl<FillMeshInvalidTopologyException>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FillMeshInvalidTopologyException&&(identical(other.reason, reason) || other.reason == reason));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,reason);
+
+@override
+String toString() {
+  return 'FillMeshBuildException.invalidTopology(reason: $reason)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $FillMeshInvalidTopologyExceptionCopyWith<$Res> implements $FillMeshBuildExceptionCopyWith<$Res> {
+  factory $FillMeshInvalidTopologyExceptionCopyWith(FillMeshInvalidTopologyException value, $Res Function(FillMeshInvalidTopologyException) _then) = _$FillMeshInvalidTopologyExceptionCopyWithImpl;
+@override @useResult
+$Res call({
+ String reason
+});
+
+
+
+
+}
+/// @nodoc
+class _$FillMeshInvalidTopologyExceptionCopyWithImpl<$Res>
+    implements $FillMeshInvalidTopologyExceptionCopyWith<$Res> {
+  _$FillMeshInvalidTopologyExceptionCopyWithImpl(this._self, this._then);
+
+  final FillMeshInvalidTopologyException _self;
+  final $Res Function(FillMeshInvalidTopologyException) _then;
+
+/// Create a copy of FillMeshBuildException
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? reason = null,}) {
+  return _then(FillMeshInvalidTopologyException(
 reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
 as String,
   ));

--- a/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder.dart
@@ -4,6 +4,7 @@ import 'package:dart_earcut/dart_earcut.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh_build_exception.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh_builder_limits.dart';
+import 'package:eqmonitor_map/src/mesh/polygon_self_intersection_validator.dart';
 import 'package:eqmonitor_map/src/tile/mvt/mvt_tile.dart';
 
 /// index bufferがUint16のため、1つの[FillMesh] segmentが持てる頂点数の
@@ -27,6 +28,13 @@ final class FillMeshBuilder {
             'are stored as Uint16.',
       );
     }
+    if (limits.maxIntersectionChecks < 0) {
+      throw ArgumentError.value(
+        limits.maxIntersectionChecks,
+        'limits.maxIntersectionChecks',
+        'must not be negative.',
+      );
+    }
   }
 
   final FillMeshBuilderLimits limits;
@@ -44,6 +52,7 @@ final class FillMeshBuilder {
     final segments = <FillMesh>[];
     var positions = <double>[];
     var indices = <int>[];
+    var remainingIntersectionChecks = limits.maxIntersectionChecks;
 
     void flush() {
       if (positions.isEmpty) {
@@ -70,6 +79,12 @@ final class FillMeshBuilder {
       }
 
       final polygons = _classifyRings(feature.rings, limits: limits);
+      final intersectionChecks = const PolygonSelfIntersectionValidator()
+          .validate(
+            rings: feature.rings,
+            maxIntersectionChecks: remainingIntersectionChecks,
+          );
+      remainingIntersectionChecks -= intersectionChecks;
       final featurePositions = <double>[];
       final featureTriangleIndices = <int>[];
       var localOffset = 0;

--- a/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor_map/src/mesh/fill_mesh.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh_build_exception.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh_builder_limits.dart';
 import 'package:eqmonitor_map/src/mesh/polygon_self_intersection_validator.dart';
+import 'package:eqmonitor_map/src/mesh/polygon_signed_area.dart';
 import 'package:eqmonitor_map/src/mesh/polygon_topology_validator.dart';
 import 'package:eqmonitor_map/src/tile/mvt/mvt_tile.dart';
 
@@ -187,14 +188,14 @@ List<_RawPolygon> _classifyRings(
       );
     }
 
-    final signedAreaTwice = _signedAreaTwice(ring);
-    if (signedAreaTwice == 0) {
+    final signedAreaSign = const PolygonSignedArea().sign(ring);
+    if (signedAreaSign == 0) {
       throw const FillMeshBuildException.degenerateRing(
         reason: 'A ring has zero signed area and encloses no surface.',
       );
     }
 
-    if (signedAreaTwice > 0) {
+    if (signedAreaSign > 0) {
       polygons.add(_RawPolygon(exterior: ring));
       continue;
     }
@@ -217,23 +218,6 @@ List<_RawPolygon> _classifyRings(
     current.holes.add(ring);
   }
   return polygons;
-}
-
-/// ringの符号付き面積の2倍を整数のまま計算する。tile-local座標はint32の
-/// 範囲を持ち得るため、doubleではなくint(64bit)で積算し、ゼロ判定の丸め
-/// 誤差を避ける。
-int _signedAreaTwice(Int32List ring) {
-  final vertexCount = ring.length ~/ 2;
-  var sum = 0;
-  for (var i = 0; i < vertexCount; i++) {
-    final x0 = ring[i * 2];
-    final y0 = ring[i * 2 + 1];
-    final nextIndex = (i + 1) % vertexCount;
-    final x1 = ring[nextIndex * 2];
-    final y1 = ring[nextIndex * 2 + 1];
-    sum += x0 * y1 - x1 * y0;
-  }
-  return sum;
 }
 
 /// 1つのpolygon(外形+穴)を`dart_earcut`で三角形化する。

--- a/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor_map/src/mesh/fill_mesh.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh_build_exception.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh_builder_limits.dart';
 import 'package:eqmonitor_map/src/mesh/polygon_self_intersection_validator.dart';
+import 'package:eqmonitor_map/src/mesh/polygon_topology_validator.dart';
 import 'package:eqmonitor_map/src/tile/mvt/mvt_tile.dart';
 
 /// index bufferがUint16のため、1つの[FillMesh] segmentが持てる頂点数の
@@ -18,7 +19,8 @@ const _maxIndexableVerticesPerSegment = 65536;
 /// (docs/knowledge/20260805_maplibre_native_renderer_reference.md
 /// 「Fill頂点生成」節: `classifyRings` → `limitHoles` → `earcut`)。
 final class FillMeshBuilder {
-  new({required this.limits}) {
+  new({required this.limits})
+    : _remainingIntersectionChecks = limits.maxIntersectionChecks {
     if (limits.maxVerticesPerSegment <= 0 ||
         limits.maxVerticesPerSegment > _maxIndexableVerticesPerSegment) {
       throw ArgumentError.value(
@@ -38,6 +40,7 @@ final class FillMeshBuilder {
   }
 
   final FillMeshBuilderLimits limits;
+  int _remainingIntersectionChecks;
 
   /// [features]をtile-local座標のfill meshへ変換する。全featureの頂点が
   /// 1 segmentに収まらない場合、featureの境界でのみ分割した複数の
@@ -48,12 +51,12 @@ final class FillMeshBuilder {
   /// それ以外の型が混じっているのは呼び出し側の実装誤りなので
   /// [ArgumentError]で落とす([FillMeshBuildException]は入力データ
   /// (untrusted tile bytes)由来の問題専用に予約する)。
+  /// 比較回数の残量は呼び出し間で共有されるため、呼び出し側はtileごとに
+  /// builderを1つ生成し、そのtileの全fill layerで同じinstanceを使う。
   List<FillMesh> build(Iterable<MvtFeature> features) {
     final segments = <FillMesh>[];
     var positions = <double>[];
     var indices = <int>[];
-    var remainingIntersectionChecks = limits.maxIntersectionChecks;
-
     void flush() {
       if (positions.isEmpty) {
         return;
@@ -82,9 +85,17 @@ final class FillMeshBuilder {
       final intersectionChecks = const PolygonSelfIntersectionValidator()
           .validate(
             rings: feature.rings,
-            maxIntersectionChecks: remainingIntersectionChecks,
+            maxIntersectionChecks: _remainingIntersectionChecks,
           );
-      remainingIntersectionChecks -= intersectionChecks;
+      _remainingIntersectionChecks -= intersectionChecks;
+      final topologyChecks = const PolygonTopologyValidator().validate(
+        polygons: [
+          for (final polygon in polygons)
+            (exterior: polygon.exterior, holes: polygon.holes),
+        ],
+        maxChecks: _remainingIntersectionChecks,
+      );
+      _remainingIntersectionChecks -= topologyChecks;
       final featurePositions = <double>[];
       final featureTriangleIndices = <int>[];
       var localOffset = 0;

--- a/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder_limits.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder_limits.dart
@@ -25,5 +25,8 @@ abstract class FillMeshBuilderLimits with _$FillMeshBuilderLimits {
     /// 場合`FillMeshBuilder`はArgumentErrorを投げる(index値がuint16の範囲を
     /// 静かに超えて壊れたmeshを生成することを避けるための防御)。
     required int maxVerticesPerSegment,
+
+    /// 自己交差検査で調べる、X範囲が重なる非隣接辺ペア数の上限。
+    required int maxIntersectionChecks,
   }) = _FillMeshBuilderLimits;
 }

--- a/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder_limits.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder_limits.dart
@@ -26,7 +26,9 @@ abstract class FillMeshBuilderLimits with _$FillMeshBuilderLimits {
     /// 静かに超えて壊れたmeshを生成することを避けるための防御)。
     required int maxVerticesPerSegment,
 
-    /// 自己交差検査で調べる、X範囲が重なる非隣接辺ペア数の上限。
+    /// 1 tile用に生成した`FillMeshBuilder`の全`build`呼び出しを通じて、
+    /// 境界交差候補の辺ペア比較と包含判定の辺比較に使える回数の合計上限。
+    /// decoderはtileごとにbuilderを1つ生成して全fill layerで共有する。
     required int maxIntersectionChecks,
   }) = _FillMeshBuilderLimits;
 }

--- a/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder_limits.freezed.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder_limits.freezed.dart
@@ -24,7 +24,9 @@ mixin _$FillMeshBuilderLimits {
 /// `Uint16List`であるため、呼び出し側がこの値を65536以下に設定しない
 /// 場合`FillMeshBuilder`はArgumentErrorを投げる(index値がuint16の範囲を
 /// 静かに超えて壊れたmeshを生成することを避けるための防御)。
- int get maxVerticesPerSegment;/// 自己交差検査で調べる、X範囲が重なる非隣接辺ペア数の上限。
+ int get maxVerticesPerSegment;/// 1 tile用に生成した`FillMeshBuilder`の全`build`呼び出しを通じて、
+/// 境界交差候補の辺ペア比較と包含判定の辺比較に使える回数の合計上限。
+/// decoderはtileごとにbuilderを1つ生成して全fill layerで共有する。
  int get maxIntersectionChecks;
 /// Create a copy of FillMeshBuilderLimits
 /// with the given fields replaced by the non-null parameter values.
@@ -235,7 +237,9 @@ class _FillMeshBuilderLimits implements FillMeshBuilderLimits {
 /// 場合`FillMeshBuilder`はArgumentErrorを投げる(index値がuint16の範囲を
 /// 静かに超えて壊れたmeshを生成することを避けるための防御)。
 @override final  int maxVerticesPerSegment;
-/// 自己交差検査で調べる、X範囲が重なる非隣接辺ペア数の上限。
+/// 1 tile用に生成した`FillMeshBuilder`の全`build`呼び出しを通じて、
+/// 境界交差候補の辺ペア比較と包含判定の辺比較に使える回数の合計上限。
+/// decoderはtileごとにbuilderを1つ生成して全fill layerで共有する。
 @override final  int maxIntersectionChecks;
 
 /// Create a copy of FillMeshBuilderLimits

--- a/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder_limits.freezed.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder_limits.freezed.dart
@@ -24,7 +24,8 @@ mixin _$FillMeshBuilderLimits {
 /// `Uint16List`であるため、呼び出し側がこの値を65536以下に設定しない
 /// 場合`FillMeshBuilder`はArgumentErrorを投げる(index値がuint16の範囲を
 /// 静かに超えて壊れたmeshを生成することを避けるための防御)。
- int get maxVerticesPerSegment;
+ int get maxVerticesPerSegment;/// 自己交差検査で調べる、X範囲が重なる非隣接辺ペア数の上限。
+ int get maxIntersectionChecks;
 /// Create a copy of FillMeshBuilderLimits
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -35,16 +36,16 @@ $FillMeshBuilderLimitsCopyWith<FillMeshBuilderLimits> get copyWith => _$FillMesh
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is FillMeshBuilderLimits&&(identical(other.maxHolesPerPolygon, maxHolesPerPolygon) || other.maxHolesPerPolygon == maxHolesPerPolygon)&&(identical(other.maxVerticesPerFeature, maxVerticesPerFeature) || other.maxVerticesPerFeature == maxVerticesPerFeature)&&(identical(other.maxVerticesPerSegment, maxVerticesPerSegment) || other.maxVerticesPerSegment == maxVerticesPerSegment));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FillMeshBuilderLimits&&(identical(other.maxHolesPerPolygon, maxHolesPerPolygon) || other.maxHolesPerPolygon == maxHolesPerPolygon)&&(identical(other.maxVerticesPerFeature, maxVerticesPerFeature) || other.maxVerticesPerFeature == maxVerticesPerFeature)&&(identical(other.maxVerticesPerSegment, maxVerticesPerSegment) || other.maxVerticesPerSegment == maxVerticesPerSegment)&&(identical(other.maxIntersectionChecks, maxIntersectionChecks) || other.maxIntersectionChecks == maxIntersectionChecks));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,maxHolesPerPolygon,maxVerticesPerFeature,maxVerticesPerSegment);
+int get hashCode => Object.hash(runtimeType,maxHolesPerPolygon,maxVerticesPerFeature,maxVerticesPerSegment,maxIntersectionChecks);
 
 @override
 String toString() {
-  return 'FillMeshBuilderLimits(maxHolesPerPolygon: $maxHolesPerPolygon, maxVerticesPerFeature: $maxVerticesPerFeature, maxVerticesPerSegment: $maxVerticesPerSegment)';
+  return 'FillMeshBuilderLimits(maxHolesPerPolygon: $maxHolesPerPolygon, maxVerticesPerFeature: $maxVerticesPerFeature, maxVerticesPerSegment: $maxVerticesPerSegment, maxIntersectionChecks: $maxIntersectionChecks)';
 }
 
 
@@ -55,7 +56,7 @@ abstract mixin class $FillMeshBuilderLimitsCopyWith<$Res>  {
   factory $FillMeshBuilderLimitsCopyWith(FillMeshBuilderLimits value, $Res Function(FillMeshBuilderLimits) _then) = _$FillMeshBuilderLimitsCopyWithImpl;
 @useResult
 $Res call({
- int maxHolesPerPolygon, int maxVerticesPerFeature, int maxVerticesPerSegment
+ int maxHolesPerPolygon, int maxVerticesPerFeature, int maxVerticesPerSegment, int maxIntersectionChecks
 });
 
 
@@ -72,11 +73,12 @@ class _$FillMeshBuilderLimitsCopyWithImpl<$Res>
 
 /// Create a copy of FillMeshBuilderLimits
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? maxHolesPerPolygon = null,Object? maxVerticesPerFeature = null,Object? maxVerticesPerSegment = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? maxHolesPerPolygon = null,Object? maxVerticesPerFeature = null,Object? maxVerticesPerSegment = null,Object? maxIntersectionChecks = null,}) {
   return _then(FillMeshBuilderLimits(
 maxHolesPerPolygon: null == maxHolesPerPolygon ? _self.maxHolesPerPolygon : maxHolesPerPolygon // ignore: cast_nullable_to_non_nullable
 as int,maxVerticesPerFeature: null == maxVerticesPerFeature ? _self.maxVerticesPerFeature : maxVerticesPerFeature // ignore: cast_nullable_to_non_nullable
 as int,maxVerticesPerSegment: null == maxVerticesPerSegment ? _self.maxVerticesPerSegment : maxVerticesPerSegment // ignore: cast_nullable_to_non_nullable
+as int,maxIntersectionChecks: null == maxIntersectionChecks ? _self.maxIntersectionChecks : maxIntersectionChecks // ignore: cast_nullable_to_non_nullable
 as int,
   ));
 }
@@ -162,10 +164,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int maxHolesPerPolygon,  int maxVerticesPerFeature,  int maxVerticesPerSegment)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int maxHolesPerPolygon,  int maxVerticesPerFeature,  int maxVerticesPerSegment,  int maxIntersectionChecks)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _FillMeshBuilderLimits() when $default != null:
-return $default(_that.maxHolesPerPolygon,_that.maxVerticesPerFeature,_that.maxVerticesPerSegment);case _:
+return $default(_that.maxHolesPerPolygon,_that.maxVerticesPerFeature,_that.maxVerticesPerSegment,_that.maxIntersectionChecks);case _:
   return orElse();
 
 }
@@ -183,10 +185,10 @@ return $default(_that.maxHolesPerPolygon,_that.maxVerticesPerFeature,_that.maxVe
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int maxHolesPerPolygon,  int maxVerticesPerFeature,  int maxVerticesPerSegment)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int maxHolesPerPolygon,  int maxVerticesPerFeature,  int maxVerticesPerSegment,  int maxIntersectionChecks)  $default,) {final _that = this;
 switch (_that) {
 case _FillMeshBuilderLimits():
-return $default(_that.maxHolesPerPolygon,_that.maxVerticesPerFeature,_that.maxVerticesPerSegment);case _:
+return $default(_that.maxHolesPerPolygon,_that.maxVerticesPerFeature,_that.maxVerticesPerSegment,_that.maxIntersectionChecks);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -203,10 +205,10 @@ return $default(_that.maxHolesPerPolygon,_that.maxVerticesPerFeature,_that.maxVe
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int maxHolesPerPolygon,  int maxVerticesPerFeature,  int maxVerticesPerSegment)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int maxHolesPerPolygon,  int maxVerticesPerFeature,  int maxVerticesPerSegment,  int maxIntersectionChecks)?  $default,) {final _that = this;
 switch (_that) {
 case _FillMeshBuilderLimits() when $default != null:
-return $default(_that.maxHolesPerPolygon,_that.maxVerticesPerFeature,_that.maxVerticesPerSegment);case _:
+return $default(_that.maxHolesPerPolygon,_that.maxVerticesPerFeature,_that.maxVerticesPerSegment,_that.maxIntersectionChecks);case _:
   return null;
 
 }
@@ -218,7 +220,7 @@ return $default(_that.maxHolesPerPolygon,_that.maxVerticesPerFeature,_that.maxVe
 
 
 class _FillMeshBuilderLimits implements FillMeshBuilderLimits {
-  const _FillMeshBuilderLimits({required this.maxHolesPerPolygon, required this.maxVerticesPerFeature, required this.maxVerticesPerSegment});
+  const _FillMeshBuilderLimits({required this.maxHolesPerPolygon, required this.maxVerticesPerFeature, required this.maxVerticesPerSegment, required this.maxIntersectionChecks});
   
 
 /// 1つのpolygon(1つの外形とその穴の組)に含められる穴数の上限。
@@ -233,6 +235,8 @@ class _FillMeshBuilderLimits implements FillMeshBuilderLimits {
 /// 場合`FillMeshBuilder`はArgumentErrorを投げる(index値がuint16の範囲を
 /// 静かに超えて壊れたmeshを生成することを避けるための防御)。
 @override final  int maxVerticesPerSegment;
+/// 自己交差検査で調べる、X範囲が重なる非隣接辺ペア数の上限。
+@override final  int maxIntersectionChecks;
 
 /// Create a copy of FillMeshBuilderLimits
 /// with the given fields replaced by the non-null parameter values.
@@ -244,16 +248,16 @@ _$FillMeshBuilderLimitsCopyWith<_FillMeshBuilderLimits> get copyWith => __$FillM
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FillMeshBuilderLimits&&(identical(other.maxHolesPerPolygon, maxHolesPerPolygon) || other.maxHolesPerPolygon == maxHolesPerPolygon)&&(identical(other.maxVerticesPerFeature, maxVerticesPerFeature) || other.maxVerticesPerFeature == maxVerticesPerFeature)&&(identical(other.maxVerticesPerSegment, maxVerticesPerSegment) || other.maxVerticesPerSegment == maxVerticesPerSegment));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FillMeshBuilderLimits&&(identical(other.maxHolesPerPolygon, maxHolesPerPolygon) || other.maxHolesPerPolygon == maxHolesPerPolygon)&&(identical(other.maxVerticesPerFeature, maxVerticesPerFeature) || other.maxVerticesPerFeature == maxVerticesPerFeature)&&(identical(other.maxVerticesPerSegment, maxVerticesPerSegment) || other.maxVerticesPerSegment == maxVerticesPerSegment)&&(identical(other.maxIntersectionChecks, maxIntersectionChecks) || other.maxIntersectionChecks == maxIntersectionChecks));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,maxHolesPerPolygon,maxVerticesPerFeature,maxVerticesPerSegment);
+int get hashCode => Object.hash(runtimeType,maxHolesPerPolygon,maxVerticesPerFeature,maxVerticesPerSegment,maxIntersectionChecks);
 
 @override
 String toString() {
-  return 'FillMeshBuilderLimits(maxHolesPerPolygon: $maxHolesPerPolygon, maxVerticesPerFeature: $maxVerticesPerFeature, maxVerticesPerSegment: $maxVerticesPerSegment)';
+  return 'FillMeshBuilderLimits(maxHolesPerPolygon: $maxHolesPerPolygon, maxVerticesPerFeature: $maxVerticesPerFeature, maxVerticesPerSegment: $maxVerticesPerSegment, maxIntersectionChecks: $maxIntersectionChecks)';
 }
 
 
@@ -264,7 +268,7 @@ abstract mixin class _$FillMeshBuilderLimitsCopyWith<$Res> implements $FillMeshB
   factory _$FillMeshBuilderLimitsCopyWith(_FillMeshBuilderLimits value, $Res Function(_FillMeshBuilderLimits) _then) = __$FillMeshBuilderLimitsCopyWithImpl;
 @override @useResult
 $Res call({
- int maxHolesPerPolygon, int maxVerticesPerFeature, int maxVerticesPerSegment
+ int maxHolesPerPolygon, int maxVerticesPerFeature, int maxVerticesPerSegment, int maxIntersectionChecks
 });
 
 
@@ -281,11 +285,12 @@ class __$FillMeshBuilderLimitsCopyWithImpl<$Res>
 
 /// Create a copy of FillMeshBuilderLimits
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? maxHolesPerPolygon = null,Object? maxVerticesPerFeature = null,Object? maxVerticesPerSegment = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? maxHolesPerPolygon = null,Object? maxVerticesPerFeature = null,Object? maxVerticesPerSegment = null,Object? maxIntersectionChecks = null,}) {
   return _then(_FillMeshBuilderLimits(
 maxHolesPerPolygon: null == maxHolesPerPolygon ? _self.maxHolesPerPolygon : maxHolesPerPolygon // ignore: cast_nullable_to_non_nullable
 as int,maxVerticesPerFeature: null == maxVerticesPerFeature ? _self.maxVerticesPerFeature : maxVerticesPerFeature // ignore: cast_nullable_to_non_nullable
 as int,maxVerticesPerSegment: null == maxVerticesPerSegment ? _self.maxVerticesPerSegment : maxVerticesPerSegment // ignore: cast_nullable_to_non_nullable
+as int,maxIntersectionChecks: null == maxIntersectionChecks ? _self.maxIntersectionChecks : maxIntersectionChecks // ignore: cast_nullable_to_non_nullable
 as int,
   ));
 }

--- a/packages/eqmonitor_map/lib/src/mesh/polygon_orientation.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/polygon_orientation.dart
@@ -1,0 +1,37 @@
+/// Int32座標の3点が作る外積の符号を正確に返す。
+final class PolygonOrientation {
+  const new();
+
+  int sign({
+    required int ax,
+    required int ay,
+    required int bx,
+    required int by,
+    required int cx,
+    required int cy,
+  }) {
+    final abx = bx - ax;
+    final aby = by - ay;
+    final acx = cx - ax;
+    final acy = cy - ay;
+    if (_productFitsSigned64(abx, acy) && _productFitsSigned64(aby, acx)) {
+      final left = abx * acy;
+      final right = aby * acx;
+      if (left != 0 && right != 0 && left.isNegative != right.isNegative) {
+        return left.sign;
+      }
+      return (left - right).sign;
+    }
+    return (BigInt.from(abx) * BigInt.from(acy) -
+            BigInt.from(aby) * BigInt.from(acx))
+        .sign;
+  }
+}
+
+const _maxSigned64 = 0x7FFFFFFFFFFFFFFF;
+
+bool _productFitsSigned64(int left, int right) {
+  final leftMagnitude = left.abs();
+  final rightMagnitude = right.abs();
+  return leftMagnitude == 0 || rightMagnitude <= _maxSigned64 ~/ leftMagnitude;
+}

--- a/packages/eqmonitor_map/lib/src/mesh/polygon_self_intersection_validator.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/polygon_self_intersection_validator.dart
@@ -1,0 +1,166 @@
+import 'dart:collection';
+import 'dart:typed_data';
+
+import 'package:eqmonitor_map/src/mesh/fill_mesh_build_exception.dart';
+
+/// Polygon境界をX方向に走査し、非隣接辺の接触・交差・重複を拒否する。
+final class PolygonSelfIntersectionValidator {
+  const new();
+
+  int validate({
+    required List<Int32List> rings,
+    required int maxIntersectionChecks,
+  }) {
+    final segments = <_PolygonSegment>[
+      for (var ringIndex = 0; ringIndex < rings.length; ringIndex++)
+        for (
+          var edgeIndex = 0;
+          edgeIndex < rings[ringIndex].length ~/ 2;
+          edgeIndex++
+        )
+          _PolygonSegment.fromRing(
+            ring: rings[ringIndex],
+            ringIndex: ringIndex,
+            edgeIndex: edgeIndex,
+          ),
+    ]..sort(_comparePolygonSegments);
+    final active = LinkedHashSet<_PolygonSegment>.identity();
+    final expiration = SplayTreeMap<int, List<_PolygonSegment>>();
+    var checks = 0;
+
+    for (final segment in segments) {
+      while (expiration.isNotEmpty) {
+        final maxX = expiration.firstKey();
+        if (maxX == null || maxX >= segment.minX) {
+          break;
+        }
+        active.removeAll(expiration.remove(maxX) ?? const []);
+      }
+      for (final other in active) {
+        if (_areAdjacentPolygonSegments(segment, other)) {
+          continue;
+        }
+        checks++;
+        if (checks > maxIntersectionChecks) {
+          throw FillMeshBuildException.limitExceeded(
+            reason:
+                'Polygon intersection checks exceed the configured limit '
+                '($maxIntersectionChecks).',
+          );
+        }
+        if (_rangesOverlap(
+              segment.minY,
+              segment.maxY,
+              other.minY,
+              other.maxY,
+            ) &&
+            _polygonSegmentsIntersect(segment, other)) {
+          throw const FillMeshBuildException.selfIntersection(
+            reason: 'Polygon boundaries intersect or touch.',
+          );
+        }
+      }
+      active.add(segment);
+      expiration.putIfAbsent(segment.maxX, () => []).add(segment);
+    }
+    return checks;
+  }
+}
+
+final class _PolygonSegment {
+  _PolygonSegment({
+    required this.ringIndex,
+    required this.edgeIndex,
+    required this.edgeCount,
+    required this.ax,
+    required this.ay,
+    required this.bx,
+    required this.by,
+  }) : minX = ax < bx ? ax : bx,
+       maxX = ax > bx ? ax : bx,
+       minY = ay < by ? ay : by,
+       maxY = ay > by ? ay : by;
+
+  factory _PolygonSegment.fromRing({
+    required Int32List ring,
+    required int ringIndex,
+    required int edgeIndex,
+  }) {
+    final edgeCount = ring.length ~/ 2;
+    final next = (edgeIndex + 1) % edgeCount;
+    return _PolygonSegment(
+      ringIndex: ringIndex,
+      edgeIndex: edgeIndex,
+      edgeCount: edgeCount,
+      ax: ring[edgeIndex * 2],
+      ay: ring[edgeIndex * 2 + 1],
+      bx: ring[next * 2],
+      by: ring[next * 2 + 1],
+    );
+  }
+
+  final int ringIndex;
+  final int edgeIndex;
+  final int edgeCount;
+  final int ax;
+  final int ay;
+  final int bx;
+  final int by;
+  final int minX;
+  final int maxX;
+  final int minY;
+  final int maxY;
+}
+
+int _comparePolygonSegments(_PolygonSegment left, _PolygonSegment right) {
+  final byMinX = left.minX.compareTo(right.minX);
+  if (byMinX != 0) {
+    return byMinX;
+  }
+  final byMinY = left.minY.compareTo(right.minY);
+  if (byMinY != 0) {
+    return byMinY;
+  }
+  final byRing = left.ringIndex.compareTo(right.ringIndex);
+  return byRing != 0 ? byRing : left.edgeIndex.compareTo(right.edgeIndex);
+}
+
+bool _areAdjacentPolygonSegments(_PolygonSegment a, _PolygonSegment b) {
+  if (a.ringIndex != b.ringIndex) {
+    return false;
+  }
+  final distance = (a.edgeIndex - b.edgeIndex).abs();
+  return distance == 1 || distance == a.edgeCount - 1;
+}
+
+bool _rangesOverlap(int aMin, int aMax, int bMin, int bMax) =>
+    aMin <= bMax && bMin <= aMax;
+
+bool _polygonSegmentsIntersect(_PolygonSegment a, _PolygonSegment b) {
+  final abA = _polygonOrientation(a.ax, a.ay, a.bx, a.by, b.ax, b.ay);
+  final abB = _polygonOrientation(a.ax, a.ay, a.bx, a.by, b.bx, b.by);
+  final cdA = _polygonOrientation(b.ax, b.ay, b.bx, b.by, a.ax, a.ay);
+  final cdB = _polygonOrientation(b.ax, b.ay, b.bx, b.by, a.bx, a.by);
+  if (abA == 0 && _pointIsOnPolygonSegment(b.ax, b.ay, a)) {
+    return true;
+  }
+  if (abB == 0 && _pointIsOnPolygonSegment(b.bx, b.by, a)) {
+    return true;
+  }
+  if (cdA == 0 && _pointIsOnPolygonSegment(a.ax, a.ay, b)) {
+    return true;
+  }
+  if (cdB == 0 && _pointIsOnPolygonSegment(a.bx, a.by, b)) {
+    return true;
+  }
+  return (abA < 0) != (abB < 0) && (cdA < 0) != (cdB < 0);
+}
+
+int _polygonOrientation(int ax, int ay, int bx, int by, int cx, int cy) =>
+    (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
+
+bool _pointIsOnPolygonSegment(int x, int y, _PolygonSegment segment) =>
+    x >= segment.minX &&
+    x <= segment.maxX &&
+    y >= segment.minY &&
+    y <= segment.maxY;

--- a/packages/eqmonitor_map/lib/src/mesh/polygon_self_intersection_validator.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/polygon_self_intersection_validator.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 import 'dart:typed_data';
 
 import 'package:eqmonitor_map/src/mesh/fill_mesh_build_exception.dart';
+import 'package:eqmonitor_map/src/mesh/polygon_orientation.dart';
 
 /// Polygon境界をX方向に走査し、非隣接辺の接触・交差・重複を拒否する。
 final class PolygonSelfIntersectionValidator {
@@ -137,10 +138,39 @@ bool _rangesOverlap(int aMin, int aMax, int bMin, int bMax) =>
     aMin <= bMax && bMin <= aMax;
 
 bool _polygonSegmentsIntersect(_PolygonSegment a, _PolygonSegment b) {
-  final abA = _polygonOrientation(a.ax, a.ay, a.bx, a.by, b.ax, b.ay);
-  final abB = _polygonOrientation(a.ax, a.ay, a.bx, a.by, b.bx, b.by);
-  final cdA = _polygonOrientation(b.ax, b.ay, b.bx, b.by, a.ax, a.ay);
-  final cdB = _polygonOrientation(b.ax, b.ay, b.bx, b.by, a.bx, a.by);
+  const orientation = PolygonOrientation();
+  final abA = orientation.sign(
+    ax: a.ax,
+    ay: a.ay,
+    bx: a.bx,
+    by: a.by,
+    cx: b.ax,
+    cy: b.ay,
+  );
+  final abB = orientation.sign(
+    ax: a.ax,
+    ay: a.ay,
+    bx: a.bx,
+    by: a.by,
+    cx: b.bx,
+    cy: b.by,
+  );
+  final cdA = orientation.sign(
+    ax: b.ax,
+    ay: b.ay,
+    bx: b.bx,
+    by: b.by,
+    cx: a.ax,
+    cy: a.ay,
+  );
+  final cdB = orientation.sign(
+    ax: b.ax,
+    ay: b.ay,
+    bx: b.bx,
+    by: b.by,
+    cx: a.bx,
+    cy: a.by,
+  );
   if (abA == 0 && _pointIsOnPolygonSegment(b.ax, b.ay, a)) {
     return true;
   }
@@ -155,9 +185,6 @@ bool _polygonSegmentsIntersect(_PolygonSegment a, _PolygonSegment b) {
   }
   return (abA < 0) != (abB < 0) && (cdA < 0) != (cdB < 0);
 }
-
-int _polygonOrientation(int ax, int ay, int bx, int by, int cx, int cy) =>
-    (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
 
 bool _pointIsOnPolygonSegment(int x, int y, _PolygonSegment segment) =>
     x >= segment.minX &&

--- a/packages/eqmonitor_map/lib/src/mesh/polygon_signed_area.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/polygon_signed_area.dart
@@ -1,0 +1,32 @@
+import 'dart:typed_data';
+
+/// Int32 ringの符号付き面積の符号を、64bit累積のoverflowなしで返す。
+/// 各辺の積差はsigned 64bit内に収まるため、累積だけが範囲を外れる時点で
+/// `BigInt`へ切り替える。
+final class PolygonSignedArea {
+  const new();
+
+  int sign(Int32List ring) {
+    var sum = 0;
+    BigInt? exactSum;
+    for (var index = 0; index < ring.length ~/ 2; index++) {
+      final next = (index + 1) % (ring.length ~/ 2);
+      final term =
+          ring[index * 2] * ring[next * 2 + 1] -
+          ring[next * 2] * ring[index * 2 + 1];
+      final currentExact = exactSum;
+      if (currentExact != null) {
+        exactSum = currentExact + BigInt.from(term);
+      } else if ((term > 0 && sum > _maxSigned64 - term) ||
+          (term < 0 && sum < _minSigned64 - term)) {
+        exactSum = BigInt.from(sum) + BigInt.from(term);
+      } else {
+        sum += term;
+      }
+    }
+    return exactSum?.sign ?? sum.sign;
+  }
+}
+
+const _minSigned64 = -0x8000000000000000;
+const _maxSigned64 = 0x7FFFFFFFFFFFFFFF;

--- a/packages/eqmonitor_map/lib/src/mesh/polygon_topology_validator.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/polygon_topology_validator.dart
@@ -44,7 +44,7 @@ final class _TopologyCheckCounter {
   _TopologyCheckCounter({required this.maxChecks});
 
   final int maxChecks;
-  var used = 0;
+  int used = 0;
 
   void consume() {
     used++;

--- a/packages/eqmonitor_map/lib/src/mesh/polygon_topology_validator.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/polygon_topology_validator.dart
@@ -1,0 +1,124 @@
+import 'dart:typed_data';
+
+import 'package:eqmonitor_map/src/mesh/fill_mesh_build_exception.dart';
+import 'package:eqmonitor_map/src/mesh/polygon_orientation.dart';
+
+typedef PolygonRings = ({Int32List exterior, List<Int32List> holes});
+
+/// 交差しないring間の包含関係がPolygon topologyとして正しいか検証する。
+final class PolygonTopologyValidator {
+  const new();
+
+  int validate({
+    required List<PolygonRings> polygons,
+    required int maxChecks,
+  }) {
+    final counter = _TopologyCheckCounter(maxChecks: maxChecks);
+    for (final polygon in polygons) {
+      for (final hole in polygon.holes) {
+        if (_locatePoint(
+              ring: polygon.exterior,
+              x: hole.first,
+              y: hole[1],
+              counter: counter,
+            ) !=
+            _PointRingLocation.inside) {
+          throw const FillMeshBuildException.invalidTopology(
+            reason: 'A hole is not strictly inside its exterior.',
+          );
+        }
+      }
+      _rejectNestedRings(rings: polygon.holes, counter: counter);
+    }
+    _rejectNestedRings(
+      rings: [for (final polygon in polygons) polygon.exterior],
+      counter: counter,
+    );
+    return counter.used;
+  }
+}
+
+enum _PointRingLocation { outside, inside, boundary }
+
+final class _TopologyCheckCounter {
+  _TopologyCheckCounter({required this.maxChecks});
+
+  final int maxChecks;
+  var used = 0;
+
+  void consume() {
+    used++;
+    if (used > maxChecks) {
+      throw FillMeshBuildException.limitExceeded(
+        reason:
+            'Polygon topology checks exceed the configured limit '
+            '($maxChecks).',
+      );
+    }
+  }
+}
+
+void _rejectNestedRings({
+  required List<Int32List> rings,
+  required _TopologyCheckCounter counter,
+}) {
+  for (var left = 0; left < rings.length; left++) {
+    for (var right = left + 1; right < rings.length; right++) {
+      if (_locatePoint(
+                ring: rings[left],
+                x: rings[right].first,
+                y: rings[right][1],
+                counter: counter,
+              ) !=
+              _PointRingLocation.outside ||
+          _locatePoint(
+                ring: rings[right],
+                x: rings[left].first,
+                y: rings[left][1],
+                counter: counter,
+              ) !=
+              _PointRingLocation.outside) {
+        throw const FillMeshBuildException.invalidTopology(
+          reason: 'Polygon rings must not contain one another.',
+        );
+      }
+    }
+  }
+}
+
+_PointRingLocation _locatePoint({
+  required Int32List ring,
+  required int x,
+  required int y,
+  required _TopologyCheckCounter counter,
+}) {
+  const orientation = PolygonOrientation();
+  var inside = false;
+  for (var index = 0; index < ring.length ~/ 2; index++) {
+    counter.consume();
+    final next = (index + 1) % (ring.length ~/ 2);
+    final ax = ring[index * 2];
+    final ay = ring[index * 2 + 1];
+    final bx = ring[next * 2];
+    final by = ring[next * 2 + 1];
+    final sign = orientation.sign(
+      ax: ax,
+      ay: ay,
+      bx: bx,
+      by: by,
+      cx: x,
+      cy: y,
+    );
+    if (sign == 0 &&
+        x >= (ax < bx ? ax : bx) &&
+        x <= (ax > bx ? ax : bx) &&
+        y >= (ay < by ? ay : by) &&
+        y <= (ay > by ? ay : by)) {
+      return _PointRingLocation.boundary;
+    }
+    if ((ay > y) != (by > y) && (sign > 0) == (by > ay)) {
+      inside = !inside;
+    }
+  }
+  return inside ? _PointRingLocation.inside : _PointRingLocation.outside;
+}

--- a/packages/eqmonitor_map/lib/src/mesh/polygon_topology_validator.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/polygon_topology_validator.dart
@@ -6,6 +6,8 @@ import 'package:eqmonitor_map/src/mesh/polygon_orientation.dart';
 typedef PolygonRings = ({Int32List exterior, List<Int32List> holes});
 
 /// 交差しないring間の包含関係がPolygon topologyとして正しいか検証する。
+/// 全ring境界の交差・接触を先に拒否しているため、代表点がring内なら対象ring
+/// 全体がそのring内にある。この前提により辺同士の再比較をせず包含を判定する。
 final class PolygonTopologyValidator {
   const new();
 
@@ -30,8 +32,8 @@ final class PolygonTopologyValidator {
       }
       _rejectNestedRings(rings: polygon.holes, counter: counter);
     }
-    _rejectNestedRings(
-      rings: [for (final polygon in polygons) polygon.exterior],
+    _rejectInvalidExteriorNesting(
+      polygons: polygons,
       counter: counter,
     );
     return counter.used;
@@ -57,6 +59,56 @@ final class _TopologyCheckCounter {
       );
     }
   }
+}
+
+void _rejectInvalidExteriorNesting({
+  required List<PolygonRings> polygons,
+  required _TopologyCheckCounter counter,
+}) {
+  for (var left = 0; left < polygons.length; left++) {
+    for (var right = left + 1; right < polygons.length; right++) {
+      _rejectExteriorInsideFill(
+        container: polygons[left],
+        nested: polygons[right].exterior,
+        counter: counter,
+      );
+      _rejectExteriorInsideFill(
+        container: polygons[right],
+        nested: polygons[left].exterior,
+        counter: counter,
+      );
+    }
+  }
+}
+
+void _rejectExteriorInsideFill({
+  required PolygonRings container,
+  required Int32List nested,
+  required _TopologyCheckCounter counter,
+}) {
+  final location = _locatePoint(
+    ring: container.exterior,
+    x: nested.first,
+    y: nested[1],
+    counter: counter,
+  );
+  if (location == _PointRingLocation.outside) {
+    return;
+  }
+  for (final hole in container.holes) {
+    if (_locatePoint(
+          ring: hole,
+          x: nested.first,
+          y: nested[1],
+          counter: counter,
+        ) ==
+        _PointRingLocation.inside) {
+      return;
+    }
+  }
+  throw const FillMeshBuildException.invalidTopology(
+    reason: 'An exterior must not be nested directly inside filled area.',
+  );
 }
 
 void _rejectNestedRings({

--- a/packages/eqmonitor_map/lib/src/mesh/polygon_topology_validator.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/polygon_topology_validator.dart
@@ -44,11 +44,12 @@ final class _TopologyCheckCounter {
   _TopologyCheckCounter({required this.maxChecks});
 
   final int maxChecks;
-  int used = 0;
+  var _used = 0;
+  int get used => _used;
 
   void consume() {
-    used++;
-    if (used > maxChecks) {
+    _used++;
+    if (_used > maxChecks) {
       throw FillMeshBuildException.limitExceeded(
         reason:
             'Polygon topology checks exceed the configured limit '

--- a/packages/eqmonitor_map/lib/src/tile/base_map_tile_decoder.dart
+++ b/packages/eqmonitor_map/lib/src/tile/base_map_tile_decoder.dart
@@ -11,6 +11,7 @@ import 'package:eqmonitor_map/src/tile/earthquake_area_tile_geometry.dart';
 import 'package:eqmonitor_map/src/tile/mvt/mvt_decode_limits.dart';
 import 'package:eqmonitor_map/src/tile/mvt/mvt_decoder.dart';
 import 'package:eqmonitor_map/src/tile/mvt/mvt_tile.dart';
+import 'package:eqmonitor_map/src/tile/mvt/polygon_boundary_builder.dart';
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -372,7 +373,9 @@ List<LineMesh> _buildLineMeshes({
         // polygonの外形・穴ringそのものを線として描く(MapLibre GLの
         // line rendererがPolygon地物をline layerでも描画できるのと同じ
         // 挙動)。
-        MvtGeometryType.polygon => _polygonFeatureAsClosedLines(feature),
+        MvtGeometryType.polygon => const PolygonBoundaryBuilder().build(
+          feature: feature,
+        ),
         // Pointは線として描けないため読み飛ばす。
         MvtGeometryType.point => null,
       },
@@ -381,29 +384,4 @@ List<LineMesh> _buildLineMeshes({
     return const [];
   }
   return builder.build(lineFeatures);
-}
-
-/// Polygon地物の各ringを、始点を末尾へ複製した閉じたLineStringへ変換する。
-///
-/// `decodeMvtTile`が返すpolygon ringはMVTの`ClosePath`規則どおり終端の
-/// 重複頂点を持たない(始点=終点の座標は1回しか現れない)。`LineMeshBuilder`
-/// はring先頭・末尾の座標が一致するかどうかで閉路(`isClosed`)を判定する
-/// ([LineMeshBuilder]のdoc comment、`_dedupeRing`参照)ため、始点を末尾へ
-/// 複製しないと最後の1辺(終点→始点)が生成されず境界が閉じない。
-MvtFeature _polygonFeatureAsClosedLines(MvtFeature feature) {
-  final closedRings = <Int32List>[
-    for (final ring in feature.rings) _closeRing(ring),
-  ];
-  return MvtFeature(
-    type: MvtGeometryType.lineString,
-    rings: closedRings,
-    properties: feature.properties,
-  );
-}
-
-Int32List _closeRing(Int32List ring) {
-  final closed = Int32List(ring.length + 2)..setRange(0, ring.length, ring);
-  closed[ring.length] = ring[0];
-  closed[ring.length + 1] = ring[1];
-  return closed;
 }

--- a/packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_decode_exception.dart
+++ b/packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_decode_exception.dart
@@ -1,0 +1,21 @@
+/// 推計震度 tile 全体を拒否した理由。入力 bytes や下位例外は保持しない。
+enum EstimatedIntensityTileDecodeFailure {
+  invalidMvt,
+  resourceLimitExceeded,
+  missingSourceLayer,
+  duplicateSourceLayer,
+  wrongGeometry,
+  missingName,
+  unknownClass,
+  invalidGeometry,
+}
+
+final class EstimatedIntensityTileDecodeException implements Exception {
+  const new(this.failure);
+
+  final EstimatedIntensityTileDecodeFailure failure;
+
+  @override
+  String toString() =>
+      'EstimatedIntensityTileDecodeException(failure: $failure)';
+}

--- a/packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_decode_limits.dart
+++ b/packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_decode_limits.dart
@@ -1,0 +1,30 @@
+import 'package:eqmonitor_map/src/mesh/fill_mesh_builder_limits.dart';
+import 'package:eqmonitor_map/src/mesh/line_mesh_builder_limits.dart';
+import 'package:eqmonitor_map/src/tile/mvt/mvt_decode_limits.dart';
+
+/// 推計震度 MVT decode と mesh 生成へ適用する caller-owned 上限。
+final class EstimatedIntensityTileDecodeLimits {
+  const new({
+    required this.mvtLimits,
+    required this.fillLimits,
+    required this.lineLimits,
+    required this.lineMiterLimit,
+  });
+
+  final MvtDecodeLimits mvtLimits;
+  final FillMeshBuilderLimits fillLimits;
+  final LineMeshBuilderLimits lineLimits;
+  final double lineMiterLimit;
+
+  EstimatedIntensityTileDecodeLimits copyWith({
+    MvtDecodeLimits? mvtLimits,
+    FillMeshBuilderLimits? fillLimits,
+    LineMeshBuilderLimits? lineLimits,
+    double? lineMiterLimit,
+  }) => EstimatedIntensityTileDecodeLimits(
+    mvtLimits: mvtLimits ?? this.mvtLimits,
+    fillLimits: fillLimits ?? this.fillLimits,
+    lineLimits: lineLimits ?? this.lineLimits,
+    lineMiterLimit: lineMiterLimit ?? this.lineMiterLimit,
+  );
+}

--- a/packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_decoder.dart
+++ b/packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_decoder.dart
@@ -126,6 +126,10 @@ EstimatedIntensityTileGeometry decodeEstimatedIntensityTileSync(
     throw const EstimatedIntensityTileDecodeException(
       EstimatedIntensityTileDecodeFailure.invalidGeometry,
     );
+  } on FillMeshSelfIntersectionException {
+    throw const EstimatedIntensityTileDecodeException(
+      EstimatedIntensityTileDecodeFailure.invalidGeometry,
+    );
   } on MvtDecodeException {
     throw const EstimatedIntensityTileDecodeException(
       EstimatedIntensityTileDecodeFailure.invalidMvt,

--- a/packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_decoder.dart
+++ b/packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_decoder.dart
@@ -130,6 +130,10 @@ EstimatedIntensityTileGeometry decodeEstimatedIntensityTileSync(
     throw const EstimatedIntensityTileDecodeException(
       EstimatedIntensityTileDecodeFailure.invalidGeometry,
     );
+  } on FillMeshInvalidTopologyException {
+    throw const EstimatedIntensityTileDecodeException(
+      EstimatedIntensityTileDecodeFailure.invalidGeometry,
+    );
   } on MvtDecodeException {
     throw const EstimatedIntensityTileDecodeException(
       EstimatedIntensityTileDecodeFailure.invalidMvt,

--- a/packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_decoder.dart
+++ b/packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_decoder.dart
@@ -1,0 +1,134 @@
+import 'dart:isolate';
+
+import 'package:eqmonitor_map/src/mesh/fill_mesh_build_exception.dart';
+import 'package:eqmonitor_map/src/mesh/fill_mesh_builder.dart';
+import 'package:eqmonitor_map/src/mesh/line_mesh_build_exception.dart';
+import 'package:eqmonitor_map/src/mesh/line_mesh_builder.dart';
+import 'package:eqmonitor_map/src/tile/estimated_intensity_tile_decode_exception.dart';
+import 'package:eqmonitor_map/src/tile/estimated_intensity_tile_decode_limits.dart';
+import 'package:eqmonitor_map/src/tile/estimated_intensity_tile_geometry.dart';
+import 'package:eqmonitor_map/src/tile/mvt/mvt_decode_exception.dart';
+import 'package:eqmonitor_map/src/tile/mvt/mvt_decoder.dart';
+import 'package:eqmonitor_map/src/tile/mvt/mvt_tile.dart';
+import 'package:eqmonitor_map/src/tile/mvt/polygon_boundary_builder.dart';
+import 'package:flutter/foundation.dart';
+
+export 'estimated_intensity_tile_decode_exception.dart';
+export 'estimated_intensity_tile_decode_limits.dart';
+
+const estimatedIntensitySourceLayerName = 'seismic_intensity';
+
+final class EstimatedIntensityTileDecoder {
+  const new();
+
+  Future<EstimatedIntensityTileGeometry> decode({
+    required Uint8List tileBytes,
+    required EstimatedIntensityTileDecodeLimits limits,
+  }) => Isolate.run(() => decodeEstimatedIntensityTileSync(tileBytes, limits));
+}
+
+/// Themeやapp stateに依存せず、推計震度tileをclass別meshへ変換する同期本体。
+@visibleForTesting
+EstimatedIntensityTileGeometry decodeEstimatedIntensityTileSync(
+  Uint8List tileBytes,
+  EstimatedIntensityTileDecodeLimits limits,
+) {
+  final fillBuilder = FillMeshBuilder(limits: limits.fillLimits);
+  final lineBuilder = LineMeshBuilder(
+    limits: limits.lineLimits,
+    miterLimit: limits.lineMiterLimit,
+  );
+  try {
+    final tile = decodeMvtTile(tileBytes, limits: limits.mvtLimits);
+    final matchingLayers = tile.layers
+        .where((layer) => layer.name == estimatedIntensitySourceLayerName)
+        .toList(growable: false);
+    if (matchingLayers.isEmpty) {
+      throw const EstimatedIntensityTileDecodeException(
+        EstimatedIntensityTileDecodeFailure.missingSourceLayer,
+      );
+    }
+    if (matchingLayers.length != 1) {
+      throw const EstimatedIntensityTileDecodeException(
+        EstimatedIntensityTileDecodeFailure.duplicateSourceLayer,
+      );
+    }
+    final layer = matchingLayers.single;
+    if (layer.features.isEmpty) {
+      return EstimatedIntensityTileEmpty(extent: layer.extent);
+    }
+
+    final featuresByClass = {
+      for (final intensityClass in EstimatedIntensityClass.values)
+        intensityClass: <MvtFeature>[],
+    };
+    for (final feature in layer.features) {
+      if (feature.type != MvtGeometryType.polygon) {
+        throw const EstimatedIntensityTileDecodeException(
+          EstimatedIntensityTileDecodeFailure.wrongGeometry,
+        );
+      }
+      final name = feature.properties['name'];
+      if (name == null || name.isEmpty) {
+        throw const EstimatedIntensityTileDecodeException(
+          EstimatedIntensityTileDecodeFailure.missingName,
+        );
+      }
+      final intensityClass = EstimatedIntensityClass.fromSourceName(name);
+      if (intensityClass == null) {
+        throw const EstimatedIntensityTileDecodeException(
+          EstimatedIntensityTileDecodeFailure.unknownClass,
+        );
+      }
+      featuresByClass[intensityClass]?.add(feature);
+    }
+
+    const boundaryBuilder = PolygonBoundaryBuilder();
+    return EstimatedIntensityTileReady(
+      extent: layer.extent,
+      classes: [
+        for (final intensityClass in EstimatedIntensityClass.values)
+          if (featuresByClass[intensityClass] case final features?
+              when features.isNotEmpty)
+            EstimatedIntensityClassGeometry(
+              intensityClass: intensityClass,
+              fillMeshes: fillBuilder.build(features),
+              boundaryMeshes: lineBuilder.build([
+                for (final feature in features)
+                  boundaryBuilder.build(feature: feature),
+              ]),
+            ),
+      ],
+    );
+  } on EstimatedIntensityTileDecodeException {
+    rethrow;
+  } on MvtLimitExceededException {
+    throw const EstimatedIntensityTileDecodeException(
+      EstimatedIntensityTileDecodeFailure.resourceLimitExceeded,
+    );
+  } on FillMeshLimitExceededException {
+    throw const EstimatedIntensityTileDecodeException(
+      EstimatedIntensityTileDecodeFailure.resourceLimitExceeded,
+    );
+  } on LineMeshLimitExceededException {
+    throw const EstimatedIntensityTileDecodeException(
+      EstimatedIntensityTileDecodeFailure.resourceLimitExceeded,
+    );
+  } on MvtInvalidGeometryCommandException {
+    throw const EstimatedIntensityTileDecodeException(
+      EstimatedIntensityTileDecodeFailure.invalidGeometry,
+    );
+  } on FillMeshDegenerateRingException {
+    throw const EstimatedIntensityTileDecodeException(
+      EstimatedIntensityTileDecodeFailure.invalidGeometry,
+    );
+  } on FillMeshHoleBeforeExteriorException {
+    throw const EstimatedIntensityTileDecodeException(
+      EstimatedIntensityTileDecodeFailure.invalidGeometry,
+    );
+  } on MvtDecodeException {
+    throw const EstimatedIntensityTileDecodeException(
+      EstimatedIntensityTileDecodeFailure.invalidMvt,
+    );
+  }
+}

--- a/packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_geometry.dart
+++ b/packages/eqmonitor_map/lib/src/tile/estimated_intensity_tile_geometry.dart
@@ -1,0 +1,64 @@
+import 'package:eqmonitor_map/src/mesh/fill_mesh.dart';
+import 'package:eqmonitor_map/src/mesh/line_mesh.dart';
+
+/// `seismic_intensity.name` が受理できる推計震度 class。
+enum EstimatedIntensityClass {
+  intensity4('intensity:4'),
+  intensity5Lower('intensity:5-'),
+  intensity5Upper('intensity:5+'),
+  intensity6Lower('intensity:6-'),
+  intensity6Upper('intensity:6+'),
+  intensity7('intensity:7');
+
+  const EstimatedIntensityClass(this.sourceName);
+
+  final String sourceName;
+
+  static EstimatedIntensityClass? fromSourceName(String value) =>
+      switch (value) {
+        'intensity:4' => intensity4,
+        'intensity:5-' => intensity5Lower,
+        'intensity:5+' => intensity5Upper,
+        'intensity:6-' => intensity6Lower,
+        'intensity:6+' => intensity6Upper,
+        'intensity:7' => intensity7,
+        _ => null,
+      };
+}
+
+/// 1 class 分の style 非依存 geometry。
+final class EstimatedIntensityClassGeometry {
+  new({
+    required this.intensityClass,
+    required List<FillMesh> fillMeshes,
+    required List<LineMesh> boundaryMeshes,
+  }) : fillMeshes = List.unmodifiable(fillMeshes),
+       boundaryMeshes = List.unmodifiable(boundaryMeshes);
+
+  final EstimatedIntensityClass intensityClass;
+  final List<FillMesh> fillMeshes;
+  final List<LineMesh> boundaryMeshes;
+}
+
+/// Required layer が存在した推計震度 tile の decode 結果。
+sealed class EstimatedIntensityTileGeometry {
+  const new({required this.extent});
+
+  final int extent;
+}
+
+/// Required layer は存在するが feature が0件の authoritative empty。
+final class EstimatedIntensityTileEmpty extends EstimatedIntensityTileGeometry {
+  const new({required super.extent});
+}
+
+/// 全 feature の検証と mesh 化が完了した tile。
+final class EstimatedIntensityTileReady extends EstimatedIntensityTileGeometry {
+  new({
+    required super.extent,
+    required List<EstimatedIntensityClassGeometry> classes,
+  }) : classes = List.unmodifiable(classes);
+
+  /// Feature が存在した class だけを enum 宣言順で保持する。
+  final List<EstimatedIntensityClassGeometry> classes;
+}

--- a/packages/eqmonitor_map/lib/src/tile/mvt/polygon_boundary_builder.dart
+++ b/packages/eqmonitor_map/lib/src/tile/mvt/polygon_boundary_builder.dart
@@ -1,0 +1,28 @@
+import 'dart:typed_data';
+
+import 'package:eqmonitor_map/src/tile/mvt/mvt_tile.dart';
+
+/// Polygon の ring を閉じた LineString として再利用可能にする変換器。
+///
+/// MVT Polygon は ClosePath を終端の重複座標として保持しないため、境界線の
+/// 最後の一辺を line mesh の利用側へ伝えるには始点の複製が必要。
+final class PolygonBoundaryBuilder {
+  const new();
+
+  MvtFeature build({required MvtFeature feature}) {
+    if (feature.type != MvtGeometryType.polygon) {
+      throw ArgumentError.value(feature.type, 'feature', 'must be polygon');
+    }
+    return MvtFeature(
+      type: MvtGeometryType.lineString,
+      rings: List.unmodifiable([
+        for (final ring in feature.rings)
+          Int32List(ring.length + 2)
+            ..setRange(0, ring.length, ring)
+            ..[ring.length] = ring[0]
+            ..[ring.length + 1] = ring[1],
+      ]),
+      properties: feature.properties,
+    );
+  }
+}

--- a/packages/eqmonitor_map/test/mesh/fill_mesh_builder_test.dart
+++ b/packages/eqmonitor_map/test/mesh/fill_mesh_builder_test.dart
@@ -27,12 +27,14 @@ FillMeshBuilder _builder({
   int maxHolesPerPolygon = 8,
   int maxVerticesPerFeature = 1 << 20,
   int maxVerticesPerSegment = 65536,
+  int maxIntersectionChecks = 1 << 20,
 }) {
   return FillMeshBuilder(
     limits: FillMeshBuilderLimits(
       maxHolesPerPolygon: maxHolesPerPolygon,
       maxVerticesPerFeature: maxVerticesPerFeature,
       maxVerticesPerSegment: maxVerticesPerSegment,
+      maxIntersectionChecks: maxIntersectionChecks,
     ),
   );
 }

--- a/packages/eqmonitor_map/test/mesh/fill_mesh_builder_test.dart
+++ b/packages/eqmonitor_map/test/mesh/fill_mesh_builder_test.dart
@@ -141,6 +141,39 @@ void main() {
       expect(_totalTriangleArea(mesh), closeTo(expectedArea, 1e-9));
     });
 
+    test('Int32四隅の正逆ringを外形とholeに分類する', () {
+      const min = -2147483648;
+      const max = 2147483647;
+      final exterior = _ring([
+        (min, min),
+        (max, min),
+        (max, max),
+        (min, max),
+      ]);
+      final reversed = _ring([
+        (min, min),
+        (min, max),
+        (max, max),
+        (max, min),
+      ]);
+
+      expect(
+        _builder()
+            .build([
+              _polygonFeature([exterior]),
+            ])
+            .single
+            .vertexCount,
+        4,
+      );
+      expect(
+        () => _builder().build([
+          _polygonFeature([reversed]),
+        ]),
+        throwsA(isA<FillMeshHoleBeforeExteriorException>()),
+      );
+    });
+
     test('rejects a ring with fewer than 3 vertices', () {
       final degenerate = _ring([(0, 0), (10, 0)]);
       final feature = _polygonFeature([degenerate]);
@@ -364,6 +397,7 @@ void main() {
         throwsA(isA<FillMeshInvalidTopologyException>()),
       );
     });
+
   });
 
   group('segment splitting at the Uint16 index boundary', () {

--- a/packages/eqmonitor_map/test/mesh/fill_mesh_builder_test.dart
+++ b/packages/eqmonitor_map/test/mesh/fill_mesh_builder_test.dart
@@ -174,6 +174,22 @@ void main() {
       );
     });
 
+    test('shares the comparison limit across build calls', () {
+      final square = _ring([(0, 0), (10, 0), (10, 10), (0, 10)]);
+      final builder = _builder(maxIntersectionChecks: 1);
+
+      builder.build([
+        _polygonFeature([square]),
+      ]);
+
+      expect(
+        () => builder.build([
+          _polygonFeature([square]),
+        ]),
+        throwsA(isA<FillMeshLimitExceededException>()),
+      );
+    });
+
     test(
       'rejects a lone ring wound as a hole (negative signed area) '
       'with no preceding exterior',
@@ -296,57 +312,58 @@ void main() {
         throwsA(isA<FillMeshSelfIntersectionException>()),
       );
     });
+
+    for (final testCase in [
+      (
+        name: 'hole outside its exterior',
+        rings: [
+          _ring([(0, 0), (10, 0), (10, 10), (0, 10)]),
+          _ring([(20, 20), (20, 30), (30, 30), (30, 20)]),
+        ],
+      ),
+      (
+        name: 'nested holes',
+        rings: [
+          _ring([(0, 0), (30, 0), (30, 30), (0, 30)]),
+          _ring([(5, 5), (5, 25), (25, 25), (25, 5)]),
+          _ring([(10, 10), (10, 20), (20, 20), (20, 10)]),
+        ],
+      ),
+    ]) {
+      test('rejects ${testCase.name}', () {
+        expect(
+          () => _builder().build([_polygonFeature(testCase.rings)]),
+          throwsA(isA<FillMeshInvalidTopologyException>()),
+        );
+      });
+    }
   });
 
   group('multiple exterior rings in one feature', () {
-    test(
-      'a feature with two same-winding rings is classified as two '
-      'polygons, not exterior+hole (classification is sign-only, '
-      'independent of geometric nesting)',
-      () {
-        // squareBはsquareAの内部に幾何学的にネストしているが、同じ向き
-        // (どちらもshoelace > 0)で巻かれているため、MVT仕様に従い2つ目の
-        // 独立したexteriorとして扱われる(穴としては扱わない)。
-        final squareA = _ring([(0, 0), (20, 0), (20, 20), (0, 20)]);
-        final squareB = _ring([(5, 5), (10, 5), (10, 10), (5, 10)]);
-        expect(_signedAreaTwice(squareA), greaterThan(0));
-        expect(_signedAreaTwice(squareB), greaterThan(0));
-        final feature = _polygonFeature([squareA, squareB]);
+    test('triangulates two disjoint exteriors', () {
+      final squareA = _ring([(0, 0), (20, 0), (20, 20), (0, 20)]);
+      final squareB = _ring([(30, 30), (40, 30), (40, 40), (30, 40)]);
 
-        final meshes = _builder().build([feature]);
+      final mesh = _builder().build([
+        _polygonFeature([squareA, squareB]),
+      ]).single;
 
-        expect(meshes, hasLength(1));
-        final mesh = meshes.single;
-        expect(mesh.vertexCount, 8);
-        // 穴を持たない2つの独立したpolygon: (4-2) + (4-2) == 4。
-        expect(mesh.indices.length ~/ 3, 4);
+      expect(mesh.vertexCount, 8);
+      expect(mesh.indices.length ~/ 3, 4);
+      expect(_totalTriangleArea(mesh), closeTo(500, 1e-9));
+    });
 
-        // 面積は「差し引き」ではなく「足し算」になる(独立した2 polygonの
-        // 総和であり、穴なら引き算になるはずの符号がここでは両方正)。
-        final expectedArea = (400 + 25).toDouble();
-        expect(_totalTriangleArea(mesh), closeTo(expectedArea, 1e-9));
+    test('rejects nested exteriors', () {
+      final outer = _ring([(0, 0), (20, 0), (20, 20), (0, 20)]);
+      final nested = _ring([(5, 5), (10, 5), (10, 10), (5, 10)]);
 
-        // 各三角形のindexは、squareA由来の頂点範囲[0,4)かsquareB由来の
-        // 頂点範囲[4,8)のどちらか一方に完全に収まる
-        // (別polygonのearcut結果が混ざらないことの確認。
-        // earcutの内部実装ではなく、builderの頂点割り当てロジックを
-        // 検証する不変条件)。
-        for (var i = 0; i < mesh.indices.length; i += 3) {
-          final indicesOfTriangle = [
-            mesh.indices[i],
-            mesh.indices[i + 1],
-            mesh.indices[i + 2],
-          ];
-          final allInA = indicesOfTriangle.every((index) => index < 4);
-          final allInB = indicesOfTriangle.every((index) => index >= 4);
-          expect(
-            allInA || allInB,
-            isTrue,
-            reason: '三角形が複数polygonの頂点を混ぜて参照している',
-          );
-        }
-      },
-    );
+      expect(
+        () => _builder().build([
+          _polygonFeature([outer, nested]),
+        ]),
+        throwsA(isA<FillMeshInvalidTopologyException>()),
+      );
+    });
   });
 
   group('segment splitting at the Uint16 index boundary', () {

--- a/packages/eqmonitor_map/test/mesh/fill_mesh_builder_test.dart
+++ b/packages/eqmonitor_map/test/mesh/fill_mesh_builder_test.dart
@@ -398,6 +398,18 @@ void main() {
       );
     });
 
+    test('allows an exterior fully contained by another polygon hole', () {
+      final outer = _ring([(0, 0), (30, 0), (30, 30), (0, 30)]);
+      final hole = _ring([(5, 5), (5, 25), (25, 25), (25, 5)]);
+      final island = _ring([(10, 10), (20, 10), (20, 20), (10, 20)]);
+
+      final mesh = _builder().build([
+        _polygonFeature([outer, hole, island]),
+      ]).single;
+
+      expect(mesh.vertexCount, 12);
+      expect(_totalTriangleArea(mesh), closeTo(600, 1e-9));
+    });
   });
 
   group('segment splitting at the Uint16 index boundary', () {

--- a/packages/eqmonitor_map/test/mesh/fill_mesh_builder_test.dart
+++ b/packages/eqmonitor_map/test/mesh/fill_mesh_builder_test.dart
@@ -162,6 +162,18 @@ void main() {
       );
     });
 
+    test('rejects a self-intersecting ring with non-zero signed area', () {
+      final crossing = _ring([(3, 0), (2, 5), (1, 0), (4, 3), (0, 3)]);
+      expect(_signedAreaTwice(crossing), greaterThan(0));
+
+      expect(
+        () => _builder().build([
+          _polygonFeature([crossing]),
+        ]),
+        throwsA(isA<FillMeshSelfIntersectionException>()),
+      );
+    });
+
     test(
       'rejects a lone ring wound as a hole (negative signed area) '
       'with no preceding exterior',
@@ -270,6 +282,18 @@ void main() {
       expect(
         () => _builder(maxHolesPerPolygon: 1).build([feature]),
         throwsA(isA<FillMeshLimitExceededException>()),
+      );
+    });
+
+    test('rejects a hole boundary crossing its exterior boundary', () {
+      final exterior = _ring([(0, 0), (10, 0), (10, 10), (0, 10)]);
+      final crossingHole = _ring([(5, 5), (5, 15), (15, 15), (15, 5)]);
+
+      expect(
+        () => _builder().build([
+          _polygonFeature([exterior, crossingHole]),
+        ]),
+        throwsA(isA<FillMeshSelfIntersectionException>()),
       );
     });
   });

--- a/packages/eqmonitor_map/test/mesh/polygon_self_intersection_validator_test.dart
+++ b/packages/eqmonitor_map/test/mesh/polygon_self_intersection_validator_test.dart
@@ -1,0 +1,39 @@
+import 'dart:typed_data';
+
+import 'package:eqmonitor_map/src/mesh/fill_mesh_build_exception.dart';
+import 'package:eqmonitor_map/src/mesh/polygon_self_intersection_validator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('非0面積の自己交差ringを拒否する', () {
+    final ring = Int32List.fromList([3, 0, 2, 5, 1, 0, 4, 3, 0, 3]);
+
+    expect(
+      () => const PolygonSelfIntersectionValidator().validate(
+        rings: [ring],
+        maxIntersectionChecks: 32,
+      ),
+      throwsA(isA<FillMeshSelfIntersectionException>()),
+    );
+  });
+
+  test('65536頂点の単純境界を有限の比較数で受理する', () {
+    const half = 32768;
+    final ring = Int32List(half * 4);
+    for (var index = 0; index < half; index++) {
+      ring[index * 2] = index;
+      ring[index * 2 + 1] = 0;
+      final reverseIndex = half * 2 - index - 1;
+      ring[reverseIndex * 2] = index;
+      ring[reverseIndex * 2 + 1] = 1;
+    }
+
+    expect(
+      () => const PolygonSelfIntersectionValidator().validate(
+        rings: [ring],
+        maxIntersectionChecks: 1 << 20,
+      ),
+      returnsNormally,
+    );
+  });
+}

--- a/packages/eqmonitor_map/test/mesh/polygon_self_intersection_validator_test.dart
+++ b/packages/eqmonitor_map/test/mesh/polygon_self_intersection_validator_test.dart
@@ -17,6 +17,27 @@ void main() {
     );
   });
 
+  test('int64の積差範囲を超える交差を拒否する', () {
+    final ring = Int32List.fromList([
+      -2147483648,
+      -2147483647,
+      2000000000,
+      2000000000,
+      -2147483647,
+      1000000000,
+      1000000000,
+      1000000000,
+    ]);
+
+    expect(
+      () => const PolygonSelfIntersectionValidator().validate(
+        rings: [ring],
+        maxIntersectionChecks: 16,
+      ),
+      throwsA(isA<FillMeshSelfIntersectionException>()),
+    );
+  });
+
   test('65536頂点の単純境界を有限の比較数で受理する', () {
     const half = 32768;
     final ring = Int32List(half * 4);

--- a/packages/eqmonitor_map/test/tile/base_map_render_plan_builder_test.dart
+++ b/packages/eqmonitor_map/test/tile/base_map_render_plan_builder_test.dart
@@ -32,6 +32,7 @@ void main() {
       maxHolesPerPolygon: 16,
       maxVerticesPerFeature: 4096,
       maxVerticesPerSegment: 65536,
+      maxIntersectionChecks: 1 << 16,
     ),
     lineLimits: LineMeshBuilderLimits(maxVerticesPerSegment: 65536),
     lineMiterLimit: 4,

--- a/packages/eqmonitor_map/test/tile/base_map_tile_decoder_test.dart
+++ b/packages/eqmonitor_map/test/tile/base_map_tile_decoder_test.dart
@@ -12,6 +12,7 @@
 // layer名の取り違えを避ける。
 import 'dart:typed_data';
 
+import 'package:eqmonitor_map/src/mesh/fill_mesh_build_exception.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh_builder_limits.dart';
 import 'package:eqmonitor_map/src/mesh/line_mesh_builder_limits.dart';
 import 'package:eqmonitor_map/src/tile/base_map_tile_decoder.dart';
@@ -58,6 +59,15 @@ Uint8List _buildFeatureTriangle() {
     ],
   );
 }
+
+Uint8List _buildFeatureSquare() => _builder.buildFeature(
+  geomType: MvtFixtureBuilder.geomTypePolygon,
+  rawCommands: [
+    ..._builder.moveTo([(0, 0)]),
+    ..._builder.lineTo([(10, 0), (0, 10), (-10, 0)]),
+    ..._builder.closePath(),
+  ],
+);
 
 Uint8List _buildTaggedFeatureTriangle({List<int> tags = const []}) {
   return _builder.feature(
@@ -124,6 +134,31 @@ void main() {
   });
 
   group('decodeBaseMapTileSync', () {
+    test('shares the Fill comparison limit across source layers', () {
+      final tile = _builder.buildTile(
+        layers: [
+          _builder.buildLayer(
+            name: 'countries',
+            features: [_buildFeatureSquare()],
+          ),
+          _builder.buildLayer(
+            name: 'areaForecastLocalE',
+            features: [_buildFeatureSquare()],
+          ),
+        ],
+      );
+
+      expect(
+        () => decodeBaseMapTileSync(
+          tile,
+          _limits.copyWith(
+            fillLimits: _limits.fillLimits.copyWith(maxIntersectionChecks: 1),
+          ),
+        ),
+        throwsA(isA<FillMeshLimitExceededException>()),
+      );
+    });
+
     test('keeps each coded earthquake area mesh with its source code', () {
       final tile = _builder.buildTile(
         layers: [

--- a/packages/eqmonitor_map/test/tile/base_map_tile_decoder_test.dart
+++ b/packages/eqmonitor_map/test/tile/base_map_tile_decoder_test.dart
@@ -39,6 +39,7 @@ const _limits = BaseMapTileDecodeLimits(
     maxHolesPerPolygon: 16,
     maxVerticesPerFeature: 4096,
     maxVerticesPerSegment: 65536,
+    maxIntersectionChecks: 1 << 16,
   ),
   lineLimits: LineMeshBuilderLimits(maxVerticesPerSegment: 65536),
   lineMiterLimit: 4,

--- a/packages/eqmonitor_map/test/tile/estimated_intensity_tile_decoder_test.dart
+++ b/packages/eqmonitor_map/test/tile/estimated_intensity_tile_decoder_test.dart
@@ -162,6 +162,17 @@ void main() {
           ),
           failure: EstimatedIntensityTileDecodeFailure.invalidGeometry,
         ),
+        (
+          name: 'hole outside its exterior',
+          bytes: _tile(
+            features: [
+              _polygonWithOutsideHole(tags: const [0, 0]),
+            ],
+            keys: const ['name'],
+            values: [_builder.stringValue(_classes.first)],
+          ),
+          failure: EstimatedIntensityTileDecodeFailure.invalidGeometry,
+        ),
       ]) {
     test('${testCase.name}はtile全体をfail closedにする', () {
       expect(
@@ -236,6 +247,36 @@ void main() {
       ),
     );
   });
+
+  test('比較上限を震度class間で共有する', () {
+    final bytes = _tile(
+      features: [
+        _square(tags: const [0, 0]),
+        _square(tags: const [0, 1]),
+      ],
+      keys: const ['name'],
+      values: [
+        _builder.stringValue(_classes[0]),
+        _builder.stringValue(_classes[1]),
+      ],
+    );
+
+    expect(
+      () => decodeEstimatedIntensityTileSync(
+        bytes,
+        _limits.copyWith(
+          fillLimits: _limits.fillLimits.copyWith(maxIntersectionChecks: 1),
+        ),
+      ),
+      throwsA(
+        isA<EstimatedIntensityTileDecodeException>().having(
+          (error) => error.failure,
+          'failure',
+          EstimatedIntensityTileDecodeFailure.resourceLimitExceeded,
+        ),
+      ),
+    );
+  });
 }
 
 Uint8List _tile({
@@ -299,6 +340,20 @@ Uint8List _selfIntersectingPolygon({required List<int> tags}) =>
       rawCommands: [
         ..._builder.moveTo([(3, 0)]),
         ..._builder.lineTo([(-1, 5), (-1, -5), (3, 3), (-4, 0)]),
+        ..._builder.closePath(),
+      ],
+    );
+
+Uint8List _polygonWithOutsideHole({required List<int> tags}) =>
+    _builder.feature(
+      geomType: MvtFixtureBuilder.geomTypePolygon,
+      tags: tags,
+      rawCommands: [
+        ..._builder.moveTo([(0, 0)]),
+        ..._builder.lineTo([(10, 0), (0, 10), (-10, 0)]),
+        ..._builder.closePath(),
+        ..._builder.moveTo([(20, 10)]),
+        ..._builder.lineTo([(0, 10), (10, 0), (0, -10)]),
         ..._builder.closePath(),
       ],
     );

--- a/packages/eqmonitor_map/test/tile/estimated_intensity_tile_decoder_test.dart
+++ b/packages/eqmonitor_map/test/tile/estimated_intensity_tile_decoder_test.dart
@@ -36,6 +36,7 @@ const _limits = EstimatedIntensityTileDecodeLimits(
     maxHolesPerPolygon: 4,
     maxVerticesPerFeature: 32,
     maxVerticesPerSegment: 128,
+    maxIntersectionChecks: 4096,
   ),
   lineLimits: LineMeshBuilderLimits(maxVerticesPerSegment: 128),
   lineMiterLimit: 4,

--- a/packages/eqmonitor_map/test/tile/estimated_intensity_tile_decoder_test.dart
+++ b/packages/eqmonitor_map/test/tile/estimated_intensity_tile_decoder_test.dart
@@ -151,6 +151,17 @@ void main() {
           ),
           failure: EstimatedIntensityTileDecodeFailure.invalidGeometry,
         ),
+        (
+          name: 'self-intersecting polygon',
+          bytes: _tile(
+            features: [
+              _selfIntersectingPolygon(tags: const [0, 0]),
+            ],
+            keys: const ['name'],
+            values: [_builder.stringValue(_classes.first)],
+          ),
+          failure: EstimatedIntensityTileDecodeFailure.invalidGeometry,
+        ),
       ]) {
     test('${testCase.name}はtile全体をfail closedにする', () {
       expect(
@@ -199,6 +210,32 @@ void main() {
       );
     }
   });
+
+  test('自己交差検査の比較上限超過をresource limitへ変換する', () {
+    final bytes = _tile(
+      features: [
+        _square(tags: const [0, 0]),
+      ],
+      keys: const ['name'],
+      values: [_builder.stringValue(_classes.first)],
+    );
+
+    expect(
+      () => decodeEstimatedIntensityTileSync(
+        bytes,
+        _limits.copyWith(
+          fillLimits: _limits.fillLimits.copyWith(maxIntersectionChecks: 0),
+        ),
+      ),
+      throwsA(
+        isA<EstimatedIntensityTileDecodeException>().having(
+          (error) => error.failure,
+          'failure',
+          EstimatedIntensityTileDecodeFailure.resourceLimitExceeded,
+        ),
+      ),
+    );
+  });
 }
 
 Uint8List _tile({
@@ -244,3 +281,24 @@ Uint8List _line({required List<int> tags}) => _builder.feature(
     ..._builder.lineTo([(10, 0)]),
   ],
 );
+
+Uint8List _square({required List<int> tags}) => _builder.feature(
+  geomType: MvtFixtureBuilder.geomTypePolygon,
+  tags: tags,
+  rawCommands: [
+    ..._builder.moveTo([(0, 0)]),
+    ..._builder.lineTo([(10, 0), (0, 10), (-10, 0)]),
+    ..._builder.closePath(),
+  ],
+);
+
+Uint8List _selfIntersectingPolygon({required List<int> tags}) =>
+    _builder.feature(
+      geomType: MvtFixtureBuilder.geomTypePolygon,
+      tags: tags,
+      rawCommands: [
+        ..._builder.moveTo([(3, 0)]),
+        ..._builder.lineTo([(-1, 5), (-1, -5), (3, 3), (-4, 0)]),
+        ..._builder.closePath(),
+      ],
+    );

--- a/packages/eqmonitor_map/test/tile/estimated_intensity_tile_decoder_test.dart
+++ b/packages/eqmonitor_map/test/tile/estimated_intensity_tile_decoder_test.dart
@@ -1,0 +1,245 @@
+import 'dart:typed_data';
+
+import 'package:eqmonitor_map/src/mesh/fill_mesh_builder_limits.dart';
+import 'package:eqmonitor_map/src/mesh/line_mesh_builder_limits.dart';
+import 'package:eqmonitor_map/src/tile/estimated_intensity_tile_decoder.dart';
+import 'package:eqmonitor_map/src/tile/estimated_intensity_tile_geometry.dart';
+import 'package:eqmonitor_map/src/tile/mvt/mvt_decode_limits.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'mvt/support/mvt_fixture_builder.dart';
+
+const _builder = MvtFixtureBuilder();
+const _classes = [
+  'intensity:4',
+  'intensity:5-',
+  'intensity:5+',
+  'intensity:6-',
+  'intensity:6+',
+  'intensity:7',
+];
+const _mvtLimits = MvtDecodeLimits(
+  maxLayers: 4,
+  maxFeaturesPerLayer: 16,
+  maxRingsPerFeature: 4,
+  maxVerticesPerRing: 32,
+  maxCommandsPerFeature: 64,
+  maxLayerNameBytes: 64,
+  maxKeysPerLayer: 8,
+  maxValuesPerLayer: 16,
+  maxTagsPerFeature: 8,
+  maxPropertyStringBytes: 32,
+);
+const _limits = EstimatedIntensityTileDecodeLimits(
+  mvtLimits: _mvtLimits,
+  fillLimits: FillMeshBuilderLimits(
+    maxHolesPerPolygon: 4,
+    maxVerticesPerFeature: 32,
+    maxVerticesPerSegment: 128,
+  ),
+  lineLimits: LineMeshBuilderLimits(maxVerticesPerSegment: 128),
+  lineMiterLimit: 4,
+);
+
+void main() {
+  test('6 classをstyle非依存meshへ変換しfill propertyを無視する', () {
+    final bytes = _tile(
+      features: [
+        for (var index = 0; index < _classes.length; index++)
+          _triangle(tags: index == 0 ? [0, index, 1, 6] : [0, index]),
+      ],
+      keys: const ['name', 'fill'],
+      values: [..._classes.map(_builder.stringValue), _builder.intValue(99)],
+    );
+
+    final result = decodeEstimatedIntensityTileSync(bytes, _limits);
+
+    expect(result, isA<EstimatedIntensityTileReady>());
+    final ready = result as EstimatedIntensityTileReady;
+    expect(ready.extent, 4096);
+    expect(
+      ready.classes.map((geometry) => geometry.intensityClass),
+      EstimatedIntensityClass.values,
+    );
+    for (final geometry in ready.classes) {
+      expect(geometry.fillMeshes.single.vertexCount, 3);
+      expect(geometry.boundaryMeshes.single.indices, hasLength(18));
+    }
+  });
+
+  test('required layer absentとpresent emptyを区別する', () {
+    final absent = _builder.buildTile(
+      layers: [_builder.buildLayer(name: 'Seismic_Intensity')],
+    );
+    expect(
+      () => decodeEstimatedIntensityTileSync(absent, _limits),
+      throwsA(
+        isA<EstimatedIntensityTileDecodeException>().having(
+          (error) => error.failure,
+          'failure',
+          EstimatedIntensityTileDecodeFailure.missingSourceLayer,
+        ),
+      ),
+    );
+
+    final empty = decodeEstimatedIntensityTileSync(
+      _tile(features: const []),
+      _limits,
+    );
+    expect(empty, isA<EstimatedIntensityTileEmpty>());
+    expect((empty as EstimatedIntensityTileEmpty).extent, 4096);
+  });
+
+  for (final testCase
+      in <
+        ({
+          String name,
+          Uint8List bytes,
+          EstimatedIntensityTileDecodeFailure failure,
+        })
+      >[
+        (
+          name: 'wrong geometry',
+          bytes: _tile(
+            features: [
+              _line(tags: const [0, 0]),
+            ],
+            keys: const ['name'],
+            values: [_builder.stringValue(_classes.first)],
+          ),
+          failure: EstimatedIntensityTileDecodeFailure.wrongGeometry,
+        ),
+        (
+          name: 'missing name',
+          bytes: _tile(features: [_triangle()]),
+          failure: EstimatedIntensityTileDecodeFailure.missingName,
+        ),
+        (
+          name: 'unknown class',
+          bytes: _tile(
+            features: [
+              _triangle(tags: const [0, 0]),
+            ],
+            keys: const ['name'],
+            values: [_builder.stringValue('intensity:3')],
+          ),
+          failure: EstimatedIntensityTileDecodeFailure.unknownClass,
+        ),
+        (
+          name: 'duplicate conflicting property',
+          bytes: _tile(
+            features: [
+              _triangle(tags: const [0, 0, 0, 1]),
+            ],
+            keys: const ['name'],
+            values: [
+              _builder.stringValue('intensity:4'),
+              _builder.stringValue('intensity:7'),
+            ],
+          ),
+          failure: EstimatedIntensityTileDecodeFailure.invalidMvt,
+        ),
+        (
+          name: 'invalid geometry',
+          bytes: _tile(
+            features: [
+              _degenerateTriangle(tags: const [0, 0]),
+            ],
+            keys: const ['name'],
+            values: [_builder.stringValue(_classes.first)],
+          ),
+          failure: EstimatedIntensityTileDecodeFailure.invalidGeometry,
+        ),
+      ]) {
+    test('${testCase.name}はtile全体をfail closedにする', () {
+      expect(
+        () => decodeEstimatedIntensityTileSync(testCase.bytes, _limits),
+        throwsA(
+          isA<EstimatedIntensityTileDecodeException>().having(
+            (error) => error.failure,
+            'failure',
+            testCase.failure,
+          ),
+        ),
+      );
+    });
+  }
+
+  test('MVTとmeshの上限超過をresource limitへ集約する', () {
+    final bytes = _tile(
+      features: [
+        _triangle(tags: const [0, 0]),
+      ],
+      keys: const ['name'],
+      values: [_builder.stringValue(_classes.first)],
+    );
+    final constrainedLimits = [
+      _limits.copyWith(
+        mvtLimits: _mvtLimits.copyWith(maxFeaturesPerLayer: 0),
+      ),
+      _limits.copyWith(
+        fillLimits: _limits.fillLimits.copyWith(maxVerticesPerFeature: 2),
+      ),
+      _limits.copyWith(
+        lineLimits: _limits.lineLimits.copyWith(maxVerticesPerSegment: 5),
+      ),
+    ];
+
+    for (final limits in constrainedLimits) {
+      expect(
+        () => decodeEstimatedIntensityTileSync(bytes, limits),
+        throwsA(
+          isA<EstimatedIntensityTileDecodeException>().having(
+            (error) => error.failure,
+            'failure',
+            EstimatedIntensityTileDecodeFailure.resourceLimitExceeded,
+          ),
+        ),
+      );
+    }
+  });
+}
+
+Uint8List _tile({
+  required List<Uint8List> features,
+  List<String> keys = const [],
+  List<Uint8List> values = const [],
+}) => _builder.buildTile(
+  layers: [
+    _builder.buildLayer(
+      name: 'seismic_intensity',
+      features: features,
+      keys: keys,
+      values: values,
+    ),
+  ],
+);
+
+Uint8List _triangle({List<int> tags = const []}) => _builder.feature(
+  geomType: MvtFixtureBuilder.geomTypePolygon,
+  tags: tags,
+  rawCommands: [
+    ..._builder.moveTo([(0, 0)]),
+    ..._builder.lineTo([(10, 0), (-10, 10)]),
+    ..._builder.closePath(),
+  ],
+);
+
+Uint8List _degenerateTriangle({required List<int> tags}) => _builder.feature(
+  geomType: MvtFixtureBuilder.geomTypePolygon,
+  tags: tags,
+  rawCommands: [
+    ..._builder.moveTo([(0, 0)]),
+    ..._builder.lineTo([(10, 0), (10, 0)]),
+    ..._builder.closePath(),
+  ],
+);
+
+Uint8List _line({required List<int> tags}) => _builder.feature(
+  geomType: MvtFixtureBuilder.geomTypeLineString,
+  tags: tags,
+  rawCommands: [
+    ..._builder.moveTo([(0, 0)]),
+    ..._builder.lineTo([(10, 0)]),
+  ],
+);

--- a/packages/eqmonitor_map/test/tile/mvt/polygon_boundary_builder_test.dart
+++ b/packages/eqmonitor_map/test/tile/mvt/polygon_boundary_builder_test.dart
@@ -1,0 +1,38 @@
+import 'dart:typed_data';
+
+import 'package:eqmonitor_map/src/tile/mvt/mvt_tile.dart';
+import 'package:eqmonitor_map/src/tile/mvt/polygon_boundary_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('polygon の各 ring を閉じた LineString に変換する', () {
+    final feature = MvtFeature(
+      type: MvtGeometryType.polygon,
+      rings: [
+        Int32List.fromList([1, 2, 3, 4, 5, 6]),
+      ],
+      properties: const {'name': 'intensity:4'},
+    );
+
+    final result = const PolygonBoundaryBuilder().build(feature: feature);
+
+    expect(result.type, MvtGeometryType.lineString);
+    expect(result.rings.single, [1, 2, 3, 4, 5, 6, 1, 2]);
+    expect(result.properties, same(feature.properties));
+  });
+
+  test('polygon 以外は caller error として拒否する', () {
+    final feature = MvtFeature(
+      type: MvtGeometryType.lineString,
+      rings: [
+        Int32List.fromList([1, 2, 3, 4]),
+      ],
+      properties: const {},
+    );
+
+    expect(
+      () => const PolygonBoundaryBuilder().build(feature: feature),
+      throwsArgumentError,
+    );
+  });
+}

--- a/packages/eqmonitor_map/test/tile/tile_pipeline_contract_test.dart
+++ b/packages/eqmonitor_map/test/tile/tile_pipeline_contract_test.dart
@@ -59,6 +59,7 @@ const _decodeLimits = BaseMapTileDecodeLimits(
     maxHolesPerPolygon: 16,
     maxVerticesPerFeature: 4096,
     maxVerticesPerSegment: 65536,
+    maxIntersectionChecks: 1 << 16,
   ),
   lineLimits: LineMeshBuilderLimits(maxVerticesPerSegment: 65536),
   lineMiterLimit: 4,

--- a/packages/eqmonitor_map/test/widget/base_map_view_test.dart
+++ b/packages/eqmonitor_map/test/widget/base_map_view_test.dart
@@ -139,6 +139,7 @@ void main() {
             maxHolesPerPolygon: 10,
             maxVerticesPerFeature: 100,
             maxVerticesPerSegment: 100,
+            maxIntersectionChecks: 4096,
           ),
           lineLimits: LineMeshBuilderLimits(maxVerticesPerSegment: 100),
           lineMiterLimit: 4,


### PR DESCRIPTION
## 概要
- seismic_intensity layerを完全一致で検証
- Polygonと6種類の震度classだけを受理
- class別の塗りmeshと閉じた境界meshを生成
- 自己交差・非隣接接触・重複・ring間交差を三角形化前に拒否
- 外形外hole・不正包含を拒否し、hole内の島は許可
- Int32全域で面積と方向の符号を正確に判定
- Polygon交差比較を1 tile単位のcaller必須上限内に制限
- layer欠損とfeature 0件を区別
- 不正入力と上限超過を機密情報を含まない型付き失敗へ変換

## 検証
- 実装側の関連87テスト成功
- 独立確認49テスト成功
- 変更関連17ファイルの静的解析成功
- 65,536頂点の有効境界を確認
- 独立レビューで指摘なし
- diff-check成功