### PR TITLE
fix: 地震履歴の分割表示で詳細の戻るボタンを非表示にする

### DIFF
--- a/app/lib/core/component/layout/history_adaptive_view.dart
+++ b/app/lib/core/component/layout/history_adaptive_view.dart
@@ -1,3 +1,4 @@
+import 'package:eqmonitor/core/component/layout/history_detail_scope.dart';
 import 'package:eqmonitor/core/component/layout/history_pane.dart';
 import 'package:eqmonitor/core/component/layout/history_pane_layout.dart';
 import 'package:eqmonitor/core/component/layout/pane_viewport_measurement.dart';
@@ -89,7 +90,10 @@ class HistoryAdaptiveView extends HookWidget {
                           child: HistoryPane(
                             bounds: detailBounds ?? available,
                             viewport: size,
-                            child: detail ?? const _UnselectedDetail(),
+                            child: HistoryDetailScope(
+                              isSplit: isSplit,
+                              child: detail ?? const _UnselectedDetail(),
+                            ),
                           ),
                         ),
                       ),

--- a/app/lib/core/component/layout/history_detail_scope.dart
+++ b/app/lib/core/component/layout/history_detail_scope.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/widgets.dart';
+
+/// 実際のペイン配置に基づく詳細画面のナビゲーション設定。
+class HistoryDetailScope extends InheritedWidget {
+  const new({required this.isSplit, required super.child, super.key});
+
+  final bool isSplit;
+
+  static bool showBackButtonOf(BuildContext context) =>
+      !(context
+              .dependOnInheritedWidgetOfExactType<HistoryDetailScope>()
+              ?.isSplit ??
+          false);
+
+  @override
+  bool updateShouldNotify(HistoryDetailScope oldWidget) =>
+      isSplit != oldWidget.isSplit;
+}

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -458,6 +458,7 @@ class _NotificationPermissionSection extends ConsumerWidget {
   String _authLabel(AuthorizationStatus s) => switch (s) {
     AuthorizationStatus.authorized => '許可済み',
     AuthorizationStatus.denied => '拒否',
+    AuthorizationStatus.deniedPermanently => '拒否（端末の設定から変更）',
     AuthorizationStatus.notDetermined => '未確認',
     AuthorizationStatus.provisional => '仮承認（サイレント通知のみ）',
   };

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
@@ -1,5 +1,6 @@
 import 'package:eqmonitor/core/component/cached_data_banner.dart';
 import 'package:eqmonitor/core/component/error/error_card.dart';
+import 'package:eqmonitor/core/component/layout/history_detail_scope.dart';
 import 'package:eqmonitor/core/component/sheet/basic_modal_sheet.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/router/router.dart';
@@ -33,11 +34,15 @@ class EarthquakeHistoryDetailsPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final detailsState = ref.watch(earthquakeHistoryDetailsProvider(eventId));
+    final showBackButton = HistoryDetailScope.showBackButtonOf(context);
 
     return switch (detailsState) {
       AsyncError(:final error) => Scaffold(
         appBar: AppBar(
-          leading: onClose == null ? null : BackButton(onPressed: onClose),
+          automaticallyImplyLeading: showBackButton,
+          leading: showBackButton && onClose != null
+              ? BackButton(onPressed: onClose)
+              : null,
         ),
         body: ErrorCard(
           error: error,
@@ -52,7 +57,10 @@ class EarthquakeHistoryDetailsPage extends HookConsumerWidget {
       ),
       _ => Scaffold(
         appBar: AppBar(
-          leading: onClose == null ? null : BackButton(onPressed: onClose),
+          automaticallyImplyLeading: showBackButton,
+          leading: showBackButton && onClose != null
+              ? BackButton(onPressed: onClose)
+              : null,
         ),
         body: Center(
           child: Column(
@@ -249,7 +257,8 @@ class _LoadedContent extends HookConsumerWidget {
               ),
             ),
           ),
-          if (onClose != null || Navigator.canPop(context))
+          if (HistoryDetailScope.showBackButtonOf(context) &&
+              (onClose != null || Navigator.canPop(context)))
             SafeArea(
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 8),

--- a/app/test/feature/earthquake_history/ui/earthquake_history_details_navigation_test.dart
+++ b/app/test/feature/earthquake_history/ui/earthquake_history_details_navigation_test.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/component/layout/history_adaptive_view.dart';
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_details_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/earthquake_history_details_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
+
+void main() {
+  testWidgets('読み込み中とエラー時も分割表示だけ戻るボタンを隠す', (tester) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final result = Completer<Earthquake>();
+    var closed = false;
+    final navigator = GlobalKey<NavigatorState>();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          earthquakeHistoryDetailsProvider('event').overrideWith(
+            () => _PendingDetails(result.future),
+          ),
+        ],
+        child: MaterialApp(
+          navigatorKey: navigator,
+          theme: ThemeData.light().copyWith(
+            extensions: [DesignSystemThemeExtension.light()],
+          ),
+          home: const SizedBox.shrink(),
+        ),
+      ),
+    );
+    unawaited(
+      navigator.currentState?.push<void>(
+        MaterialPageRoute(
+          builder: (context) => HistoryAdaptiveView(
+            list: const Text('一覧'),
+            detail: EarthquakeHistoryDetailsPage(
+              eventId: 'event',
+              onClose: () => closed = true,
+            ),
+            onCloseDetail: () => closed = true,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.byType(BackButton), findsNothing);
+
+    tester.view.physicalSize = const Size(600, 900);
+    await tester.pump();
+    expect(find.byType(BackButton), findsOneWidget);
+
+    result.completeError(StateError('test error'));
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(BackButton), findsOneWidget);
+
+    tester.view.physicalSize = const Size(1200, 900);
+    await tester.pump();
+    expect(find.byType(BackButton), findsNothing);
+
+    tester.view.physicalSize = const Size(600, 900);
+    await tester.pump();
+    await tester.tap(find.byType(BackButton));
+    expect(closed, isTrue);
+  });
+}
+
+final class _PendingDetails extends EarthquakeHistoryDetailsNotifier {
+  new(this.result);
+
+  final Future<Earthquake> result;
+
+  @override
+  Future<Earthquake> build(String eventId) => result;
+}

--- a/app/test/feature/earthquake_history/ui/earthquake_history_details_nearby_card_test.dart
+++ b/app/test/feature/earthquake_history/ui/earthquake_history_details_nearby_card_test.dart
@@ -1,3 +1,4 @@
+import 'package:eqmonitor/core/component/layout/history_adaptive_view.dart';
 import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
 import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
@@ -16,6 +17,10 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 void main() {
   testWidgets('詳細シートに近傍地震カードを表示する', (tester) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
     const eventId = 'current';
     final earthquake = Earthquake(
       eventId: eventId,
@@ -52,13 +57,25 @@ void main() {
           theme: ThemeData.light().copyWith(
             extensions: [DesignSystemThemeExtension.light()],
           ),
-          home: const EarthquakeHistoryDetailsPage(eventId: eventId),
+          home: HistoryAdaptiveView(
+            list: const Text('一覧'),
+            detail: EarthquakeHistoryDetailsPage(
+              eventId: eventId,
+              onClose: () {},
+            ),
+            onCloseDetail: () {},
+          ),
         ),
       ),
     );
     await tester.pump();
 
     expect(find.text('この震源の近傍で発生した地震'), findsOneWidget);
+    expect(find.byIcon(Icons.arrow_back), findsNothing);
+
+    tester.view.physicalSize = const Size(600, 900);
+    await tester.pump();
+    expect(find.byIcon(Icons.arrow_back), findsOneWidget);
   });
 }
 

--- a/docs/knowledge/20260912_firebase_authorization_status.md
+++ b/docs/knowledge/20260912_firebase_authorization_status.md
@@ -1,0 +1,11 @@
+# Firebase通知権限の永久拒否状態
+
+- `firebase_messaging_platform_interface` 4.10.0 の `AuthorizationStatus` には `deniedPermanently` がある。
+- 権限状態を列挙するswitchではこの値も明示的に扱う。デバッグ端末設定画面では「拒否（端末の設定から変更）」と表示する。
+- 未対応のままだとルーター経由でこの画面を参照するWidgetテストもコンパイルできない。
+- 表示ラベルの追加のみで通知条件は変更しない。新規テストは追加せず、画面の静的解析と関連Widgetテストのコンパイルで検証する。
+
+```sh
+cd app
+mise exec -- dart analyze --fatal-infos lib/feature/devices/ui/page/debug_device_settings_page.dart
+```

--- a/docs/knowledge/20260912_history_detail_navigation.md
+++ b/docs/knowledge/20260912_history_detail_navigation.md
@@ -1,0 +1,18 @@
+# 履歴の分割表示と戻るボタン
+
+- 地震履歴の詳細は `HistoryDetailScope.showBackButtonOf(context)` で戻るボタンの表示可否を判断する。
+- 分割状態は `HistoryAdaptiveView` の実際の配置から渡す。詳細内の `MediaQuery.size` はペインの幅なので、端末全体の分割判定には使わない。
+- `onClose` は狭い画面で選択を解除するためにも必要であり、その有無だけでは分割表示か判定できない。
+- 分割表示では、読み込み中・エラー時のAppBarも `automaticallyImplyLeading: false` にする。明示したボタンを除くだけでは親Navigatorから戻るボタンが補完される。
+- 詳細ルートから直接開いた場合は、従来どおりNavigatorの戻る操作を利用する。
+
+## 検証
+
+```sh
+cd app
+mise exec -- flutter test --no-pub \
+  test/feature/earthquake_history/ui/earthquake_history_details_navigation_test.dart \
+  test/feature/earthquake_history/ui/earthquake_history_details_nearby_card_test.dart
+mise exec -- dart analyze --fatal-infos lib/core/component/layout \
+  lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+```


### PR DESCRIPTION
地震履歴の一覧と詳細を分割表示したとき、詳細側に不要な戻るボタンが表示される問題を修正します。

実際のペイン配置を詳細画面へ伝え、分割時はデータ表示後・読み込み中・エラー時のすべてで戻るボタンを非表示にします。画面幅を狭めた場合は選択解除用のボタンを表示し、詳細ルートから直接開いた場合のナビゲーションは維持します。

検証:
- 分割表示と狭い画面の切り替え、読み込み・エラー・詳細表示時の戻るボタン、選択解除をWidgetテストで確認
- 既存の詳細ソース切り替えテストを実行
- 変更箇所とテストの `dart analyze --fatal-infos` を実行

最新developでテストのコンパイルを妨げていた、デバッグ端末設定画面の `AuthorizationStatus.deniedPermanently` の表示分岐も別コミットで補っています。

タブレット実機の表示確認は未実施です。マップインスタンスの再利用は別の変更として扱います。
