### PR TITLE
feat: EEW Live Activityを現在地情報中心の表示に刷新する

### DIFF
--- a/app/ios/EQMonitorPreviewWidget/EQMonitorPreviewWidgetBundle.swift
+++ b/app/ios/EQMonitorPreviewWidget/EQMonitorPreviewWidgetBundle.swift
@@ -23,49 +23,49 @@ struct EQMonitorPreviewWidgetBundle: WidgetBundle {
 private let eewPreviewAttributes = EewLiveActivityAttributes(eventId: "20240101161009")
 
 #Preview(
-    "EEW 報の進行 - Lock Screen",
+    "EEW デザイン確認 - Lock Screen",
     as: .content,
     using: eewPreviewAttributes
 ) {
     EewLiveActivityWidget()
 } contentStates: {
-    for state in EewContentState.warningSequence() {
+    for state in EewContentState.designReviewStates() {
         state
     }
 }
 
 #Preview(
-    "EEW 報の進行 - Expanded",
+    "EEW デザイン確認 - Expanded",
     as: .dynamicIsland(.expanded),
     using: eewPreviewAttributes
 ) {
     EewLiveActivityWidget()
 } contentStates: {
-    for state in EewContentState.warningSequence() {
+    for state in EewContentState.designReviewStates() {
         state
     }
 }
 
 #Preview(
-    "EEW 報の進行 - Compact",
+    "EEW デザイン確認 - Compact",
     as: .dynamicIsland(.compact),
     using: eewPreviewAttributes
 ) {
     EewLiveActivityWidget()
 } contentStates: {
-    for state in EewContentState.warningSequence() {
+    for state in EewContentState.designReviewStates() {
         state
     }
 }
 
 #Preview(
-    "EEW 報の進行 - Minimal",
+    "EEW デザイン確認 - Minimal",
     as: .dynamicIsland(.minimal),
     using: eewPreviewAttributes
 ) {
     EewLiveActivityWidget()
 } contentStates: {
-    for state in EewContentState.warningSequence() {
+    for state in EewContentState.designReviewStates() {
         state
     }
 }

--- a/app/ios/EQMonitorPreviewWidget/EQMonitorPreviewWidgetBundle.swift
+++ b/app/ios/EQMonitorPreviewWidget/EQMonitorPreviewWidgetBundle.swift
@@ -20,6 +20,10 @@ struct EQMonitorPreviewWidgetBundle: WidgetBundle {
 
 // MARK: - Live Activity Previews
 
+// State 1: 現在地が警報対象 / 2: 警報対象外・震度3 / 3: 予報・震度4
+// 4: 現在地なし / 5: 到達予想なし / 6: 警報対象・震度なし / 7: 取消
+// 8: 深発 / 9: PLUM / 10: 予報・震度3非表示 / 11: 震度1 / 12: 震度2
+
 private let eewPreviewAttributes = EewLiveActivityAttributes(eventId: "20240101161009")
 
 #Preview(

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		EE0700000000000000000001 /* LocationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0700000000000000000002 /* LocationInfo.swift */; };
 		010DC8E64C7C76B8F4F166D5 /* EarthquakeDisplayItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62ACEBEF0EEEF36A8EC1B1B1 /* EarthquakeDisplayItem.swift */; };
 		03155D2EC2B76909DF1A4693 /* ColorRGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687B9A2C44EF493FAA2AA83C /* ColorRGB.swift */; };
 		0653ECA8737307C2CA836FC7 /* IntensityValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 381A26E10F0EF7D7FEC86D79 /* IntensityValue.swift */; };
@@ -89,6 +88,11 @@
 		A55E7C010000000000000001 /* platform in Resources */ = {isa = PBXBuildFile; fileRef = A55E7C010000000000000002 /* platform */; };
 		A5A2B0013268000000000001 /* ApnsTokenEventChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A2B0003268000000000001 /* ApnsTokenEventChannel.swift */; };
 		AABB00032F30A00100000003 /* EQMonitorAPI in Frameworks */ = {isa = PBXBuildFile; productRef = AABB00022F30A00100000002 /* EQMonitorAPI */; };
+		B17000000000000000000001 /* BackgroundLocationPendingLocationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17000000000000000000003 /* BackgroundLocationPendingLocationStoreTests.swift */; };
+		B17000000000000000000002 /* PendingLocationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17000000000000000000004 /* PendingLocationStore.swift */; };
+		B18000000000000000000001 /* BackgroundLocationHeadlessTaskStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18000000000000000000003 /* BackgroundLocationHeadlessTaskStateTests.swift */; };
+		B18000000000000000000002 /* HeadlessTaskState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18000000000000000000004 /* HeadlessTaskState.swift */; };
+		B19000000000000000000001 /* HeadlessExecutionLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19000000000000000000002 /* HeadlessExecutionLifecycle.swift */; };
 		B4B358134720AB041967E6FF /* RegionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90F30E033EFA7F3A113F856 /* RegionType.swift */; };
 		BC0CFBCC72CE2AE431EFB5A8 /* RegionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90F30E033EFA7F3A113F856 /* RegionType.swift */; };
 		BFEAEC9B65D462419D75AB02 /* IntensityValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 381A26E10F0EF7D7FEC86D79 /* IntensityValue.swift */; };
@@ -100,6 +104,7 @@
 		D11444444444444444444444 /* EarthquakeDetailURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11222222222222222222222 /* EarthquakeDetailURL.swift */; };
 		D11555555555555555555555 /* WidgetBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11333333333333333333333 /* WidgetBehaviorTests.swift */; };
 		E8CFD3E6506B946469164594 /* ColorRGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687B9A2C44EF493FAA2AA83C /* ColorRGB.swift */; };
+		EE0700000000000000000001 /* LocationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0700000000000000000002 /* LocationInfo.swift */; };
 		EQ0000000000000000000065 /* LiveActivityDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000001 /* LiveActivityDate.swift */; };
 		EQ0000000000000000000066 /* LiveActivityDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000001 /* LiveActivityDate.swift */; };
 		EQ0000000000000000000067 /* WidgetErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000002 /* WidgetErrorMessage.swift */; };
@@ -112,11 +117,6 @@
 		EQ0000000000000000000070 /* EewDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000006 /* EewDisplayTests.swift */; };
 		EQ0000000000000000000071 /* WidgetRegionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000007 /* WidgetRegionResolverTests.swift */; };
 		EQ00000000000000000000C8 /* LiveActivityDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000001 /* LiveActivityDate.swift */; };
-		B17000000000000000000001 /* BackgroundLocationPendingLocationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17000000000000000000003 /* BackgroundLocationPendingLocationStoreTests.swift */; };
-		B17000000000000000000002 /* PendingLocationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17000000000000000000004 /* PendingLocationStore.swift */; };
-		B18000000000000000000001 /* BackgroundLocationHeadlessTaskStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18000000000000000000003 /* BackgroundLocationHeadlessTaskStateTests.swift */; };
-		B18000000000000000000002 /* HeadlessTaskState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18000000000000000000004 /* HeadlessTaskState.swift */; };
-		B19000000000000000000001 /* HeadlessExecutionLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19000000000000000000002 /* HeadlessExecutionLifecycle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -200,13 +200,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		EE0700000000000000000002 /* LocationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LocationInfo.swift; path = Widget/LiveActivity/Common/LocationInfo.swift; sourceTree = SOURCE_ROOT; };
 		09B0693317F839417671E186 /* GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf"; path = "../assets/fonts/GoogleSansFlex/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		2709A8752F1FFFF400FBE962 /* LiveActivityUtil.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = LiveActivityUtil.xcframework; sourceTree = "<group>"; };
-		27145F013039E00000C3DBAF /* EQMonitorPreviewWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = EQMonitorPreviewWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		27145E043039D29C00C3DBAF /* EQMonitorPreview.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EQMonitorPreview.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		27145F013039E00000C3DBAF /* EQMonitorPreviewWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = EQMonitorPreviewWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		27D62BB52FF6E75000EF6A27 /* AppIntentExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = AppIntentExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		381A26E10F0EF7D7FEC86D79 /* IntensityValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntensityValue.swift; sourceTree = "<group>"; };
 		3993800175F9E9F9140BCEE0 /* WidgetModelsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WidgetModelsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -253,6 +252,11 @@
 		A5A2B0003268000000000001 /* ApnsTokenEventChannel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApnsTokenEventChannel.swift; sourceTree = "<group>"; };
 		AB5330C1132EC785A60DE272 /* EarthquakeAPIClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EarthquakeAPIClient.swift; sourceTree = "<group>"; };
 		AD5D302A98B76C01E6D49E1B /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		B17000000000000000000003 /* BackgroundLocationPendingLocationStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundLocationPendingLocationStoreTests.swift; sourceTree = "<group>"; };
+		B17000000000000000000004 /* PendingLocationStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PendingLocationStore.swift; path = ../../packages/background_location_tracker/ios/background_location_tracker/Sources/background_location_tracker/PendingLocationStore.swift; sourceTree = SOURCE_ROOT; };
+		B18000000000000000000003 /* BackgroundLocationHeadlessTaskStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundLocationHeadlessTaskStateTests.swift; sourceTree = "<group>"; };
+		B18000000000000000000004 /* HeadlessTaskState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HeadlessTaskState.swift; path = ../../packages/background_location_tracker/ios/background_location_tracker/Sources/background_location_tracker/HeadlessTaskState.swift; sourceTree = SOURCE_ROOT; };
+		B19000000000000000000002 /* HeadlessExecutionLifecycle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HeadlessExecutionLifecycle.swift; path = ../../packages/background_location_tracker/ios/background_location_tracker/Sources/background_location_tracker/HeadlessExecutionLifecycle.swift; sourceTree = SOURCE_ROOT; };
 		B6B6DA9CE2EEF26041AC4AA5 /* WidgetRegionResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetRegionResolver.swift; sourceTree = "<group>"; };
 		C90F30E033EFA7F3A113F856 /* RegionType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RegionType.swift; sourceTree = "<group>"; };
 		C983AB8FC2BFED453E240464 /* EarthquakeDisplayItemTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EarthquakeDisplayItemTests.swift; sourceTree = "<group>"; };
@@ -260,6 +264,7 @@
 		E11111111111111111111111 /* WidgetLayoutPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetLayoutPolicy.swift; sourceTree = "<group>"; };
 		E11222222222222222222222 /* EarthquakeDetailURL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EarthquakeDetailURL.swift; sourceTree = "<group>"; };
 		E11333333333333333333333 /* WidgetBehaviorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetBehaviorTests.swift; sourceTree = "<group>"; };
+		EE0700000000000000000002 /* LocationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LocationInfo.swift; path = Widget/LiveActivity/Common/LocationInfo.swift; sourceTree = SOURCE_ROOT; };
 		EQ0000000000000000000001 /* LiveActivityDate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveActivityDate.swift; sourceTree = "<group>"; };
 		EQ0000000000000000000002 /* WidgetErrorMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetErrorMessage.swift; sourceTree = "<group>"; };
 		EQ0000000000000000000003 /* LiveActivityDateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveActivityDateTests.swift; sourceTree = "<group>"; };
@@ -267,11 +272,6 @@
 		EQ0000000000000000000005 /* EewDisplay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EewDisplay.swift; sourceTree = "<group>"; };
 		EQ0000000000000000000006 /* EewDisplayTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EewDisplayTests.swift; sourceTree = "<group>"; };
 		EQ0000000000000000000007 /* WidgetRegionResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetRegionResolverTests.swift; sourceTree = "<group>"; };
-		B17000000000000000000003 /* BackgroundLocationPendingLocationStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundLocationPendingLocationStoreTests.swift; sourceTree = "<group>"; };
-		B17000000000000000000004 /* PendingLocationStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PendingLocationStore.swift; path = ../../packages/background_location_tracker/ios/background_location_tracker/Sources/background_location_tracker/PendingLocationStore.swift; sourceTree = SOURCE_ROOT; };
-		B18000000000000000000003 /* BackgroundLocationHeadlessTaskStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundLocationHeadlessTaskStateTests.swift; sourceTree = "<group>"; };
-		B18000000000000000000004 /* HeadlessTaskState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HeadlessTaskState.swift; path = ../../packages/background_location_tracker/ios/background_location_tracker/Sources/background_location_tracker/HeadlessTaskState.swift; sourceTree = SOURCE_ROOT; };
-		B19000000000000000000002 /* HeadlessExecutionLifecycle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HeadlessExecutionLifecycle.swift; path = ../../packages/background_location_tracker/ios/background_location_tracker/Sources/background_location_tracker/HeadlessExecutionLifecycle.swift; sourceTree = SOURCE_ROOT; };
 		FB4211733B19AA27C617F8A5 /* TelegramStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TelegramStatus.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -284,8 +284,11 @@
 				DesignSystem.swift,
 				LiveActivity/Common/LocationInfo.swift,
 				LiveActivity/Common/SharedComponents.swift,
+				LiveActivity/Eew/EewIntensityViews.swift,
 				LiveActivity/Eew/EewLiveActivityAttributes.swift,
 				LiveActivity/Eew/EewLiveActivityView.swift,
+				LiveActivity/Eew/EewLocationViews.swift,
+				LiveActivity/Eew/EewSourceMetricsView.swift,
 				LiveActivity/EQMonitorLiveActivityWidget.swift,
 				LiveActivity/ShakeDetection/ShakeDetectionLiveActivityAttributes.swift,
 				LiveActivity/ShakeDetection/ShakeDetectionLiveActivityView.swift,
@@ -327,8 +330,8 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		27145F023039E00000C3DBAF /* EQMonitorPreviewWidget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (27145F043039E00000C3DBAF /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = EQMonitorPreviewWidget; sourceTree = "<group>"; };
 		27145E053039D29C00C3DBAF /* EQMonitorPreview */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = EQMonitorPreview; sourceTree = "<group>"; };
