### PR TITLE
feat: Siriの地震読み上げと地域名検索を追加

### DIFF
--- a/app/ios/AppIntentExtension/EarthquakeEntity.swift
+++ b/app/ios/AppIntentExtension/EarthquakeEntity.swift
@@ -42,7 +42,7 @@ struct EarthquakeEntity: AppEntity, Identifiable {
         self.hypocenterName = item.hypocenterName
         self.magnitude = item.magnitude
         self.depth = item.depth.isEmpty ? "不明" : item.depth
-        self.maxIntensity = item.maxIntensity?.titleText ?? "不明"
+        self.maxIntensity = EarthquakeIntentDialog.maximumIntensityLabel(item: item)
         self.occurredAt = item.formattedTime
     }
 }

--- a/app/ios/AppIntentExtension/GetEarthquakesNearMeIntent.swift
+++ b/app/ios/AppIntentExtension/GetEarthquakesNearMeIntent.swift
@@ -22,7 +22,7 @@ struct GetEarthquakesNearMeIntent: AppIntent {
     var limit: Int
 
     func perform() async throws
-        -> some IntentResult & ReturnsValue<[EarthquakeEntity]> & ShowsSnippetIntent {
+        -> some IntentResult & ReturnsValue<[EarthquakeEntity]> & ProvidesDialog & ShowsSnippetIntent {
         // 現在地未設定時の全国フォールバックは「現在地の情報」としては誤りに
         // なるため、明示エラーで案内する
         let resolved = WidgetRegionResolver.resolve(regionType: .currentLocation)
@@ -34,8 +34,12 @@ struct GetEarthquakesNearMeIntent: AppIntent {
             limit: limit,
             minIntensity: minIntensity?.apiValue
         )
+        let summary = EarthquakeIntentDialog.summary(
+            items: items, area: "アプリに保存された現在地の地域", isRegional: true
+        )
         return .result(
             value: items.map(EarthquakeEntity.init),
+            dialog: IntentDialog(full: "\(summary)", supporting: "保存された地域の地震情報を\(items.count)件取得しました。"),
             snippetIntent: EarthquakeSnippetIntent(
                 regionID: "region:\(code)",
                 minIntensity: minIntensity,

--- a/app/ios/AppIntentExtension/GetLatestEarthquakesIntent.swift
+++ b/app/ios/AppIntentExtension/GetLatestEarthquakesIntent.swift
@@ -27,7 +27,7 @@ struct GetLatestEarthquakesIntent: AppIntent {
     var limit: Int
 
     func perform() async throws
-        -> some IntentResult & ReturnsValue<[EarthquakeEntity]> & ShowsSnippetIntent {
+        -> some IntentResult & ReturnsValue<[EarthquakeEntity]> & ProvidesDialog & ShowsSnippetIntent {
         if region != nil, !ProStatus.isPro {
             throw EQIntentError.proRequired
         }
@@ -36,8 +36,12 @@ struct GetLatestEarthquakesIntent: AppIntent {
             limit: limit,
             minIntensity: minIntensity?.apiValue
         )
+        let summary = EarthquakeIntentDialog.summary(
+            items: items, area: region?.name ?? "全国", isRegional: region != nil
+        )
         return .result(
             value: items.map(EarthquakeEntity.init),
+            dialog: IntentDialog(full: "\(summary)", supporting: "\(items.count)件の地震情報を取得しました。"),
             snippetIntent: EarthquakeSnippetIntent(
                 regionID: region?.id,
                 minIntensity: minIntensity,

--- a/app/ios/Packages/EQMonitorAPI/Scripts/generate-intensity-partial.py
+++ b/app/ios/Packages/EQMonitorAPI/Scripts/generate-intensity-partial.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Regenerate IntensityPartial while preserving legacy device API contracts.
+
+The checked-in OpenAPI snapshot omits legacy Live Activity operations that are
+still present in GeneratedSources. A full regeneration would delete those APIs.
+Generate the changed schema with Apple's generator and replace only that type.
+Usage: python3 Scripts/generate-intensity-partial.py /path/to/swift-openapi-generator
+"""
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+
+def declaration_span(source: str) -> tuple[int, int]:
+    marker = "        public struct IntensityPartial:"
+    start = source.index(marker)
+    opening = source.index("{", start)
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return start, index + 1
+    raise ValueError("Incomplete generated IntensityPartial declaration")
+
+
+def main() -> None:
+    package = pathlib.Path(__file__).resolve().parent.parent
+    source_dir = package / "Sources/EQMonitorAPI"
+    target = source_dir / "GeneratedSources/Types.swift"
+    with tempfile.TemporaryDirectory(prefix="eqmonitor-intensity-schema-") as directory:
+        output = pathlib.Path(directory)
+        config = output / "config.yaml"
+        config.write_text("generate: [types]\naccessModifier: public\n")
+        subprocess.run([
+            sys.argv[1], "generate", str(source_dir / "openapi.json"),
+            "--config", str(config), "--output-directory", str(output),
+        ], check=True)
+        original = target.read_text()
+        generated = (output / "Types.swift").read_text()
+        old_start, old_end = declaration_span(original)
+        new_start, new_end = declaration_span(generated)
+        target.write_text(original[:old_start] + generated[new_start:new_end] + original[old_end:])
+
+
+if __name__ == "__main__":
+    main()

--- a/app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/GeneratedSources/Types.swift
+++ b/app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/GeneratedSources/Types.swift
@@ -5208,30 +5208,54 @@ public enum Components {
                 public init(value1: Components.Schemas.JmaLpgmIntensity) {
                     self.value1 = value1
                 }
-                public init(from decoder: any Swift.Decoder) throws {
+                public init(from decoder: any Decoder) throws {
                     self.value1 = try decoder.decodeFromSingleValueContainer()
                 }
-                public func encode(to encoder: any Swift.Encoder) throws {
+                public func encode(to encoder: any Encoder) throws {
                     try encoder.encodeToSingleValueContainer(self.value1)
                 }
             }
             /// - Remark: Generated from `#/components/schemas/IntensityPartial/max_lpgm_intensity`.
             public var max_lpgm_intensity: Components.Schemas.IntensityPartial.max_lpgm_intensityPayload?
+            /// - Remark: Generated from `#/components/schemas/IntensityPartial/max_intensity_class`.
+            public struct max_intensity_classPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/IntensityPartial/max_intensity_class/value1`.
+                public var value1: Components.Schemas.CatalogIntensityClass
+                /// Creates a new `max_intensity_classPayload`.
+                ///
+                /// - Parameters:
+                ///   - value1:
+                public init(value1: Components.Schemas.CatalogIntensityClass) {
+                    self.value1 = value1
+                }
+                public init(from decoder: any Decoder) throws {
+                    self.value1 = try decoder.decodeFromSingleValueContainer()
+                }
+                public func encode(to encoder: any Encoder) throws {
+                    try encoder.encodeToSingleValueContainer(self.value1)
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/IntensityPartial/max_intensity_class`.
+            public var max_intensity_class: Components.Schemas.IntensityPartial.max_intensity_classPayload?
             /// Creates a new `IntensityPartial`.
             ///
             /// - Parameters:
             ///   - max_intensity:
             ///   - max_lpgm_intensity:
+            ///   - max_intensity_class:
             public init(
                 max_intensity: Components.Schemas.JmaIntensity,
-                max_lpgm_intensity: Components.Schemas.IntensityPartial.max_lpgm_intensityPayload? = nil
+                max_lpgm_intensity: Components.Schemas.IntensityPartial.max_lpgm_intensityPayload? = nil,
+                max_intensity_class: Components.Schemas.IntensityPartial.max_intensity_classPayload? = nil
             ) {
                 self.max_intensity = max_intensity
                 self.max_lpgm_intensity = max_lpgm_intensity
+                self.max_intensity_class = max_intensity_class
             }
             public enum CodingKeys: String, CodingKey {
                 case max_intensity
                 case max_lpgm_intensity
+                case max_intensity_class
             }
         }
         /// - Remark: Generated from `#/components/schemas/EarthquakePartial`.

--- a/app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/openapi.json
+++ b/app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/openapi.json
@@ -7694,6 +7694,13 @@
                 "$ref": "#/components/schemas/JmaLpgmIntensity"
               }
             ]
+          },
+          "max_intensity_class": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CatalogIntensityClass"
+              }
+            ]
           }
         },
         "required": [

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -117,6 +117,13 @@
 		EQ0000000000000000000070 /* EewDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000006 /* EewDisplayTests.swift */; };
 		EQ0000000000000000000071 /* WidgetRegionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000007 /* WidgetRegionResolverTests.swift */; };
 		EQ00000000000000000000C8 /* LiveActivityDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EQ0000000000000000000001 /* LiveActivityDate.swift */; };
+		A91000000000000000000001 /* EarthquakeIntentDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9100000000000000000000B /* EarthquakeIntentDialog.swift */; };
+		A91000000000000000000002 /* EarthquakeIntentDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9100000000000000000000B /* EarthquakeIntentDialog.swift */; };
+		A91000000000000000000003 /* EarthquakeIntentDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9100000000000000000000B /* EarthquakeIntentDialog.swift */; };
+		A91000000000000000000004 /* EarthquakeIntentDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9100000000000000000000C /* EarthquakeIntentDialogTests.swift */; };
+		A91000000000000000000005 /* SearchEarthquakesIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9100000000000000000000D /* SearchEarthquakesIntent.swift */; };
+		A91000000000000000000006 /* EarthquakeSearchURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9100000000000000000000E /* EarthquakeSearchURL.swift */; };
+		A91000000000000000000007 /* EarthquakeSearchURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9100000000000000000000E /* EarthquakeSearchURL.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -273,6 +280,10 @@
 		EQ0000000000000000000006 /* EewDisplayTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EewDisplayTests.swift; sourceTree = "<group>"; };
 		EQ0000000000000000000007 /* WidgetRegionResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetRegionResolverTests.swift; sourceTree = "<group>"; };
 		FB4211733B19AA27C617F8A5 /* TelegramStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TelegramStatus.swift; sourceTree = "<group>"; };
+		A9100000000000000000000B /* EarthquakeIntentDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarthquakeIntentDialog.swift; sourceTree = "<group>"; };
+		A9100000000000000000000C /* EarthquakeIntentDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarthquakeIntentDialogTests.swift; sourceTree = "<group>"; };
+		A9100000000000000000000D /* SearchEarthquakesIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEarthquakesIntent.swift; sourceTree = "<group>"; };
+		A9100000000000000000000E /* EarthquakeSearchURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarthquakeSearchURL.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -434,6 +445,7 @@
 		3770F148FEB3FAEFF53D21CE /* WidgetModelsTests */ = {
 			isa = PBXGroup;
 			children = (
+				A9100000000000000000000C /* EarthquakeIntentDialogTests.swift */,
 				C983AB8FC2BFED453E240464 /* EarthquakeDisplayItemTests.swift */,
 				E11333333333333333333333 /* WidgetBehaviorTests.swift */,
 				EQ0000000000000000000003 /* LiveActivityDateTests.swift */,
@@ -535,6 +547,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				A9100000000000000000000D /* SearchEarthquakesIntent.swift */,
 				2709A8762F1FFFF400FBE962 /* Frameworks */,
 				85145B082B1F59A900784C85 /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
@@ -556,6 +569,8 @@
 		EB0182E4C221D99352C4222C /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				A9100000000000000000000B /* EarthquakeIntentDialog.swift */,
+				A9100000000000000000000E /* EarthquakeSearchURL.swift */,
 				62ACEBEF0EEEF36A8EC1B1B1 /* EarthquakeDisplayItem.swift */,
 				381A26E10F0EF7D7FEC86D79 /* IntensityValue.swift */,
 				FB4211733B19AA27C617F8A5 /* TelegramStatus.swift */,
@@ -963,6 +978,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A91000000000000000000001 /* EarthquakeIntentDialog.swift in Sources */,
 				EQ00000000000000000000C8 /* LiveActivityDate.swift in Sources */,
 				EQ0000000000000000000069 /* WidgetErrorMessage.swift in Sources */,
 				010DC8E64C7C76B8F4F166D5 /* EarthquakeDisplayItem.swift in Sources */,
@@ -981,6 +997,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A91000000000000000000007 /* EarthquakeSearchURL.swift in Sources */,
+				A91000000000000000000004 /* EarthquakeIntentDialogTests.swift in Sources */,
+				A91000000000000000000003 /* EarthquakeIntentDialog.swift in Sources */,
 				B19000000000000000000001 /* HeadlessExecutionLifecycle.swift in Sources */,
 				B18000000000000000000002 /* HeadlessTaskState.swift in Sources */,
 				B18000000000000000000001 /* BackgroundLocationHeadlessTaskStateTests.swift in Sources */,
@@ -1011,6 +1030,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A91000000000000000000002 /* EarthquakeIntentDialog.swift in Sources */,
 				EQ000000000000000000006E /* EewDisplay.swift in Sources */,
 				EQ0000000000000000000065 /* LiveActivityDate.swift in Sources */,
 				EQ0000000000000000000067 /* WidgetErrorMessage.swift in Sources */,
@@ -1041,6 +1061,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A91000000000000000000006 /* EarthquakeSearchURL.swift in Sources */,
+				A91000000000000000000005 /* SearchEarthquakesIntent.swift in Sources */,
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				85A1B0012F59A00000000001 /* AppGroupMethodChannel.swift in Sources */,
 				85A1B0212F59C00000000021 /* LiveActivityDebugMethodChannel.swift in Sources */,

--- a/app/ios/Runner/SearchEarthquakesIntent.swift
+++ b/app/ios/Runner/SearchEarthquakesIntent.swift
@@ -1,0 +1,29 @@
+import AppIntents
+import UIKit
+
+@available(iOS 27.0, *)
+@AppIntent(schema: .system.searchInApp)
+struct SearchEarthquakesIntent {
+    static let title: LocalizedStringResource = "地域名で地震を検索"
+    static let description = IntentDescription("地域名で検索し、アプリで地域を選んで地震履歴を表示します。")
+    static let supportedModes: IntentModes = .foreground
+
+    var criteria: StringSearchCriteria
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        guard let url = EarthquakeSearchURL.make(query: criteria.term),
+              await UIApplication.shared.open(url) else {
+            throw EarthquakeSearchError.cannotOpen
+        }
+        return .result()
+    }
+}
+
+enum EarthquakeSearchError: Error, CustomLocalizedStringResourceConvertible {
+    case cannotOpen
+
+    var localizedStringResource: LocalizedStringResource {
+        "検索画面を開けませんでした。EQMonitorを起動して、もう一度お試しください。"
+    }
+}

--- a/app/ios/Shared/EarthquakeDisplayItem.swift
+++ b/app/ios/Shared/EarthquakeDisplayItem.swift
@@ -14,9 +14,18 @@ import EQMonitorAPI
 struct EarthquakeDisplayItem: Identifiable, Equatable {
     let id: String
     let hypocenterName: String
+    /// 見出しの震度フォールバックを含まない、APIの震源名。
+    let sourceHypocenterName: String?
     let magnitude: String
     let magnitudeValue: Double?
     let maxIntensity: IntensityValue?
+    /// 地域検索でも地震全体の最大震度を保持する。
+    let earthquakeMaxIntensity: IntensityValue?
+    let earthquakeMaxIntensityClass: Components.Schemas.CatalogIntensityClass?
+    let earthquakeType: Components.Schemas.EarthquakeType
+    let sourceOriginTime: Date?
+    let sourceArrivalTime: Date?
+    let originTimePrecision: Components.Schemas.OriginTimePrecision
     let depth: String
     let originTime: Date
     let formattedTime: String
@@ -64,6 +73,15 @@ struct EarthquakeDisplayItem: Identifiable, Equatable {
     /// Components.Schemas.EarthquakePartial からの変換初期化
     init(from partial: Components.Schemas.EarthquakePartial) {
         let maxIntensity = IntensityValue(from: partial.intensity?.value1.max_intensity)
+        self.earthquakeMaxIntensity = maxIntensity
+        self.sourceHypocenterName = [partial.hypocenter?.value1.name,
+                                    partial.hypocenter?.value1.detailed?.value1.name]
+            .compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: "、")
+        self.earthquakeType = partial.earthquake_type
+        self.earthquakeMaxIntensityClass = partial.intensity?.value1.max_intensity_class?.value1
+        self.sourceOriginTime = partial.origin_time
+        self.sourceArrivalTime = partial.arrival_time
+        self.originTimePrecision = partial.origin_time_precision
         self.id = partial.event_id
         self.hypocenterName = Self.resolveTitle(
             name: partial.hypocenter?.value1.name,
@@ -110,6 +128,15 @@ struct EarthquakeDisplayItem: Identifiable, Equatable {
         earthquake partial: Components.Schemas.EarthquakePartial
     ) {
         // 地域の震度情報を優先（検索結果の場合）
+        self.earthquakeMaxIntensity = IntensityValue(from: partial.intensity?.value1.max_intensity)
+        self.sourceHypocenterName = [partial.hypocenter?.value1.name,
+                                    partial.hypocenter?.value1.detailed?.value1.name]
+            .compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: "、")
+        self.earthquakeType = partial.earthquake_type
+        self.earthquakeMaxIntensityClass = partial.intensity?.value1.max_intensity_class?.value1
+        self.sourceOriginTime = partial.origin_time
+        self.sourceArrivalTime = partial.arrival_time
+        self.originTimePrecision = partial.origin_time_precision
         let maxIntensity = IntensityValue(from: regionIntensity)
             ?? IntensityValue(from: partial.intensity?.value1.max_intensity)
         self.id = partial.event_id
@@ -154,9 +181,16 @@ struct EarthquakeDisplayItem: Identifiable, Equatable {
     ) {
         self.id = id
         self.hypocenterName = hypocenterName
+        self.sourceHypocenterName = hypocenterName.isEmpty ? nil : hypocenterName
         self.magnitude = magnitude
         self.magnitudeValue = magnitudeValue
         self.maxIntensity = maxIntensity
+        self.earthquakeMaxIntensity = maxIntensity
+        self.earthquakeMaxIntensityClass = nil
+        self.earthquakeType = .NORMAL
+        self.sourceOriginTime = originTime
+        self.sourceArrivalTime = nil
+        self.originTimePrecision = .MINUTE
         self.depth = depth
         self.originTime = originTime
         self.formattedTime = Self.formatTime(originTime, isArrival: false)

--- a/app/ios/Shared/EarthquakeIntentDialog.swift
+++ b/app/ios/Shared/EarthquakeIntentDialog.swift
@@ -1,0 +1,91 @@
+import Foundation
+import EQMonitorAPI
+
+/// 表示用の見出しや現在日時のフォールバックを、地震の事実として読み上げない。
+enum EarthquakeIntentDialog {
+    static func summary(
+        items: [EarthquakeDisplayItem], area: String, isRegional: Bool
+    ) -> String {
+        guard let item = items.first else {
+            return "\(area)で条件に合う地震情報は見つかりませんでした。"
+        }
+        var sentences = ["\(area)の地震・噴火情報を\(items.count)件取得しました。最新の1件を読み上げます。"]
+        if !item.status.isNormal {
+            sentences.append("これは\(item.status.displayString)の情報です。")
+        }
+        switch item.earthquakeType {
+        case .NORMAL: break
+        case .DISTANT: sentences.append("遠地地震の情報です。")
+        case .VOLCANO: sentences.append("火山噴火の情報です。")
+        }
+        sentences.append(timeDescription(item: item))
+        let locationLabel = item.earthquakeType == .VOLCANO ? "発生場所" : "震源"
+        if let name = item.sourceHypocenterName, !name.isEmpty {
+            sentences.append("\(locationLabel)は\(name)です。")
+        } else {
+            sentences.append("\(locationLabel)は不明です。")
+        }
+        if item.earthquakeType != .VOLCANO {
+            if let intensityClass = item.earthquakeMaxIntensityClass,
+               let description = historicalDescription(intensityClass) {
+                sentences.append("地震データベース上の分類は\(description)です。")
+            } else if item.earthquakeType == .NORMAL || item.earthquakeMaxIntensity != nil {
+                sentences.append("地震全体の最大震度は\(maximumIntensityLabel(item: item))です。")
+            }
+        }
+        if isRegional {
+            sentences.append("対象地域の震度は\(item.maxIntensity?.titleText ?? "不明")です。")
+        }
+        if item.earthquakeType == .NORMAL || item.magnitude != "M不明" {
+            sentences.append("\(item.magnitude.replacingOccurrences(of: "M", with: "マグニチュード"))。")
+        }
+        if !item.depth.isEmpty {
+            sentences.append("深さは\(item.depth.replacingOccurrences(of: "km", with: "キロメートル"))です。")
+        }
+        return sentences.joined()
+    }
+
+    static func timeDescription(item: EarthquakeDisplayItem) -> String {
+        guard let date = item.sourceOriginTime ?? item.sourceArrivalTime else {
+            return "時刻は不明です。"
+        }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.timeZone = TimeZone(identifier: "Asia/Tokyo")
+        let precision = item.sourceOriginTime == nil ? .MINUTE : item.originTimePrecision
+        switch precision {
+        case .MILLISECOND, .SECOND, .MINUTE: formatter.dateFormat = "yyyy年M月d日H時m分"
+        case .HOUR: formatter.dateFormat = "yyyy年M月d日H時"
+        case .DAY: formatter.dateFormat = "yyyy年M月d日"
+        case .MONTH: formatter.dateFormat = "yyyy年M月"
+        }
+        return formatter.string(from: date) + (item.sourceOriginTime == nil ? "頃検知。" : "頃発生。")
+    }
+
+    static func maximumIntensityLabel(item: EarthquakeDisplayItem) -> String {
+        guard let value = item.earthquakeMaxIntensityClass else {
+            return item.earthquakeMaxIntensity?.titleText ?? "不明"
+        }
+        switch value {
+        case .A: return "5弱"
+        case .B: return "5強"
+        case .C: return "6弱"
+        case .D: return "6強"
+        case ._1, ._2, ._3, ._4, ._5, ._6, ._7: return value.rawValue
+        default: return historicalDescription(value) ?? "不明"
+        }
+    }
+
+    static func historicalDescription(_ value: Components.Schemas.CatalogIntensityClass) -> String? {
+        switch value {
+        case ._9: return "有感であったが震度は不明"
+        case .R: return "顕著地震"
+        case .M: return "やや顕著地震"
+        case .S: return "小局発地震"
+        case .L: return "局発地震"
+        case .F: return "有感"
+        case .X: return "付近有感"
+        default: return nil
+        }
+    }
+}

--- a/app/ios/Shared/EarthquakeSearchURL.swift
+++ b/app/ios/Shared/EarthquakeSearchURL.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum EarthquakeSearchURL {
+    static func make(query: String) -> URL? {
+        var components = URLComponents()
+        components.scheme = "eqmonitor"
+        components.host = ""
+        components.path = "/earthquake-history/search"
+        components.queryItems = [URLQueryItem(name: "query", value: query)]
+        // Dart Uri.queryParameters interprets an unescaped plus as a space.
+        components.percentEncodedQuery = components.percentEncodedQuery?
+            .replacingOccurrences(of: "+", with: "%2B")
+        return components.url
+    }
+}

--- a/app/ios/WidgetModelsTests/EarthquakeIntentDialogTests.swift
+++ b/app/ios/WidgetModelsTests/EarthquakeIntentDialogTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Testing
+import EQMonitorAPI
+
+struct EarthquakeIntentDialogTests {
+    func earthquake() throws -> Components.Schemas.EarthquakePartial {
+        let json = """
+        {"event_id":"20260830001711","status":"NORMAL",
+         "origin_time":"2026-08-29T15:17:00Z","origin_time_precision":"SECOND",
+         "hypocenter":{"code":"473","name":"千葉県東方沖",
+           "magnitude":{"type":"NORMAL","value":4.8},
+           "depth":{"type":"NORMAL","value":30}},
+         "intensity":{"max_intensity":"4"},"datasources":[],
+         "telegram_types":[],"earthquake_type":"NORMAL"}
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(Components.Schemas.EarthquakePartial.self, from: Data(json.utf8))
+    }
+
+    @Test func regionalIntensityDoesNotReplaceEarthquakeMaximum() throws {
+        let item = EarthquakeDisplayItem(from: Components.Schemas.IntensityPrefectureSearchItem(
+            intensity: ._1, earthquake: try earthquake()
+        ))
+        let dialog = EarthquakeIntentDialog.summary(items: [item], area: "東京都", isRegional: true)
+        #expect(item.earthquakeMaxIntensity == .four)
+        #expect(item.maxIntensity == .one)
+        #expect(dialog.contains("地震全体の最大震度は4です。対象地域の震度は1です。"))
+        #expect(dialog.contains("2026年8月30日0時17分頃発生"))
+        #expect(dialog.contains("震源は千葉県東方沖です。"))
+        #expect(dialog.contains("マグニチュード4.8"))
+    }
+
+    @Test func nationwideDoesNotDescribeRegionalIntensity() throws {
+        let dialog = EarthquakeIntentDialog.summary(
+            items: [EarthquakeDisplayItem(from: try earthquake())], area: "全国", isRegional: false
+        )
+        #expect(dialog.contains("全国の地震・噴火情報を1件取得"))
+        #expect(!dialog.contains("対象地域の震度"))
+    }
+
+    @Test func missingTimeAndHypocenterAreNotInvented() throws {
+        var source = try earthquake()
+        source.origin_time = nil
+        source.hypocenter = nil
+        let dialog = EarthquakeIntentDialog.summary(
+            items: [EarthquakeDisplayItem(from: source)], area: "全国", isRegional: false
+        )
+        #expect(dialog.contains("時刻は不明です。震源は不明です。"))
+        #expect(!dialog.contains("頃発生"))
+        #expect(!dialog.contains("震源は最大震度"))
+        #expect(dialog.contains("マグニチュード不明"))
+    }
+
+    @Test func detectionTimeIsNotAnnouncedAsOriginTime() throws {
+        var source = try earthquake()
+        source.arrival_time = source.origin_time
+        source.origin_time = nil
+        let dialog = EarthquakeIntentDialog.summary(
+            items: [EarthquakeDisplayItem(from: source)], area: "全国", isRegional: false
+        )
+        #expect(dialog.contains("頃検知"))
+        #expect(!dialog.contains("頃発生"))
+    }
+
+    @Test(arguments: [Components.Schemas.TelegramStatus.TRAINING, .TEST])
+    func nonNormalInformationIsAnnouncedBeforeDetails(status: Components.Schemas.TelegramStatus) throws {
+        var source = try earthquake()
+        source.status = status
+        let dialog = EarthquakeIntentDialog.summary(
+            items: [EarthquakeDisplayItem(from: source)], area: "全国", isRegional: false
+        )
+        let warning = status == .TRAINING ? "これは訓練の情報です。" : "これはテストの情報です。"
+        #expect(dialog.contains(warning + "2026年8月30日"))
+    }
+
+    @Test func emptyResultDoesNotClaimThatNoEarthquakeOccurred() {
+        #expect(EarthquakeIntentDialog.summary(items: [], area: "東京都", isRegional: true)
+            == "東京都で条件に合う地震情報は見つかりませんでした。")
+    }
+
+    @Test func multipleResultsReadOnlyTheFirstAndStateTheCount() throws {
+        let item = EarthquakeDisplayItem(from: try earthquake())
+        let dialog = EarthquakeIntentDialog.summary(items: [item, item], area: "全国", isRegional: false)
+        #expect(dialog.contains("2件取得しました。最新の1件を読み上げます。"))
+        #expect(dialog.components(separatedBy: "震源は").count == 2)
+    }
+
+    @Test func detailedHypocenterKeepsBothNamesLikeFlutter() throws {
+        var source = try earthquake()
+        source.hypocenter?.value1.detailed = .init(value1: .init(code: "1", name: "補足の地域名"))
+        let item = EarthquakeDisplayItem(from: source)
+        #expect(item.sourceHypocenterName == "千葉県東方沖、補足の地域名")
+    }
+
+    @Test(arguments: [Components.Schemas.EarthquakeType.VOLCANO, .DISTANT])
+    func overseasEventsDoNotInventMissingElements(type: Components.Schemas.EarthquakeType) throws {
+        var source = try earthquake()
+        source.earthquake_type = type
+        source.intensity = nil
+        source.hypocenter?.value1.magnitude = .init(_type: .UNKNOWN)
+        source.hypocenter?.value1.depth = .init(_type: .UNKNOWN)
+        let dialog = EarthquakeIntentDialog.summary(
+            items: [EarthquakeDisplayItem(from: source)], area: "全国", isRegional: false
+        )
+        #expect(!dialog.contains("最大震度"))
+        #expect(!dialog.contains("マグニチュード"))
+        #expect(!dialog.contains("調査中"))
+        #expect(!dialog.contains("深さ"))
+        if type == .VOLCANO {
+            #expect(dialog.contains("火山噴火の情報です。"))
+            #expect(dialog.contains("発生場所は千葉県東方沖です。"))
+            #expect(!dialog.contains("震源は"))
+        }
+    }
+
+    @Test(arguments: [Components.Schemas.OriginTimePrecision.HOUR, .DAY, .MONTH])
+    func coarseTimesDoNotInventPrecision(precision: Components.Schemas.OriginTimePrecision) throws {
+        var source = try earthquake()
+        source.origin_time_precision = precision
+        let time = EarthquakeIntentDialog.timeDescription(item: EarthquakeDisplayItem(from: source))
+        #expect(!time.contains("分"))
+        if precision != .HOUR { #expect(!time.contains("時")) }
+        if precision == .MONTH { #expect(time == "2026年8月頃発生。") }
+    }
+
+    @Test func overM8AndShallowDepthMatchFlutterSemantics() throws {
+        var source = try earthquake()
+        source.hypocenter?.value1.magnitude = .init(_type: .OVER_M8)
+        source.hypocenter?.value1.depth = .init(_type: .SHALLOW)
+        let dialog = EarthquakeIntentDialog.summary(
+            items: [EarthquakeDisplayItem(from: source)], area: "全国", isRegional: false
+        )
+        #expect(dialog.contains("マグニチュード8超"))
+        #expect(dialog.contains("深さはごく浅いです。"))
+    }
+
+    @Test func historicalFiveIsNotAnnouncedAsFiveLower() throws {
+        var source = try earthquake()
+        source.intensity?.value1.max_intensity = ._5_hyphen_
+        source.intensity?.value1.max_intensity_class = .init(value1: ._5)
+        let dialog = EarthquakeIntentDialog.summary(
+            items: [EarthquakeDisplayItem(from: source)], area: "全国", isRegional: false
+        )
+        #expect(dialog.contains("最大震度は5です。"))
+        #expect(!dialog.contains("5弱"))
+    }
+
+    @Test func historicalNonNumericClassDoesNotBecomeNumericIntensity() throws {
+        var source = try earthquake()
+        source.intensity?.value1.max_intensity_class = .init(value1: .R)
+        let dialog = EarthquakeIntentDialog.summary(
+            items: [EarthquakeDisplayItem(from: source)], area: "全国", isRegional: false
+        )
+        #expect(dialog.contains("地震データベース上の分類は顕著地震です。"))
+        #expect(!dialog.contains("最大震度は4"))
+    }
+
+    @Test func searchURLPreservesJapaneseAndReservedCharacters() throws {
+        let query = "東京 & 千代田区+沿岸/#"
+        let url = try #require(EarthquakeSearchURL.make(query: query))
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        #expect(components.scheme == "eqmonitor")
+        #expect(components.path == "/earthquake-history/search")
+        #expect(components.queryItems == [URLQueryItem(name: "query", value: query)])
+        #expect(components.fragment == nil)
+        #expect(url.absoluteString.contains("%2B"))
+        #expect(!url.absoluteString.contains("+"))
+        #expect(EarthquakeSearchURL.make(query: "Tokyo+Chiyoda")?.absoluteString
+            == "eqmonitor:///earthquake-history/search?query=Tokyo%2BChiyoda")
+    }
+}

--- a/app/lib/core/fcm/notification_deep_link.dart
+++ b/app/lib/core/fcm/notification_deep_link.dart
@@ -9,7 +9,10 @@ sealed class NotificationDeepLink {
     '/earthquake-history-details/',
     '/feed/source/',
   ];
-  static const _allowedExactPaths = ['/earthquake-history'];
+  static const _allowedExactPaths = [
+    '/earthquake-history',
+    '/earthquake-history/search',
+  ];
 
   static NotificationDeepLink? fromUri(Uri uri) {
     if (uri.scheme == _internalScheme) {

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -1,3 +1,5 @@
+import 'package:eqmonitor/feature/earthquake_history/ui/page/earthquake_history_search_page.dart';
+
 import 'dart:async';
 
 import 'package:eqmonitor/app.dart';
@@ -219,6 +221,18 @@ class EarthquakeHistoryRoute extends GoRouteData
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       EarthquakeHistoryPage(initialParameter: $extra);
+}
+
+@TypedGoRoute<EarthquakeHistorySearchRoute>(path: '/earthquake-history/search')
+class EarthquakeHistorySearchRoute extends GoRouteData
+    with $EarthquakeHistorySearchRoute, MaterialPageMixin {
+  const new({this.query = ''});
+
+  final String query;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      EarthquakeHistorySearchPage(key: ValueKey(query), initialQuery: query);
 }
 
 @TypedGoRoute<EewHistoryRoute>(path: '/eew-history')

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -14,6 +14,7 @@ List<RouteBase> get $appRoutes => [
   $onboardingWebViewRoute,
   $betaTestingWarningRoute,
   $earthquakeHistoryRoute,
+  $earthquakeHistorySearchRoute,
   $eewHistoryRoute,
   $seismicityRoute,
   $intensityHistoryRoute,
@@ -178,6 +179,41 @@ mixin $EarthquakeHistoryRoute on GoRouteData {
   @override
   void replace(BuildContext context) =>
       context.replace(location, extra: _self.$extra);
+}
+
+RouteBase get $earthquakeHistorySearchRoute => GoRouteData.$route(
+  path: '/earthquake-history/search',
+  hasOverriddenOnExit: false,
+  factory: $EarthquakeHistorySearchRoute._fromState,
+);
+
+mixin $EarthquakeHistorySearchRoute on GoRouteData {
+  static EarthquakeHistorySearchRoute _fromState(GoRouterState state) =>
+      EarthquakeHistorySearchRoute(
+        query: state.uri.queryParameters['query'] ?? '',
+      );
+
+  EarthquakeHistorySearchRoute get _self =>
+      this as EarthquakeHistorySearchRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/earthquake-history/search',
+    queryParams: {if (_self.query != '') 'query': _self.query},
+  );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
 }
 
 RouteBase get $eewHistoryRoute => GoRouteData.$route(

--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_search_result.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_search_result.dart
@@ -1,0 +1,13 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
+
+class EarthquakeHistorySearchResult {
+  const new({
+    required this.name,
+    required this.areaDescription,
+    required this.parameter,
+  });
+
+  final String name;
+  final String areaDescription;
+  final EarthquakeHistoryParameter parameter;
+}

--- a/app/lib/feature/earthquake_history/data/provider/earthquake_history_search_results.dart
+++ b/app/lib/feature/earthquake_history/data/provider/earthquake_history_search_results.dart
@@ -1,0 +1,23 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_search_result.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/earthquake_region_search.dart';
+import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'earthquake_history_search_results.g.dart';
+
+@riverpod
+Future<List<EarthquakeHistorySearchResult>> earthquakeHistorySearchResults(
+  Ref ref,
+  String query,
+) async {
+  if (query.trim().isEmpty) {
+    return const [];
+  }
+  final parameters = await ref.watch(parameterSetProvider.future);
+  return ref
+      .watch(earthquakeRegionSearchProvider)
+      .search(
+        parameter: parameters.earthquake,
+        query: query,
+      );
+}

--- a/app/lib/feature/earthquake_history/data/provider/earthquake_history_search_results.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/earthquake_history_search_results.g.dart
@@ -1,0 +1,96 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'earthquake_history_search_results.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(earthquakeHistorySearchResults)
+final earthquakeHistorySearchResultsProvider =
+    EarthquakeHistorySearchResultsFamily._();
+
+final class EarthquakeHistorySearchResultsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<EarthquakeHistorySearchResult>>,
+          List<EarthquakeHistorySearchResult>,
+          FutureOr<List<EarthquakeHistorySearchResult>>
+        >
+    with
+        $FutureModifier<List<EarthquakeHistorySearchResult>>,
+        $FutureProvider<List<EarthquakeHistorySearchResult>> {
+  EarthquakeHistorySearchResultsProvider._({
+    required EarthquakeHistorySearchResultsFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'earthquakeHistorySearchResultsProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$earthquakeHistorySearchResultsHash();
+
+  @override
+  String toString() {
+    return r'earthquakeHistorySearchResultsProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<List<EarthquakeHistorySearchResult>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<EarthquakeHistorySearchResult>> create(Ref ref) {
+    final argument = this.argument as String;
+    return earthquakeHistorySearchResults(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is EarthquakeHistorySearchResultsProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$earthquakeHistorySearchResultsHash() =>
+    r'0f25582e09742ee7750ca3b032404a408d7946e9';
+
+final class EarthquakeHistorySearchResultsFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<List<EarthquakeHistorySearchResult>>,
+          String
+        > {
+  EarthquakeHistorySearchResultsFamily._()
+    : super(
+        retry: null,
+        name: r'earthquakeHistorySearchResultsProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  EarthquakeHistorySearchResultsProvider call(String query) =>
+      EarthquakeHistorySearchResultsProvider._(argument: query, from: this);
+
+  @override
+  String toString() => r'earthquakeHistorySearchResultsProvider';
+}

--- a/app/lib/feature/earthquake_history/data/provider/earthquake_region_search.dart
+++ b/app/lib/feature/earthquake_history/data/provider/earthquake_region_search.dart
@@ -1,0 +1,66 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_search_result.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'earthquake_region_search.g.dart';
+
+@riverpod
+EarthquakeRegionSearch earthquakeRegionSearch(Ref ref) =>
+    const EarthquakeRegionSearch();
+
+class EarthquakeRegionSearch {
+  const new();
+
+  List<EarthquakeHistorySearchResult> search({
+    required EarthquakeParameter parameter,
+    required String query,
+  }) {
+    final term = query.trim().toLowerCase();
+    if (term.isEmpty) {
+      return const [];
+    }
+    return [
+      for (final prefecture in parameter.prefectures) ...[
+        if (prefecture.name.ja.contains(term) ||
+            (prefecture.name.en?.toLowerCase().contains(term) ?? false))
+          EarthquakeHistorySearchResult(
+            name: prefecture.name.ja,
+            areaDescription: '都道府県',
+            parameter: EarthquakeHistoryParameter.prefecture(
+              sortBy: .eventId,
+              sortOrder: .desc,
+              prefectureCode: prefecture.code,
+            ),
+          ),
+        for (final region in prefecture.regions) ...[
+          if (region.name.ja.contains(term) ||
+              (region.name.en?.toLowerCase().contains(term) ?? false) ||
+              (region.kana?.contains(term) ?? false))
+            EarthquakeHistorySearchResult(
+              name: region.name.ja,
+              areaDescription: '${prefecture.name.ja}・地域',
+              parameter: EarthquakeHistoryParameter.region(
+                sortBy: .eventId,
+                sortOrder: .desc,
+                regionCode: region.code,
+              ),
+            ),
+          for (final city in region.cities)
+            if (city.name.ja.contains(term) ||
+                (city.name.en?.toLowerCase().contains(term) ?? false) ||
+                (city.kana?.contains(term) ?? false))
+              EarthquakeHistorySearchResult(
+                name: city.name.ja,
+                areaDescription: '${prefecture.name.ja}・${region.name.ja}',
+                parameter: EarthquakeHistoryParameter.city(
+                  sortBy: .eventId,
+                  sortOrder: .desc,
+                  cityCode: city.code,
+                ),
+              ),
+        ],
+      ],
+    ];
+  }
+}

--- a/app/lib/feature/earthquake_history/data/provider/earthquake_region_search.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/earthquake_region_search.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'earthquake_region_search.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(earthquakeRegionSearch)
+final earthquakeRegionSearchProvider = EarthquakeRegionSearchProvider._();
+
+final class EarthquakeRegionSearchProvider
+    extends
+        $FunctionalProvider<
+          EarthquakeRegionSearch,
+          EarthquakeRegionSearch,
+          EarthquakeRegionSearch
+        >
+    with $Provider<EarthquakeRegionSearch> {
+  EarthquakeRegionSearchProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'earthquakeRegionSearchProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$earthquakeRegionSearchHash();
+
+  @$internal
+  @override
+  $ProviderElement<EarthquakeRegionSearch> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EarthquakeRegionSearch create(Ref ref) {
+    return earthquakeRegionSearch(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EarthquakeRegionSearch value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EarthquakeRegionSearch>(value),
+    );
+  }
+}
+
+String _$earthquakeRegionSearchHash() =>
+    r'634daf37d417dea5b8c96a72d5f497e5362445fc';

--- a/app/lib/feature/earthquake_history/ui/page/earthquake_history_search_page.dart
+++ b/app/lib/feature/earthquake_history/ui/page/earthquake_history_search_page.dart
@@ -1,0 +1,90 @@
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/earthquake_history_search_results.dart';
+import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
+
+class EarthquakeHistorySearchPage extends HookConsumerWidget {
+  const new({super.key, required this.initialQuery});
+
+  final String initialQuery;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = useTextEditingController(text: initialQuery);
+    useListenable(controller);
+    final query = controller.text;
+    final results = ref.watch(earthquakeHistorySearchResultsProvider(query));
+    return Scaffold(
+      appBar: AppBar(title: const Text('地域名で地震を検索')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: TextField(
+              controller: controller,
+              textInputAction: .search,
+              decoration: InputDecoration(
+                labelText: '都道府県・地域・市区町村名',
+                hintText: '例：東京都、千代田区',
+                prefixIcon: const Icon(Icons.search),
+                suffixIcon: IconButton(
+                  tooltip: '検索語を消去',
+                  onPressed: controller.clear,
+                  icon: const Icon(Icons.clear),
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: results.when(
+              loading: () =>
+                  const Center(child: CircularProgressIndicator.adaptive()),
+              error: (_, _) => Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    mainAxisSize: .min,
+                    children: [
+                      const Text('地域情報を読み込めませんでした。'),
+                      TextButton(
+                        onPressed: () => ref.invalidate(parameterSetProvider),
+                        child: const Text('再読み込み'),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              data: (items) => items.isEmpty
+                  ? Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Text(
+                          query.trim().isEmpty
+                              ? '地域名を入力してください。'
+                              : '一致する地域がありません。東京都、千代田区などの地域名で検索してください。',
+                        ),
+                      ),
+                    )
+                  : ListView.builder(
+                      itemCount: items.length,
+                      itemBuilder: (context, index) {
+                        final item = items[index];
+                        return ListTile(
+                          title: Text(item.name),
+                          subtitle: Text(item.areaDescription),
+                          trailing: const Icon(Icons.chevron_right),
+                          onTap: () => EarthquakeHistoryRoute(
+                            $extra: item.parameter,
+                          ).push<void>(context),
+                        );
+                      },
+                    ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/test/core/router/earthquake_history_search_route_test.dart
+++ b/app/test/core/router/earthquake_history_search_route_test.dart
@@ -1,0 +1,45 @@
+import 'package:eqmonitor/core/fcm/notification_deep_link.dart';
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('検索語の日本語とURL特殊文字がディープリンクで保持される', () {
+    const query = '東京 & 千代田区+沿岸/#';
+    final incoming = Uri(
+      scheme: 'eqmonitor',
+      host: '',
+      path: '/earthquake-history/search',
+      queryParameters: {'query': query},
+    );
+    final link = NotificationDeepLink.fromUri(incoming);
+    expect(link, isA<NotificationRouteLink>());
+    final location = (link as NotificationRouteLink).location;
+    expect(Uri.parse(location).queryParameters['query'], query);
+    expect(location, const EarthquakeHistorySearchRoute(query: query).location);
+  });
+  test('Swiftが出力するURLのプラス記号を空白に変えない', () {
+    final link = NotificationDeepLink.fromUri(
+      Uri.parse('eqmonitor:///earthquake-history/search?query=Tokyo%2BChiyoda'),
+    );
+    expect(link, isA<NotificationRouteLink>());
+    expect(
+      Uri.parse((link as NotificationRouteLink).location)
+          .queryParameters['query'],
+      'Tokyo+Chiyoda',
+    );
+  });
+  test('検索の未指定は空の検索画面を開く', () {
+    expect(
+      const EarthquakeHistorySearchRoute().location,
+      '/earthquake-history/search',
+    );
+  });
+  test('検索画面より深い未知のパスを許可しない', () {
+    expect(
+      NotificationDeepLink.fromUri(
+        Uri.parse('eqmonitor:///earthquake-history/search/admin'),
+      ),
+      isNull,
+    );
+  });
+}

--- a/app/test/feature/earthquake_history/earthquake_history_search_page_test.dart
+++ b/app/test/feature/earthquake_history/earthquake_history_search_page_test.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_search_result.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/earthquake_history_search_results.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/page/earthquake_history_search_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
+
+void main() {
+  testWidgets('読み込み中から検索結果なしに遷移する', (tester) async {
+    final result = Completer<List<EarthquakeHistorySearchResult>>();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          earthquakeHistorySearchResultsProvider('東京').overrideWith(
+            (ref) => result.future,
+          ),
+        ],
+        child: const MaterialApp(
+          home: EarthquakeHistorySearchPage(initialQuery: '東京'),
+        ),
+      ),
+    );
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    result.complete(const []);
+    await tester.pumpAndSettle();
+    expect(find.textContaining('一致する地域がありません'), findsOneWidget);
+    expect(find.text('東京'), findsOneWidget);
+  });
+
+  testWidgets('例外の詳細を表示せず読み込み失敗と再読み込みを案内する', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          earthquakeHistorySearchResultsProvider('東京').overrideWith(
+            (ref) => Future.error(StateError('internal error details')),
+          ),
+        ],
+        child: const MaterialApp(
+          home: EarthquakeHistorySearchPage(initialQuery: '東京'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('地域情報を読み込めませんでした。'), findsOneWidget);
+    expect(find.text('再読み込み'), findsOneWidget);
+    expect(find.textContaining('internal error details'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/app/test/feature/earthquake_history/earthquake_region_search_test.dart
+++ b/app/test/feature/earthquake_history/earthquake_region_search_test.dart
@@ -1,0 +1,131 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/earthquake_region_search.dart';
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_common.dart';
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_metadata.dart';
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_type.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class EarthquakeSearchFixture {
+  static const parameter = EarthquakeParameter(
+    metadata: ParameterMetadata(
+      type: ParameterType.earthquakeStations,
+      schemaVersion: 1,
+      sourceVersion: 'test',
+      sourceUpdatedAt: null,
+      sourceUrls: [],
+      sha256: 'test',
+    ),
+    prefectures: [
+      EarthquakeParameterPrefectureItem(
+        code: '13',
+        name: LocalizedName(ja: '東京都', en: 'Tokyo'),
+        regions: [
+          EarthquakeParameterRegionItem(
+            code: '350',
+            name: LocalizedName(ja: '東京都多摩東部'),
+            kana: 'とうきょうとたまとうぶ',
+            cities: [
+              EarthquakeParameterCityItem(
+                code: '1320600',
+                name: LocalizedName(ja: '府中市'),
+                kana: 'ふちゅうし',
+                stations: [],
+              ),
+            ],
+          ),
+        ],
+      ),
+      EarthquakeParameterPrefectureItem(
+        code: '34',
+        name: LocalizedName(ja: '広島県'),
+        regions: [
+          EarthquakeParameterRegionItem(
+            code: '671',
+            name: LocalizedName(ja: '広島県南東部'),
+            kana: null,
+            cities: [
+              EarthquakeParameterCityItem(
+                code: '3420800',
+                name: LocalizedName(ja: '府中市'),
+                kana: 'ふちゅうし',
+                stations: [],
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
+void main() {
+  const search = EarthquakeRegionSearch();
+  test('空白や未対応の自由文を全国検索に置き換えない', () {
+    for (final query in ['', '  ', '昨日の東京の震度3以上', '存在しない地域']) {
+      expect(
+        search.search(
+          parameter: EarthquakeSearchFixture.parameter,
+          query: query,
+        ),
+        isEmpty,
+      );
+    }
+  });
+  test('都道府県の英語名は大文字小文字と前後の空白を無視する', () {
+    final result = search.search(
+      parameter: EarthquakeSearchFixture.parameter,
+      query: ' TOKYO ',
+    );
+    expect(result.single.name, '東京都');
+    expect(
+      result.single.parameter,
+      const EarthquakeHistoryParameter.prefecture(
+        sortBy: .eventId,
+        sortOrder: .desc,
+        prefectureCode: '13',
+      ),
+    );
+  });
+  test('地域名と読み仮名から正しい地域コードを返す', () {
+    for (final query in ['多摩東部', 'とうきょうとたまとうぶ']) {
+      final result = search.search(
+        parameter: EarthquakeSearchFixture.parameter,
+        query: query,
+      );
+      expect(
+        result.single.parameter,
+        const EarthquakeHistoryParameter.region(
+          sortBy: .eventId,
+          sortOrder: .desc,
+          regionCode: '350',
+        ),
+      );
+    }
+  });
+  test('同名の市を自動選択せず、所属地域を表示した候補にする', () {
+    final results = search.search(
+      parameter: EarthquakeSearchFixture.parameter,
+      query: '府中市',
+    );
+    expect(results, hasLength(2));
+    expect(results.first.areaDescription, '東京都・東京都多摩東部');
+    expect(results.last.areaDescription, '広島県・広島県南東部');
+    expect(
+      results.first.parameter,
+      const EarthquakeHistoryParameter.city(
+        sortBy: .eventId,
+        sortOrder: .desc,
+        cityCode: '1320600',
+      ),
+    );
+    expect(
+      results.last.parameter,
+      const EarthquakeHistoryParameter.city(
+        sortBy: .eventId,
+        sortOrder: .desc,
+        cityCode: '3420800',
+      ),
+    );
+  });
+}

--- a/docs/knowledge/20260910_siri_dialog_search.md
+++ b/docs/knowledge/20260910_siri_dialog_search.md
@@ -1,0 +1,55 @@
+# Siriの読み上げと地域検索の実装・検証ルール
+
+## 読み上げは表示用フォールバックを事実として扱わない
+
+- `EarthquakeIntentDialog`はAPIの震源名・詳細名と元の日時を使う。Widget見出しの「最大震度…」を震源として読まず、日時欠落を現在日時で補わない。
+- 地域検索でも地震全体の最大震度を別に保持する。地域の震度と全体最大震度を区別する。
+- Flutterと同じく`max_intensity_class`を優先し、歴史上の震度5・6を5弱・6弱に置換しない。非数値分類は分類名として伝える。
+- 訓練・試験は詳細より先に伝える。遠地地震と火山噴火を区別し、欠けたM・深さを補わない。
+- 発生時刻がない場合は検知時刻と区別する。`origin_time_precision`が月・日・時の場合は分まで読まない。Flutterの履歴表示には精度を尊重しない既存課題がある。
+- 全件読み上げではなく、取得件数を伝えて最新の1件を読む。保存位置は「アプリに保存された現在地の地域」と伝える。位置の鮮度保証は別課題。
+
+## 検索IntentはRunnerで実行する
+
+- Xcode 27 beta 4の`.system.searchInApp`はiOS 27以上。`StringSearchCriteria.term`をアプリ内検索へ渡す。
+- Appleの`OpenURLIntent`契約はUniversal Link限定で、カスタムスキームは対象外。`eqmonitor:///earthquake-history/search?query=...`はRunnerの`UIApplication.shared.open`から既存app_links導線へ渡す。
+- URLは`URLComponents`で構築し、日本語・`&`・`+`・`/`・`#`を損失なく渡す。
+- 検索は地域名に限定する。同名市区町村は所属地域とともに候補表示し、利用者が選択する。曖昧な自然文を全国検索に置換しない。
+- 検索パラメータは既存`ParameterSet`を使う。読み込み失敗時に内部例外を表示せず、再読み込みを案内する。
+
+## Swift API生成時の注意
+
+現在の元スキーマには、生成済みClientに存在する旧Live Activity操作5件が含まれない。通常の全生成は既存APIを削除するため、契約整理まで対象型だけを生成器で更新する。
+
+```sh
+cd app/ios/Packages/EQMonitorAPI
+python3 Scripts/generate-intensity-partial.py /path/to/swift-openapi-generator
+```
+
+今回使用したAppleの生成器は1.10.4。生成物を手編集せず、`openapi.json`の`IntensityPartial`を修正してから実行する。これは暫定手順であり、元契約の整理はIssue #1794で追跡する。
+
+## Simulatorを使わない検証
+
+```sh
+xcodebuild -project app/ios/Runner.xcodeproj -scheme WidgetModelsTests \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+xcodebuild -project app/ios/Runner.xcodeproj -target AppIntentExtension \
+  -configuration Debug -sdk iphoneos CODE_SIGNING_ALLOWED=NO
+cd app
+mise exec -- flutter test test/feature/earthquake_history/earthquake_region_search_test.dart \
+  test/core/router/earthquake_history_search_route_test.dart \
+  test/feature/earthquake_history/earthquake_history_search_page_test.dart
+```
+
+- Swift共有テスト122件、Flutter追加10件、Flutter既存表示・変換30件が成功。変更したDartソース・テストの静的解析成功。
+- Flutterテストはworktree内の配信用parametersアセット未配置を警告したが、今回のテストはfixture/Provider overrideを用いて成功。配布アセットを使うE2E検証ではない。
+- Flutterによるプラグインリンクの再生成とXcodeの依存解決を同時に実行しない。Firebaseのtargetがemptyと誤認される場合があり、再生成完了後の再実行で解消した。
+- build_runnerの`--build-filter`指定でも範囲外の生成済みファイルが削除される場合がある。生成前後の差分を必ず確認し、無関係な生成物の削除・変更を含めない。
+- AppIntentExtensionのiPhone向け署名なしbuild成功。Runnerの新しい検索IntentはiOS 27 SDKでマクロを含むSwift型検査成功。本体アプリの全体buildは実行していない。
+- 署名なしbuild・型検査・単体テストは、実機Siriの登録・音声・画面遷移・日本語での認識を保証しない。Simulatorも実機Siriも今回実行していない。
+
+## 公式資料
+
+- https://developer.apple.com/videos/play/wwdc2026/343/
+- https://developer.apple.com/documentation/appintents/openurlintent
+- https://developer.apple.com/videos/play/wwdc2026/240/

--- a/docs/todo/930_app_intents_result_consistency.md
+++ b/docs/todo/930_app_intents_result_consistency.md
@@ -1,10 +1,10 @@
 # App Intents の情報整合性と音声呼び出しを改善する
 
-2026-09-10調査。未修正。拡張buildと共有テストの成功だけでは正常動作とは判断しない。
+2026-09-10調査、一部修正。Issue: https://github.com/YumNumm/EQMonitor/issues/1794 。拡張buildと共有テストの成功だけでは正常動作とは判断しない。
 
 ## 優先して修正・検証する項目
 
-1. 地域震度を「最大震度」として返している。
+1. 【今回修正】地域震度を「最大震度」として返している。
    - `Shared/EarthquakeDisplayItem.swift`の地域検索用initは地域震度をmaxIntensityへ格納。
    - `AppIntentExtension/EarthquakeEntity.swift`はこれを「最大震度」プロパティへ変換。
    - 公開APIのprefecture/13で、event_id=20260830001711は地域震度1・全国最大震度4。
@@ -36,10 +36,18 @@
 - 地域指定Pro判定は主Intentのみ。Snippet直接実行・更新時の判定を統一する。
 - 通信失敗は主Intent/Fetcherからそのままthrowされ、APIError.fromによる正規化を通らない。
   オフライン・デコード失敗を含め、Siri向けの短い日本語案内を検証する。
-- 主IntentにProvidesDialogがなく、アプリが指定する地震の読み上げ文がない。
+- 【今回修正】主IntentにProvidesDialogを追加。訓練・試験を先に読み上げ、全体最大震度と地域震度を区別する。
 - Intentのperform・Entity復元・Snippet入力検証の専用テストがない。
 
 ## 検証記録
 
 `docs/knowledge/20260910_app_intents_verification_and_siri_ai.md`を参照。
-今回は調査依頼のため動作コードを変更せず、課題を記録した。
+追加実装の記録は `docs/knowledge/20260910_siri_dialog_search.md` を参照。
+
+## Flutterとの照合で判明した追加項目
+
+- 【今回修正】Swift APIの`IntensityPartial`に`max_intensity_class`がなく、過去の震度5・6や非数値分類を保持できなかった。元スキーマへ追加し、生成器で対象型を再生成した。
+- Flutterの履歴時刻表示も`originTimePrecision`を使わず分まで表示する。粗い歴史時刻を精度以上に表示しない対応を別途行う。今回の音声応答は精度を尊重する。
+- 既存Widget/Snippetの`OpenURLIntent`はカスタムスキームを指定しているが、Appleの契約はUniversal Link限定。実機で既存導線を検証し、対応リンクへ移行する。今回の検索はRunnerの`UIApplication.open`で開く。
+- Swift APIの元スキーマには生成済みコードの旧Live Activity操作が5件含まれない。全生成で削除されるため、契約の整理が必要。今回の限定生成スクリプトは恒久的な全生成手順の代替ではない。
+- 検索連携は地域名の候補選択まで。自然文の日付・震度・複合条件の解釈は未実装。


### PR DESCRIPTION
## 変更内容

Siriで地震を取得した際の音声応答を追加し、iOS 27の`system.searchInApp`から地域名検索へ進めるようにしました。検索候補の選択後は既存の地震履歴を表示します。

読み上げをFlutter実装と照合し、地域震度と地震全体の最大震度を分離しました。訓練・試験、発生と検知、時刻の精度、遠地地震・噴火、過去の震度5・6と非数値分類を区別し、欠けた情報を表示用フォールバックで補いません。

Swift APIの歴史震度分類は元スキーマを修正して生成しています。元スキーマに旧Live Activity操作が欠ける既存問題があるため、今回の生成は対象型に限定しています。

## 検証

- Swift共有テスト122件成功（Mac実行）
- Flutter追加10件、既存の表示・変換30件成功
- 変更したDartソース・テストの静的解析成功
- AppIntentExtensionのiPhone向け署名なしビルド成功
- 新しい検索IntentはiOS 27 SDKでマクロを含む型検査成功
- Swift API限定再生成の差分不変を確認

Simulatorは使用していません。本体アプリ全体のビルドと実機Siriの登録・音声・画面遷移は未確認です。Flutterテストは配信用parametersアセット未配置を警告していますが、今回のfixture/Provider overrideによるテストは成功しています。

Refs #1794。保存位置の鮮度、IntentとSnippetの二重取得、既存URL導線など残件があるため、Issue全体は閉じません。
