### PR TITLE
fix: Control Centerから地震履歴を開く処理を修正

### DIFF
--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -141,6 +141,9 @@
 		B1794000000000000000000E /* EarthquakeEntityRestorationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1794000000000000000000E /* EarthquakeEntityRestorationTests.swift */; };
 		B1794000000000000000000F /* EarthquakeIntentTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1794000000000000000000F /* EarthquakeIntentTransportTests.swift */; };
 		B17940000000000000000010 /* EarthquakeIntentExecutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17940000000000000000010 /* EarthquakeIntentExecutionTests.swift */; };
+		C17940000000000000000002 /* OpenEarthquakeHistoryIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17940000000000000000001 /* OpenEarthquakeHistoryIntent.swift */; };
+		C17940000000000000000003 /* OpenEarthquakeHistoryIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17940000000000000000001 /* OpenEarthquakeHistoryIntent.swift */; };
+		C17940000000000000000004 /* OpenEarthquakeHistoryIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17940000000000000000001 /* OpenEarthquakeHistoryIntent.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -318,6 +321,7 @@
 		A1794000000000000000000E /* EarthquakeEntityRestorationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WidgetModelsTests/EarthquakeEntityRestorationTests.swift"; sourceTree = SOURCE_ROOT; };
 		A1794000000000000000000F /* EarthquakeIntentTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WidgetModelsTests/EarthquakeIntentTransportTests.swift"; sourceTree = SOURCE_ROOT; };
 		A17940000000000000000010 /* EarthquakeIntentExecutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WidgetModelsTests/EarthquakeIntentExecutionTests.swift"; sourceTree = SOURCE_ROOT; };
+		C17940000000000000000001 /* OpenEarthquakeHistoryIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenEarthquakeHistoryIntent.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -608,6 +612,7 @@
 			isa = PBXGroup;
 			children = (
 				A9100000000000000000000B /* EarthquakeIntentDialog.swift */,
+				C17940000000000000000001 /* OpenEarthquakeHistoryIntent.swift */,
 				A9100000000000000000000E /* EarthquakeSearchURL.swift */,
 				62ACEBEF0EEEF36A8EC1B1B1 /* EarthquakeDisplayItem.swift */,
 				381A26E10F0EF7D7FEC86D79 /* IntensityValue.swift */,
@@ -1035,6 +1040,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C17940000000000000000004 /* OpenEarthquakeHistoryIntent.swift in Sources */,
 				B17940000000000000000010 /* EarthquakeIntentExecutionTests.swift in Sources */,
 				B1794000000000000000000F /* EarthquakeIntentTransportTests.swift in Sources */,
 				B1794000000000000000000E /* EarthquakeEntityRestorationTests.swift in Sources */,
@@ -1085,6 +1091,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C17940000000000000000003 /* OpenEarthquakeHistoryIntent.swift in Sources */,
 				A91000000000000000000002 /* EarthquakeIntentDialog.swift in Sources */,
 				EQ000000000000000000006E /* EewDisplay.swift in Sources */,
 				EQ0000000000000000000065 /* LiveActivityDate.swift in Sources */,
@@ -1116,6 +1123,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C17940000000000000000002 /* OpenEarthquakeHistoryIntent.swift in Sources */,
 				A91000000000000000000006 /* EarthquakeSearchURL.swift in Sources */,
 				A91000000000000000000005 /* SearchEarthquakesIntent.swift in Sources */,
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		C17940000000000000000002 /* OpenEarthquakeHistoryIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17940000000000000000001 /* OpenEarthquakeHistoryIntent.swift */; };
 		C17940000000000000000003 /* OpenEarthquakeHistoryIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17940000000000000000001 /* OpenEarthquakeHistoryIntent.swift */; };
 		C17940000000000000000004 /* OpenEarthquakeHistoryIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17940000000000000000001 /* OpenEarthquakeHistoryIntent.swift */; };