+		27145F023039E00000C3DBAF /* EQMonitorPreviewWidget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (27145F043039E00000C3DBAF /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = EQMonitorPreviewWidget; sourceTree = "<group>"; };
 		27D62BB62FF6E75000EF6A27 /* AppIntentExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (463834D25A2C7A8F74710E0C /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 27D62BC32FF6E75000EF6A27 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = AppIntentExtension; sourceTree = "<group>"; };
 		85C54CFE2E96C7E800BFBBAB /* Widget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (85C54D102E96C7EA00BFBBAB /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 27145E1B3039D35E00C3DBAF /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Widget; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -409,6 +412,14 @@
 				A1B2C3D42F6A000100000001 /* AssetsUtil.xcframework */,
 			);
 			path = Frameworks;
+			sourceTree = "<group>";
+		};
+		27724A23304DC4E300666426 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				EE0700000000000000000002 /* LocationInfo.swift */,
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		350740DFB98F1F20FD8318FB /* Fonts */ = {
@@ -503,6 +514,7 @@
 				3770F148FEB3FAEFF53D21CE /* WidgetModelsTests */,
 				350740DFB98F1F20FD8318FB /* Fonts */,
 				F8BCF7FBC6A9336C62FA711E /* Parameters */,
+				27724A23304DC4E300666426 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1348,6 +1360,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = CPL7H8SHVM;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1365,20 +1378,19 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = net.yumnumm.EQMonitorPreview.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		EE0700000000000000000001 /* LocationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0700000000000000000002 /* LocationInfo.swift */; };
 		010DC8E64C7C76B8F4F166D5 /* EarthquakeDisplayItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62ACEBEF0EEEF36A8EC1B1B1 /* EarthquakeDisplayItem.swift */; };
 		03155D2EC2B76909DF1A4693 /* ColorRGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687B9A2C44EF493FAA2AA83C /* ColorRGB.swift */; };
 		0653ECA8737307C2CA836FC7 /* IntensityValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 381A26E10F0EF7D7FEC86D79 /* IntensityValue.swift */; };
@@ -199,6 +200,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		EE0700000000000000000002 /* LocationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LocationInfo.swift; path = Widget/LiveActivity/Common/LocationInfo.swift; sourceTree = SOURCE_ROOT; };
 		09B0693317F839417671E186 /* GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf"; path = "../assets/fonts/GoogleSansFlex/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
@@ -975,6 +977,7 @@
 				EQ0000000000000000000071 /* WidgetRegionResolverTests.swift in Sources */,
 				EQ000000000000000000006F /* EewDisplay.swift in Sources */,
 				EQ0000000000000000000070 /* EewDisplayTests.swift in Sources */,
+				EE0700000000000000000001 /* LocationInfo.swift in Sources */,
 				EQ0000000000000000000066 /* LiveActivityDate.swift in Sources */,
 				EQ0000000000000000000068 /* WidgetErrorMessage.swift in Sources */,
 				EQ000000000000000000006A /* LiveActivityDateTests.swift in Sources */,

