### PR TITLE
feat: 推計震度PMTiles headerを検証

### DIFF
--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_header_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_header_verifier.dart
@@ -30,6 +30,14 @@ final class EstimatedIntensityArchiveHeaderVerifier {
       result = failure == null
           ? EstimatedIntensityArchiveHeaderAccepted(header)
           : EstimatedIntensityArchiveHeaderRejected(failure);
+    } on PmTilesV3SourceReadFailedException {
+      result = const EstimatedIntensityArchiveHeaderRejected(
+        EstimatedIntensityArchiveHeaderFailure.storageFailure,
+      );
+    } on PmTilesV3ResourceLimitExceededException {
+      result = const EstimatedIntensityArchiveHeaderRejected(
+        EstimatedIntensityArchiveHeaderFailure.resourceLimitExceeded,
+      );
     } on FileSystemException {
       result = const EstimatedIntensityArchiveHeaderRejected(
         EstimatedIntensityArchiveHeaderFailure.storageFailure,

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_header_verifier.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_header_verifier.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_pmtiles_opener.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/logic/estimated_intensity_archive_header_validator.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_header_validation.dart';
+import 'package:pmtiles_v3/pmtiles_v3.dart';
+
+/// SHA-256検証済みの一時fileを開き、受入可能なPMTilesか確認する。
+final class EstimatedIntensityArchiveHeaderVerifier {
+  const new({
+    this.opener = const DartIoEstimatedIntensityArchivePmTilesOpener(),
+    this.headerValidator = const EstimatedIntensityArchiveHeaderValidator(),
+  });
+
+  final EstimatedIntensityArchivePmTilesOpener opener;
+  final EstimatedIntensityArchiveHeaderValidator headerValidator;
+
+  Future<EstimatedIntensityArchiveHeaderValidationResult> verify({
+    required VerifiedEstimatedIntensityArchiveDownload download,
+    required PmTilesV3Limits limits,
+  }) async {
+    PmTilesV3Archive? archive;
+    late final EstimatedIntensityArchiveHeaderValidationResult result;
+    var closeFailed = false;
+    try {
+      archive = await opener.open(file: download.file, limits: limits);
+      final header = archive.header;
+      final failure = headerValidator.validate(header);
+      result = failure == null
+          ? EstimatedIntensityArchiveHeaderAccepted(header)
+          : EstimatedIntensityArchiveHeaderRejected(failure);
+    } on FileSystemException {
+      result = const EstimatedIntensityArchiveHeaderRejected(
+        EstimatedIntensityArchiveHeaderFailure.storageFailure,
+      );
+    } on PmTilesV3Exception {
+      result = const EstimatedIntensityArchiveHeaderRejected(
+        EstimatedIntensityArchiveHeaderFailure.invalidArchive,
+      );
+    } finally {
+      if (archive case final openedArchive?) {
+        try {
+          await openedArchive.close();
+          // Archive implementations may throw any error while closing.
+          // ignore: avoid_catches_without_on_clauses
+        } catch (_) {
+          closeFailed = true;
+        }
+      }
+    }
+    if (closeFailed && result is EstimatedIntensityArchiveHeaderAccepted) {
+      return const EstimatedIntensityArchiveHeaderRejected(
+        EstimatedIntensityArchiveHeaderFailure.closeFailure,
+      );
+    }
+    return result;
+  }
+}

--- a/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_pmtiles_opener.dart
+++ b/app/lib/feature/earthquake_history/data/data_source/estimated_intensity_archive_pmtiles_opener.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:pmtiles_v3/pmtiles_v3.dart';
+
+abstract interface class EstimatedIntensityArchivePmTilesOpener {
+  /// 成功時はreader所有権を返値のarchiveへ移す。
+  ///
+  /// 失敗時は`PmTilesV3Archive.open`がreaderをcloseするため、
+  /// 呼出元は返値を受け取った場合にだけcloseする。
+  Future<PmTilesV3Archive> open({
+    required File file,
+    required PmTilesV3Limits limits,
+  });
+}
+
+/// 検証済み一時fileをPMTiles v3 archiveとして開く本番実装。
+/// resource上限は呼出元が必ず[PmTilesV3Limits]で渡す。
+final class DartIoEstimatedIntensityArchivePmTilesOpener
+    implements EstimatedIntensityArchivePmTilesOpener {
+  const new();
+
+  @override
+  Future<PmTilesV3Archive> open({
+    required File file,
+    required PmTilesV3Limits limits,
+  }) async {
+    final reader = await PmTilesV3FileRandomAccessReader.open(path: file.path);
+    return PmTilesV3Archive.open(reader: reader, limits: limits);
+  }
+}

--- a/app/lib/feature/earthquake_history/data/logic/estimated_intensity_archive_header_validator.dart
+++ b/app/lib/feature/earthquake_history/data/logic/estimated_intensity_archive_header_validator.dart
@@ -1,0 +1,43 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_header_validation.dart';
+import 'package:pmtiles_v3/pmtiles_v3.dart';
+
+/// `PmTilesV3Archive.open`済みheaderの推計震度固有制約を検証する。
+///
+/// PMTiles version、section範囲と重なり、internal compressionの対応状況は
+/// archive open側の検証を正とし、ここでは再実装しない。
+final class EstimatedIntensityArchiveHeaderValidator {
+  const new();
+
+  static const mvtTileType = 1;
+  static const gzipTileCompression = 2;
+
+  EstimatedIntensityArchiveHeaderFailure? validate(PmTilesV3Header header) {
+    if (header.tileType != mvtTileType) {
+      return EstimatedIntensityArchiveHeaderFailure.invalidTileType;
+    }
+    if (header.tileCompression != gzipTileCompression) {
+      return EstimatedIntensityArchiveHeaderFailure.invalidTileCompression;
+    }
+    if (header.minZoom < 0 ||
+        header.minZoom > header.maxZoom ||
+        header.maxZoom > PmTilesV3TileId.maxZoom) {
+      return EstimatedIntensityArchiveHeaderFailure.invalidZoomRange;
+    }
+    final bounds = [
+      header.minLongitude,
+      header.minLatitude,
+      header.maxLongitude,
+      header.maxLatitude,
+    ];
+    if (bounds.any((coordinate) => !coordinate.isFinite) ||
+        header.minLongitude < -180 ||
+        header.maxLongitude > 180 ||
+        header.minLatitude < -90 ||
+        header.maxLatitude > 90 ||
+        header.minLongitude > header.maxLongitude ||
+        header.minLatitude > header.maxLatitude) {
+      return EstimatedIntensityArchiveHeaderFailure.invalidBounds;
+    }
+    return null;
+  }
+}

--- a/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_header_validation.dart
+++ b/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_header_validation.dart
@@ -1,0 +1,9 @@
+enum EstimatedIntensityArchiveHeaderFailure {
+  invalidArchive,
+  invalidTileType,
+  invalidTileCompression,
+  invalidZoomRange,
+  invalidBounds,
+  storageFailure,
+  closeFailure,
+}

--- a/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_header_validation.dart
+++ b/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_header_validation.dart
@@ -7,6 +7,7 @@ enum EstimatedIntensityArchiveHeaderFailure {
   invalidZoomRange,
   invalidBounds,
   storageFailure,
+  resourceLimitExceeded,
   closeFailure,
 }
 

--- a/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_header_validation.dart
+++ b/app/lib/feature/earthquake_history/data/model/estimated_intensity_archive_header_validation.dart
@@ -1,3 +1,5 @@
+import 'package:pmtiles_v3/pmtiles_v3.dart';
+
 enum EstimatedIntensityArchiveHeaderFailure {
   invalidArchive,
   invalidTileType,
@@ -6,4 +8,32 @@ enum EstimatedIntensityArchiveHeaderFailure {
   invalidBounds,
   storageFailure,
   closeFailure,
+}
+
+sealed class EstimatedIntensityArchiveHeaderValidationResult {
+  const new();
+}
+
+final class EstimatedIntensityArchiveHeaderAccepted
+    extends EstimatedIntensityArchiveHeaderValidationResult {
+  const new(this.header);
+
+  final PmTilesV3Header header;
+
+  @override
+  String toString() =>
+      'EstimatedIntensityArchiveHeaderValidationResult.accepted('
+      'zoom: ${header.minZoom}-${header.maxZoom})';
+}
+
+final class EstimatedIntensityArchiveHeaderRejected
+    extends EstimatedIntensityArchiveHeaderValidationResult {
+  const new(this.failure);
+
+  final EstimatedIntensityArchiveHeaderFailure failure;
+
+  @override
+  String toString() =>
+      'EstimatedIntensityArchiveHeaderValidationResult.rejected('
+      'failure: $failure)';
 }

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_test_support.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_test_support.dart
@@ -1,0 +1,28 @@
+import 'package:pmtiles_v3/pmtiles_v3.dart';
+
+const validEstimatedIntensityArchiveHeader = PmTilesV3Header(
+  rootDirectoryOffset: 127,
+  rootDirectoryLength: 1,
+  metadataOffset: 128,
+  metadataLength: 1,
+  leafDirectoriesOffset: 129,
+  leafDirectoriesLength: 0,
+  tileDataOffset: 129,
+  tileDataLength: 1,
+  addressedTilesCount: 1,
+  tileEntriesCount: 1,
+  tileContentsCount: 1,
+  clustered: true,
+  internalCompression: 2,
+  tileCompression: 2,
+  tileType: 1,
+  minZoom: 0,
+  maxZoom: 14,
+  minLongitude: 122,
+  minLatitude: 20,
+  maxLongitude: 154,
+  maxLatitude: 46,
+  centerZoom: 7,
+  centerLongitude: 138,
+  centerLatitude: 33,
+);

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_validator_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_validator_test.dart
@@ -1,0 +1,72 @@
+import 'package:eqmonitor/feature/earthquake_history/data/logic/estimated_intensity_archive_header_validator.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_header_validation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pmtiles_v3/pmtiles_v3.dart';
+
+import 'estimated_intensity_archive_header_test_support.dart';
+
+void main() {
+  const validator = EstimatedIntensityArchiveHeaderValidator();
+
+  test('MVT gzipと有効なzoom boundsのheaderを受理する', () {
+    expect(validator.validate(validEstimatedIntensityArchiveHeader), isNull);
+  });
+
+  test('MVT以外とgzip以外を分類して拒否する', () {
+    final cases =
+        <
+          ({
+            PmTilesV3Header header,
+            EstimatedIntensityArchiveHeaderFailure failure,
+          })
+        >[
+          (
+            header: validEstimatedIntensityArchiveHeader.copyWith(tileType: 2),
+            failure: EstimatedIntensityArchiveHeaderFailure.invalidTileType,
+          ),
+          (
+            header: validEstimatedIntensityArchiveHeader.copyWith(
+              tileCompression: 1,
+            ),
+            failure:
+                EstimatedIntensityArchiveHeaderFailure.invalidTileCompression,
+          ),
+        ];
+    for (final testCase in cases) {
+      expect(validator.validate(testCase.header), testCase.failure);
+    }
+  });
+
+  test('PMTiles範囲外または逆転したzoomを拒否する', () {
+    for (final header in [
+      validEstimatedIntensityArchiveHeader.copyWith(minZoom: 15),
+      validEstimatedIntensityArchiveHeader.copyWith(
+        maxZoom: PmTilesV3TileId.maxZoom + 1,
+      ),
+    ]) {
+      expect(
+        validator.validate(header),
+        EstimatedIntensityArchiveHeaderFailure.invalidZoomRange,
+      );
+    }
+  });
+
+  test('有限なWGS84範囲外または逆転したboundsを拒否する', () {
+    for (final header in [
+      validEstimatedIntensityArchiveHeader.copyWith(minLongitude: -181),
+      validEstimatedIntensityArchiveHeader.copyWith(maxLatitude: 91),
+      validEstimatedIntensityArchiveHeader.copyWith(
+        minLongitude: 155,
+        maxLongitude: 154,
+      ),
+      validEstimatedIntensityArchiveHeader.copyWith(
+        minLatitude: double.nan,
+      ),
+    ]) {
+      expect(
+        validator.validate(header),
+        EstimatedIntensityArchiveHeaderFailure.invalidBounds,
+      );
+    }
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_verifier_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_verifier_test.dart
@@ -83,6 +83,53 @@ void main() {
     );
   });
 
+  test('archive読み取り失敗をstorage failureへ分類する', () async {
+    const secretPath = '/private/archive/source.pmtiles';
+    const secretUrl = 'https://private.example/';
+    const secretSha = 'secret-sha';
+    const secretReason = '$secretPath $secretUrl $secretSha';
+    final result = await EstimatedIntensityArchiveHeaderVerifier(
+      opener: ControlledEstimatedIntensityArchiveOpener(
+        failure: const PmTilesV3Exception.sourceReadFailed(
+          reason: secretReason,
+        ),
+      ),
+    ).verify(download: download, limits: estimatedIntensityHeaderTestLimits);
+
+    expect(
+      result,
+      isA<EstimatedIntensityArchiveHeaderRejected>().having(
+        (value) => value.failure,
+        'failure',
+        EstimatedIntensityArchiveHeaderFailure.storageFailure,
+      ),
+    );
+    for (final secret in [secretPath, secretUrl, secretSha]) {
+      expect(result.toString(), isNot(contains(secret)));
+    }
+  });
+
+  test('archiveの資源上限超過を専用failureへ分類する', () async {
+    final result = await EstimatedIntensityArchiveHeaderVerifier(
+      opener: ControlledEstimatedIntensityArchiveOpener(
+        failure: const PmTilesV3Exception.resourceLimitExceeded(
+          resource: PmTilesV3Resource.directoryDecoded,
+          limit: 1024,
+          actual: 1025,
+        ),
+      ),
+    ).verify(download: download, limits: estimatedIntensityHeaderTestLimits);
+
+    expect(
+      result,
+      isA<EstimatedIntensityArchiveHeaderRejected>().having(
+        (value) => value.failure,
+        'failure',
+        EstimatedIntensityArchiveHeaderFailure.resourceLimitExceeded,
+      ),
+    );
+  });
+
   test('archive close失敗を型付きにしcloseを繰り返さない', () async {
     const secretPath = '/private/archive/source.pmtiles';
     const secretMessage = 'private failure';

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_verifier_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_verifier_test.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_header_verifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_download.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/estimated_intensity_archive_header_validation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pmtiles_v3/pmtiles_v3.dart';
+
+import 'estimated_intensity_archive_download_test_support.dart';
+import 'estimated_intensity_archive_header_test_support.dart';
+import 'estimated_intensity_archive_header_verifier_test_support.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+  late VerifiedEstimatedIntensityArchiveDownload download;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'estimated_intensity_header_verifier_test_',
+    );
+    final result = await downloadBody(
+      temporaryDirectory: temporaryDirectory,
+      contentLength: 11,
+      body: 'hello world'.codeUnits,
+    );
+    download = switch (result) {
+      EstimatedIntensityArchiveDownloadSuccess(:final archive) => archive,
+      EstimatedIntensityArchiveDownloadRejected() => throw StateError(
+        'fixture download failed',
+      ),
+    };
+  });
+
+  tearDown(() => temporaryDirectory.delete(recursive: true));
+
+  test('正当なheaderを返しarchiveを1回closeする', () async {
+    final archive = RecordingEstimatedIntensityArchive(
+      header: validEstimatedIntensityArchiveHeader,
+    );
+    final result = await EstimatedIntensityArchiveHeaderVerifier(
+      opener: ControlledEstimatedIntensityArchiveOpener(archive: archive),
+    ).verify(download: download, limits: estimatedIntensityHeaderTestLimits);
+
+    expect(result, isA<EstimatedIntensityArchiveHeaderAccepted>());
+    expect(archive.closeCount, 1);
+  });
+
+  test('不正headerを分類しarchiveを1回closeする', () async {
+    final archive = RecordingEstimatedIntensityArchive(
+      header: validEstimatedIntensityArchiveHeader.copyWith(tileCompression: 1),
+    );
+    final result = await EstimatedIntensityArchiveHeaderVerifier(
+      opener: ControlledEstimatedIntensityArchiveOpener(archive: archive),
+    ).verify(download: download, limits: estimatedIntensityHeaderTestLimits);
+
+    expect(
+      result,
+      isA<EstimatedIntensityArchiveHeaderRejected>().having(
+        (value) => value.failure,
+        'failure',
+        EstimatedIntensityArchiveHeaderFailure.invalidTileCompression,
+      ),
+    );
+    expect(archive.closeCount, 1);
+  });
+
+  test('archive openの非対応internal compressionを分類する', () async {
+    final result = await EstimatedIntensityArchiveHeaderVerifier(
+      opener: ControlledEstimatedIntensityArchiveOpener(
+        failure: const PmTilesV3Exception.unsupportedCompression(
+          compression: 3,
+        ),
+      ),
+    ).verify(download: download, limits: estimatedIntensityHeaderTestLimits);
+
+    expect(
+      result,
+      isA<EstimatedIntensityArchiveHeaderRejected>().having(
+        (value) => value.failure,
+        'failure',
+        EstimatedIntensityArchiveHeaderFailure.invalidArchive,
+      ),
+    );
+  });
+}

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_verifier_test.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_verifier_test.dart
@@ -82,4 +82,28 @@ void main() {
       ),
     );
   });
