### PR TITLE
Fix: 地震履歴の観測点Circleレイヤーを削除

### DIFF
--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart
@@ -23,10 +23,6 @@ abstract class EarthquakeHistoryMapLayerParameter
     @Default(0.8) double regionLineOpacity,
     @Default(0.6) double cityFillOpacity,
 
-    // 観測点サイズ (circle-radius interpolation)
-    @Default(0.8) double stationCircleRadiusMin,
-    @Default(6.7) double stationCircleRadiusMax,
-
     // 観測点アイコンサイズ (icon-size interpolation)
     @Default(0.03) double stationIconSizeMin,
     @Default(0.13) double stationIconSizeMid,

--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.freezed.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EarthquakeHistoryMapLayerParameter {
 
- double get regionToCity; double get stationMinZoom; double get stationLabelMinZoom; double get stationTextZoom; double get hypocenterFadeZoom; double get hypocenterErrorMinZoom; double get regionFillOpacity; double get regionLineOpacity; double get cityFillOpacity; double get stationCircleRadiusMin; double get stationCircleRadiusMax; double get stationIconSizeMin; double get stationIconSizeMid; double get stationIconSizeMax; double get hypocenterIconSizeMin; double get hypocenterIconSizeMax; double get hypocenterFadeOpacity;
+ double get regionToCity; double get stationMinZoom; double get stationLabelMinZoom; double get stationTextZoom; double get hypocenterFadeZoom; double get hypocenterErrorMinZoom; double get regionFillOpacity; double get regionLineOpacity; double get cityFillOpacity; double get stationIconSizeMin; double get stationIconSizeMid; double get stationIconSizeMax; double get hypocenterIconSizeMin; double get hypocenterIconSizeMax; double get hypocenterFadeOpacity;
 /// Create a copy of EarthquakeHistoryMapLayerParameter
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $EarthquakeHistoryMapLayerParameterCopyWith<EarthquakeHistoryMapLayerParameter> 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EarthquakeHistoryMapLayerParameter&&(identical(other.regionToCity, regionToCity) || other.regionToCity == regionToCity)&&(identical(other.stationMinZoom, stationMinZoom) || other.stationMinZoom == stationMinZoom)&&(identical(other.stationLabelMinZoom, stationLabelMinZoom) || other.stationLabelMinZoom == stationLabelMinZoom)&&(identical(other.stationTextZoom, stationTextZoom) || other.stationTextZoom == stationTextZoom)&&(identical(other.hypocenterFadeZoom, hypocenterFadeZoom) || other.hypocenterFadeZoom == hypocenterFadeZoom)&&(identical(other.hypocenterErrorMinZoom, hypocenterErrorMinZoom) || other.hypocenterErrorMinZoom == hypocenterErrorMinZoom)&&(identical(other.regionFillOpacity, regionFillOpacity) || other.regionFillOpacity == regionFillOpacity)&&(identical(other.regionLineOpacity, regionLineOpacity) || other.regionLineOpacity == regionLineOpacity)&&(identical(other.cityFillOpacity, cityFillOpacity) || other.cityFillOpacity == cityFillOpacity)&&(identical(other.stationCircleRadiusMin, stationCircleRadiusMin) || other.stationCircleRadiusMin == stationCircleRadiusMin)&&(identical(other.stationCircleRadiusMax, stationCircleRadiusMax) || other.stationCircleRadiusMax == stationCircleRadiusMax)&&(identical(other.stationIconSizeMin, stationIconSizeMin) || other.stationIconSizeMin == stationIconSizeMin)&&(identical(other.stationIconSizeMid, stationIconSizeMid) || other.stationIconSizeMid == stationIconSizeMid)&&(identical(other.stationIconSizeMax, stationIconSizeMax) || other.stationIconSizeMax == stationIconSizeMax)&&(identical(other.hypocenterIconSizeMin, hypocenterIconSizeMin) || other.hypocenterIconSizeMin == hypocenterIconSizeMin)&&(identical(other.hypocenterIconSizeMax, hypocenterIconSizeMax) || other.hypocenterIconSizeMax == hypocenterIconSizeMax)&&(identical(other.hypocenterFadeOpacity, hypocenterFadeOpacity) || other.hypocenterFadeOpacity == hypocenterFadeOpacity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EarthquakeHistoryMapLayerParameter&&(identical(other.regionToCity, regionToCity) || other.regionToCity == regionToCity)&&(identical(other.stationMinZoom, stationMinZoom) || other.stationMinZoom == stationMinZoom)&&(identical(other.stationLabelMinZoom, stationLabelMinZoom) || other.stationLabelMinZoom == stationLabelMinZoom)&&(identical(other.stationTextZoom, stationTextZoom) || other.stationTextZoom == stationTextZoom)&&(identical(other.hypocenterFadeZoom, hypocenterFadeZoom) || other.hypocenterFadeZoom == hypocenterFadeZoom)&&(identical(other.hypocenterErrorMinZoom, hypocenterErrorMinZoom) || other.hypocenterErrorMinZoom == hypocenterErrorMinZoom)&&(identical(other.regionFillOpacity, regionFillOpacity) || other.regionFillOpacity == regionFillOpacity)&&(identical(other.regionLineOpacity, regionLineOpacity) || other.regionLineOpacity == regionLineOpacity)&&(identical(other.cityFillOpacity, cityFillOpacity) || other.cityFillOpacity == cityFillOpacity)&&(identical(other.stationIconSizeMin, stationIconSizeMin) || other.stationIconSizeMin == stationIconSizeMin)&&(identical(other.stationIconSizeMid, stationIconSizeMid) || other.stationIconSizeMid == stationIconSizeMid)&&(identical(other.stationIconSizeMax, stationIconSizeMax) || other.stationIconSizeMax == stationIconSizeMax)&&(identical(other.hypocenterIconSizeMin, hypocenterIconSizeMin) || other.hypocenterIconSizeMin == hypocenterIconSizeMin)&&(identical(other.hypocenterIconSizeMax, hypocenterIconSizeMax) || other.hypocenterIconSizeMax == hypocenterIconSizeMax)&&(identical(other.hypocenterFadeOpacity, hypocenterFadeOpacity) || other.hypocenterFadeOpacity == hypocenterFadeOpacity));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,regionToCity,stationMinZoom,stationLabelMinZoom,stationTextZoom,hypocenterFadeZoom,hypocenterErrorMinZoom,regionFillOpacity,regionLineOpacity,cityFillOpacity,stationCircleRadiusMin,stationCircleRadiusMax,stationIconSizeMin,stationIconSizeMid,stationIconSizeMax,hypocenterIconSizeMin,hypocenterIconSizeMax,hypocenterFadeOpacity);
+int get hashCode => Object.hash(runtimeType,regionToCity,stationMinZoom,stationLabelMinZoom,stationTextZoom,hypocenterFadeZoom,hypocenterErrorMinZoom,regionFillOpacity,regionLineOpacity,cityFillOpacity,stationIconSizeMin,stationIconSizeMid,stationIconSizeMax,hypocenterIconSizeMin,hypocenterIconSizeMax,hypocenterFadeOpacity);
 
 @override
 String toString() {
-  return 'EarthquakeHistoryMapLayerParameter(regionToCity: $regionToCity, stationMinZoom: $stationMinZoom, stationLabelMinZoom: $stationLabelMinZoom, stationTextZoom: $stationTextZoom, hypocenterFadeZoom: $hypocenterFadeZoom, hypocenterErrorMinZoom: $hypocenterErrorMinZoom, regionFillOpacity: $regionFillOpacity, regionLineOpacity: $regionLineOpacity, cityFillOpacity: $cityFillOpacity, stationCircleRadiusMin: $stationCircleRadiusMin, stationCircleRadiusMax: $stationCircleRadiusMax, stationIconSizeMin: $stationIconSizeMin, stationIconSizeMid: $stationIconSizeMid, stationIconSizeMax: $stationIconSizeMax, hypocenterIconSizeMin: $hypocenterIconSizeMin, hypocenterIconSizeMax: $hypocenterIconSizeMax, hypocenterFadeOpacity: $hypocenterFadeOpacity)';
+  return 'EarthquakeHistoryMapLayerParameter(regionToCity: $regionToCity, stationMinZoom: $stationMinZoom, stationLabelMinZoom: $stationLabelMinZoom, stationTextZoom: $stationTextZoom, hypocenterFadeZoom: $hypocenterFadeZoom, hypocenterErrorMinZoom: $hypocenterErrorMinZoom, regionFillOpacity: $regionFillOpacity, regionLineOpacity: $regionLineOpacity, cityFillOpacity: $cityFillOpacity, stationIconSizeMin: $stationIconSizeMin, stationIconSizeMid: $stationIconSizeMid, stationIconSizeMax: $stationIconSizeMax, hypocenterIconSizeMin: $hypocenterIconSizeMin, hypocenterIconSizeMax: $hypocenterIconSizeMax, hypocenterFadeOpacity: $hypocenterFadeOpacity)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $EarthquakeHistoryMapLayerParameterCopyWith<$Res>  {
   factory $EarthquakeHistoryMapLayerParameterCopyWith(EarthquakeHistoryMapLayerParameter value, $Res Function(EarthquakeHistoryMapLayerParameter) _then) = _$EarthquakeHistoryMapLayerParameterCopyWithImpl;
 @useResult
 $Res call({
- double regionToCity, double stationMinZoom, double stationLabelMinZoom, double stationTextZoom, double hypocenterFadeZoom, double hypocenterErrorMinZoom, double regionFillOpacity, double regionLineOpacity, double cityFillOpacity, double stationCircleRadiusMin, double stationCircleRadiusMax, double stationIconSizeMin, double stationIconSizeMid, double stationIconSizeMax, double hypocenterIconSizeMin, double hypocenterIconSizeMax, double hypocenterFadeOpacity
+ double regionToCity, double stationMinZoom, double stationLabelMinZoom, double stationTextZoom, double hypocenterFadeZoom, double hypocenterErrorMinZoom, double regionFillOpacity, double regionLineOpacity, double cityFillOpacity, double stationIconSizeMin, double stationIconSizeMid, double stationIconSizeMax, double hypocenterIconSizeMin, double hypocenterIconSizeMax, double hypocenterFadeOpacity
 });
 
 
@@ -66,7 +66,7 @@ class _$EarthquakeHistoryMapLayerParameterCopyWithImpl<$Res>
 
 /// Create a copy of EarthquakeHistoryMapLayerParameter
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? regionToCity = null,Object? stationMinZoom = null,Object? stationLabelMinZoom = null,Object? stationTextZoom = null,Object? hypocenterFadeZoom = null,Object? hypocenterErrorMinZoom = null,Object? regionFillOpacity = null,Object? regionLineOpacity = null,Object? cityFillOpacity = null,Object? stationCircleRadiusMin = null,Object? stationCircleRadiusMax = null,Object? stationIconSizeMin = null,Object? stationIconSizeMid = null,Object? stationIconSizeMax = null,Object? hypocenterIconSizeMin = null,Object? hypocenterIconSizeMax = null,Object? hypocenterFadeOpacity = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? regionToCity = null,Object? stationMinZoom = null,Object? stationLabelMinZoom = null,Object? stationTextZoom = null,Object? hypocenterFadeZoom = null,Object? hypocenterErrorMinZoom = null,Object? regionFillOpacity = null,Object? regionLineOpacity = null,Object? cityFillOpacity = null,Object? stationIconSizeMin = null,Object? stationIconSizeMid = null,Object? stationIconSizeMax = null,Object? hypocenterIconSizeMin = null,Object? hypocenterIconSizeMax = null,Object? hypocenterFadeOpacity = null,}) {
   return _then(EarthquakeHistoryMapLayerParameter(
 regionToCity: null == regionToCity ? _self.regionToCity : regionToCity // ignore: cast_nullable_to_non_nullable
 as double,stationMinZoom: null == stationMinZoom ? _self.stationMinZoom : stationMinZoom // ignore: cast_nullable_to_non_nullable
@@ -77,8 +77,6 @@ as double,hypocenterErrorMinZoom: null == hypocenterErrorMinZoom ? _self.hypocen
 as double,regionFillOpacity: null == regionFillOpacity ? _self.regionFillOpacity : regionFillOpacity // ignore: cast_nullable_to_non_nullable
 as double,regionLineOpacity: null == regionLineOpacity ? _self.regionLineOpacity : regionLineOpacity // ignore: cast_nullable_to_non_nullable
 as double,cityFillOpacity: null == cityFillOpacity ? _self.cityFillOpacity : cityFillOpacity // ignore: cast_nullable_to_non_nullable
-as double,stationCircleRadiusMin: null == stationCircleRadiusMin ? _self.stationCircleRadiusMin : stationCircleRadiusMin // ignore: cast_nullable_to_non_nullable
-as double,stationCircleRadiusMax: null == stationCircleRadiusMax ? _self.stationCircleRadiusMax : stationCircleRadiusMax // ignore: cast_nullable_to_non_nullable
 as double,stationIconSizeMin: null == stationIconSizeMin ? _self.stationIconSizeMin : stationIconSizeMin // ignore: cast_nullable_to_non_nullable
 as double,stationIconSizeMid: null == stationIconSizeMid ? _self.stationIconSizeMid : stationIconSizeMid // ignore: cast_nullable_to_non_nullable
 as double,stationIconSizeMax: null == stationIconSizeMax ? _self.stationIconSizeMax : stationIconSizeMax // ignore: cast_nullable_to_non_nullable
@@ -170,10 +168,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double regionToCity,  double stationMinZoom,  double stationLabelMinZoom,  double stationTextZoom,  double hypocenterFadeZoom,  double hypocenterErrorMinZoom,  double regionFillOpacity,  double regionLineOpacity,  double cityFillOpacity,  double stationCircleRadiusMin,  double stationCircleRadiusMax,  double stationIconSizeMin,  double stationIconSizeMid,  double stationIconSizeMax,  double hypocenterIconSizeMin,  double hypocenterIconSizeMax,  double hypocenterFadeOpacity)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double regionToCity,  double stationMinZoom,  double stationLabelMinZoom,  double stationTextZoom,  double hypocenterFadeZoom,  double hypocenterErrorMinZoom,  double regionFillOpacity,  double regionLineOpacity,  double cityFillOpacity,  double stationIconSizeMin,  double stationIconSizeMid,  double stationIconSizeMax,  double hypocenterIconSizeMin,  double hypocenterIconSizeMax,  double hypocenterFadeOpacity)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EarthquakeHistoryMapLayerParameter() when $default != null:
-return $default(_that.regionToCity,_that.stationMinZoom,_that.stationLabelMinZoom,_that.stationTextZoom,_that.hypocenterFadeZoom,_that.hypocenterErrorMinZoom,_that.regionFillOpacity,_that.regionLineOpacity,_that.cityFillOpacity,_that.stationCircleRadiusMin,_that.stationCircleRadiusMax,_that.stationIconSizeMin,_that.stationIconSizeMid,_that.stationIconSizeMax,_that.hypocenterIconSizeMin,_that.hypocenterIconSizeMax,_that.hypocenterFadeOpacity);case _:
+return $default(_that.regionToCity,_that.stationMinZoom,_that.stationLabelMinZoom,_that.stationTextZoom,_that.hypocenterFadeZoom,_that.hypocenterErrorMinZoom,_that.regionFillOpacity,_that.regionLineOpacity,_that.cityFillOpacity,_that.stationIconSizeMin,_that.stationIconSizeMid,_that.stationIconSizeMax,_that.hypocenterIconSizeMin,_that.hypocenterIconSizeMax,_that.hypocenterFadeOpacity);case _:
   return orElse();
 
 }