--- a/app/ios/Shared/EewDisplay.swift
+++ b/app/ios/Shared/EewDisplay.swift
@@ -138,7 +138,7 @@ struct EewDisplay: Equatable {
 
     // MARK: - 取消報の文言
 
-    static let canceledTitle = "緊急地震速報は取り消されました"
+    static let canceledTitle = "先ほどの緊急地震速報は取り消されました"
 
     // MARK: - 深発地震の文言
 

--- a/app/ios/Shared/EewDisplay.swift
+++ b/app/ios/Shared/EewDisplay.swift
@@ -104,10 +104,10 @@ struct EewDisplay: Equatable {
 
     // MARK: - 文言
 
-    /// 「緊急地震速報(警報)」「緊急地震速報(予報)」「緊急地震速報(取消)」
+    /// 取消時は種別を付けず、見出しで取り消された事実を伝える。
     var typeLabel: String {
         if isCanceled {
-            return "緊急地震速報(取消)"
+            return "緊急地震速報"
         }
         return isWarning ? "緊急地震速報(警報)" : "緊急地震速報(予報)"
     }
@@ -139,7 +139,6 @@ struct EewDisplay: Equatable {
     // MARK: - 取消報の文言
 
     static let canceledTitle = "緊急地震速報は取り消されました"
-    static let canceledDescription = "予想震度・主要動到達の予想は無効です"
 
     // MARK: - 深発地震の文言
 

--- a/app/ios/Shared/EewDisplay.swift
+++ b/app/ios/Shared/EewDisplay.swift
@@ -66,7 +66,7 @@ struct EewDisplay: Equatable {
     var locationNotice: EewLocationNotice? {
         guard !isCanceled else { return nil }
         if isWarning && isLocationWarning { return .warning }
-        if let localIntensity, localIntensity >= .four { return .forecast }
+        if let localIntensity { return localIntensity < .two ? .weak : .forecast }
         return nil
     }
 
@@ -152,11 +152,13 @@ struct EewDisplay: Equatable {
 enum EewLocationNotice: Equatable {
     case warning
     case forecast
+    case weak
 
     var title: String {
         switch self {
         case .warning: return "現在地で強い揺れ"
         case .forecast: return "現在地で揺れ"
+        case .weak: return "現在地で弱い揺れ"
         }
     }
 }

--- a/app/ios/Shared/EewDisplay.swift
+++ b/app/ios/Shared/EewDisplay.swift
@@ -63,6 +63,8 @@ struct EewDisplay: Equatable {
 
     var usesLocalIntensity: Bool { localIntensity != nil }
 
+    var showsEventTime: Bool { !isCanceled && !usesLocalIntensity }
+
     var locationNotice: EewLocationNotice? {
         guard !isCanceled else { return nil }
         if isWarning && isLocationWarning { return .warning }

--- a/app/ios/Shared/EewDisplay.swift
+++ b/app/ios/Shared/EewDisplay.swift
@@ -39,6 +39,8 @@ struct EewDisplay: Equatable {
     let depth: Double?
     /// PLUM法・レベル法・1点検知など、仮定震源要素による低精度の検知か
     let isLowAccuracyDetection: Bool
+    var isLocationWarning: Bool = false
+    var isLocationPlum: Bool = false
 
     // MARK: - 表示可否
 
@@ -49,17 +51,33 @@ struct EewDisplay: Equatable {
     /// 無ければ全国の最大震度にフォールバックする。取消報では出さない。
     var intensity: IntensityValue? {
         guard !isCanceled else { return nil }
-        return forecastIntensity ?? maxIntensity
+        return localIntensity ?? maxIntensity
+    }
+
+    /// 予報では現在地の予想震度4以上のみ表示する。警報でも未提供の値は補わない。
+    var localIntensity: IntensityValue? {
+        guard !isCanceled, let forecastIntensity,
+              isWarning || forecastIntensity >= .four else { return nil }
+        return forecastIntensity
+    }
+
+    var usesLocalIntensity: Bool { localIntensity != nil }
+
+    var locationNotice: EewLocationNotice? {
+        guard !isCanceled else { return nil }
+        if isWarning && isLocationWarning { return .warning }
+        if let localIntensity, localIntensity >= .four { return .forecast }
+        return nil
     }
 
     /// [intensity] がどちらの震度かを示すラベル
     var intensityLabel: String {
-        forecastIntensity != nil ? "予想震度" : "最大震度"
+        usesLocalIntensity ? "予想震度" : "最大震度"
     }
 
     /// 主要動到達カウントダウンに使う時刻。取消報では到達予想も無効。
     var countdownArrivalDate: Date? {
-        isCanceled ? nil : arrivalDate
+        usesLocalIntensity && !isLocationPlum ? arrivalDate : nil
     }
 
     /// 深発地震のため予想震度が発表されない旨の注釈を出すか。
@@ -129,4 +147,16 @@ struct EewDisplay: Equatable {
     /// `EewDeepHypocenterIntensityNotice` と同じ基準にする。
     static let deepHypocenterDepthThreshold: Double = 150
     static let deepHypocenterIntensityNotice = "震源の深さが150kmより深いため、予想震度は発表されていません"
+}
+
+enum EewLocationNotice: Equatable {
+    case warning
+    case forecast
+
+    var title: String {
+        switch self {
+        case .warning: return "現在地で強い揺れ"
+        case .forecast: return "現在地で揺れ"
+        }
+    }
 }

--- a/app/ios/Widget/LiveActivity/Common/LocationInfo.swift
+++ b/app/ios/Widget/LiveActivity/Common/LocationInfo.swift
@@ -11,6 +11,8 @@ struct LocationInfo: Codable, Hashable {
     let forecastLpgmIntensity: String?
     let arrivalTime: String?
     let intensity: Double?
+    var isWarning: Bool? = nil
+    var isPlum: Bool? = nil
 
     var forecastIntensityValue: IntensityValue? {
         guard let forecastIntensity = forecastIntensity else { return nil }

--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -192,6 +192,14 @@ struct EewExpandedBottomView: View {
                 EewHypocenterSummaryView(state: state, size: 16)
             }
 
+            if state.display.showsEventTime, let date = state.timeDate {
+                Text("\(state.timeLabel)  \(JSTDateFormat.monthDay(date)) \(JSTDateFormat.timeWithSeconds(date))")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.75))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+
             if state.display.usesLocalIntensity || state.display.locationNotice != nil {
                 EewExpandedLocationView(state: state, intensitySize: compact ? 44 : 56)
             }

--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -28,7 +28,14 @@ struct EewLiveActivityWidget: Widget {
                         .dynamicIsland(verticalPlacement: .belowIfTooWide)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    EewExpandedBottomView(state: context.state)
+                    ViewThatFits(in: .vertical) {
+                        EewExpandedBottomView(state: context.state)
+                            .fixedSize(horizontal: false, vertical: true)
+                        EewExpandedBottomView(state: context.state, compact: true)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.bottom, 8)
                 }
             } compactLeading: {
                 EewCompactLeadingView(state: context.state)
@@ -168,6 +175,7 @@ struct EewExpandedTrailingView: View {
 @available(iOS 16.1, *)
 struct EewExpandedBottomView: View {
     let state: EewContentState
+    var compact = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
@@ -179,19 +187,19 @@ struct EewExpandedBottomView: View {
                     .foregroundStyle(.white.opacity(0.75))
             } else {
                 Text(state.display.typeLabel)
-                    .font(AppFonts.flex(size: 11, weight: .medium))
+                    .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.white.opacity(0.8))
-                    .fixedSize(horizontal: false, vertical: true)
+                    .fixedSize(horizontal: true, vertical: true)
                 if let headline = state.display.headline(from: state.headline) {
                     Text(headline)
                         .font(AppFonts.flex(size: 16, weight: .heavy))
-                        .lineLimit(2)
+                        .lineLimit(compact ? 1 : 2)
                 } else {
                     EewHypocenterSummaryView(state: state, size: 16)
                 }
 
                 if state.display.usesLocalIntensity || state.display.locationNotice != nil {
-                    EewExpandedLocationView(state: state)
+                    EewExpandedLocationView(state: state, intensitySize: compact ? 44 : 56)
                 }
             }
         }
@@ -202,6 +210,7 @@ struct EewExpandedBottomView: View {
 @available(iOS 16.1, *)
 private struct EewExpandedLocationView: View {
     let state: EewContentState
+    let intensitySize: CGFloat
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 8) {
@@ -225,7 +234,7 @@ private struct EewExpandedLocationView: View {
                     .fixedSize()
             }
             if let intensity = state.display.localIntensity {
-                EewLocalIntensityView(intensity: intensity, size: 56)
+                EewLocalIntensityView(intensity: intensity, size: intensitySize)
                     .fixedSize()
             }
         }

--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -146,11 +146,10 @@ struct EewExpandedLeadingView: View {
     let state: EewContentState
 
     var body: some View {
-        if state.display.isCanceled {
-            EewCanceledSymbol(size: 30)
-        } else {
-            EewMaximumIntensityView(intensity: state.display.maxIntensity, size: 38)
-        }
+        EewMaximumIntensityView(intensity: state.display.maxIntensity, size: 38, inlineMaximumLabel: true)
+            .padding(.horizontal, 4)
+            .opacity(state.display.isCanceled ? 0 : 1)
+            .accessibilityHidden(state.display.isCanceled)
     }
 }
 
@@ -162,8 +161,10 @@ struct EewExpandedTrailingView: View {
         if state.display.isCanceled {
             if let serialLabel = state.display.serialLabel {
                 Text(serialLabel)
-                    .font(AppFonts.code(size: 11, weight: .bold))
+                    .font(.system(size: 11, weight: .bold))
                     .foregroundStyle(.white.opacity(0.75))
+                    .fixedSize()
+                    .padding(4)
             }
         } else {
             EewSourceMetricsView(state: state, vertical: true, size: 21)
@@ -179,30 +180,23 @@ struct EewExpandedBottomView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
-            if state.display.isCanceled {
-                Text(EewDisplay.canceledTitle)
-                    .font(AppFonts.flex(size: 15, weight: .bold))
-                Text(EewDisplay.canceledDescription)
-                    .font(AppFonts.flex(size: 12))
-                    .foregroundStyle(.white.opacity(0.75))
+            Text(state.display.typeLabel)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.white.opacity(0.8))
+                .fixedSize(horizontal: true, vertical: true)
+            if let headline = state.display.headerHeadline(from: state.headline) {
+                Text(headline)
+                    .font(AppFonts.flex(size: 16, weight: .heavy))
+                    .lineLimit(compact ? 1 : 2)
             } else {
-                Text(state.display.typeLabel)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.8))
-                    .fixedSize(horizontal: true, vertical: true)
-                if let headline = state.display.headline(from: state.headline) {
-                    Text(headline)
-                        .font(AppFonts.flex(size: 16, weight: .heavy))
-                        .lineLimit(compact ? 1 : 2)
-                } else {
-                    EewHypocenterSummaryView(state: state, size: 16)
-                }
+                EewHypocenterSummaryView(state: state, size: 16)
+            }
 
-                if state.display.usesLocalIntensity || state.display.locationNotice != nil {
-                    EewExpandedLocationView(state: state, intensitySize: compact ? 44 : 56)
-                }
+            if state.display.usesLocalIntensity || state.display.locationNotice != nil {
+                EewExpandedLocationView(state: state, intensitySize: compact ? 44 : 56)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .foregroundStyle(.white)
     }
 }
@@ -234,7 +228,7 @@ private struct EewExpandedLocationView: View {
                     .fixedSize()
             }
             if let intensity = state.display.localIntensity {
-                EewLocalIntensityView(intensity: intensity, size: intensitySize)
+                EewLocalIntensityView(intensity: intensity, size: intensitySize, containerRelative: true)
                     .fixedSize()
             }
         }

--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -14,6 +14,8 @@ struct EewLiveActivityWidget: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: EewLiveActivityAttributes.self) { context in
             EewLockScreenView(state: context.state)
+                .activityBackgroundTint(.black)
+                .activitySystemActionForegroundColor(.white)
         } dynamicIsland: { context in
             DynamicIsland {
                 // leading / trailing は TrueDepth カメラ脇の細い L 字領域で、
@@ -28,9 +30,6 @@ struct EewLiveActivityWidget: Widget {
                 }
                 DynamicIslandExpandedRegion(.bottom) {
                     EewExpandedBottomView(state: context.state)
-                }
-                DynamicIslandExpandedRegion(.center) {
-                    EewExpandedCenterView(state: context.state)
                 }
             } compactLeading: {
                 EewCompactLeadingView(state: context.state)
@@ -96,26 +95,21 @@ struct EewCompactLeadingView: View {
     var body: some View {
         if state.display.isCanceled {
             EewCanceledSymbol(size: 20)
+        } else if let intensity = state.display.localIntensity {
+            EewLocalIntensityView(intensity: intensity, size: 26)
         } else {
-            DynamicIslandIntensityBadge(
-                intensity: state.display.intensity,
-                size: 24
-            )
+            EewMaximumIntensityView(intensity: state.display.maxIntensity, size: 20)
         }
     }
 }
 
-/// compact では主要動到達までの残り時間を最優先で出す。
-/// Apple のタイマーと同じく、畳んだ状態で知りたいのは「あと何秒か」だけ。
 @available(iOS 16.1, *)
 struct EewCompactTrailingView: View {
     let state: EewContentState
 
     var body: some View {
-        if let remaining = ArrivalCountdown.remaining(
-            until: state.display.countdownArrivalDate
-        ) {
-            ArrivalCountdownText(remaining: remaining, size: 14)
+        if let remaining = ArrivalCountdown.remaining(until: state.display.countdownArrivalDate) {
+            ArrivalCountdownText(remaining: remaining, size: 14, color: .white)
         } else {
             EewStatusPill(
                 isWarning: state.display.isWarning,
@@ -133,30 +127,23 @@ struct EewMinimalView: View {
     var body: some View {
         if state.display.isCanceled {
             EewCanceledSymbol(size: 18)
+        } else if let intensity = state.display.localIntensity {
+            EewLocalIntensityView(intensity: intensity, size: 24)
         } else {
-            DynamicIslandIntensityBadge(
-                intensity: state.display.intensity,
-                size: 22
-            )
+            EewMaximumIntensityView(intensity: state.display.maxIntensity, size: 19)
         }
     }
 }
 
-/// 展開時の leading。細い L 字領域では要素を積むと角で切り取られるため、
-/// ラベルは center 行へ回して常に 1 要素だけ置く。
 @available(iOS 16.1, *)
 struct EewExpandedLeadingView: View {
     let state: EewContentState
 
     var body: some View {
-        switch state.display.dynamicIslandLayout {
-        case .canceled:
-            EewCanceledSymbol(size: DynamicIslandMetrics.expandedBadgeSize * 0.75)
-        case .countdown, .summary:
-            DynamicIslandIntensityBadge(
-                intensity: state.display.intensity,
-                size: DynamicIslandMetrics.expandedBadgeSize
-            )
+        if state.display.isCanceled {
+            EewCanceledSymbol(size: 30)
+        } else {
+            EewMaximumIntensityView(intensity: state.display.maxIntensity, size: 32)
         }
     }
 }
@@ -166,92 +153,16 @@ struct EewExpandedTrailingView: View {
     let state: EewContentState
 
     var body: some View {
-        switch state.display.dynamicIslandLayout {
-        case .canceled:
-            // center の主文と重ならないよう、取消バッジではなく報番号だけを添える
+        if state.display.isCanceled {
             if let serialLabel = state.display.serialLabel {
                 Text(serialLabel)
                     .font(AppFonts.code(size: 11, weight: .bold))
-                    .monospacedDigit()
-                    .foregroundStyle(Color.eqTextTertiary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.7)
+                    .foregroundStyle(.white.opacity(0.75))
             }
-        case .countdown:
-            if let remaining = ArrivalCountdown.remaining(
-                until: state.display.countdownArrivalDate
-            ) {
-                ArrivalCountdownText(remaining: remaining, size: 26)
-            }
-        case .summary:
-            EewStatusPill(
-                isWarning: state.display.isWarning,
-                isCanceled: state.display.isCanceled
-            )
-        }
-    }
-}
-
-/// leading / trailing の値に対する説明ラベル行。
-/// カメラ下の全幅領域なので、左右端に寄せれば上の値の真下に並ぶ。
-@available(iOS 16.1, *)
-struct EewExpandedCenterView: View {
-    let state: EewContentState
-
-    var body: some View {
-        switch state.display.dynamicIslandLayout {
-        case .canceled:
-            Text(EewDisplay.canceledTitle)
-                .font(AppFonts.flex(size: 14, weight: .bold))
-                .foregroundStyle(Color.eqTextPrimary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-        case .countdown:
-            HStack(spacing: 6) {
-                intensityCaption
-                Spacer(minLength: 4)
-                captionText("主要動到達まで")
-            }
-        case .summary:
-            HStack(spacing: 6) {
-                intensityCaption
-                Spacer(minLength: 4)
-                if let serialLabel = state.display.serialLabel {
-                    captionText(serialLabel)
-                }
-            }
-        }
-    }
-
-    /// leading のバッジがどの震度かを示すラベル。
-    /// 現在地の予想震度を出しているときだけ地名を添える。全国の最大震度に
-    /// フォールバックしている場合に地名を出すと誤読を招く。
-    @ViewBuilder
-    private var intensityCaption: some View {
-        if state.display.forecastIntensity != nil,
-           let regionName = state.location?.regionName,
-           !regionName.isEmpty {
-            HStack(spacing: 2) {
-                // SF Symbol はカスタムフォントのメトリクスに引っ張られるためシステムフォントで描く
-                Image(systemName: "location.fill")
-                    .font(.system(size: 9, weight: .semibold))
-                Text(regionName)
-                    .font(AppFonts.flex(size: 11, weight: .semibold))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.7)
-            }
-            .foregroundStyle(Color.eqTextSecondary)
         } else {
-            captionText(state.display.intensityLabel)
+            EewSourceMetricsView(state: state, vertical: true, size: 54.196 / 3)
+                .foregroundStyle(.white)
         }
-    }
-
-    private func captionText(_ text: String) -> some View {
-        Text(text)
-            .font(AppFonts.flex(size: 11, weight: .medium))
-            .foregroundStyle(Color.eqTextSecondary)
-            .lineLimit(1)
-            .minimumScaleFactor(0.7)
     }
 }
 
@@ -260,30 +171,62 @@ struct EewExpandedBottomView: View {
     let state: EewContentState
 
     var body: some View {
-        switch state.display.dynamicIslandLayout {
-        case .canceled:
-            Text(EewDisplay.canceledDescription)
-                .font(AppFonts.flex(size: 12, weight: .medium))
-                .foregroundStyle(Color.eqTextSecondary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-        case .countdown:
-            // カウントダウンを主役にするため、震源要素は 1 行に抑える
-            HStack(alignment: .firstTextBaseline, spacing: 6) {
-                EewStatusPill(
-                    isWarning: state.display.isWarning,
-                    isCanceled: state.display.isCanceled,
-                    compact: true
-                )
-                EewHypocenterSummaryView(state: state, size: 13)
-                Spacer(minLength: 4)
-                EewHypocenterDetailView(state: state, size: 14)
+        VStack(alignment: .leading, spacing: 5) {
+            if state.display.isCanceled {
+                Text(EewDisplay.canceledTitle)
+                    .font(AppFonts.flex(size: 15, weight: .bold))
+                Text(EewDisplay.canceledDescription)
+                    .font(AppFonts.flex(size: 12))
+                    .foregroundStyle(.white.opacity(0.75))
+            } else {
+                Text(state.display.typeLabel)
+                    .font(AppFonts.flex(size: 11, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.8))
+                if let headline = state.display.headline(from: state.headline) {
+                    Text(headline)
+                        .font(AppFonts.flex(size: 16, weight: .heavy))
+                        .lineLimit(2)
+                } else {
+                    EewHypocenterSummaryView(state: state, size: 16)
+                }
+
+                if state.display.usesLocalIntensity || state.display.locationNotice != nil {
+                    EewExpandedLocationView(state: state)
+                }
             }
-        case .summary:
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                EewHypocenterSummaryView(state: state, size: 15)
-                Spacer(minLength: 4)
-                EewHypocenterDetailView(state: state, size: 16)
+        }
+        .foregroundStyle(.white)
+    }
+}
+
+@available(iOS 16.1, *)
+private struct EewExpandedLocationView: View {
+    let state: EewContentState
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            if let notice = state.display.locationNotice {
+                EewLocationNoticeView(notice: notice, intensity: state.display.localIntensity)
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("現在地")
+                        .font(AppFonts.flex(size: 10, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.75))
+                    if let regionName = state.location?.regionName, !regionName.isEmpty {
+                        Text(regionName)
+                            .font(AppFonts.flex(size: 12, weight: .bold))
+                            .lineLimit(2)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            if let arrivalDate = state.display.countdownArrivalDate {
+                EewArrivalView(arrivalDate: arrivalDate)
+                    .fixedSize()
+            }
+            if let intensity = state.display.localIntensity {
+                EewLocalIntensityView(intensity: intensity, size: 56)
+                    .fixedSize()
             }
         }
     }
@@ -318,64 +261,6 @@ struct EewHypocenterSummaryView: View {
     }
 }
 
-/// M・深さ。精度の低い検知（PLUM法・レベル法・1点検知）では
-/// 数値を出さず検知方法を示す（Lock Screen と同じ判断）。
-@available(iOS 16.1, *)
-struct EewHypocenterDetailView: View {
-    let state: EewContentState
-    let size: CGFloat
-
-    var body: some View {
-        if let detectionMethod = detectionMethod {
-            Text(detectionMethod)
-                .font(AppFonts.flex(size: size * 0.8, weight: .semibold))
-                .foregroundStyle(Color.eqTextSecondary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-        } else {
-            HStack(alignment: .firstTextBaseline, spacing: 10) {
-                if let magnitude = state.magnitude {
-                    HStack(alignment: .firstTextBaseline, spacing: 1) {
-                        Text("M")
-                            .font(AppFonts.flex(size: size * 0.7, weight: .semibold))
-                            .foregroundStyle(Color.eqTextSecondary)
-                        Text(String(format: "%.1f", magnitude))
-                            .font(AppFonts.code(size: size, weight: .bold))
-                            .monospacedDigit()
-                            .foregroundStyle(Color.eqTextPrimary)
-                    }
-                }
-                if let depth = state.depth {
-                    HStack(alignment: .firstTextBaseline, spacing: 1) {
-                        Text("深さ")
-                            .font(AppFonts.flex(size: size * 0.7, weight: .medium))
-                            .foregroundStyle(Color.eqTextSecondary)
-                        Text("\(Int(depth))")
-                            .font(AppFonts.code(size: size, weight: .bold))
-                            .monospacedDigit()
-                            .foregroundStyle(Color.eqTextPrimary)
-                        Text("km")
-                            .font(AppFonts.flex(size: size * 0.7, weight: .medium))
-                            .foregroundStyle(Color.eqTextSecondary)
-                    }
-                }
-            }
-        }
-    }
-
-    private var detectionMethod: String? {
-        if state.isPlum == true {
-            return "PLUM法"
-        }
-        if state.isLevel == true {
-            return "レベル法"
-        }
-        if state.isOnePoint == true {
-            return "1点検知(低精度)"
-        }
-        return nil
-    }
-}
 
 // MARK: - Shake Detection Dynamic Island Views
 
@@ -542,22 +427,6 @@ enum DynamicIslandMetrics {
     static let expandedBadgeSize: CGFloat = 32
 }
 
-@available(iOS 16.1, *)
-struct DynamicIslandIntensityBadge: View {
-    /// nil は予想震度が未発表であることを示し、灰色の「-」で描く
-    let intensity: IntensityValue?
-    var size: CGFloat = 24
-
-    var body: some View {
-        let appearance = IntensityBadgeAppearance(intensity: intensity)
-        IntensityBadge(
-            intensity: (appearance.main, appearance.sub),
-            backgroundColor: appearance.backgroundColor,
-            textColor: appearance.textColor,
-            size: size
-        )
-    }
-}
 
 @available(iOS 16.1, *)
 struct EewStatusPill: View {

--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -18,8 +18,7 @@ struct EewLiveActivityWidget: Widget {
                 .activitySystemActionForegroundColor(.white)
         } dynamicIsland: { context in
             DynamicIsland {
-                // leading / trailing は TrueDepth カメラ脇の細い L 字領域で、
-                // 収まらないと切り取られる。belowIfTooWide でカメラ下へ回り込ませる。
+                // カメラ脇と下部で高さの割り当てが異なるため本文はbottomに置く。
                 DynamicIslandExpandedRegion(.leading) {
                     EewExpandedLeadingView(state: context.state)
                         .dynamicIsland(verticalPlacement: .belowIfTooWide)
@@ -143,7 +142,7 @@ struct EewExpandedLeadingView: View {
         if state.display.isCanceled {
             EewCanceledSymbol(size: 30)
         } else {
-            EewMaximumIntensityView(intensity: state.display.maxIntensity, size: 32)
+            EewMaximumIntensityView(intensity: state.display.maxIntensity, size: 38)
         }
     }
 }
@@ -160,7 +159,7 @@ struct EewExpandedTrailingView: View {
                     .foregroundStyle(.white.opacity(0.75))
             }
         } else {
-            EewSourceMetricsView(state: state, vertical: true, size: 54.196 / 3)
+            EewSourceMetricsView(state: state, vertical: true, size: 21)
                 .foregroundStyle(.white)
         }
     }
@@ -171,7 +170,7 @@ struct EewExpandedBottomView: View {
     let state: EewContentState
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 5) {
+        VStack(alignment: .leading, spacing: 1) {
             if state.display.isCanceled {
                 Text(EewDisplay.canceledTitle)
                     .font(AppFonts.flex(size: 15, weight: .bold))
@@ -182,6 +181,7 @@ struct EewExpandedBottomView: View {
                 Text(state.display.typeLabel)
                     .font(AppFonts.flex(size: 11, weight: .medium))
                     .foregroundStyle(.white.opacity(0.8))
+                    .fixedSize(horizontal: false, vertical: true)
                 if let headline = state.display.headline(from: state.headline) {
                     Text(headline)
                         .font(AppFonts.flex(size: 16, weight: .heavy))
@@ -243,7 +243,7 @@ struct EewHypocenterSummaryView: View {
         if let text = text {
             Text(text)
                 .font(AppFonts.flex(size: size, weight: .bold))
-                .foregroundStyle(Color.eqTextPrimary)
+                .foregroundStyle(.white)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
         }

--- a/app/ios/Widget/LiveActivity/Eew/EewIntensityViews.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewIntensityViews.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// 最大震度は現在地の色付きバッジと混同させない。未発表でもMAXと「-」を残す。
+@available(iOS 16.1, *)
+struct EewMaximumIntensityView: View {
+    let intensity: IntensityValue?
+    let size: CGFloat
+
+    var body: some View {
+        let appearance = IntensityBadgeAppearance(intensity: intensity)
+        Group {
+            if let sub = appearance.sub {
+                HStack(alignment: .bottom, spacing: 0) {
+                    Text(appearance.main)
+                        .font(AppFonts.code(size: size, weight: .heavy))
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text("MAX")
+                            .font(AppFonts.code(size: max(7, size * 0.28), weight: .heavy))
+                        Text(sub)
+                            .font(AppFonts.flex(size: size * 0.45, weight: .heavy))
+                    }
+                    .padding(.bottom, size * 0.12)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: -size * 0.12) {
+                    Text("MAX")
+                        .font(AppFonts.code(size: max(7, size * 0.28), weight: .heavy))
+                    Text(appearance.main)
+                        .font(AppFonts.code(size: size, weight: .heavy))
+                }
+            }
+        }
+        .foregroundStyle(.white)
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("最大予想震度 \(intensity?.displayString ?? "未発表")")
+    }
+}
+
+@available(iOS 16.1, *)
+struct EewLocalIntensityView: View {
+    let intensity: IntensityValue
+    let size: CGFloat
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 0) {
+            Text(intensity.mainNumber)
+                .font(AppFonts.code(size: size * 0.76, weight: .heavy))
+            if let sub = intensity.subText {
+                Text(sub)
+                    .font(AppFonts.flex(size: size * 0.36, weight: .heavy))
+            }
+        }
+        .foregroundStyle(intensity.textColor)
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+        .padding(.horizontal, size * 0.08)
+        .frame(minWidth: size, minHeight: size)
+        .background(intensity.backgroundColor, in: RoundedRectangle(cornerRadius: size * 0.2))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("現在地の予想震度 \(intensity.displayString)")
+    }
+}

--- a/app/ios/Widget/LiveActivity/Eew/EewIntensityViews.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewIntensityViews.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct EewMaximumIntensityView: View {
     let intensity: IntensityValue?
     let size: CGFloat
+    var inlineMaximumLabel = false
 
     var body: some View {
         let appearance = IntensityBadgeAppearance(intensity: intensity)
@@ -20,6 +21,14 @@ struct EewMaximumIntensityView: View {
                             .font(AppFonts.flex(size: size * 0.45, weight: .heavy))
                     }
                     .padding(.bottom, size * 0.12)
+                }
+            } else if inlineMaximumLabel {
+                HStack(alignment: .top, spacing: 0) {
+                    Text(appearance.main)
+                        .font(AppFonts.code(size: size, weight: .heavy))
+                    Text("MAX")
+                        .font(AppFonts.code(size: max(7, size * 0.28), weight: .heavy))
+                        .padding(.top, size * 0.18)
                 }
             } else {
                 VStack(alignment: .leading, spacing: -size * 0.12) {
@@ -42,6 +51,7 @@ struct EewMaximumIntensityView: View {
 struct EewLocalIntensityView: View {
     let intensity: IntensityValue
     let size: CGFloat
+    var containerRelative = false
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 0) {
@@ -57,7 +67,13 @@ struct EewLocalIntensityView: View {
         .minimumScaleFactor(0.7)
         .padding(.horizontal, size * 0.08)
         .frame(minWidth: size, minHeight: size)
-        .background(intensity.backgroundColor, in: RoundedRectangle(cornerRadius: size * 0.2))
+        .background {
+            if containerRelative {
+                ContainerRelativeShape().fill(intensity.backgroundColor)
+            } else {
+                RoundedRectangle(cornerRadius: size * 0.2).fill(intensity.backgroundColor)
+            }
+        }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("現在地の予想震度 \(intensity.displayString)")
     }

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
@@ -59,7 +59,9 @@ struct EewContentState: Codable, Hashable {
             arrivalDate: location?.arrivalDate,
             depth: depth,
             isLowAccuracyDetection: isPlum == true || isLevel == true
-                || isOnePoint == true
+                || isOnePoint == true,
+            isLocationWarning: location?.isWarning == true,
+            isLocationPlum: location?.isPlum == true
         )
     }
 }

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
@@ -88,6 +88,8 @@ extension EewContentState {
             .deepHypocenter,
             .plum,
             designReview(now: now, warning: false, localIntensity: "3"),
+            designReview(now: now, localIntensity: "1"),
+            designReview(now: now, localIntensity: "2"),
         ]
     }
 

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
@@ -75,6 +75,63 @@ extension EewLiveActivityAttributes {
 // MARK: - Preview Data
 
 extension EewContentState {
+    /// Preview生成時を基準にすることで固定日時による常時0秒表示を避ける。
+    static func designReviewStates(now: Date = Date()) -> [EewContentState] {
+        [
+            designReview(now: now, localIntensity: "6+", locationWarning: true),
+            designReview(now: now, localIntensity: "3"),
+            designReview(now: now, warning: false, localIntensity: "4"),
+            designReview(now: now, warning: false),
+            designReview(now: now, localIntensity: "6+", locationWarning: true, arrival: false),
+            designReview(now: now, localIntensity: nil, locationWarning: true),
+            designReview(now: now, localIntensity: "6+", locationWarning: true, canceled: true),
+            .deepHypocenter,
+            .plum,
+            designReview(now: now, warning: false, localIntensity: "3"),
+        ]
+    }
+
+    private static func designReview(
+        now: Date,
+        warning: Bool = true,
+        localIntensity: String? = nil,
+        locationWarning: Bool = false,
+        arrival: Bool = true,
+        canceled: Bool = false
+    ) -> EewContentState {
+        let formatter = ISO8601DateFormatter()
+        let location: LocationInfo? = localIntensity != nil || locationWarning
+            ? LocationInfo(
+                regionName: "神奈川県東部",
+                forecastIntensity: localIntensity,
+                forecastLpgmIntensity: nil,
+                arrivalTime: arrival ? formatter.string(from: now.addingTimeInterval(31)) : nil,
+                intensity: nil,
+                isWarning: locationWarning
+            ) : nil
+        return EewContentState(
+            eventId: "preview-design-review",
+            type: "eew",
+            hypocenterName: "石川県能登地方",
+            magnitude: 5.8,
+            depth: 50,
+            time: formatter.string(from: now.addingTimeInterval(-12)),
+            isOriginTime: true,
+            maxIntensity: warning ? "6+" : "4",
+            serialNo: 32,
+            isFinal: false,
+            isWarning: warning,
+            isCanceled: canceled,
+            headline: warning ? "石川県で地震 北陸で強い揺れ" : "石川県で地震",
+            isPlum: false,
+            isLevel: false,
+            isOnePoint: false,
+            location: location
+        )
+    }
+}
+
+extension EewContentState {
     static let noto32 = EewContentState(
         eventId: "20240101123456",
         type: "eew",

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
@@ -90,15 +90,7 @@ struct EewLockScreenView: View {
                 headline: state.display.headline(from: state.headline) ?? state.hypocenterName
             )
 
-            if state.display.isCanceled {
-                HStack(spacing: 8) {
-                    EewCanceledSymbol(size: 24)
-                    Text(EewDisplay.canceledDescription)
-                        .font(AppFonts.flex(size: 12, weight: .semibold))
-                        .foregroundStyle(.white.opacity(0.8))
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            } else {
+            if !state.display.isCanceled {
                 HStack(alignment: .bottom, spacing: 8) {
                     VStack(alignment: .leading, spacing: 8) {
                         if let date = state.timeDate {

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
@@ -8,18 +8,8 @@ import WidgetKit
 
 // MARK: - EEW用カラー定義
 
-private let eewSecondaryTextColor: Color = liveActivitySecondaryTextColor
 private let eewHeaderPrimaryTextColor: Color = liveActivityHeaderPrimaryTextColor
 private let eewHeaderSecondaryTextColor: Color = liveActivityHeaderSecondaryTextColor
-
-// MARK: - EEW用スタイル
-
-@available(iOS 16.1, *)
-extension View {
-    func eewLabelStyle(_ variant: LiveActivityLabelStyle.Variant = .primary) -> some View {
-        liveActivityLabelStyle(variant)
-    }
-}
 
 // MARK: - Header Container
 
@@ -39,13 +29,7 @@ struct HeaderContainer: View {
                 VStack(alignment: .leading, spacing: 2) {
                     // 「緊急地震速報(警報|予報|取消) 第N報」または「… 最終 第N報」
                     Text(display.headerLabel)
-                        .font(
-                            .system(
-                                size: 12,
-                                weight: .semibold,
-                                design: .monospaced
-                            )
-                        )
+                        .font(AppFonts.flex(size: 11, weight: .semibold))
                         .foregroundColor(eewHeaderSecondaryTextColor)
                         .lineLimit(1)
                         .minimumScaleFactor(0.7)
@@ -53,7 +37,7 @@ struct HeaderContainer: View {
                     // headline: "XXXで地震" / 警報時 "XX YYで強い揺れ" / 取消時 "取り消されました"
                     if let headline = display.headerHeadline(from: headline) {
                         Text(headline)
-                            .font(.system(size: 15, weight: .heavy))
+                            .font(AppFonts.flex(size: 15, weight: .heavy))
                             .foregroundColor(eewHeaderPrimaryTextColor)
                             .lineLimit(1)
                             .minimumScaleFactor(0.5)
@@ -61,16 +45,9 @@ struct HeaderContainer: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-                if let remaining = ArrivalCountdown.remaining(until: display.countdownArrivalDate) {
-                    VStack(alignment: .trailing, spacing: 0) {
-                        Text("主要動到達まで")
-                            .eewLabelStyle(.header)
-                        ArrivalCountdownText(
-                            remaining: remaining,
-                            size: 20,
-                            color: eewHeaderPrimaryTextColor
-                        )
-                    }
+                if !display.isCanceled {
+                    EewMaximumIntensityView(intensity: display.maxIntensity, size: 32)
+                        .fixedSize()
                 }
             }
             .padding(.horizontal, 12)
@@ -106,292 +83,54 @@ struct HeaderContainer: View {
 struct EewLockScreenView: View {
     let state: EewContentState
 
-    private let standardMargin: CGFloat = 14
-
     var body: some View {
-        let display = state.display
-        VStack(spacing: 0) {
-            HeaderContainer(display: display, headline: state.headline)
-                .padding(.horizontal, standardMargin)
-                .padding(.top, standardMargin)
-                .padding(.bottom, display.isCanceled ? 8 : 4)
+        VStack(alignment: .leading, spacing: 8) {
+            HeaderContainer(
+                display: state.display,
+                headline: state.display.headline(from: state.headline) ?? state.hypocenterName
+            )
 
-            contentView
-                .padding(.horizontal, standardMargin)
-                .padding(.bottom, standardMargin)
-        }
-    }
-
-    @ViewBuilder
-    private var contentView: some View {
-        if state.display.isCanceled {
-            canceledContentView
-        } else {
-            earthquakeContentView
-        }
-    }
-
-    // MARK: - 取消報
-
-    /// 取消報では震源・予想震度・到達予想がすべて無効。
-    /// 主文はヘッダーの見出し行に出しているため、ここは値を出していない理由だけを添える。
-    private var canceledContentView: some View {
-        HStack(alignment: .center, spacing: 8) {
-            EewCanceledSymbol(size: 24)
-            Text(EewDisplay.canceledDescription)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(eewSecondaryTextColor)
-                .lineLimit(2)
-                .minimumScaleFactor(0.8)
-            Spacer(minLength: 0)
-        }
-    }
-
-    // MARK: - 通常報
-
-    private var earthquakeContentView: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(alignment: .bottom, spacing: 10) {
-                // 未発表（nil）でも枠を残す。消すと震度 0 の発表と区別できない
-                VStack(spacing: 2) {
-                    Text("最大震度")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundColor(eewSecondaryTextColor)
-                    SquareIntensityBadge(
-                        intensity: state.display.maxIntensity,
-                        size: .normal
-                    )
+            if state.display.isCanceled {
+                HStack(spacing: 8) {
+                    EewCanceledSymbol(size: 24)
+                    Text(EewDisplay.canceledDescription)
+                        .font(AppFonts.flex(size: 12, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.8))
+                        .fixedSize(horizontal: false, vertical: true)
                 }
-
-                uncanceledDetailsView
+            } else {
+                HStack(alignment: .bottom, spacing: 8) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        if let date = state.timeDate {
+                            Text("\(state.timeLabel)  \(JSTDateFormat.monthDay(date)) \(JSTDateFormat.timeWithSeconds(date))")
+                                .font(AppFonts.code(size: 10, weight: .medium))
+                                .foregroundStyle(.white.opacity(0.8))
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.8)
+                        }
+                        EewSourceMetricsView(state: state)
+                    }
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                if let intensity = state.display.forecastIntensity,
-                   let regionName = state.location?.regionName,
-                   !regionName.isEmpty {
-                    forecastIntensityView(
-                        regionName: regionName,
-                        intensity: intensity
-                    )
-                }
-            }
-
-            if state.display.showsDeepHypocenterIntensityNotice {
-                Text(EewDisplay.deepHypocenterIntensityNotice)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(eewSecondaryTextColor)
-                    .lineLimit(2)
-                    .minimumScaleFactor(0.8)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-    }
-
-    /// 取消報以外で表示する震源・規模・時刻。取消報ではこれらの値がすべて無効なため出さない。
-    private var uncanceledDetailsView: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            if let hypocenterName = state.hypocenterName {
-                HStack(alignment: .firstTextBaseline, spacing: 4) {
-                    Text(
-                        state.isPlum == true || state.isLevel == true ? "検知観測点" : "震源地"
-                    )
-                    .eewLabelStyle()
-                    Text(hypocenterName)
-                        .font(.system(size: 16, weight: .heavy))
-                        .foregroundColor(.primary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
-                }
-            }
-
-            // PLUM法/レベル法/1点検知の場合は特別な表示
-            if state.isPlum == true {
-                detectionMethodLabel("PLUM法による検知")
-            } else if state.isLevel == true {
-                detectionMethodLabel("レベル法による検知")
-            } else if state.isOnePoint == true {
-                detectionMethodLabel("低精度の緊急地震速報")
-            } else {
-                HStack(spacing: 14) {
-                    if let magnitude = state.magnitude {
-                        HStack(alignment: .firstTextBaseline, spacing: 0) {
-                            Text("M")
-                                .eewLabelStyle()
-                            Text(String(format: "%.1f", magnitude))
-                                .font(
-                                    .system(
-                                        size: 18,
-                                        weight: .bold,
-                                        design: .monospaced
-                                    )
-                                )
-                                .tracking(-2.5)
-                                .foregroundColor(.primary)
-                        }
-                    }
-                    if let depth = state.depth {
-                        depthView(depth: Int(depth))
+                    if state.display.usesLocalIntensity || state.display.locationNotice == .warning {
+                        EewLockScreenLocationView(state: state)
                     }
                 }
-            }
 
-            // 発生/検知時刻
-            if let date = state.timeDate {
-                HStack(alignment: .firstTextBaseline, spacing: 4) {
-                    Text(state.timeLabel)
-                        .eewLabelStyle()
-                    Text(JSTDateFormat.monthDay(date))
-                        .font(
-                            .system(
-                                size: 12,
-                                weight: .semibold,
-                                design: .monospaced
-                            )
-                        )
-                        .foregroundColor(.primary)
-                        .tracking(-1)
-                    Text(JSTDateFormat.timeWithSeconds(date))
-                        .font(
-                            .system(
-                                size: 14,
-                                weight: .bold,
-                                design: .monospaced
-                            )
-                        )
-                        .foregroundColor(.primary)
-                        .tracking(-1)
+                if state.display.showsDeepHypocenterIntensityNotice {
+                    Text(EewDisplay.deepHypocenterIntensityNotice)
+                        .font(AppFonts.flex(size: 11, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.75))
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }
-    }
-
-    // 検知方法ラベル（PLUM法/レベル法/1点検知）
-    private func detectionMethodLabel(_ text: String) -> some View {
-        Text(text)
-            .font(.system(size: 14, weight: .bold, design: .monospaced))
-            .lineLimit(1)
-    }
-
-    // 深さ表示（数値を大きく）
-    private func depthView(depth: Int) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 0) {
-            Text("深さ")
-                .eewLabelStyle()
-            Text("\(depth)")
-                .font(.system(size: 18, weight: .bold, design: .monospaced))
-                .tracking(-1)
-                .foregroundColor(.primary)
-            Text(" km")
-                .font(.system(size: 10, weight: .medium))
-                .foregroundColor(eewSecondaryTextColor)
-        }
-    }
-
-    // MARK: - 現在地の予想震度
-
-    private func forecastIntensityView(
-        regionName: String,
-        intensity: IntensityValue
-    ) -> some View {
-        VStack(spacing: 2) {
-            HStack(spacing: 2) {
-                Image(systemName: "location.fill")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundColor(eewSecondaryTextColor)
-                    .symbolEffect(.pulse)
-                Text(regionName)
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundColor(.primary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.75)
-            }
-            SquareIntensityBadge(intensity: intensity, size: .normal)
-        }
+        .padding(12)
+        .foregroundStyle(.white)
+        .background(.black)
     }
 }
 
-// MARK: - Square Intensity Badge
-
-@available(iOS 16.1, *)
-struct SquareIntensityBadge: View {
-    enum Size {
-        case normal
-        case small
-        case compact  // 横長でコンパクト
-
-        var badgeSize: CGFloat {
-            switch self {
-            case .normal: return 50
-            case .small: return 38
-            case .compact: return 24
-            }
-        }
-
-        var mainFontSize: CGFloat {
-            switch self {
-            case .normal: return 38
-            case .small: return 28
-            case .compact: return 18
-            }
-        }
-
-        var subFontSize: CGFloat {
-            switch self {
-            case .normal: return 16
-            case .small: return 12
-            case .compact: return 10
-            }
-        }
-
-        var cornerRadius: CGFloat {
-            switch self {
-            case .normal: return 12
-            case .small: return 10
-            case .compact: return 8
-            }
-        }
-
-        var horizontalPadding: CGFloat {
-            switch self {
-            case .normal, .small: return 0
-            case .compact: return 6
-            }
-        }
-    }
-
-    /// nil は予想最大震度が未発表であることを示し、灰色の「-」で描く
-    let intensity: IntensityValue?
-    var size: Size = .normal
-
-    var body: some View {
-        let appearance = IntensityBadgeAppearance(intensity: intensity)
-        HStack(alignment: .firstTextBaseline, spacing: 0) {
-            Text(appearance.main)
-                .font(
-                    .system(
-                        size: size.mainFontSize,
-                        weight: .bold,
-                        design: .monospaced
-                    )
-                )
-            if let sub = appearance.sub {
-                Text(sub)
-                    .font(.system(size: size.subFontSize, weight: .heavy))
-            }
-        }
-        .foregroundColor(appearance.textColor)
-        .frame(height: size.badgeSize)
-        .frame(minWidth: size.badgeSize)
-        .padding(.horizontal, size.horizontalPadding)
-        .background(appearance.backgroundColor)
-        .clipShape(
-            RoundedRectangle(
-                cornerRadius: size.cornerRadius,
-                style: .continuous
-            )
-        )
-    }
-}
 
 // MARK: - Preview
 

--- a/app/ios/Widget/LiveActivity/Eew/EewLocationViews.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLocationViews.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+@available(iOS 16.1, *)
+struct EewLocationNoticeView: View {
+    let notice: EewLocationNotice
+    let intensity: IntensityValue?
+
+    var body: some View {
+        Text(notice.title)
+            .font(AppFonts.flex(size: 14, weight: .heavy))
+            .foregroundStyle(notice == .warning ? .white : intensity?.textColor ?? .white)
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 8)
+            .background(
+                notice == .warning ? Color(rgb: 0xBE0100) : intensity?.backgroundColor ?? .clear,
+                in: RoundedRectangle(cornerRadius: 10)
+            )
+            .accessibilityLabel(notice == .warning ? "現在地は緊急地震速報の警報対象地域です" : notice.title)
+    }
+}
+
+@available(iOS 16.1, *)
+struct EewArrivalView: View {
+    let arrivalDate: Date
+    var size: CGFloat = 22
+
+    var body: some View {
+        if let remaining = ArrivalCountdown.remaining(until: arrivalDate) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("到達まで")
+                    .font(AppFonts.flex(size: 10, weight: .bold))
+                    .foregroundStyle(.white.opacity(0.8))
+                ArrivalCountdownText(remaining: remaining, size: size, color: .white)
+            }
+        }
+    }
+}
+
+@available(iOS 16.1, *)
+struct EewLockScreenLocationView: View {
+    let state: EewContentState
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 6) {
+            VStack(alignment: .leading, spacing: 7) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(state.display.locationNotice == .warning ? "現在地に警報" : "現在地")
+                        .font(AppFonts.flex(size: 9, weight: .bold))
+                        .foregroundStyle(.white.opacity(0.8))
+                    if let regionName = state.location?.regionName, !regionName.isEmpty {
+                        Text(regionName)
+                            .font(AppFonts.flex(size: 10, weight: .heavy))
+                            .lineLimit(2)
+                    }
+                }
+                if let arrivalDate = state.display.countdownArrivalDate {
+                    EewArrivalView(arrivalDate: arrivalDate)
+                }
+            }
+            if let intensity = state.display.localIntensity {
+                EewLocalIntensityView(intensity: intensity, size: 56)
+            }
+        }
+        .foregroundStyle(.white)
+        .padding(.leading, 7)
+        .overlay(alignment: .leading) {
+            Rectangle().fill(.white.opacity(0.35)).frame(width: 0.5)
+        }
+    }
+}

--- a/app/ios/Widget/LiveActivity/Eew/EewLocationViews.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLocationViews.swift
@@ -26,7 +26,7 @@ struct EewLocationNoticeView: View {
             .padding(.vertical, 8)
             .background(
                 background,
-                in: RoundedRectangle(cornerRadius: 10)
+                in: ContainerRelativeShape()
             )
             .accessibilityLabel(notice == .warning ? "現在地は緊急地震速報の警報対象地域です" : notice.title)
     }

--- a/app/ios/Widget/LiveActivity/Eew/EewLocationViews.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLocationViews.swift
@@ -6,16 +6,26 @@ struct EewLocationNoticeView: View {
     let intensity: IntensityValue?
 
     var body: some View {
+        let background: Color = switch notice {
+        case .warning: Color(rgb: 0xBE0100)
+        case .forecast: intensity?.backgroundColor ?? .clear
+        case .weak: Color(rgb: 0xCDEEFF)
+        }
+        let foreground: Color = switch notice {
+        case .warning: .white
+        case .forecast: intensity?.textColor ?? .white
+        case .weak: .black
+        }
         Text(notice.title)
             .font(AppFonts.flex(size: 14, weight: .heavy))
-            .foregroundStyle(notice == .warning ? .white : intensity?.textColor ?? .white)
+            .foregroundStyle(foreground)
             .lineLimit(1)
             .minimumScaleFactor(0.8)
             .frame(maxWidth: .infinity)
             .padding(.horizontal, 8)
             .padding(.vertical, 8)
             .background(
-                notice == .warning ? Color(rgb: 0xBE0100) : intensity?.backgroundColor ?? .clear,
+                background,
                 in: RoundedRectangle(cornerRadius: 10)
             )
             .accessibilityLabel(notice == .warning ? "現在地は緊急地震速報の警報対象地域です" : notice.title)

--- a/app/ios/Widget/LiveActivity/Eew/EewSourceMetricsView.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewSourceMetricsView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// 低精度時にM・深さを出さない既存方針を、ロック画面とExpandedで共有する。
+@available(iOS 16.1, *)
+struct EewSourceMetricsView: View {
+    let state: EewContentState
+    var vertical: Bool = false
+    var size: CGFloat = 77.23 / 3
+
+    var body: some View {
+        if state.display.isLowAccuracyDetection {
+            Text(state.isPlum == true ? "PLUM法" : state.isLevel == true ? "レベル法" : "低精度")
+                .font(AppFonts.flex(size: 12, weight: .bold))
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .overlay(Capsule().strokeBorder(.white.opacity(0.5)))
+        } else {
+            let layout = vertical
+                // Figmaはcap heightでトリム済み。Google Sans Codeの行ボックスには
+                // 約10ptの上下余白があるため、10ptをさらに足すと行間が二重になる。
+                ? AnyLayout(VStackLayout(alignment: .center, spacing: 0))
+                : AnyLayout(HStackLayout(alignment: .firstTextBaseline, spacing: 8 / 3))
+            layout {
+                if let magnitude = state.magnitude {
+                    EewMetricView(
+                        label: "M", value: String(format: "%.1f", magnitude),
+                        size: size, trackingRatio: -0.22, spacing: 0
+                    )
+                }
+                if let depth = state.depth {
+                    EewMetricView(
+                        label: "深さ", value: String(Int(depth)), unit: "km",
+                        size: size, trackingRatio: -0.03, spacing: size * 0.074
+                    )
+                }
+            }
+        }
+    }
+}
+
+@available(iOS 16.1, *)
+private struct EewMetricView: View {
+    let label: String
+    let value: String
+    var unit: String = ""
+    let size: CGFloat
+    let trackingRatio: CGFloat
+    let spacing: CGFloat
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: spacing) {
+            Text(label)
+                .font(AppFonts.code(size: size * 0.44, weight: .medium))
+                .foregroundStyle(.white.opacity(0.8))
+            Text(value)
+                .font(AppFonts.code(size: size, weight: .bold))
+                .tracking(size * trackingRatio)
+            if !unit.isEmpty {
+                Text(unit)
+                    .font(AppFonts.code(size: size * 0.44, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.8))
+            }
+        }
+        .foregroundStyle(.white)
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+    }
+}

--- a/app/ios/Widget/LiveActivity/Eew/EewSourceMetricsView.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewSourceMetricsView.swift
@@ -10,10 +10,12 @@ struct EewSourceMetricsView: View {
     var body: some View {
         if state.display.isLowAccuracyDetection {
             Text(state.isPlum == true ? "PLUM法" : state.isLevel == true ? "レベル法" : "低精度")
-                .font(AppFonts.flex(size: 12, weight: .bold))
+                .font(.system(size: 12, weight: .bold))
+                .fixedSize()
                 .padding(.horizontal, 7)
                 .padding(.vertical, 3)
-                .overlay(Capsule().strokeBorder(.white.opacity(0.5)))
+                .overlay(ContainerRelativeShape().strokeBorder(.white.opacity(0.5)))
+                .padding(4)
         } else {
             let layout = vertical
                 // Figmaはcap heightでトリム済み。Google Sans Codeの行ボックスには

--- a/app/ios/WidgetModelsTests/EewDisplayTests.swift
+++ b/app/ios/WidgetModelsTests/EewDisplayTests.swift
@@ -145,6 +145,14 @@ struct EewDisplayTests {
         #expect(subject.dynamicIslandLayout == .summary)
     }
 
+    @Test func eventTimeIsShownOnlyWithoutDisplayedLocalIntensity() {
+        #expect(display(forecastIntensity: nil).showsEventTime)
+        #expect(display(isWarning: false, forecastIntensity: .three).showsEventTime)
+        #expect(display(forecastIntensity: nil, isLocationWarning: true).showsEventTime)
+        #expect(display(forecastIntensity: .four).showsEventTime == false)
+        #expect(display(isCanceled: true, forecastIntensity: nil).showsEventTime == false)
+    }
+
     @Test func localPlumSuppressesArrivalButKeepsIntensity() {
         let subject = display(isLocationPlum: true)
         #expect(subject.localIntensity == .fiveLower)

--- a/app/ios/WidgetModelsTests/EewDisplayTests.swift
+++ b/app/ios/WidgetModelsTests/EewDisplayTests.swift
@@ -22,7 +22,9 @@ struct EewDisplayTests {
         forecastIntensity: IntensityValue? = .fiveLower,
         arrivalDate: Date? = nil,
         depth: Double? = 10,
-        isLowAccuracyDetection: Bool = false
+        isLowAccuracyDetection: Bool = false,
+        isLocationWarning: Bool = false,
+        isLocationPlum: Bool = false
     ) -> EewDisplay {
         EewDisplay(
             isCanceled: isCanceled,
@@ -33,7 +35,9 @@ struct EewDisplayTests {
             forecastIntensity: forecastIntensity,
             arrivalDate: arrivalDate ?? arrival,
             depth: depth,
-            isLowAccuracyDetection: isLowAccuracyDetection
+            isLowAccuracyDetection: isLowAccuracyDetection,
+            isLocationWarning: isLocationWarning,
+            isLocationPlum: isLocationPlum
         )
     }
 
@@ -83,6 +87,72 @@ struct EewDisplayTests {
     }
 
     // MARK: - 深発地震の注釈
+
+    @Test func forecastBelowFourUsesMaximumAndHidesCountdown() {
+        let subject = display(isWarning: false, forecastIntensity: .three)
+        #expect(subject.localIntensity == nil)
+        #expect(subject.intensity == .sixUpper)
+        #expect(subject.intensityLabel == "最大震度")
+        #expect(subject.countdownArrivalDate == nil)
+        #expect(subject.locationNotice == nil)
+    }
+
+    @Test func forecastAtFourShowsLocalIntensityAndCountdown() {
+        let subject = display(isWarning: false, forecastIntensity: .four)
+        #expect(subject.localIntensity == .four)
+        #expect(subject.usesLocalIntensity)
+        #expect(subject.countdownArrivalDate == arrival)
+        #expect(subject.locationNotice == .forecast)
+    }
+
+    @Test func warningCanShowLocalIntensityBelowFour() {
+        let subject = display(forecastIntensity: .three)
+        #expect(subject.localIntensity == .three)
+        #expect(subject.countdownArrivalDate == arrival)
+        #expect(subject.locationNotice == nil)
+    }
+
+    @Test func warningNoticeRequiresCurrentLocationTarget() {
+        #expect(display().locationNotice == .forecast)
+        #expect(display(isLocationWarning: true).locationNotice == .warning)
+        #expect(display(isWarning: false, isLocationWarning: true).locationNotice == .forecast)
+        #expect(display(forecastIntensity: nil, isLocationWarning: true).locationNotice == .warning)
+    }
+
+    @Test func missingLocalIntensityNeverPairsMaximumWithCountdown() {
+        let subject = display(forecastIntensity: nil)
+        #expect(subject.usesLocalIntensity == false)
+        #expect(subject.countdownArrivalDate == nil)
+        #expect(subject.dynamicIslandLayout == .summary)
+    }
+
+    @Test func localPlumSuppressesArrivalButKeepsIntensity() {
+        let subject = display(isLocationPlum: true)
+        #expect(subject.localIntensity == .fiveLower)
+        #expect(subject.countdownArrivalDate == nil)
+    }
+
+    @Test func canceledReportSuppressesLocalWarningAndForecast() {
+        let subject = display(isCanceled: true, isLocationWarning: true)
+        #expect(subject.localIntensity == nil)
+        #expect(subject.locationNotice == nil)
+        #expect(subject.countdownArrivalDate == nil)
+    }
+
+    @Test func decodesCurrentLocationWarningAndPlumFromPayload() throws {
+        let data = Data(#"{"regionName":"神奈川県東部","forecastIntensity":"6+","isWarning":true,"isPlum":true}"#.utf8)
+        let location = try JSONDecoder().decode(LocationInfo.self, from: data)
+        #expect(location.isWarning == true)
+        #expect(location.isPlum == true)
+        #expect(location.forecastIntensityValue == .sixUpper)
+    }
+
+    @Test func oldPayloadDoesNotImplyCurrentLocationWarning() throws {
+        let data = Data(#"{"regionName":"神奈川県東部","forecastIntensity":"3"}"#.utf8)
+        let location = try JSONDecoder().decode(LocationInfo.self, from: data)
+        #expect(location.isWarning == nil)
+        #expect(location.isPlum == nil)
+    }
 
     /// 深さ 150km より深く予想震度が未発表のときだけ理由を添える
     @Test func deepHypocenterNoticeRequiresMissingIntensityAndDeepDepth() {

--- a/app/ios/WidgetModelsTests/EewDisplayTests.swift
+++ b/app/ios/WidgetModelsTests/EewDisplayTests.swift
@@ -65,7 +65,7 @@ struct EewDisplayTests {
     }
 
     @Test func canceledReportOverridesWarningInTypeLabel() {
-        #expect(display(isCanceled: true, isWarning: true).typeLabel == "緊急地震速報(取消)")
+        #expect(display(isCanceled: true, isWarning: true).typeLabel == "緊急地震速報")
     }
 
     // MARK: - 震度の優先順位

--- a/app/ios/WidgetModelsTests/EewDisplayTests.swift
+++ b/app/ios/WidgetModelsTests/EewDisplayTests.swift
@@ -109,7 +109,26 @@ struct EewDisplayTests {
         let subject = display(forecastIntensity: .three)
         #expect(subject.localIntensity == .three)
         #expect(subject.countdownArrivalDate == arrival)
-        #expect(subject.locationNotice == nil)
+        #expect(subject.locationNotice == .forecast)
+    }
+
+    @Test(arguments: [IntensityValue.zero, .one])
+    func weakShakingRequiresIntensityBelowTwo(intensity: IntensityValue) {
+        let subject = display(forecastIntensity: intensity)
+        #expect(subject.locationNotice == .weak)
+        #expect(subject.locationNotice?.title == "現在地で弱い揺れ")
+        #expect(subject.localIntensity == intensity)
+    }
+
+    @Test(arguments: [IntensityValue.two, .three, .four, .seven])
+    func shakingAtTwoAndAbove(intensity: IntensityValue) {
+        #expect(display(forecastIntensity: intensity).locationNotice == .forecast)
+    }
+
+    @Test func warningAndCancellationTakePriorityOverWeakShaking() {
+        #expect(display(forecastIntensity: .one, isLocationWarning: true).locationNotice == .warning)
+        #expect(display(isCanceled: true, forecastIntensity: .one).locationNotice == nil)
+        #expect(display(forecastIntensity: nil).locationNotice == nil)
     }
 
     @Test func warningNoticeRequiresCurrentLocationTarget() {

--- a/docs/knowledge/20260907_eew_live_activity_design_preview.md
+++ b/docs/knowledge/20260907_eew_live_activity_design_preview.md
@@ -70,3 +70,19 @@ Previewターゲット向け`membershipExceptions`への追加が必要。
 - 予報時の現在地震度4以上という表示条件は変更していない。
 - Canvasの確認は`Editor > Canvas > Refresh Canvas`で再生成してから行う。
   200%で警報名の末尾、注意帯・震度バッジの四隅、到達予想の下端を確認する。
+
+## 取消・低精度ラベル・角丸
+
+- 取消も通常と同じ左揃えの種別ラベル・見出しを使う。「予想は無効です」の
+  説明は出さない。震度・到達予想の抑止は変更しない。
+- 取消時の種別は「緊急地震速報」とし、`(取消)`は付けない。Expanded左上の
+  取消記号は出さず、不可視かつアクセシビリティ対象外の最大震度枠で配置を維持する。
+- ExpandedのMAX表示には左右4ptを確保する。単数字でもMAXを数字の右上に置き、
+  6強などと行高を揃える。MAXを数字の上に縦積みするとState 3だけ上段が高くなり、
+  下段のコンパクト候補でも高さを超える。Compact/Minimalの配置は変更しない。
+- 取消時の報数とPLUM法などの混在文はシステムフォント＋`fixedSize()`を使う。
+  カメラ脇の外周で切られないよう、枠の外側にも4ptの余白を確保する。
+- Expandedの注意帯・現在地震度背景・低精度ラベルの枠は
+  `ContainerRelativeShape()`でシステムのコンテナ形状に追従させる。
+  独自の`containerShape`でDynamic Island側の形状を上書きしない。
+- 参考: https://developer.apple.com/documentation/swiftui/containerrelativeshape

--- a/docs/knowledge/20260907_eew_live_activity_design_preview.md
+++ b/docs/knowledge/20260907_eew_live_activity_design_preview.md
@@ -25,6 +25,7 @@ Xcodeで`app/ios/Runner.xcodeproj`を開き、スキーム`EQMonitorPreview`とi
 
 状態順は、警報対象、警報対象外（現在地3）、予報（現在地4）、現在地情報なし、
 到達予想なし、警報対象だが震度なし、取消、深発、PLUM、予報（現在地3・非表示）。
+続くState 11は警報対象外・震度1、State 12は警報対象外・震度2。
 カウントダウンはPreview生成時点から31秒。再開するときはPreviewを再生成する。
 
 ```sh
@@ -45,8 +46,13 @@ Previewターゲット向け`membershipExceptions`への追加が必要。
 
 - 黒背景のEEWは文字色を白で明示する。PreviewのLight Appearanceでは
   `activityBackgroundTint(.black)`だけに頼らず、ロック画面Viewにも黒背景を指定する。
-- Expandedの本文全体に縦方向の`fixedSize`を付けると、割り当て高さを超えて
-  下端が切れる場合がある。警報名など必要なTextだけに指定する。
+- Expandedの本文を単に`fixedSize`にすると、割り当て高さを超えて下端が切れる。
+  `ViewThatFits(in: .vertical)`内の候補の測定にだけ使い、高さ不足時には
+  震度バッジ44pt・見出し1行のコンパクト配置を選ぶ。通常候補は56pt・2行。
+  下部の左右・下には8ptを追加し、塗りつぶしをIslandの丸い外周から離す。
+- Google Sans Flexを使った「緊急地震速報(警報)」は、幅の`fixedSize`だけでは
+  末尾の省略が直らなかった。同サイズのシステムフォントに替えると全体を表示できた。
+  この混在文のフォントはシステムを使う。数値のGoogle Sans Codeは維持する。
 - 単一leading領域＋`belowIfTooWide`も試したが、現在地情報の下端がCanvasで切れた。
   本実装はleading/trailing/bottomを分離し、OS標準の外周余白を維持する。
   カメラ高さの固定値や負のpaddingで補正しない。
@@ -54,3 +60,13 @@ Previewターゲット向け`membershipExceptions`への追加が必要。
   VStackのspacingにそのまま足すと二重になるため、M・深さの縦積みはspacing 0。
 - Expandedの最大震度は38pt、震源要素の数値は21pt。表示サイズだけの調整では
   テストを追加せず、既存モデルテスト・静的解析・Canvasで確認する。
+
+## 現在地の注意帯
+
+- 現在地が警報対象なら「現在地で強い揺れ」を優先する。
+- 警報対象外で表示可能な予想震度が2未満なら「現在地で弱い揺れ」、
+  背景は薄い蒼`#CDEEFF`・文字は黒。震度2以上なら「現在地で揺れ」。
+- 震度なしを弱い揺れに補完しない。取消時は注意帯を抑止する。
+- 予報時の現在地震度4以上という表示条件は変更していない。
+- Canvasの確認は`Editor > Canvas > Refresh Canvas`で再生成してから行う。
+  200%で警報名の末尾、注意帯・震度バッジの四隅、到達予想の下端を確認する。

--- a/docs/knowledge/20260907_eew_live_activity_design_preview.md
+++ b/docs/knowledge/20260907_eew_live_activity_design_preview.md
@@ -86,3 +86,9 @@ Previewターゲット向け`membershipExceptions`への追加が必要。
   `ContainerRelativeShape()`でシステムのコンテナ形状に追従させる。
   独自の`containerShape`でDynamic Island側の形状を上書きしない。
 - 参考: https://developer.apple.com/documentation/swiftui/containerrelativeshape
+
+## 現在地震度がない場合の時刻
+
+- Expandedで現在地の予想震度を表示しない場合、見出しの下に発生／検知時刻を表示する。
+- `EewDisplay.showsEventTime`で取消を除外し、`state.timeDate`が解析できる場合だけ出す。
+  区分は既存の`state.timeLabel`、日時は`JSTDateFormat`を使い、受信時刻などで補完しない。

--- a/docs/knowledge/20260907_eew_live_activity_design_preview.md
+++ b/docs/knowledge/20260907_eew_live_activity_design_preview.md
@@ -1,0 +1,56 @@
+# EEW Live Activityの現在地表示とPreview
+
+## 表示規則
+
+- Figma `1628:1745`がロック画面、`1628:1694`がExpandedの基準。
+- Minimal/Compactの現在地震度は塗りつぶしあり。最大震度は塗りつぶしなし＋`MAX`。
+- 未発表の最大震度は`MAX -`。取消は取消記号に切り替える。
+- `EewDisplay.localIntensity`が現在地情報の可否を判断する。予報は震度4以上、警報は提供された現在地震度を表示する。
+- 現在地が警報対象かは`location.isWarning`で受信する。電文全体の`isWarning`だけで現在地の警報帯を出さない。
+- 警報対象でも予想震度・到達予想が欠けていれば値を補わない。
+- 取消・現在地震度非表示・現在地PLUMではカウントダウンを出さない。
+- カウントダウンの`Text(timerInterval:)`と幅確保用placeholderは同じフォントを使用する。
+- ヘッダーのしましまは`StripePattern`を再利用。取消の灰色も維持する。
+- 最大長周期地震動階級の配信不足は`docs/todo/500_eew_live_activity_max_lpgm.md`を参照。
+
+本規則は`20260815_dynamic_island_eew_layout.md`の旧配置と、
+`20260823_eew_missing_forecast_intensity.md`のiOS最大震度の背景色規則に優先する。
+Flutterアプリの震度表示は変更していない。
+
+## Swift Preview
+
+Xcodeで`app/ios/Runner.xcodeproj`を開き、スキーム`EQMonitorPreview`とiPhone Simulatorを選ぶ。
+`EQMonitorPreviewWidget/EQMonitorPreviewWidgetBundle.swift`を開いてCanvasを表示する。
+`EEW デザイン確認`のLock Screen / Expanded / Compact / Minimalが同じ状態一覧を使う。
+
+状態順は、警報対象、警報対象外（現在地3）、予報（現在地4）、現在地情報なし、
+到達予想なし、警報対象だが震度なし、取消、深発、PLUM、予報（現在地3・非表示）。
+カウントダウンはPreview生成時点から31秒。再開するときはPreviewを再生成する。
+
+```sh
+xcodebuild build -project app/ios/Runner.xcodeproj -scheme EQMonitorPreview \
+  -destination 'generic/platform=iOS Simulator' \
+  -disableAutomaticPackageResolution -skipPackageUpdates CODE_SIGNING_ALLOWED=NO
+
+xcodebuild test -project app/ios/Runner.xcodeproj -scheme WidgetModelsTests \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
+  -disableAutomaticPackageResolution -skipPackageUpdates CODE_SIGNING_ALLOWED=NO
+```
+
+新しい`Widget/`ファイルをPreview拡張に含めるには、`project.pbxproj`の
+Previewターゲット向け`membershipExceptions`への追加が必要。
+見た目の最終確認はCanvasで行う。ビルド成功だけでカメラ脇の切り取りがないとは判断しない。
+
+## 外観・余白の注意
+
+- 黒背景のEEWは文字色を白で明示する。PreviewのLight Appearanceでは
+  `activityBackgroundTint(.black)`だけに頼らず、ロック画面Viewにも黒背景を指定する。
+- Expandedの本文全体に縦方向の`fixedSize`を付けると、割り当て高さを超えて
+  下端が切れる場合がある。警報名など必要なTextだけに指定する。
+- 単一leading領域＋`belowIfTooWide`も試したが、現在地情報の下端がCanvasで切れた。
+  本実装はleading/trailing/bottomを分離し、OS標準の外周余白を維持する。
+  カメラ高さの固定値や負のpaddingで補正しない。
+- Google Sans Codeは行ボックスに上下余白を持つ。Figmaのcap height基準の行間を
+  VStackのspacingにそのまま足すと二重になるため、M・深さの縦積みはspacing 0。
+- Expandedの最大震度は38pt、震源要素の数値は21pt。表示サイズだけの調整では
+  テストを追加せず、既存モデルテスト・静的解析・Canvasで確認する。

--- a/docs/superpowers/plans/2026-09-07-eew-live-activity-figma.md
+++ b/docs/superpowers/plans/2026-09-07-eew-live-activity-figma.md
@@ -1,0 +1,39 @@
+# EEW Live Activity Figma Implementation Plan
+
+**Goal:** 合意済みのロック画面・Expanded・Minimalを実装し、ユーザーがSwift Previewでデザインチェックできる状態にする。
+
+**Architecture:** `EewDisplay`に表示判定を集約する。既存の震度色・フォント・カウントダウン・しましまを再利用し、現在地と最大震度の部品を分離する。
+
+**Tech Stack:** SwiftUI / ActivityKit / WidgetKit / Swift Testing
+
+**Spec:** Figma `AmrOwdlmvdGU03vssT9e1H` の `1628:1745`（ロック画面）、`1628:1694`（Expanded）と本会話で合意したMinimal。
+
+## Constraints
+
+- Minimal: 現在地は塗りつぶしあり。最大震度は塗りつぶしなし＋MAX。現在地ラベルは追加しない。
+- 現在地情報は警報、または予報で現在地の予想震度4以上の場合に表示。欠損値を補完しない。
+- 現在地が警報対象かは電文全体の警報と分ける。取消時は震度・到達予想を抑止する。
+- ロック画面のヘッダーは既存のしましまを再利用し、右端を最大震度にする。
+- Expandedは上段に最大震度とM/深さ、下段に見出しと現在地の注意・カウントダウン・予想震度。
+- PLUM/レベル法/1点検知の低精度表示と深発注意を維持する。
+- フォントは既存のAppFonts。配信されない最大長周期地震動階級は表示しない。
+- 新規ブランチ`feat/eew-live-activity-figma`で変更し、ユーザーの未コミット変更はステージしない。作業前は`136f74218`。
+
+## Tasks
+
+- [x] `LocationInfo`で警報対象・PLUMを受信し、`EewDisplay`で現在地情報の可否、震度の種別、注意帯を判定する。警報対象外・予報3/4・取消・欠損・PLUMの回帰テストを追加する。
+- [x] 最大震度専用のMAX付き部品と現在地の色付き部品を作り、Compact/Minimalで使い分ける。
+- [x] ロック画面のヘッダー・地震詳細・現在地情報をFigmaに沿って組み直す。
+- [x] Expandedのleading/trailing/bottomを組み直し、現在地情報なし・取消・低精度も対応する。
+- [x] 状態別のLock Screen/Expanded/Compact/Minimal Previewを追加。WidgetModelsTestsとPreviewターゲットのビルド・静的解析で確認する。
+- [x] 配信項目の制約・Preview手順をknowledge/todoに記録する。対象ファイルのみコミット・pushする。
+
+## Verification
+
+```sh
+xcodebuild test -project app/ios/Runner.xcodeproj -scheme WidgetModelsTests -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO
+xcodebuild build -project app/ios/Runner.xcodeproj -scheme EQMonitorPreview -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO
+git --no-pager diff --check
+```
+
+最終的な見た目の採否はユーザーがSwift Previewで確認する。

--- a/docs/todo/500_eew_live_activity_max_lpgm.md
+++ b/docs/todo/500_eew_live_activity_max_lpgm.md
@@ -1,0 +1,13 @@
+# EEW Live Activityの最大長周期地震動階級
+
+バックエンド対応: https://github.com/YumNumm/eqmonitor-backend/issues/1158
+
+Figmaのロック画面案（1628:1745）には最大長周期地震動階級があるが、
+現在の`buildEewLiveActivityContentState`は該当項目を配信していない。
+現在地の`forecastLpgmIntensity`を全国の最大値として流用しない。
+
+- 配信契約に全国の最大長周期地震動階級を追加し、イベントからの変換を検証する。
+- Swiftの受信モデルと旧ペイロード互換テストを追加する。
+- 実値を受信した場合だけロック画面の発生時刻の下に表示する。
+
+2026-09-07のデザイン実装ではこの行を省略している。固定値・仮値は表示していない。


### PR DESCRIPTION
## 概要

EEW Live Activityのロック画面・Dynamic Islandを、現在地の予想震度と到達予想を優先する表示へ変更します。

## 変更内容

- 現在地の震度は色付き、全国の最大震度は塗りつぶしなし＋MAXで区別。
- 現在地の警報対象・予想震度に応じて注意帯を切り替え。震度2未満は薄い蒼の「現在地で弱い揺れ」。予報時の現在地震度4以上という表示条件は維持。
- `location.isWarning` / `location.isPlum`の受信に対応。旧ペイロードとの互換性を保ち、欠損値を補完しない。
- 取消時の震度・到達予想を抑止し、「先ほどの緊急地震速報は取り消されました」を表示。通常時と配置を共通化。
- 現在地震度を表示しない場合、見出しの下に発生／検知日時を表示。
- Expandedの高さ不足に応じたコンパクト配置、MAXの行高統一、日本語混在ラベルの省略対策を追加。
- 注意帯・Expandedの震度背景・低精度ラベル枠を`ContainerRelativeShape`で親形状に追従。
- Light Appearanceでの文字色・背景を修正。震源要素の数値はGoogle Sans Codeを使用。
- 12状態のSwift Previewと表示判定の回帰テスト、運用知見を追加。

## 検証

- `WidgetModelsTests`全体をiPhone 17 / iOS 26.5 Simulatorで実行。
- `EQMonitorPreview`のビルド・静的解析を実行。
- Xcode Canvasで警報、警報対象外、予報、現在地情報なし、取消、PLUM、弱い揺れ、震度2を確認。150〜200%表示で文字末尾と塗りつぶしの四隅を確認。
- `git diff --check`、コミットフックのgitleaks等を通過。
- 実機での確認は未実施。Flutter/Dartとbackend実装は変更対象外。

## 関連

- 最大長周期地震動階級の配信は別対応: https://github.com/YumNumm/eqmonitor-backend/issues/1158
- Preview手順・状態一覧・表示規則: `docs/knowledge/20260907_eew_live_activity_design_preview.md`

既存の未コミット変更（Package.resolved・submodule・別の作業計画）は本PRに含めていません。