+
+  test('archive close失敗を型付きにしcloseを繰り返さない', () async {
+    const secretPath = '/private/archive/source.pmtiles';
+    const secretMessage = 'private failure';
+    final archive = RecordingEstimatedIntensityArchive(
+      header: validEstimatedIntensityArchiveHeader,
+      closeFailure: const FileSystemException(secretMessage, secretPath),
+    );
+    final result = await EstimatedIntensityArchiveHeaderVerifier(
+      opener: ControlledEstimatedIntensityArchiveOpener(archive: archive),
+    ).verify(download: download, limits: estimatedIntensityHeaderTestLimits);
+
+    expect(
+      result,
+      isA<EstimatedIntensityArchiveHeaderRejected>().having(
+        (value) => value.failure,
+        'failure',
+        EstimatedIntensityArchiveHeaderFailure.closeFailure,
+      ),
+    );
+    expect(result.toString(), isNot(contains(secretPath)));
+    expect(result.toString(), isNot(contains(secretMessage)));
+    expect(archive.closeCount, 1);
+  });
 }

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_verifier_test_support.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_verifier_test_support.dart
@@ -39,14 +39,18 @@ final class ControlledEstimatedIntensityArchiveOpener
 
 final class RecordingEstimatedIntensityArchive extends Fake
     implements PmTilesV3Archive {
-  RecordingEstimatedIntensityArchive({required this.header});
+  new({required this.header, this.closeFailure});
 
   @override
   final PmTilesV3Header header;
+  final FileSystemException? closeFailure;
   var closeCount = 0;
 
   @override
   Future<void> close() async {
     closeCount += 1;
+    if (closeFailure case final failure?) {
+      throw failure;
+    }
   }
 }