+		C17940000000000000000006 /* OpenEarthquakeHistoryIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17940000000000000000005 /* OpenEarthquakeHistoryIntentTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -322,6 +323,7 @@
 		A1794000000000000000000F /* EarthquakeIntentTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WidgetModelsTests/EarthquakeIntentTransportTests.swift"; sourceTree = SOURCE_ROOT; };
 		A17940000000000000000010 /* EarthquakeIntentExecutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WidgetModelsTests/EarthquakeIntentExecutionTests.swift"; sourceTree = SOURCE_ROOT; };
 		C17940000000000000000001 /* OpenEarthquakeHistoryIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenEarthquakeHistoryIntent.swift; sourceTree = "<group>"; };
+		C17940000000000000000005 /* OpenEarthquakeHistoryIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenEarthquakeHistoryIntentTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -483,6 +485,7 @@
 		3770F148FEB3FAEFF53D21CE /* WidgetModelsTests */ = {
 			isa = PBXGroup;
 			children = (
+				C17940000000000000000005 /* OpenEarthquakeHistoryIntentTests.swift */,
 				A17940000000000000000010 /* EarthquakeIntentExecutionTests.swift */,
 				A1794000000000000000000F /* EarthquakeIntentTransportTests.swift */,
 				A1794000000000000000000E /* EarthquakeEntityRestorationTests.swift */,
@@ -1040,6 +1043,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C17940000000000000000006 /* OpenEarthquakeHistoryIntentTests.swift in Sources */,
 				C17940000000000000000004 /* OpenEarthquakeHistoryIntent.swift in Sources */,
 				B17940000000000000000010 /* EarthquakeIntentExecutionTests.swift in Sources */,
 				B1794000000000000000000F /* EarthquakeIntentTransportTests.swift in Sources */,

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -1,3 +1,4 @@
+import AppIntents
 import background_location_tracker
 import Flutter
 import flutter_local_notifications
@@ -10,6 +11,12 @@ import WidgetKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    if #available(iOS 18.0, *) {
+      AppDependencyManager.shared.add(dependency: EarthquakeHistoryNavigation { url in
+        await UIApplication.shared.open(url)
+      })
+    }
+
     let backgroundLaunchBootstrap = BackgroundLocationLaunchBootstrap(
       configurePluginRegistrants: {
         FlutterLocalNotificationsPlugin.setPluginRegistrantCallback { registry in

--- a/app/ios/Shared/OpenEarthquakeHistoryIntent.swift
+++ b/app/ios/Shared/OpenEarthquakeHistoryIntent.swift
@@ -1,0 +1,52 @@
+import AppIntents
+import Foundation
+
+/// Control CenterはSnippetを表示できないため、アプリ本体で履歴画面を開く。
+/// このIntentはRunnerとWidgetExtensionの両方に含める。
+@available(iOS 18.0, *)
+struct OpenEarthquakeHistoryIntent: OpenIntent {
+    static let title: LocalizedStringResource = "地震履歴を開く"
+    @available(iOS 26.0, *)
+    static let supportedModes: IntentModes = .foreground
+
+    @Parameter(title: "画面", default: .earthquakeHistory)
+    var target: EarthquakeHistoryDestination
+
+    @Dependency var navigation: EarthquakeHistoryNavigation
+
+    init() {}
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        try await navigation.open()
+        return .result()
+    }
+}
+
+enum EarthquakeHistoryDestination: String, AppEnum {
+    case earthquakeHistory
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "EQMonitorの画面"
+    static let caseDisplayRepresentations: [Self: DisplayRepresentation] = [
+        .earthquakeHistory: "地震履歴",
+    ]
+}
+
+/// UIApplicationへのアクセスはRunnerから注入し、Widget側では呼ばない。
+struct EarthquakeHistoryNavigation: Sendable {
+    let openURL: @MainActor @Sendable (URL) async -> Bool
+
+    @MainActor
+    func open() async throws {
+        guard let url = URL(string: "eqmonitor:///earthquake-history"),
+              await openURL(url) else {
+            throw EarthquakeHistoryNavigationError.cannotOpen
+        }
+    }
+}
+
+enum EarthquakeHistoryNavigationError: Error, Equatable, CustomLocalizedStringResourceConvertible {
+    case cannotOpen
+    var localizedStringResource: LocalizedStringResource {
+        "地震履歴を開けませんでした。EQMonitorを起動して、もう一度お試しください。"
+    }
+}

--- a/app/ios/Widget/Controls/LatestEarthquakeSnippetControl.swift
+++ b/app/ios/Widget/Controls/LatestEarthquakeSnippetControl.swift
@@ -2,27 +2,25 @@
 //  LatestEarthquakeSnippetControl.swift
 //  Widget
 //
-//  コントロールセンターから、アプリを開かずに最新の地震情報カード
-//  （EarthquakeSnippetIntent / AppIntentExtension と共有）を表示する。
+//  コントロールセンターからアプリ本体の地震履歴を開く。
 //
 
 import WidgetKit
 import SwiftUI
 import AppIntents
 
-/// Interactive Snippet（`SnippetIntent`）を表示するため iOS 26 以降。
+/// 既存コントロールの配置を維持するためkindは変更しない。
 @available(iOS 26.0, *)
 struct LatestEarthquakeSnippetControl: ControlWidget {
     static let kind = "net.yumnumm.eqmonitor.control.latest-earthquake"
 
     var body: some ControlWidgetConfiguration {
         StaticControlConfiguration(kind: Self.kind) {
-            ControlWidgetButton(action: EarthquakeSnippetIntent(
-                regionID: nil, minIntensity: nil, limit: 3)) {
+            ControlWidgetButton(action: OpenEarthquakeHistoryIntent()) {
                 Label("最新の地震", systemImage: "waveform.path.ecg")
             }
         }
         .displayName("最新の地震を確認")
-        .description("アプリを開かずに最新の地震情報を表示します")
+        .description("EQMonitorを開いて地震履歴を表示します")
     }
 }

--- a/app/ios/Widget/Controls/OpenEarthquakeHistoryControl.swift
+++ b/app/ios/Widget/Controls/OpenEarthquakeHistoryControl.swift
@@ -17,15 +17,3 @@ struct OpenEarthquakeHistoryControl: ControlWidget {
         .description("EQMonitor の地震履歴を開きます")
     }
 }
-
-/// `OpenURLIntent` は iOS 18 以降。
-@available(iOS 18.0, *)
-struct OpenEarthquakeHistoryIntent: AppIntent {
-    static let title: LocalizedStringResource = "地震履歴を開く"
-    static let openAppWhenRun = true
-
-    func perform() async throws -> some IntentResult & OpensIntent {
-        .result(opensIntent: OpenURLIntent(
-            URL(string: "eqmonitor:///earthquake-history")!))
-    }
-}

--- a/app/ios/WidgetModelsTests/EarthquakeIntentExecutionTests.swift
+++ b/app/ios/WidgetModelsTests/EarthquakeIntentExecutionTests.swift
@@ -4,7 +4,7 @@ import Testing
 import EQMonitorAPI
 
 struct EarthquakeIntentExecutionTests {
-    @Test func widgetControlCanOpenSnippetWithoutExistingSnapshot() async throws {
+    @Test func snippetCanFetchWithoutExistingSnapshot() async throws {
         let transport = IntentTestTransport(status: .ok, json: #"{"items":[]}"#)
         let service = try EarthquakeIntentTransportTests().makeService(transport: transport)
         let snippet = EarthquakeSnippetIntent(regionID: nil, minIntensity: nil, limit: 3)

--- a/app/ios/WidgetModelsTests/OpenEarthquakeHistoryIntentTests.swift
+++ b/app/ios/WidgetModelsTests/OpenEarthquakeHistoryIntentTests.swift
@@ -1,0 +1,27 @@
+import AppIntents
+import Foundation
+import Testing
+
+@MainActor
+struct OpenEarthquakeHistoryIntentTests {
+    @Test func opensHistoryThroughForegroundIntent() async throws {
+        var openedURL: URL?
+        var intent = OpenEarthquakeHistoryIntent()
+        intent.navigation = EarthquakeHistoryNavigation { url in
+            openedURL = url
+            return true
+        }
+        _ = try await intent.perform()
+        #expect(openedURL?.absoluteString == "eqmonitor:///earthquake-history")
+        #expect(intent.target == .earthquakeHistory)
+        #expect(OpenEarthquakeHistoryIntent.supportedModes == .foreground)
+    }
+
+    @Test func failedNavigationIsNotSuccessfulExecution() async {
+        var intent = OpenEarthquakeHistoryIntent()
+        intent.navigation = EarthquakeHistoryNavigation { _ in false }
+        await #expect(throws: EarthquakeHistoryNavigationError.cannotOpen) {
+            try await intent.perform()
+        }
+    }
+}

--- a/docs/knowledge/20260910_control_center_app_intent.md
+++ b/docs/knowledge/20260910_control_center_app_intent.md
@@ -1,0 +1,34 @@
+# Control Center の App Intent
+
+## 実装ルール
+
+- Control Center から起動する Intent は Snippet を表示できない。`SnippetIntent` の単体実行成功を Control Center の動作成功と解釈しない。
+- 画面を開く Control は `OpenIntent` を使い、Intent の同じソースを Runner と WidgetExtension の両ターゲットに含める。
+- 既存コントロールの配置を維持するため `kind` を変更しない。
+- `OpenURLIntent` にカスタム URL スキームを渡さない。今回の履歴導線は Runner で登録した `AppDependencyManager` の依存を通じ、`UIApplication.open` で既存ルートを開く。
+- UIApplication を参照する処理はアプリ側で登録し、共有 Intent に UIKit への依存を持たせない。
+- `@Dependency` はシステムの Intent 実行時に解決される。単体テストで直接 `perform()` を呼ぶ場合、アクセス前に `intent.navigation = ...` と代入する。初期化されていない依存へのアクセスはクラッシュする。
+
+## 検証
+
+```sh
+xcodebuild -project app/ios/Runner.xcodeproj -scheme WidgetModelsTests \
+  -destination 'platform=iOS Simulator,id=<SIMULATOR_UUID>' \
+  -derivedDataPath /private/tmp/eq-control-derived CODE_SIGNING_ALLOWED=NO test
+xcodebuild -project app/ios/Runner.xcodeproj -scheme Runner \
+  -destination 'platform=iOS Simulator,id=<SIMULATOR_UUID>' \
+  -derivedDataPath /private/tmp/eq-control-derived CODE_SIGNING_ALLOWED=NO build
+```
+
+- Runner のビルドは `-scheme Runner` を使用する。`-target Runner` のみでは Flutter の準備処理が実行されず、プラグインで Flutter module の解決に失敗した。
+- 2026-09-10: iOS 27 Simulator で Swift テスト 150 件・16 suite が成功。履歴 URL、foreground 実行設定、画面遷移失敗の伝播を追加検証した。
+- Control Center の実タップ、終了状態からの起動、署名済み実機での画面表示は別途確認する。今回の UI 操作接続は起動に失敗し、テストを実タップ確認の代用とはしない。
+
+- この worktree での Runner 全体ビルドは、既存 Flutter 地図パッケージと `flutter_scene` の API 不整合（`FmatType`、`parameterTypeOf`、`interfaceManifestFileName`）で失敗した。ネイティブ部分だけを既存 Flutter 成果物で検証しても、全体ビルド成功とは報告しない。
+
+- 検証時のみ Flutter の build script を省き、既存生成ファイル・framework・assets を参照すると Runner の AppDelegate / 共有 OpenIntent と Widget の Swift コンパイルは通過した。アプリのパッケージングまで成功したわけではない。検証用の build script 変更はコミットしない。
+
+## Apple 公式資料
+
+- https://developer.apple.com/documentation/appintents/displaying-static-and-interactive-snippets
+- https://developer.apple.com/documentation/widgetkit/creating-controls-to-perform-actions-across-the-system

--- a/docs/todo/930_app_intents_result_consistency.md
+++ b/docs/todo/930_app_intents_result_consistency.md
@@ -13,6 +13,8 @@ Issue: https://github.com/YumNumm/EQMonitor/issues/1794
 - 通信・デコード失敗の短い日本語案内、拡張表示名と生成NLUのEQMonitorへの統一。
 - Intent実行・取得回数・カード再描画・明示更新・Entity復元・欠損/エラーの自動テスト追加。
 
+- Control Center の2つの履歴導線を Runner / Widget 共通の OpenIntent に統一。Snippet とカスタムスキームの OpenURLIntent をこの導線から除去。
+
 ## 残る確認・改善
 
 1. 署名した実機で「EQMonitorで最新の地震を確認」の解決、Snippetの表示・明示更新、Pro失効、保存地域変更、オフライン時の音声を確認する。
@@ -24,5 +26,9 @@ Issue: https://github.com/YumNumm/EQMonitor/issues/1794
 5. Swiftの元スキーマにない旧Live Activity操作5件を整理し、限定生成に依存しない全生成へ戻す。
 6. Siri検索連携は地域名候補の選択まで。自然文の日付・震度・複合条件は未対応。
 
-記録: `docs/knowledge/20260910_app_intents_snapshot_contract.md`
+7. Control Center の「最新の地震を確認」「地震履歴を開く」を実タップし、起動済み・終了状態から履歴が表示されることを確認する。Simulator での Swift テスト成功は、OS による Intent 解決・UI 表示の証明ではない。
+
+8. Runner の全体ビルドを、Flutter 地図パッケージと `flutter_scene` の API が一致する環境で再確認する。今回の検証環境では `FmatType` / `parameterTypeOf` / `interfaceManifestFileName` の不整合で失敗した。無関係な submodule の作業差分は変更していない。
+
+記録: `docs/knowledge/20260910_app_intents_snapshot_contract.md`、`docs/knowledge/20260910_control_center_app_intent.md`
 実機の検証が残るため、この実装のみでIssueを閉じない。


### PR DESCRIPTION
Control Center の「最新の地震を確認」が、OS の非対応な Snippet 表示を要求していました。2つの履歴コントロールを Runner / WidgetExtension 共通の OpenIntent に統一し、EQMonitor の地震履歴を開く動作に修正します。

- Control Center からの Snippet 呼び出しと、既存履歴 Control のカスタムスキームを渡す OpenURLIntent を除去。
- アプリ起動時に画面遷移の依存を登録。既存 Control の kind は維持。
- 正しい履歴 URL、foreground 設定、遷移失敗のエラー伝播をテスト。
- プラットフォーム制約・検証範囲・残る実機確認を docs に記録。

検証: iOS 27 Simulator の Swift テスト 150 件 / 16 suite 成功。Swift コードの差分レビューで重大な指摘なし。既存 Flutter 成果物を参照した限定検証では Runner の AppDelegate / 共有 OpenIntent と Widget の Swift コンパイル通過を確認しましたが、パッケージングは完了していません。検証時の build script 変更は差分に含めていません。

制約: Runner 全体ビルドは今回未変更の Flutter 地図パッケージと flutter_scene の API 不整合（FmatType / parameterTypeOf / interfaceManifestFileName）で失敗。UI 操作ツールの接続不良により Control Center の実タップおよびコールドスタート後の画面表示は未確認です。Swift の単体テストを OS 経由の動作確認とは扱いません。Dart の変更はないため Flutter Widget Test は追加していません。

ユーザーの指示に従い、CI を確認・待機せず管理者権限で develop にマージします。

関連: #1794（残る実機検証があるため、この PR で Issue は閉じません）

Apple 公式仕様:
- https://developer.apple.com/documentation/appintents/displaying-static-and-interactive-snippets
- https://developer.apple.com/documentation/widgetkit/creating-controls-to-perform-actions-across-the-system
