### PR TITLE
feat: デバッグ画面にWebhook管理を追加

### DIFF
--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -62,6 +62,7 @@ import 'package:eqmonitor/feature/settings/children/config/debug/jma_map/debug_j
 import 'package:eqmonitor/feature/settings/children/config/debug/kyoshin_monitor/debug_kyoshin_monitor.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/navigation/navigation_debug_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/notification/debug_notification_webhook_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/playground/playground_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/secure_storage/debug_secure_storage_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/shake_detection/debug_shake_detection_card_page.dart';
@@ -409,6 +410,9 @@ class TalkerRoute extends GoRouteData with $TalkerRoute, MaterialPageMixin {
         TypedGoRoute<DebugWebSocketRoute>(path: 'websocket'),
         TypedGoRoute<DebugNotificationDeliveryLogRoute>(
           path: 'notification-delivery-log',
+        ),
+        TypedGoRoute<DebugNotificationWebhookRoute>(
+          path: 'notification-webhooks',
         ),
         TypedGoRoute<DebugDeviceAdminRoute>(path: 'device-admin'),
         TypedGoRoute<DebugDeviceSettingsRoute>(path: 'device-settings'),
@@ -761,6 +765,16 @@ class DebugNotificationDeliveryLogRoute extends GoRouteData
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return const DebugNotificationDeliveryLogPage();
+  }
+}
+
+class DebugNotificationWebhookRoute extends GoRouteData
+    with $DebugNotificationWebhookRoute, MaterialPageMixin {
+  const new();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const DebugNotificationWebhookPage();
   }
 }
 

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -667,6 +667,11 @@ RouteBase get $settingsRoute => GoRouteData.$route(
           factory: $DebugNotificationDeliveryLogRoute._fromState,
         ),
         GoRouteData.$route(
+          path: 'notification-webhooks',
+          hasOverriddenOnExit: false,
+          factory: $DebugNotificationWebhookRoute._fromState,
+        ),
+        GoRouteData.$route(
           path: 'device-admin',
           hasOverriddenOnExit: false,
           factory: $DebugDeviceAdminRoute._fromState,
@@ -1445,6 +1450,28 @@ mixin $DebugNotificationDeliveryLogRoute on GoRouteData {
   @override
   String get location =>
       GoRouteData.$location('/settings/debug/notification-delivery-log');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $DebugNotificationWebhookRoute on GoRouteData {
+  static DebugNotificationWebhookRoute _fromState(GoRouterState state) =>
+      const DebugNotificationWebhookRoute();
+
+  @override
+  String get location =>
+      GoRouteData.$location('/settings/debug/notification-webhooks');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/devices/data/model/device_notification_webhook.dart
+++ b/app/lib/feature/devices/data/model/device_notification_webhook.dart
@@ -1,0 +1,28 @@
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+
+final class DeviceNotificationWebhook {
+  const new({
+    required this.id,
+    required this.createdAt,
+    required this.expiresAt,
+    required this.approved,
+    required this.webhookUrl,
+  });
+
+  final String id;
+  final DateTime createdAt;
+  final DateTime? expiresAt;
+  final bool approved;
+  final String? webhookUrl;
+}
+
+extension DeviceNotificationWebhookConverter
+    on api.DeviceNotificationWebhookResponse {
+  DeviceNotificationWebhook toModel() => DeviceNotificationWebhook(
+    id: id,
+    createdAt: createdAt,
+    expiresAt: expiresAt,
+    approved: approved,
+    webhookUrl: webhookUrl,
+  );
+}

--- a/app/lib/feature/devices/data/repository/device_repository.dart
+++ b/app/lib/feature/devices/data/repository/device_repository.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/core/api/api_client_provider.dart';
 import 'package:eqmonitor/core/foundation/result.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/feature/devices/data/exception/device_provisioning_exception.dart';
+import 'package:eqmonitor/feature/devices/data/model/device_notification_webhook.dart';
 import 'package:eqmonitor/feature/devices/data/model/device_role.dart';
 import 'package:eqmonitor/feature/devices/data/model/registered_device.dart';
 import 'package:eqmonitor/feature/devices/data/provider/apns_environment.dart';
@@ -51,6 +52,20 @@ class DeviceRepository {
         final response = await _api.device.getV2DeviceMe();
         return response.data.role.toDeviceRole;
       });
+
+  Future<Result<List<DeviceNotificationWebhook>, Exception>>
+  getNotificationWebhooks() => Result.capture(() async {
+    final response = await _api.device.getV2DeviceMeNotificationWebhooks();
+    return response.data.map((webhook) => webhook.toModel()).toList();
+  });
+
+  Future<Result<DeviceNotificationWebhook, Exception>>
+  createNotificationWebhook() => Result.capture(() async {
+    final response = await _api.device.postV2DeviceMeNotificationWebhooks(
+      body: const api.CreateDeviceNotificationWebhookRequest(),
+    );
+    return response.data.toModel();
+  });
 
   Future<Result<RegisteredDevice, Exception>> registerDevice({
     required DevicePlatform devicePlatform,

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -400,6 +400,13 @@ class _DebugWidget extends ConsumerWidget {
                   const DebugNotificationDeliveryLogRoute().push<void>(context),
             ),
             ListTile(
+              title: const Text('通知Webhook'),
+              subtitle: const Text('Webhookの発行・一覧表示'),
+              leading: const Icon(Icons.webhook),
+              onTap: () async =>
+                  const DebugNotificationWebhookRoute().push<void>(context),
+            ),
+            ListTile(
               title: const Text('デバイス管理'),
               subtitle: const Text('登録・再登録・削除・通知条件の設定'),
               leading: const Icon(Icons.manage_accounts_outlined),

--- a/app/lib/feature/settings/children/config/debug/notification/debug_notification_webhook_page.dart
+++ b/app/lib/feature/settings/children/config/debug/notification/debug_notification_webhook_page.dart
@@ -1,0 +1,198 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/feature/devices/data/model/device_notification_webhook.dart';
+import 'package:eqmonitor/feature/devices/data/repository/device_repository.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:material_ui/material_ui.dart';
+
+class DebugNotificationWebhookPage extends HookConsumerWidget {
+  const new({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final webhooks = useState<List<DeviceNotificationWebhook>>([]);
+    final loading = useState(true);
+    final issuing = useState(false);
+    final error = useState<Exception?>(null);
+
+    Future<void> load() async {
+      loading.value = true;
+      error.value = null;
+      final repository = await ref.read(deviceRepositoryProvider.future);
+      final result = await repository.getNotificationWebhooks();
+      switch (result) {
+        case Success(:final value):
+          webhooks.value = value;
+        case Failure(:final exception):
+          webhooks.value = [];
+          error.value = exception;
+      }
+      loading.value = false;
+    }
+
+    Future<void> issue() async {
+      issuing.value = true;
+      final repository = await ref.read(deviceRepositoryProvider.future);
+      final result = await repository.createNotificationWebhook();
+      if (!context.mounted) {
+        return;
+      }
+      switch (result) {
+        case Success():
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Webhookを発行しました')),
+          );
+          await load();
+        case Failure(:final exception):
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Webhookの発行に失敗しました: $exception'),
+              backgroundColor: context.designSystem.colorTheme.error,
+            ),
+          );
+      }
+      issuing.value = false;
+    }
+
+    useEffect(() {
+      unawaited(load());
+      return null;
+      // load はローカル関数で毎ビルド識別子が変わるため keys に含めない。
+      // ignore_keys: load
+    }, const []);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('通知Webhook'),
+        actions: [
+          IconButton(
+            tooltip: '再読み込み',
+            onPressed: loading.value ? null : load,
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: issuing.value ? null : issue,
+        icon: issuing.value
+            ? const SizedBox.square(
+                dimension: 20,
+                child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+              )
+            : const Icon(Icons.add_link),
+        label: Text(issuing.value ? '発行中' : 'Webhookを発行'),
+      ),
+      body: switch ((loading.value, error.value, webhooks.value)) {
+        (true, _, []) => const Center(
+          child: CircularProgressIndicator.adaptive(),
+        ),
+        (_, final exception?, []) => _ErrorBody(
+          exception: exception,
+          onRetry: load,
+        ),
+        (_, _, []) => RefreshIndicator(
+          onRefresh: load,
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: [
+              SizedBox(height: MediaQuery.sizeOf(context).height * 0.3),
+              const Center(child: Text('発行済みWebhookはありません')),
+            ],
+          ),
+        ),
+        _ => RefreshIndicator(
+          onRefresh: load,
+          child: ListView.builder(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: const EdgeInsets.only(bottom: 96),
+            itemCount: webhooks.value.length,
+            itemBuilder: (context, index) => _WebhookTile(
+              webhook: webhooks.value[index],
+            ),
+          ),
+        ),
+      },
+    );
+  }
+}
+
+class _WebhookTile extends StatelessWidget {
+  const new({required this.webhook});
+
+  final DeviceNotificationWebhook webhook;
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('yyyy/MM/dd HH:mm:ss');
+    final expiresAt = webhook.expiresAt;
+    final url = webhook.webhookUrl;
+    return ListTile(
+      leading: Icon(
+        webhook.approved ? Icons.check_circle_outline : Icons.schedule,
+      ),
+      title: Text(webhook.approved ? '承認済み' : '承認待ち'),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SelectableText(webhook.id),
+          Text('発行: ${dateFormat.format(webhook.createdAt.toLocal())}'),
+          Text(
+            expiresAt == null
+                ? '期限: なし'
+                : '期限: ${dateFormat.format(expiresAt.toLocal())}',
+          ),
+          if (url != null) SelectableText(url),
+        ],
+      ),
+      trailing: url == null
+          ? null
+          : IconButton(
+              tooltip: 'URLをコピー',
+              onPressed: () async {
+                await Clipboard.setData(ClipboardData(text: url));
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Webhook URLをコピーしました')),
+                  );
+                }
+              },
+              icon: const Icon(Icons.copy),
+            ),
+    );
+  }
+}
+
+class _ErrorBody extends StatelessWidget {
+  const new({required this.exception, required this.onRetry});
+
+  final Exception exception;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('Webhook一覧を取得できませんでした'),
+            const SizedBox(height: 8),
+            SelectableText(exception.toString(), textAlign: TextAlign.center),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('再試行'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/feature/devices/device_repository_webhook_test.dart
+++ b/app/test/feature/devices/device_repository_webhook_test.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/feature/devices/data/model/device_notification_webhook.dart';
+import 'package:eqmonitor/feature/devices/data/repository/device_auth_repository.dart';
+import 'package:eqmonitor/feature/devices/data/repository/device_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Webhookを空のJSON bodyで発行して一覧へ変換する', () async {
+    final adapter = _WebhookAdapter();
+    final dio = Dio(BaseOptions(baseUrl: 'https://example.com'))
+      ..httpClientAdapter = adapter;
+    final repository = DeviceRepository(
+      api: api.ApiClient(dio),
+      authRepository: _FakeDeviceAuthRepository(),
+      apnsEnvironment: api.ApnsEnvironment.development,
+    );
+
+    final created = await repository.createNotificationWebhook();
+    final listed = await repository.getNotificationWebhooks();
+
+    expect(adapter.requests.first.data, <String, Object?>{});
+    expect(created, isA<Success<DeviceNotificationWebhook, Exception>>());
+    expect(
+      (listed as Success<List<DeviceNotificationWebhook>, Exception>)
+          .value
+          .single
+          .id,
+      'webhook-id',
+    );
+  });
+}
+
+final class _WebhookAdapter implements HttpClientAdapter {
+  final requests = <RequestOptions>[];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+    final webhook = {
+      'id': 'webhook-id',
+      'createdAt': '2026-08-26T00:00:00.000Z',
+      'expiresAt': null,
+      'approved': false,
+      'webhookUrl': null,
+    };
+    return ResponseBody.fromString(
+      jsonEncode(options.method == 'GET' ? [webhook] : webhook),
+      options.method == 'GET' ? 200 : 201,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+final class _FakeDeviceAuthRepository extends Fake
+    implements DeviceAuthRepository;

--- a/packages/eqmonitor_api/lib/src/clients/device_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/device_api_client.dart
@@ -6,6 +6,7 @@ import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 
 import '../models/challenge_response.dart';
+import '../models/create_device_notification_webhook_request.dart';
 import '../models/create_region_slot_request.dart';
 import '../models/device_location_request.dart';
 import '../models/device_location_response.dart';
@@ -238,7 +239,9 @@ abstract class DeviceApiClient {
 
   /// 通知 Webhook を作成
   @POST(DeviceApiClientUrls.postV2DeviceMeNotificationWebhooks)
-  Future<HttpResponse<DeviceNotificationWebhookResponse>> postV2DeviceMeNotificationWebhooks();
+  Future<HttpResponse<DeviceNotificationWebhookResponse>> postV2DeviceMeNotificationWebhooks({
+    @Body() required CreateDeviceNotificationWebhookRequest body,
+  });
 
   /// 通知 Webhook の一覧を取得
   @GET(DeviceApiClientUrls.getV2DeviceMeNotificationWebhooks)

--- a/packages/eqmonitor_api/lib/src/clients/device_api_client.g.dart
+++ b/packages/eqmonitor_api/lib/src/clients/device_api_client.g.dart
@@ -1128,11 +1128,14 @@ class _DeviceApiClient implements DeviceApiClient {
 
   @override
   Future<HttpResponse<DeviceNotificationWebhookResponse>>
-  postV2DeviceMeNotificationWebhooks() async {
+  postV2DeviceMeNotificationWebhooks({
+    required CreateDeviceNotificationWebhookRequest body,
+  }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
-    const Map<String, dynamic>? _data = null;
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
     final _options =
         _setStreamType<HttpResponse<DeviceNotificationWebhookResponse>>(
           Options(method: 'POST', headers: _headers, extra: _extra)

--- a/packages/eqmonitor_api/lib/src/export.dart
+++ b/packages/eqmonitor_api/lib/src/export.dart
@@ -115,6 +115,7 @@ export 'models/eew_warning_config_response.dart';
 export 'models/eew_warning_config_request.dart';
 export 'models/device_location_request.dart';
 export 'models/device_location_response.dart';
+export 'models/create_device_notification_webhook_request.dart';
 export 'models/device_notification_webhook_response.dart';
 export 'models/notification_log_item.dart';
 export 'models/notification_history_response.dart';

--- a/packages/eqmonitor_api/lib/src/models/create_device_notification_webhook_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/create_device_notification_webhook_request.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'create_device_notification_webhook_request.freezed.dart';
+part 'create_device_notification_webhook_request.g.dart';
+
+/// 通知Webhook作成リクエスト
+@Freezed()
+abstract class CreateDeviceNotificationWebhookRequest with _$CreateDeviceNotificationWebhookRequest {
+  const factory CreateDeviceNotificationWebhookRequest({
+    /// Webhookの有効期限（日数）。nullまたは省略時は無期限
+    @JsonKey(includeIfNull: false)
+    int? expiresInDays,
+  }) = _CreateDeviceNotificationWebhookRequest;
+
+  factory CreateDeviceNotificationWebhookRequest.fromJson(Map<String, Object?> json) => _$CreateDeviceNotificationWebhookRequestFromJson(json);
+}

--- a/packages/eqmonitor_api/lib/src/models/create_device_notification_webhook_request.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/create_device_notification_webhook_request.freezed.dart
@@ -1,0 +1,280 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'create_device_notification_webhook_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$CreateDeviceNotificationWebhookRequest {
+
+/// Webhookの有効期限（日数）。nullまたは省略時は無期限
+@JsonKey(includeIfNull: false) int? get expiresInDays;
+/// Create a copy of CreateDeviceNotificationWebhookRequest
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CreateDeviceNotificationWebhookRequestCopyWith<CreateDeviceNotificationWebhookRequest> get copyWith => _$CreateDeviceNotificationWebhookRequestCopyWithImpl<CreateDeviceNotificationWebhookRequest>(this as CreateDeviceNotificationWebhookRequest, _$identity);
+
+  /// Serializes this CreateDeviceNotificationWebhookRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CreateDeviceNotificationWebhookRequest&&(identical(other.expiresInDays, expiresInDays) || other.expiresInDays == expiresInDays));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,expiresInDays);
+
+@override
+String toString() {
+  return 'CreateDeviceNotificationWebhookRequest(expiresInDays: $expiresInDays)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CreateDeviceNotificationWebhookRequestCopyWith<$Res>  {
+  factory $CreateDeviceNotificationWebhookRequestCopyWith(CreateDeviceNotificationWebhookRequest value, $Res Function(CreateDeviceNotificationWebhookRequest) _then) = _$CreateDeviceNotificationWebhookRequestCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(includeIfNull: false) int? expiresInDays
+});
+
+
+
+
+}
+/// @nodoc
+class _$CreateDeviceNotificationWebhookRequestCopyWithImpl<$Res>
+    implements $CreateDeviceNotificationWebhookRequestCopyWith<$Res> {
+  _$CreateDeviceNotificationWebhookRequestCopyWithImpl(this._self, this._then);
+
+  final CreateDeviceNotificationWebhookRequest _self;
+  final $Res Function(CreateDeviceNotificationWebhookRequest) _then;
+
+/// Create a copy of CreateDeviceNotificationWebhookRequest
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? expiresInDays = freezed,}) {
+  return _then(CreateDeviceNotificationWebhookRequest(
+expiresInDays: freezed == expiresInDays ? _self.expiresInDays : expiresInDays // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [CreateDeviceNotificationWebhookRequest].
+extension CreateDeviceNotificationWebhookRequestPatterns on CreateDeviceNotificationWebhookRequest {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _CreateDeviceNotificationWebhookRequest value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _CreateDeviceNotificationWebhookRequest() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _CreateDeviceNotificationWebhookRequest value)  $default,){
+final _that = this;
+switch (_that) {
+case _CreateDeviceNotificationWebhookRequest():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _CreateDeviceNotificationWebhookRequest value)?  $default,){
+final _that = this;
+switch (_that) {
+case _CreateDeviceNotificationWebhookRequest() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false)  int? expiresInDays)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _CreateDeviceNotificationWebhookRequest() when $default != null:
+return $default(_that.expiresInDays);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false)  int? expiresInDays)  $default,) {final _that = this;
+switch (_that) {
+case _CreateDeviceNotificationWebhookRequest():
+return $default(_that.expiresInDays);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: false)  int? expiresInDays)?  $default,) {final _that = this;
+switch (_that) {
+case _CreateDeviceNotificationWebhookRequest() when $default != null:
+return $default(_that.expiresInDays);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _CreateDeviceNotificationWebhookRequest implements CreateDeviceNotificationWebhookRequest {
+  const _CreateDeviceNotificationWebhookRequest({@JsonKey(includeIfNull: false) this.expiresInDays});
+  factory _CreateDeviceNotificationWebhookRequest.fromJson(Map<String, dynamic> json) => _$CreateDeviceNotificationWebhookRequestFromJson(json);
+
+/// Webhookの有効期限（日数）。nullまたは省略時は無期限
+@override@JsonKey(includeIfNull: false) final  int? expiresInDays;
+
+/// Create a copy of CreateDeviceNotificationWebhookRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CreateDeviceNotificationWebhookRequestCopyWith<_CreateDeviceNotificationWebhookRequest> get copyWith => __$CreateDeviceNotificationWebhookRequestCopyWithImpl<_CreateDeviceNotificationWebhookRequest>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$CreateDeviceNotificationWebhookRequestToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CreateDeviceNotificationWebhookRequest&&(identical(other.expiresInDays, expiresInDays) || other.expiresInDays == expiresInDays));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,expiresInDays);
+
+@override
+String toString() {
+  return 'CreateDeviceNotificationWebhookRequest(expiresInDays: $expiresInDays)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CreateDeviceNotificationWebhookRequestCopyWith<$Res> implements $CreateDeviceNotificationWebhookRequestCopyWith<$Res> {
+  factory _$CreateDeviceNotificationWebhookRequestCopyWith(_CreateDeviceNotificationWebhookRequest value, $Res Function(_CreateDeviceNotificationWebhookRequest) _then) = __$CreateDeviceNotificationWebhookRequestCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(includeIfNull: false) int? expiresInDays
+});
+
+
+
+
+}
+/// @nodoc
+class __$CreateDeviceNotificationWebhookRequestCopyWithImpl<$Res>
+    implements _$CreateDeviceNotificationWebhookRequestCopyWith<$Res> {
+  __$CreateDeviceNotificationWebhookRequestCopyWithImpl(this._self, this._then);
+
+  final _CreateDeviceNotificationWebhookRequest _self;
+  final $Res Function(_CreateDeviceNotificationWebhookRequest) _then;
+
+/// Create a copy of CreateDeviceNotificationWebhookRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? expiresInDays = freezed,}) {
+  return _then(_CreateDeviceNotificationWebhookRequest(
+expiresInDays: freezed == expiresInDays ? _self.expiresInDays : expiresInDays // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/eqmonitor_api/lib/src/models/create_device_notification_webhook_request.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/create_device_notification_webhook_request.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'create_device_notification_webhook_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_CreateDeviceNotificationWebhookRequest
+_$CreateDeviceNotificationWebhookRequestFromJson(Map<String, dynamic> json) =>
+    $checkedCreate('_CreateDeviceNotificationWebhookRequest', json, (
+      $checkedConvert,
+    ) {
+      final val = _CreateDeviceNotificationWebhookRequest(
+        expiresInDays: $checkedConvert(
+          'expiresInDays',
+          (v) => (v as num?)?.toInt(),
+        ),
+      );
+      return val;
+    });
+
+Map<String, dynamic> _$CreateDeviceNotificationWebhookRequestToJson(
+  _CreateDeviceNotificationWebhookRequest instance,
+) => <String, dynamic>{'expiresInDays': ?instance.expiresInDays};


### PR DESCRIPTION
## 概要

- デバッグ画面から通知Webhookを発行
- 発行済みWebhookの一覧・更新・URLコピーに対応
- ローディング、エラー、空状態を表示
- OpenAPI生成モデルとDeviceRepositoryを追加

## 確認

- `flutter test --no-pub test/feature/devices/device_repository_webhook_test.dart test/core/router/debug_auth_route_test.dart test/core/router/material_page_mixin_test.dart`（11件成功）
- 静的解析はローカル環境で完走しなかったため、対象テストのコンパイルで確認