### PR TITLE
fix: EEW Live Activityのheadlineをライトモードでも白文字にする

### DIFF
--- a/app/ios/Widget/LiveActivity/Common/SharedComponents.swift
+++ b/app/ios/Widget/LiveActivity/Common/SharedComponents.swift
@@ -12,6 +12,8 @@ import WidgetKit
 
 /// 薄い文字色（ラベル、補助テキスト用）
 let liveActivitySecondaryTextColor: Color = .primary.opacity(0.55)
+/// ヘッダー内の主要な文字色。ヘッダー背景は常に濃色のため、外観に依らず白で固定する
+let liveActivityHeaderPrimaryTextColor: Color = .white
 /// ヘッダー内の薄い文字色（白ベース）
 let liveActivityHeaderSecondaryTextColor: Color = .white.opacity(0.7)
 

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
@@ -9,6 +9,7 @@ import WidgetKit
 // MARK: - EEW用カラー定義
 
 private let eewSecondaryTextColor: Color = liveActivitySecondaryTextColor
+private let eewHeaderPrimaryTextColor: Color = liveActivityHeaderPrimaryTextColor
 private let eewHeaderSecondaryTextColor: Color = liveActivityHeaderSecondaryTextColor
 
 // MARK: - EEW用スタイル
@@ -53,7 +54,7 @@ struct HeaderContainer: View {
                     if let headline = display.headerHeadline(from: headline) {
                         Text(headline)
                             .font(.system(size: 15, weight: .heavy))
-                            .foregroundColor(.primary)
+                            .foregroundColor(eewHeaderPrimaryTextColor)
                             .lineLimit(1)
                             .minimumScaleFactor(0.5)
                     }
@@ -67,7 +68,7 @@ struct HeaderContainer: View {
                         ArrivalCountdownText(
                             remaining: remaining,
                             size: 20,
-                            color: .white
+                            color: eewHeaderPrimaryTextColor
                         )
                     }
                 }

--- a/docs/knowledge/20260905_live_activity_header_text_color.md
+++ b/docs/knowledge/20260905_live_activity_header_text_color.md
@@ -1,0 +1,19 @@
+# Live Activity ヘッダー文字は `.primary` ではなく白固定
+
+- 日付: 2026-09-05
+- 対象: iOS Live Activity（EEW / 揺れ検知のヘッダー帯）
+
+## 制約
+
+EEW Live Activity のヘッダー背景は警報・予報・取消で常に濃色（赤 / 橙 / 灰）である。
+ここに `.foregroundColor(.primary)` を使うと、ライトモードでは黒文字になり、帯の上で読めなくなる。
+
+`.primary` はシステム外観に追従する。ヘッダー帯は外観に依らず濃色なので、文字色も外観に依らず白にする。
+
+## 方針
+
+- ヘッダー内の見出し・カウントダウンは `liveActivityHeaderPrimaryTextColor`（`.white`）
+- ヘッダー内の補助ラベルは既存の `liveActivityHeaderSecondaryTextColor`（`.white.opacity(0.7)`）
+- 白い本文エリア（震源地・M・深さ・時刻など）はこれまで通り `.primary`
+
+揺れ検知 Live Activity のヘッダーは当初から `.white` 直書きだった。EEW 側も同じ定数に揃える。


### PR DESCRIPTION
## Summary
- EEW Live Activity のヘッダー見出しが `.primary` のため、ライトモードで黒文字になっていた
- ヘッダー背景は警報・予報・取消いずれも濃色なので、見出しと到達カウントダウンを `liveActivityHeaderPrimaryTextColor`（白）に固定した
- 白い本文エリア（震源地・M など）の文字色は変更していない

## Before / After

| Before（ライトモードで見出しが黒） | After（見出しを白固定） |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/YumNumm/be55f89b101be16a1815ce9f14731a94/raw/d8b5d6672d093f6d829fab358a7f08df673ea126/before.jpg) | ![After](https://gist.githubusercontent.com/YumNumm/be55f89b101be16a1815ce9f14731a94/raw/385da8834c1979ab97c6b8ab341fcab88e455d14/after.jpg) |

## Test plan
- [ ] Xcode の Live Activity Preview（Lock Screen）をライトモードで開き、ヘッダーの見出しが白いことを確認する
- [ ] 警報・予報・取消の各プレビューで、ヘッダー内の見出しと到達カウントダウンが白いことを確認する
- [ ] 白い本文エリアの震源地・M・深さ・時刻が、ライトモードでは通常の濃色文字のままであることを確認する
- [ ] ダークモードでもヘッダー見出しが白いことを確認する


Made with [Cursor](https://cursor.com)