--- a/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_verifier_test_support.dart
+++ b/app/test/feature/earthquake_history/data/estimated_intensity_archive_header_verifier_test_support.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:eqmonitor/feature/earthquake_history/data/data_source/estimated_intensity_archive_pmtiles_opener.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pmtiles_v3/pmtiles_v3.dart';
+
+const estimatedIntensityHeaderTestLimits = PmTilesV3Limits(
+  maxDirectoryDepth: 3,
+  rootDirectoryWindowLength: 16384,
+  maxDirectoryEncodedBytes: 1024,
+  maxDirectoryDecodedBytes: 4096,
+  maxDirectoryEntries: 32,
+  maxCachedLeafDirectories: 2,
+  maxTileEncodedBytes: 1024,
+  maxTileDecodedBytes: 4096,
+);
+
+final class ControlledEstimatedIntensityArchiveOpener
+    implements EstimatedIntensityArchivePmTilesOpener {
+  const new({this.archive, this.failure});
+
+  final PmTilesV3Archive? archive;
+  final PmTilesV3Exception? failure;
+
+  @override
+  Future<PmTilesV3Archive> open({
+    required File file,
+    required PmTilesV3Limits limits,
+  }) async {
+    if (failure case final value?) {
+      throw value;
+    }
+    return switch (archive) {
+      final value? => value,
+      null => throw StateError('archive fixture is missing'),
+    };
+  }
+}
+
+final class RecordingEstimatedIntensityArchive extends Fake
+    implements PmTilesV3Archive {
+  RecordingEstimatedIntensityArchive({required this.header});
+
+  @override
+  final PmTilesV3Header header;
+  var closeCount = 0;
+
+  @override
+  Future<void> close() async {
+    closeCount += 1;
+  }
+}

