### PR TITLE
fix(knet): JST以外の端末でK-NETの時刻を正しく扱う

### DIFF
--- a/docs/knowledge/20260829_knet_timestamp_timezone.md
+++ b/docs/knowledge/20260829_knet_timestamp_timezone.md
@@ -1,0 +1,12 @@
+# K-NET日時のtimezoneルール
+
+- K-NET/KiK-netのディレクトリ名`YYYYMMDDHHmmss`はAsia/Tokyoの日時として解析する。
+- `KnetDirectoryParser.parseRecords`は`TZDateTime`を返し、端末のtimezoneへ依存させない。
+- 解析した日時は表示だけでなく、図・動画・波形ZIPのURLパス生成にも使われる。
+- UTCの`DateTime`へ置き換えて日時成分を変えると、K-NET上のディレクトリ名と一致しなくなるため注意する。
+- 利用前にtimezone DBを初期化する。アプリでは`core.initializeTimeZones()`を使う。
+
+```bash
+mise exec -- dart analyze packages/knet_api_client
+mise -C packages/knet_api_client exec -- dart test
+```

--- a/packages/knet_api_client/lib/src/knet_directory_parser.dart
+++ b/packages/knet_api_client/lib/src/knet_directory_parser.dart
@@ -1,8 +1,11 @@
 import 'package:html/parser.dart' as html_parser;
+import 'package:timezone/timezone.dart' as tz;
 
 /// Apache style directory listing HTML から エントリ名一覧を抽出するパーサー
 class KnetDirectoryParser {
   const new _();
+
+  static final _tokyo = tz.getLocation('Asia/Tokyo');
 
   /// HTML から相対リンク（末尾 `/` 付きディレクトリ）の名前一覧を返す
   ///
@@ -64,13 +67,13 @@ class KnetDirectoryParser {
       ..sort();
   }
 
-  /// 記録一覧ページ HTML から地震発生時刻（ローカル時刻）のリストを返す
+  /// 記録一覧ページ HTML から地震発生時刻（Asia/Tokyo）のリストを返す
   ///
   /// 各エントリは `YYYYMMDDHHmmss` 形式のディレクトリ名として表現される。
   /// パース失敗したエントリは除外する。
-  static List<DateTime> parseRecords(String html) {
+  static List<tz.TZDateTime> parseRecords(String html) {
     final entries = parseEntries(html);
-    final records = <DateTime>[];
+    final records = <tz.TZDateTime>[];
     for (final entry in entries) {
       final dt = _parseTimestamp(entry);
       if (dt != null) {
@@ -80,7 +83,7 @@ class KnetDirectoryParser {
     return records;
   }
 
-  static DateTime? _parseTimestamp(String s) {
+  static tz.TZDateTime? _parseTimestamp(String s) {
     if (s.length != 14) {
       return null;
     }
@@ -98,6 +101,6 @@ class KnetDirectoryParser {
         second == null) {
       return null;
     }
-    return DateTime(year, month, day, hour, minute, second);
+    return tz.TZDateTime(_tokyo, year, month, day, hour, minute, second);
   }
 }

--- a/packages/knet_api_client/pubspec.yaml
+++ b/packages/knet_api_client/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   knet_waveform_parser:
     path: ../knet_waveform_parser
   retrofit: ^4.9.0
+  timezone: ^0.11.1
 
 dev_dependencies:
   build_runner: ^2.7.1

--- a/packages/knet_api_client/test/knet_directory_parser_test.dart
+++ b/packages/knet_api_client/test/knet_directory_parser_test.dart
@@ -2,10 +2,14 @@ import 'dart:io';
 
 import 'package:knet_api_client/knet_api_client.dart';
 import 'package:test/test.dart';
+import 'package:timezone/data/latest.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
 
 String _fixture(String name) => File('test/fixtures/$name').readAsStringSync();
 
 void main() {
+  setUpAll(tz_data.initializeTimeZones);
+
   group('KnetDirectoryParser.parseYears', () {
     late String html;
 
@@ -48,7 +52,10 @@ void main() {
 
     test('先頭レコードが 2024-01-01 16:06:00', () {
       final records = KnetDirectoryParser.parseRecords(html);
-      expect(records.first, equals(DateTime(2024, 1, 1, 16, 6)));
+      final first = records.first;
+      expect(first, isA<tz.TZDateTime>());
+      expect(first.location.name, 'Asia/Tokyo');
+      expect(first.toUtc(), DateTime.utc(2024, 1, 1, 7, 6));
     });
 
     test('すべて 2024 年 1 月のレコードである', () {
@@ -74,7 +81,7 @@ void main() {
 </body></html>''';
       final records = KnetDirectoryParser.parseRecords(badHtml);
       expect(records, hasLength(1));
-      expect(records.first, equals(DateTime(2024, 1, 1, 16, 6)));
+      expect(records.first.toUtc(), DateTime.utc(2024, 1, 1, 7, 6));
     });
   });
 


### PR DESCRIPTION
## 概要

- K-NETの`YYYYMMDDHHmmss`ディレクトリ名をAsia/Tokyoとして解析
- `KnetDirectoryParser.parseRecords`の戻り値を`List<TZDateTime>`へ変更
- 端末timezoneに依存せず、表示とダウンロードURL生成でK-NETの日時成分を維持
- Asia/Tokyo locationと対応するUTC instantを単体テストで確認

## テスト

- `dart analyze packages/knet_api_client`: 問題なし
- `dart test`（knet_api_client）: 9件成功
- `dart analyze app/lib/feature/knet_waveform`: 問題なし
