### PR TITLE
fix: Codex worktreeのローカルセットアップを修復

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -4,6 +4,7 @@ name = "EQMonitor"
 
 [setup]
 script = '''
+git submodule update --init --depth 1 third_party/flutter_scene
 mise trust
 mise install
 mise exec flutter -- flutter pub get

--- a/docs/knowledge/20260825_codex_worktree_flutter_scene_submodule.md
+++ b/docs/knowledge/20260825_codex_worktree_flutter_scene_submodule.md
@@ -1,0 +1,13 @@
+# Codex worktree の flutter_scene 初期化
+
+Codex の新規 worktree では Git submodule の作業ツリーは自動展開されない。
+`flutter pub get` より先に、path 依存で必要な public submodule だけを初期化する。
+
+```bash
+git submodule update --init --depth 1 third_party/flutter_scene
+mise exec flutter -- flutter pub get
+```
+
+`git submodule update --init --recursive` は使用しない。Dart workspace に不要な
+private `backend` まで取得し、GitHub 認証がないローカル環境ではセットアップ全体が
+失敗するためである。


### PR DESCRIPTION
## 概要

- `flutter pub get` より前に public submodule `third_party/flutter_scene` を初期化
- private な `backend` は初期化対象から外し、認証のない環境でもセットアップ可能に維持
- Codex worktree での submodule 初期化手順を `docs/knowledge` に記録

## 原因

新規 worktree では `third_party/flutter_scene` が未初期化のため、`eqmonitor_map` の path dependency を解決できず、セットアップが終了コード 66 で失敗していました。

## 検証

- `third_party/flutter_scene` を deinit した状態からセットアップ手順を再実行
- `mise exec flutter -- flutter pub get` が終了コード 0 / `Got dependencies!`
- TOML 構文確認
- `git diff --check`
- `origin/develop` とのマージ競合なし

Dart実装の変更はないため、アプリ全体のテスト・静的解析は実施していません。