--- a/packages/eqmonitor_map/lib/src/tile/verified_pm_tiles_source.dart
+++ b/packages/eqmonitor_map/lib/src/tile/verified_pm_tiles_source.dart
@@ -30,6 +30,9 @@ sealed class VerifiedTileSource {
   /// [VerifiedTileSourceCacheIdentity.cacheIdentity]だけである。remote で
   /// 照合できない理由は`MapRemotePmTilesRandomAccessReader`の doc を参照。
   String get sha256;
+
+  @override
+  String toString() => 'VerifiedTileSource(identity: redacted)';
 }
 
 /// tile cache の key に使う、**内容で決まる** source identity。
@@ -61,7 +64,7 @@ extension VerifiedTileSourceCacheIdentity on VerifiedTileSource {
 /// downloadなど)を区別するための識別子。`BaseMapTileCache`のcache keyの
 /// 一部として使い、archiveが差し替わった際に古いtileのcacheを暗黙に無効化
 /// する目的だけに使う(値そのものの生成規則はappが決める)。
-@freezed
+@Freezed(toStringOverride: false)
 abstract class VerifiedPmTilesSource
     with _$VerifiedPmTilesSource
     implements VerifiedTileSource {
@@ -89,7 +92,7 @@ abstract class VerifiedPmTilesSource
 /// [createVerifiedRemotePmTilesSource]の検証を迂回して不正な descriptor を
 /// 作れてしまい、remote reader が信頼する https/digest 境界が崩れるため。
 /// 値を変えるときは必ず[createVerifiedRemotePmTilesSource]から作り直す。
-@Freezed(copyWith: false)
+@Freezed(copyWith: false, toStringOverride: false)
 abstract class VerifiedRemotePmTilesSource
     with _$VerifiedRemotePmTilesSource
     implements VerifiedTileSource {

--- a/packages/eqmonitor_map/lib/src/tile/verified_pm_tiles_source.freezed.dart
+++ b/packages/eqmonitor_map/lib/src/tile/verified_pm_tiles_source.freezed.dart
@@ -33,10 +33,6 @@ bool operator ==(Object other) {
 @override
 int get hashCode => Object.hash(runtimeType,sourceInstanceId,absolutePath,sizeBytes,sha256);
 
-@override
-String toString() {
-  return 'VerifiedPmTilesSource(sourceInstanceId: $sourceInstanceId, absolutePath: $absolutePath, sizeBytes: $sizeBytes, sha256: $sha256)';
-}
 
 
 }
@@ -235,10 +231,6 @@ bool operator ==(Object other) {
 @override
 int get hashCode => Object.hash(runtimeType,sourceInstanceId,absolutePath,sizeBytes,sha256);
 
-@override
-String toString() {
-  return 'VerifiedPmTilesSource(sourceInstanceId: $sourceInstanceId, absolutePath: $absolutePath, sizeBytes: $sizeBytes, sha256: $sha256)';
-}
 
 
 }
@@ -294,10 +286,6 @@ bool operator ==(Object other) {
 @override
 int get hashCode => Object.hash(runtimeType,sourceInstanceId,sourceRevision,url,sizeBytes,sha256);
 
-@override
-String toString() {
-  return 'VerifiedRemotePmTilesSource(sourceInstanceId: $sourceInstanceId, sourceRevision: $sourceRevision, url: $url, sizeBytes: $sizeBytes, sha256: $sha256)';
-}
 
 
 }
@@ -331,10 +319,6 @@ bool operator ==(Object other) {
 @override
 int get hashCode => Object.hash(runtimeType,sourceInstanceId,sourceRevision,url,sizeBytes,sha256);
 
-@override
-String toString() {
-  return 'VerifiedRemotePmTilesSource._(sourceInstanceId: $sourceInstanceId, sourceRevision: $sourceRevision, url: $url, sizeBytes: $sizeBytes, sha256: $sha256)';
-}
 
 
 }

--- a/packages/eqmonitor_map/test/tile/verified_source_models_test.dart
+++ b/packages/eqmonitor_map/test/tile/verified_source_models_test.dart
@@ -24,6 +24,34 @@ void main() {
         ),
       );
     });