@@ -191,10 +189,10 @@ return $default(_that.regionToCity,_that.stationMinZoom,_that.stationLabelMinZoo
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double regionToCity,  double stationMinZoom,  double stationLabelMinZoom,  double stationTextZoom,  double hypocenterFadeZoom,  double hypocenterErrorMinZoom,  double regionFillOpacity,  double regionLineOpacity,  double cityFillOpacity,  double stationCircleRadiusMin,  double stationCircleRadiusMax,  double stationIconSizeMin,  double stationIconSizeMid,  double stationIconSizeMax,  double hypocenterIconSizeMin,  double hypocenterIconSizeMax,  double hypocenterFadeOpacity)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double regionToCity,  double stationMinZoom,  double stationLabelMinZoom,  double stationTextZoom,  double hypocenterFadeZoom,  double hypocenterErrorMinZoom,  double regionFillOpacity,  double regionLineOpacity,  double cityFillOpacity,  double stationIconSizeMin,  double stationIconSizeMid,  double stationIconSizeMax,  double hypocenterIconSizeMin,  double hypocenterIconSizeMax,  double hypocenterFadeOpacity)  $default,) {final _that = this;
 switch (_that) {
 case _EarthquakeHistoryMapLayerParameter():
-return $default(_that.regionToCity,_that.stationMinZoom,_that.stationLabelMinZoom,_that.stationTextZoom,_that.hypocenterFadeZoom,_that.hypocenterErrorMinZoom,_that.regionFillOpacity,_that.regionLineOpacity,_that.cityFillOpacity,_that.stationCircleRadiusMin,_that.stationCircleRadiusMax,_that.stationIconSizeMin,_that.stationIconSizeMid,_that.stationIconSizeMax,_that.hypocenterIconSizeMin,_that.hypocenterIconSizeMax,_that.hypocenterFadeOpacity);case _:
+return $default(_that.regionToCity,_that.stationMinZoom,_that.stationLabelMinZoom,_that.stationTextZoom,_that.hypocenterFadeZoom,_that.hypocenterErrorMinZoom,_that.regionFillOpacity,_that.regionLineOpacity,_that.cityFillOpacity,_that.stationIconSizeMin,_that.stationIconSizeMid,_that.stationIconSizeMax,_that.hypocenterIconSizeMin,_that.hypocenterIconSizeMax,_that.hypocenterFadeOpacity);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -211,10 +209,10 @@ return $default(_that.regionToCity,_that.stationMinZoom,_that.stationLabelMinZoo
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double regionToCity,  double stationMinZoom,  double stationLabelMinZoom,  double stationTextZoom,  double hypocenterFadeZoom,  double hypocenterErrorMinZoom,  double regionFillOpacity,  double regionLineOpacity,  double cityFillOpacity,  double stationCircleRadiusMin,  double stationCircleRadiusMax,  double stationIconSizeMin,  double stationIconSizeMid,  double stationIconSizeMax,  double hypocenterIconSizeMin,  double hypocenterIconSizeMax,  double hypocenterFadeOpacity)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double regionToCity,  double stationMinZoom,  double stationLabelMinZoom,  double stationTextZoom,  double hypocenterFadeZoom,  double hypocenterErrorMinZoom,  double regionFillOpacity,  double regionLineOpacity,  double cityFillOpacity,  double stationIconSizeMin,  double stationIconSizeMid,  double stationIconSizeMax,  double hypocenterIconSizeMin,  double hypocenterIconSizeMax,  double hypocenterFadeOpacity)?  $default,) {final _that = this;
 switch (_that) {
 case _EarthquakeHistoryMapLayerParameter() when $default != null:
-return $default(_that.regionToCity,_that.stationMinZoom,_that.stationLabelMinZoom,_that.stationTextZoom,_that.hypocenterFadeZoom,_that.hypocenterErrorMinZoom,_that.regionFillOpacity,_that.regionLineOpacity,_that.cityFillOpacity,_that.stationCircleRadiusMin,_that.stationCircleRadiusMax,_that.stationIconSizeMin,_that.stationIconSizeMid,_that.stationIconSizeMax,_that.hypocenterIconSizeMin,_that.hypocenterIconSizeMax,_that.hypocenterFadeOpacity);case _:
+return $default(_that.regionToCity,_that.stationMinZoom,_that.stationLabelMinZoom,_that.stationTextZoom,_that.hypocenterFadeZoom,_that.hypocenterErrorMinZoom,_that.regionFillOpacity,_that.regionLineOpacity,_that.cityFillOpacity,_that.stationIconSizeMin,_that.stationIconSizeMid,_that.stationIconSizeMax,_that.hypocenterIconSizeMin,_that.hypocenterIconSizeMax,_that.hypocenterFadeOpacity);case _:
   return null;
 
 }
@@ -226,7 +224,7 @@ return $default(_that.regionToCity,_that.stationMinZoom,_that.stationLabelMinZoo
 @JsonSerializable()
 
 class _EarthquakeHistoryMapLayerParameter implements EarthquakeHistoryMapLayerParameter {
-  const _EarthquakeHistoryMapLayerParameter({this.regionToCity = 6, this.stationMinZoom = 6, this.stationLabelMinZoom = 9, this.stationTextZoom = 9, this.hypocenterFadeZoom = 8, this.hypocenterErrorMinZoom = 8, this.regionFillOpacity = 0.6, this.regionLineOpacity = 0.8, this.cityFillOpacity = 0.6, this.stationCircleRadiusMin = 0.8, this.stationCircleRadiusMax = 6.7, this.stationIconSizeMin = 0.03, this.stationIconSizeMid = 0.13, this.stationIconSizeMax = 0.5, this.hypocenterIconSizeMin = 0.15, this.hypocenterIconSizeMax = 0.4, this.hypocenterFadeOpacity = 0.6});
+  const _EarthquakeHistoryMapLayerParameter({this.regionToCity = 6, this.stationMinZoom = 6, this.stationLabelMinZoom = 9, this.stationTextZoom = 9, this.hypocenterFadeZoom = 8, this.hypocenterErrorMinZoom = 8, this.regionFillOpacity = 0.6, this.regionLineOpacity = 0.8, this.cityFillOpacity = 0.6, this.stationIconSizeMin = 0.03, this.stationIconSizeMid = 0.13, this.stationIconSizeMax = 0.5, this.hypocenterIconSizeMin = 0.15, this.hypocenterIconSizeMax = 0.4, this.hypocenterFadeOpacity = 0.6});
   factory _EarthquakeHistoryMapLayerParameter.fromJson(Map<String, dynamic> json) => _$EarthquakeHistoryMapLayerParameterFromJson(json);
 
 @override@JsonKey() final  double regionToCity;
@@ -238,8 +236,6 @@ class _EarthquakeHistoryMapLayerParameter implements EarthquakeHistoryMapLayerPa
 @override@JsonKey() final  double regionFillOpacity;
 @override@JsonKey() final  double regionLineOpacity;
 @override@JsonKey() final  double cityFillOpacity;
-@override@JsonKey() final  double stationCircleRadiusMin;
-@override@JsonKey() final  double stationCircleRadiusMax;
 @override@JsonKey() final  double stationIconSizeMin;
 @override@JsonKey() final  double stationIconSizeMid;
 @override@JsonKey() final  double stationIconSizeMax;
@@ -260,16 +256,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EarthquakeHistoryMapLayerParameter&&(identical(other.regionToCity, regionToCity) || other.regionToCity == regionToCity)&&(identical(other.stationMinZoom, stationMinZoom) || other.stationMinZoom == stationMinZoom)&&(identical(other.stationLabelMinZoom, stationLabelMinZoom) || other.stationLabelMinZoom == stationLabelMinZoom)&&(identical(other.stationTextZoom, stationTextZoom) || other.stationTextZoom == stationTextZoom)&&(identical(other.hypocenterFadeZoom, hypocenterFadeZoom) || other.hypocenterFadeZoom == hypocenterFadeZoom)&&(identical(other.hypocenterErrorMinZoom, hypocenterErrorMinZoom) || other.hypocenterErrorMinZoom == hypocenterErrorMinZoom)&&(identical(other.regionFillOpacity, regionFillOpacity) || other.regionFillOpacity == regionFillOpacity)&&(identical(other.regionLineOpacity, regionLineOpacity) || other.regionLineOpacity == regionLineOpacity)&&(identical(other.cityFillOpacity, cityFillOpacity) || other.cityFillOpacity == cityFillOpacity)&&(identical(other.stationCircleRadiusMin, stationCircleRadiusMin) || other.stationCircleRadiusMin == stationCircleRadiusMin)&&(identical(other.stationCircleRadiusMax, stationCircleRadiusMax) || other.stationCircleRadiusMax == stationCircleRadiusMax)&&(identical(other.stationIconSizeMin, stationIconSizeMin) || other.stationIconSizeMin == stationIconSizeMin)&&(identical(other.stationIconSizeMid, stationIconSizeMid) || other.stationIconSizeMid == stationIconSizeMid)&&(identical(other.stationIconSizeMax, stationIconSizeMax) || other.stationIconSizeMax == stationIconSizeMax)&&(identical(other.hypocenterIconSizeMin, hypocenterIconSizeMin) || other.hypocenterIconSizeMin == hypocenterIconSizeMin)&&(identical(other.hypocenterIconSizeMax, hypocenterIconSizeMax) || other.hypocenterIconSizeMax == hypocenterIconSizeMax)&&(identical(other.hypocenterFadeOpacity, hypocenterFadeOpacity) || other.hypocenterFadeOpacity == hypocenterFadeOpacity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EarthquakeHistoryMapLayerParameter&&(identical(other.regionToCity, regionToCity) || other.regionToCity == regionToCity)&&(identical(other.stationMinZoom, stationMinZoom) || other.stationMinZoom == stationMinZoom)&&(identical(other.stationLabelMinZoom, stationLabelMinZoom) || other.stationLabelMinZoom == stationLabelMinZoom)&&(identical(other.stationTextZoom, stationTextZoom) || other.stationTextZoom == stationTextZoom)&&(identical(other.hypocenterFadeZoom, hypocenterFadeZoom) || other.hypocenterFadeZoom == hypocenterFadeZoom)&&(identical(other.hypocenterErrorMinZoom, hypocenterErrorMinZoom) || other.hypocenterErrorMinZoom == hypocenterErrorMinZoom)&&(identical(other.regionFillOpacity, regionFillOpacity) || other.regionFillOpacity == regionFillOpacity)&&(identical(other.regionLineOpacity, regionLineOpacity) || other.regionLineOpacity == regionLineOpacity)&&(identical(other.cityFillOpacity, cityFillOpacity) || other.cityFillOpacity == cityFillOpacity)&&(identical(other.stationIconSizeMin, stationIconSizeMin) || other.stationIconSizeMin == stationIconSizeMin)&&(identical(other.stationIconSizeMid, stationIconSizeMid) || other.stationIconSizeMid == stationIconSizeMid)&&(identical(other.stationIconSizeMax, stationIconSizeMax) || other.stationIconSizeMax == stationIconSizeMax)&&(identical(other.hypocenterIconSizeMin, hypocenterIconSizeMin) || other.hypocenterIconSizeMin == hypocenterIconSizeMin)&&(identical(other.hypocenterIconSizeMax, hypocenterIconSizeMax) || other.hypocenterIconSizeMax == hypocenterIconSizeMax)&&(identical(other.hypocenterFadeOpacity, hypocenterFadeOpacity) || other.hypocenterFadeOpacity == hypocenterFadeOpacity));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,regionToCity,stationMinZoom,stationLabelMinZoom,stationTextZoom,hypocenterFadeZoom,hypocenterErrorMinZoom,regionFillOpacity,regionLineOpacity,cityFillOpacity,stationCircleRadiusMin,stationCircleRadiusMax,stationIconSizeMin,stationIconSizeMid,stationIconSizeMax,hypocenterIconSizeMin,hypocenterIconSizeMax,hypocenterFadeOpacity);
+int get hashCode => Object.hash(runtimeType,regionToCity,stationMinZoom,stationLabelMinZoom,stationTextZoom,hypocenterFadeZoom,hypocenterErrorMinZoom,regionFillOpacity,regionLineOpacity,cityFillOpacity,stationIconSizeMin,stationIconSizeMid,stationIconSizeMax,hypocenterIconSizeMin,hypocenterIconSizeMax,hypocenterFadeOpacity);
 
 @override
 String toString() {
-  return 'EarthquakeHistoryMapLayerParameter(regionToCity: $regionToCity, stationMinZoom: $stationMinZoom, stationLabelMinZoom: $stationLabelMinZoom, stationTextZoom: $stationTextZoom, hypocenterFadeZoom: $hypocenterFadeZoom, hypocenterErrorMinZoom: $hypocenterErrorMinZoom, regionFillOpacity: $regionFillOpacity, regionLineOpacity: $regionLineOpacity, cityFillOpacity: $cityFillOpacity, stationCircleRadiusMin: $stationCircleRadiusMin, stationCircleRadiusMax: $stationCircleRadiusMax, stationIconSizeMin: $stationIconSizeMin, stationIconSizeMid: $stationIconSizeMid, stationIconSizeMax: $stationIconSizeMax, hypocenterIconSizeMin: $hypocenterIconSizeMin, hypocenterIconSizeMax: $hypocenterIconSizeMax, hypocenterFadeOpacity: $hypocenterFadeOpacity)';
+  return 'EarthquakeHistoryMapLayerParameter(regionToCity: $regionToCity, stationMinZoom: $stationMinZoom, stationLabelMinZoom: $stationLabelMinZoom, stationTextZoom: $stationTextZoom, hypocenterFadeZoom: $hypocenterFadeZoom, hypocenterErrorMinZoom: $hypocenterErrorMinZoom, regionFillOpacity: $regionFillOpacity, regionLineOpacity: $regionLineOpacity, cityFillOpacity: $cityFillOpacity, stationIconSizeMin: $stationIconSizeMin, stationIconSizeMid: $stationIconSizeMid, stationIconSizeMax: $stationIconSizeMax, hypocenterIconSizeMin: $hypocenterIconSizeMin, hypocenterIconSizeMax: $hypocenterIconSizeMax, hypocenterFadeOpacity: $hypocenterFadeOpacity)';
 }
 
 
@@ -280,7 +276,7 @@ abstract mixin class _$EarthquakeHistoryMapLayerParameterCopyWith<$Res> implemen
   factory _$EarthquakeHistoryMapLayerParameterCopyWith(_EarthquakeHistoryMapLayerParameter value, $Res Function(_EarthquakeHistoryMapLayerParameter) _then) = __$EarthquakeHistoryMapLayerParameterCopyWithImpl;
 @override @useResult
 $Res call({
- double regionToCity, double stationMinZoom, double stationLabelMinZoom, double stationTextZoom, double hypocenterFadeZoom, double hypocenterErrorMinZoom, double regionFillOpacity, double regionLineOpacity, double cityFillOpacity, double stationCircleRadiusMin, double stationCircleRadiusMax, double stationIconSizeMin, double stationIconSizeMid, double stationIconSizeMax, double hypocenterIconSizeMin, double hypocenterIconSizeMax, double hypocenterFadeOpacity
+ double regionToCity, double stationMinZoom, double stationLabelMinZoom, double stationTextZoom, double hypocenterFadeZoom, double hypocenterErrorMinZoom, double regionFillOpacity, double regionLineOpacity, double cityFillOpacity, double stationIconSizeMin, double stationIconSizeMid, double stationIconSizeMax, double hypocenterIconSizeMin, double hypocenterIconSizeMax, double hypocenterFadeOpacity
 });
 
 
@@ -297,7 +293,7 @@ class __$EarthquakeHistoryMapLayerParameterCopyWithImpl<$Res>
 
 /// Create a copy of EarthquakeHistoryMapLayerParameter
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? regionToCity = null,Object? stationMinZoom = null,Object? stationLabelMinZoom = null,Object? stationTextZoom = null,Object? hypocenterFadeZoom = null,Object? hypocenterErrorMinZoom = null,Object? regionFillOpacity = null,Object? regionLineOpacity = null,Object? cityFillOpacity = null,Object? stationCircleRadiusMin = null,Object? stationCircleRadiusMax = null,Object? stationIconSizeMin = null,Object? stationIconSizeMid = null,Object? stationIconSizeMax = null,Object? hypocenterIconSizeMin = null,Object? hypocenterIconSizeMax = null,Object? hypocenterFadeOpacity = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? regionToCity = null,Object? stationMinZoom = null,Object? stationLabelMinZoom = null,Object? stationTextZoom = null,Object? hypocenterFadeZoom = null,Object? hypocenterErrorMinZoom = null,Object? regionFillOpacity = null,Object? regionLineOpacity = null,Object? cityFillOpacity = null,Object? stationIconSizeMin = null,Object? stationIconSizeMid = null,Object? stationIconSizeMax = null,Object? hypocenterIconSizeMin = null,Object? hypocenterIconSizeMax = null,Object? hypocenterFadeOpacity = null,}) {
   return _then(_EarthquakeHistoryMapLayerParameter(
 regionToCity: null == regionToCity ? _self.regionToCity : regionToCity // ignore: cast_nullable_to_non_nullable
 as double,stationMinZoom: null == stationMinZoom ? _self.stationMinZoom : stationMinZoom // ignore: cast_nullable_to_non_nullable
@@ -308,8 +304,6 @@ as double,hypocenterErrorMinZoom: null == hypocenterErrorMinZoom ? _self.hypocen
 as double,regionFillOpacity: null == regionFillOpacity ? _self.regionFillOpacity : regionFillOpacity // ignore: cast_nullable_to_non_nullable
 as double,regionLineOpacity: null == regionLineOpacity ? _self.regionLineOpacity : regionLineOpacity // ignore: cast_nullable_to_non_nullable
 as double,cityFillOpacity: null == cityFillOpacity ? _self.cityFillOpacity : cityFillOpacity // ignore: cast_nullable_to_non_nullable
-as double,stationCircleRadiusMin: null == stationCircleRadiusMin ? _self.stationCircleRadiusMin : stationCircleRadiusMin // ignore: cast_nullable_to_non_nullable
-as double,stationCircleRadiusMax: null == stationCircleRadiusMax ? _self.stationCircleRadiusMax : stationCircleRadiusMax // ignore: cast_nullable_to_non_nullable
 as double,stationIconSizeMin: null == stationIconSizeMin ? _self.stationIconSizeMin : stationIconSizeMin // ignore: cast_nullable_to_non_nullable
 as double,stationIconSizeMid: null == stationIconSizeMid ? _self.stationIconSizeMid : stationIconSizeMid // ignore: cast_nullable_to_non_nullable
 as double,stationIconSizeMax: null == stationIconSizeMax ? _self.stationIconSizeMax : stationIconSizeMax // ignore: cast_nullable_to_non_nullable

--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.g.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.g.dart
@@ -51,14 +51,6 @@ _$EarthquakeHistoryMapLayerParameterFromJson(Map<String, dynamic> json) =>
             'city_fill_opacity',
             (v) => (v as num?)?.toDouble() ?? 0.6,
           ),
-          stationCircleRadiusMin: $checkedConvert(
-            'station_circle_radius_min',
-            (v) => (v as num?)?.toDouble() ?? 0.8,
-          ),
-          stationCircleRadiusMax: $checkedConvert(
-            'station_circle_radius_max',
-            (v) => (v as num?)?.toDouble() ?? 6.7,
-          ),
           stationIconSizeMin: $checkedConvert(
             'station_icon_size_min',
             (v) => (v as num?)?.toDouble() ?? 0.03,
@@ -96,8 +88,6 @@ _$EarthquakeHistoryMapLayerParameterFromJson(Map<String, dynamic> json) =>
         'regionFillOpacity': 'region_fill_opacity',
         'regionLineOpacity': 'region_line_opacity',
         'cityFillOpacity': 'city_fill_opacity',
-        'stationCircleRadiusMin': 'station_circle_radius_min',
-        'stationCircleRadiusMax': 'station_circle_radius_max',
         'stationIconSizeMin': 'station_icon_size_min',
         'stationIconSizeMid': 'station_icon_size_mid',
         'stationIconSizeMax': 'station_icon_size_max',
@@ -119,8 +109,6 @@ Map<String, dynamic> _$EarthquakeHistoryMapLayerParameterToJson(
   'region_fill_opacity': instance.regionFillOpacity,
   'region_line_opacity': instance.regionLineOpacity,
   'city_fill_opacity': instance.cityFillOpacity,
-  'station_circle_radius_min': instance.stationCircleRadiusMin,
-  'station_circle_radius_max': instance.stationCircleRadiusMax,
   'station_icon_size_min': instance.stationIconSizeMin,
   'station_icon_size_mid': instance.stationIconSizeMid,
   'station_icon_size_max': instance.stationIconSizeMax,

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
@@ -101,7 +101,6 @@ class _MapContent extends HookConsumerWidget {
   final IntensityDisplayMode displayMode;
   final bool showingDb;
 
-  static const _stationLayerId = 'eq-history-station-intensity-circle';
   static const _dbStationLayerId = 'eq-history-shindo-db-station-icon';
   static const _regionSourceLayerId = 'areaForecastLocalE';
   static const _citySourceLayerId = 'areaInformationCityQuake';
@@ -334,7 +333,11 @@ class _MapContent extends HookConsumerWidget {
       return;
     }
 
-    if (hits.any((h) => h.layerId == _stationLayerId)) {
+    if (hits.any(
+      (h) =>
+          h.layerId ==
+          EarthquakeHistoryStationIntensityLayerBuilder.iconLayerId,
+    )) {
       final stationNode = _findNearestStation(event.point);
       if (stationNode == null) {
         return;

--- a/app/lib/feature/earthquake_history/ui/components/modal/earthquake_history_debug_modal.dart
+++ b/app/lib/feature/earthquake_history/ui/components/modal/earthquake_history_debug_modal.dart
@@ -154,22 +154,6 @@ class EarthquakeHistoryDebugModal extends ConsumerWidget {
                 (v) => notifier.save(value.copyWith(cityFillOpacity: v)),
               ),
 
-              _header(context, '観測点サイズ (circle-radius)'),
-              _slider(
-                '最小 (z4)',
-                value.stationCircleRadiusMin,
-                0,
-                20,
-                (v) => notifier.save(value.copyWith(stationCircleRadiusMin: v)),
-              ),
-              _slider(
-                '最大 (z10)',
-                value.stationCircleRadiusMax,
-                0,
-                20,
-                (v) => notifier.save(value.copyWith(stationCircleRadiusMax: v)),
-              ),
-
               _header(context, '観測点アイコンサイズ'),
               _slider(
                 '最小 (z3)',

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer.dart
@@ -100,23 +100,14 @@ class EarthquakeHistoryStationIntensityLayer extends HookConsumerWidget {
         if (lifecycleToken.value != token) {
           return;
         }
-        await styleController.addLayer(
-          layerBuilder.buildCircleLayer(
-            parameter: latestParameter.value,
-            stationDisplayMode: latestStationDisplayMode.value,
-          ),
-        );
-        if (latestIconData.value != null) {
+        for (final layer in layerBuilder.buildStyleLayers(
+          parameter: latestParameter.value,
+          stationDisplayMode: latestStationDisplayMode.value,
+          showStationLabel: latestShowStationLabel.value,
+          hasIcon: latestIconData.value != null,
+        )) {
           await styleController.addLayer(
-            layerBuilder.buildIconLayer(
-              parameter: latestParameter.value,
-              stationDisplayMode: latestStationDisplayMode.value,
-            ),
-          );
-        }
-        if (latestShowStationLabel.value) {
-          await styleController.addLayer(
-            layerBuilder.buildLabelLayer(parameter: latestParameter.value),
+            layer,
           );
         }
         latestLayerConfiguration.value = (
@@ -139,7 +130,6 @@ class EarthquakeHistoryStationIntensityLayer extends HookConsumerWidget {
               layerIds: const [
                 EarthquakeHistoryStationIntensityLayerBuilder.labelLayerId,
                 EarthquakeHistoryStationIntensityLayerBuilder.iconLayerId,
-                EarthquakeHistoryStationIntensityLayerBuilder.circleLayerId,
               ],
               sourceIds: const [
                 EarthquakeHistoryStationIntensityLayerBuilder.sourceId,
@@ -197,29 +187,19 @@ class EarthquakeHistoryStationIntensityLayer extends HookConsumerWidget {
               layerIds: const [
                 EarthquakeHistoryStationIntensityLayerBuilder.labelLayerId,
                 EarthquakeHistoryStationIntensityLayerBuilder.iconLayerId,
-                EarthquakeHistoryStationIntensityLayerBuilder.circleLayerId,
               ],
             );
             if (lifecycleToken.value != token) {
               return;
             }
-            await styleController.addLayer(
-              layerBuilder.buildCircleLayer(
-                parameter: parameter,
-                stationDisplayMode: stationDisplayMode,
-              ),
-            );
-            if (iconData != null) {
+            for (final layer in layerBuilder.buildStyleLayers(
+              parameter: parameter,
+              stationDisplayMode: stationDisplayMode,
+              showStationLabel: showStationLabel,
+              hasIcon: iconData != null,
+            )) {
               await styleController.addLayer(
-                layerBuilder.buildIconLayer(
-                  parameter: parameter,
-                  stationDisplayMode: stationDisplayMode,
-                ),
-              );
-            }
-            if (showStationLabel) {
-              await styleController.addLayer(
-                layerBuilder.buildLabelLayer(parameter: parameter),
+                layer,
               );
             }
             latestLayerConfiguration.value = configuration;
@@ -373,75 +353,22 @@ class EarthquakeHistoryStationIntensityLayerBuilder {
   const new();
 
   static const sourceId = 'eq-history-station-intensity';
-  static const circleLayerId = 'eq-history-station-intensity-circle';
   static const iconLayerId = 'eq-history-station-intensity-icon';
   static const labelLayerId = 'eq-history-station-intensity-label';
 
-  CircleStyleLayer buildCircleLayer({
+  List<StyleLayer> buildStyleLayers({
     required EarthquakeHistoryMapLayerParameter parameter,
     required StationDisplayMode stationDisplayMode,
-  }) {
-    return CircleStyleLayer(
-      id: circleLayerId,
-      sourceId: sourceId,
-      minZoom: parameter.stationMinZoom,
-      layout: const {
-        'circle-sort-key': ['get', 'sortKey'],
-      },
-      paint: {
-        'circle-radius': switch (stationDisplayMode) {
-          StationDisplayMode.allMinimized => [
-            'interpolate',
-            ['linear'],
-            ['zoom'],
-            4,
-            parameter.stationCircleRadiusMin * 2,
-            10,
-            parameter.stationCircleRadiusMax * 1.25,
-          ],
-          StationDisplayMode.normal => [
-            'interpolate',
-            ['linear'],
-            ['zoom'],
-            4,
-            parameter.stationCircleRadiusMin,
-            10,
-            parameter.stationCircleRadiusMax,
-          ],
-          StationDisplayMode.auto || StationDisplayMode.maxFocused => [
-            'interpolate',
-            ['linear'],
-            ['zoom'],
-            4,
-            [
-              'case',
-              ['get', 'isMax'],
-              parameter.stationCircleRadiusMin * 1.5,
-              parameter.stationCircleRadiusMin * 0.5,
-            ],
-            10,
-            [
-              'case',
-              ['get', 'isMax'],
-              parameter.stationCircleRadiusMax * 1.25,
-              parameter.stationCircleRadiusMax * 0.875,
-            ],
-          ],
-        },
-        'circle-color': ['get', 'color'],
-        'circle-stroke-color': '#ffffff',
-        'circle-stroke-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          4,
-          0.3,
-          10,
-          1.5,
-        ],
-      },
-    );
-  }
+    required bool showStationLabel,
+    required bool hasIcon,
+  }) => [
+    if (hasIcon)
+      buildIconLayer(
+        parameter: parameter,
+        stationDisplayMode: stationDisplayMode,
+      ),
+    if (showStationLabel) buildLabelLayer(parameter: parameter),
+  ];
 
   SymbolStyleLayer buildIconLayer({
     required EarthquakeHistoryMapLayerParameter parameter,

--- a/app/test/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter_test.dart
+++ b/app/test/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter_test.dart
@@ -11,4 +11,21 @@ void main() {
     );
     expect(restored.stationTextZoom, 9);
   });
+
+  test('Circle 専用の旧設定を読み飛ばし、再保存しない', () {
+    final restored = EarthquakeHistoryMapLayerParameter.fromJson({
+      'station_circle_radius_min': 1.2,
+      'station_circle_radius_max': 8.4,
+    });
+
+    expect(
+      restored.toJson(),
+      isNot(
+        anyOf(
+          contains('station_circle_radius_min'),
+          contains('station_circle_radius_max'),
+        ),
+      ),
+    );
+  });
 }

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer_lifecycle_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer_lifecycle_test.dart
@@ -1,8 +1,11 @@
 import 'dart:convert';
 
 import 'package:eqmonitor/core/theme/model/app_theme.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre/maplibre.dart';
 
 void main() {
   test('観測点データがない場合も更新可能な空 GeoJSON を生成する', () {
@@ -15,5 +18,22 @@ void main() {
 
     expect(decoded['features'], isEmpty);
     expect(EarthquakeHistoryStationIntensityLayerBuilder.sourceId, isNotEmpty);
+  });
+
+  test('観測点を Symbol レイヤーだけで描画する', () {
+    final layers = const EarthquakeHistoryStationIntensityLayerBuilder()
+        .buildStyleLayers(
+          parameter: const EarthquakeHistoryMapLayerParameter(),
+          stationDisplayMode: StationDisplayMode.auto,
+          showStationLabel: false,
+          hasIcon: true,
+        );
+
+    expect(layers, hasLength(1));
+    expect(layers.single, isA<SymbolStyleLayer>());
+    expect(
+      layers.single.id,
+      EarthquakeHistoryStationIntensityLayerBuilder.iconLayerId,
+    );
   });
 }


### PR DESCRIPTION
## 概要

地震履歴詳細ページのXML観測点からCircleStyleLayerを削除し、SymbolStyleLayerのみで描画するよう変更しました。

## 変更内容

- 観測点レイヤーの初期化・再構築・cleanupをSymbol-onlyへ統一
- 観測点タップ判定をCircleレイヤーIDからSymbolレイヤーIDへ変更
- Circle専用の地図パラメータとデバッグスライダーを削除
- 保存済みの旧Circle設定キーは読み飛ばし、再保存しないことをテスト
- Symbol-onlyのレイヤー構成を回帰テスト

## 検証

- 関連Flutterテスト: 10件成功
- 変更6ファイルのflutter analyze: No issues found
- app全体テスト: 2462件成功、今回の差分外で31件失敗
  - WebViewの進捗表示Widgetテスト
  - 通知・テーマ・地域選択などのWidgetテスト
  - estimated intensity archive hash timeoutテスト

## レビュー

独立レビューでCritical/Important指摘なし、Ready to merge判定です。