+
+    test('localとremoteの文字列は配布先情報とdigestを保持しない', () {
+      const localPath = '/private/archive/source.pmtiles';
+      const localSha =
+          'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+      const remoteUrl =
+          'https://private.example/archive.pmtiles?credential=secret';
+      const remoteSha =
+          '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+      const local = VerifiedPmTilesSource(
+        sourceInstanceId: 'local-private',
+        absolutePath: localPath,
+        sizeBytes: 128,
+        sha256: localSha,
+      );
+      final remote = createVerifiedRemotePmTilesSource(
+        sourceInstanceId: 'remote-private',
+        sourceRevision: 1,
+        url: Uri.parse(remoteUrl),
+        sizeBytes: 128,
+        sha256: remoteSha,
+      );
+
+      expect(local.toString(), isNot(contains(localPath)));
+      expect(local.toString(), isNot(contains(localSha)));
+      expect(remote.toString(), isNot(contains(remoteUrl)));
+      expect(remote.toString(), isNot(contains(remoteSha)));
+    });
   });
 
   group('createVerifiedRemotePmTilesSource', () {


### PR DESCRIPTION
## 概要
- local/remote配布元型の文字列表現からURL・path・SHAを秘匿
- PMTiles v3の既存構造検証を再利用
- MVT、gzip、zoom範囲、有限かつ順序付きWGS84 boundsを型付き検証
- source read失敗とresource超過の分類を保持
- 成功・header拒否・close失敗でarchiveを正確に1回close

## 検証
- header validator/verifier 10件成功
- verified source model 11件成功
- app・eqmonitor_map変更対象の静的解析成功
- 独立レビューで指摘なし
- diff-check成功